### PR TITLE
Make OS_ACCESS_KEY and OS_SECRET_KEY only required for s3 acc tests

### DIFF
--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -59,14 +59,6 @@ func testAccPreCheckRequiredEnvVars(t *testing.T) {
 	if OS_AVAILABILITY_ZONE == "" {
 		t.Fatal("OS_AVAILABILITY_ZONE must be set for acceptance tests")
 	}
-
-	if OS_ACCESS_KEY == "" {
-		t.Fatal("OS_ACCESS_KEY must be set for acceptance tests")
-	}
-
-	if OS_SECRET_KEY == "" {
-		t.Fatal("OS_SECRET_KEY must be set for acceptance tests")
-	}
 	if OS_FLAVOR_ID == "" && OS_FLAVOR_NAME == "" {
 		t.Fatal("OS_FLAVOR_ID or OS_FLAVOR_NAME must be set for acceptance tests")
 	}
@@ -137,6 +129,14 @@ func testAccPreCheckCCENode(t *testing.T) {
 		t.Skip("OS_SSH_KEY must be set for CCE Node acceptance tests")
 	}
 }
+
+func testAccPreCheckS3(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+	if OS_ACCESS_KEY == "" || OS_SECRET_KEY == "" {
+		t.Skip("OS_ACCESS_KEY and OS_SECRET_KEY  must be set for S3 acceptance tests")
+	}
+}
+
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)

--- a/huaweicloud/resource_huaweicloud_s3_bucket_object_test.go
+++ b/huaweicloud/resource_huaweicloud_s3_bucket_object_test.go
@@ -32,7 +32,7 @@ func TestAccS3BucketObject_source(t *testing.T) {
 	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccS3BucketObject_content(t *testing.T) {
 	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -79,7 +79,7 @@ func TestAccS3BucketObject_withContentCharacteristics(t *testing.T) {
 	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -112,7 +112,7 @@ func TestAccS3BucketObject_updates(t *testing.T) {
 	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -156,7 +156,7 @@ func TestAccS3BucketObject_updatesWithVersioning(t *testing.T) {
 	var originalObj, modifiedObj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -276,7 +276,7 @@ func TestAccS3BucketObject_sse(t *testing.T) {
 	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -301,7 +301,7 @@ func TestAccS3BucketObject_acl(t *testing.T) {
 	var obj s3.GetObjectOutput
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketObjectDestroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/resource_huaweicloud_s3_bucket_policy_test.go
+++ b/huaweicloud/resource_huaweicloud_s3_bucket_policy_test.go
@@ -20,7 +20,7 @@ func TestAccS3BucketPolicy_basic(t *testing.T) {
 		name, name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccS3BucketPolicy_policyUpdate(t *testing.T) {
 		name, name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/resource_huaweicloud_s3_bucket_test.go
+++ b/huaweicloud/resource_huaweicloud_s3_bucket_test.go
@@ -25,7 +25,7 @@ func TestAccS3Bucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -50,7 +50,7 @@ func TestAccS3Bucket_basic(t *testing.T) {
 func TestAccS3MultiBucket_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckS3(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -62,7 +62,7 @@ func TestAccS3MultiBucket_withTags(t *testing.T) {
 
 func TestAccS3Bucket_namePrefix(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -80,7 +80,7 @@ func TestAccS3Bucket_namePrefix(t *testing.T) {
 
 func TestAccS3Bucket_generatedName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -98,7 +98,7 @@ func TestAccS3Bucket_region(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -117,7 +117,7 @@ func TestAccS3Bucket_Policy(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -155,7 +155,7 @@ func TestAccS3Bucket_UpdateAcl(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccS3BucketConfigWithAclUpdate, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -182,7 +182,7 @@ func TestAccS3Bucket_UpdateAcl(t *testing.T) {
 func TestAccS3Bucket_Website_Simple(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -223,7 +223,7 @@ func TestAccS3Bucket_Website_Simple(t *testing.T) {
 func TestAccS3Bucket_WebsiteRedirect(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -264,7 +264,7 @@ func TestAccS3Bucket_WebsiteRedirect(t *testing.T) {
 func TestAccS3Bucket_WebsiteRoutingRules(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -312,7 +312,7 @@ func TestAccS3Bucket_WebsiteRoutingRules(t *testing.T) {
 func TestAccS3Bucket_shouldFailNotFound(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -331,7 +331,7 @@ func TestAccS3Bucket_shouldFailNotFound(t *testing.T) {
 func TestAccS3Bucket_Versioning(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -400,7 +400,7 @@ func TestAccS3Bucket_Cors(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{
@@ -449,7 +449,7 @@ func TestAccS3Bucket_Cors(t *testing.T) {
 func TestAccS3Bucket_Lifecycle(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS3BucketDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
fixes #49 