### PR TITLE
Add X-Project-Id HEAD for AKSK auth

### DIFF
--- a/vendor/github.com/huaweicloud/golangsdk/provider_client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/provider_client.go
@@ -234,6 +234,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			AccessKey: client.AKSKAuthOptions.AccessKey,
 			SecretKey: client.AKSKAuthOptions.SecretKey,
 		})
+		req.Header.Set("X-Project-Id", client.AKSKAuthOptions.ProjectId)
 	}
 
 	// Issue the request.


### PR DESCRIPTION
X-Project-Id parameter should be added into HTTP HEAD
when we use AKSK authentication, like: huaweicloud-sdk-python do.

Related-Bug: theopenlab/openlab#130