### PR TITLE
docs: Format inline HCL code in docs to canonical format

### DIFF
--- a/website/docs/d/antiddos_v1.html.markdown
+++ b/website/docs/d/antiddos_v1.html.markdown
@@ -13,7 +13,7 @@ The HuaweiCloud Antiddos data source allows to query the status of EIP, regardle
 ## Example Usage
 
 ```hcl
-variable "eip_id" { }
+variable "eip_id" {}
 
 data "huaweicloud_antiddos_v1" "antiddos" {
   floating_ip_id = "${var.eip_id}"

--- a/website/docs/d/csbs_backup_policy_v1.html.markdown
+++ b/website/docs/d/csbs_backup_policy_v1.html.markdown
@@ -14,10 +14,10 @@ The HuaweiCloud CSBS Backup Policy data source allows access of backup Policy re
 
 
 ```hcl
-variable "policy_id" { }
+variable "policy_id" {}
 
 data "huaweicloud_csbs_backup_policy_v1" "csbs_policy" {
-  id = "${var.policy_id}" 
+  id = "${var.policy_id}"
 }
 
 ```

--- a/website/docs/d/csbs_backup_v1.html.markdown
+++ b/website/docs/d/csbs_backup_v1.html.markdown
@@ -14,10 +14,10 @@ The HuaweiCloud CSBS Backup data source allows access of backup resources.
 
 
 ```hcl
-variable "backup_name" { }
+variable "backup_name" {}
 
 data "huaweicloud_csbs_backup_v1" "csbs" {
-  backup_name = "${var.backup_name}" 
+  backup_name = "${var.backup_name}"
 }
 ```
 

--- a/website/docs/d/cts_tracker_v1.html.markdown
+++ b/website/docs/d/cts_tracker_v1.html.markdown
@@ -14,7 +14,7 @@ CTS Tracker data source allows access of Cloud Tracker.
 
 
 ```hcl
-variable "bucket_name" { }
+variable "bucket_name" {}
 
 data "huaweicloud_cts_tracker_v1" "tracker_v1" {
   bucket_name = "${var.bucket_name}"

--- a/website/docs/d/dcs_maintainwindow_v1.html.markdown
+++ b/website/docs/d/dcs_maintainwindow_v1.html.markdown
@@ -15,7 +15,7 @@ Use this data source to get the ID of an available Huaweicloud dcs maintainwindo
 ```hcl
 
 data "huaweicloud_dcs_maintainwindow_v1" "maintainwindow1" {
-seq = 1
+  seq = 1
 }
 
 ```

--- a/website/docs/d/dcs_product_v1.html.markdown
+++ b/website/docs/d/dcs_product_v1.html.markdown
@@ -15,11 +15,11 @@ Use this data source to get the ID of an available Flexibleengine dcs product.
 ```hcl
 
 data "huaweicloud_dcs_product_v1" "product1" {
-  engine = "kafka"
-  version = "1.1.0"
-  instance_type = "cluster"
-  partition_num = 300
-  storage = 600
+  engine            = "kafka"
+  version           = "1.1.0"
+  instance_type     = "cluster"
+  partition_num     = 300
+  storage           = 600
   storage_spec_code = "dcs.physical.storage.high"
 }
 ```

--- a/website/docs/d/dms_maintainwindow_v1.html.markdown
+++ b/website/docs/d/dms_maintainwindow_v1.html.markdown
@@ -15,7 +15,7 @@ Use this data source to get the ID of an available HuaweiCloud dms maintainwindo
 ```hcl
 
 data "huaweicloud_dms_maintainwindow_v1" "maintainwindow1" {
-seq = 1
+  seq = 1
 }
 
 ```

--- a/website/docs/d/dms_product_v1.html.markdown
+++ b/website/docs/d/dms_product_v1.html.markdown
@@ -15,11 +15,11 @@ Use this data source to get the ID of an available HuaweiCloud dms product.
 ```hcl
 
 data "huaweicloud_dms_product_v1" "product1" {
-  engine = "kafka"
-  version = "1.1.0"
-  instance_type = "cluster"
-  partition_num = 300
-  storage = 600
+  engine            = "kafka"
+  version           = "1.1.0"
+  instance_type     = "cluster"
+  partition_num     = 300
+  storage           = 600
   storage_spec_code = "dms.physical.storage.high"
 }
 ```

--- a/website/docs/d/images_image_v2.html.markdown
+++ b/website/docs/d/images_image_v2.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get the ID of an available HuaweiCloud image.
 
 ```hcl
 data "huaweicloud_images_image_v2" "ubuntu" {
-  name = "Ubuntu 16.04"
+  name        = "Ubuntu 16.04"
   most_recent = true
 
   properties {

--- a/website/docs/d/rds_flavors_v1.html.markdown
+++ b/website/docs/d/rds_flavors_v1.html.markdown
@@ -14,10 +14,10 @@ Use this data source to get the ID of an available HuaweiCloud rds flavor.
 
 ```hcl
 data "huaweicloud_rds_flavors_v1" "flavor" {
-    region = "eu-de"
-    datastore_name = "PostgreSQL"
-    datastore_version = "9.5.5"
-    speccode = "rds.pg.s1.medium"
+  region            = "eu-de"
+  datastore_name    = "PostgreSQL"
+  datastore_version = "9.5.5"
+  speccode          = "rds.pg.s1.medium"
 }
 ```
 

--- a/website/docs/d/vbs_backup_policy_v2.html.markdown
+++ b/website/docs/d/vbs_backup_policy_v2.html.markdown
@@ -15,13 +15,13 @@ The VBS Backup Policy data source provides details about a specific VBS backup p
 
  ```hcl
 
- variable "policy_name" { }
+variable "policy_name" {}
 
- variable "policy_id" { }
-    
+variable "policy_id" {}
+
 data "huaweicloud_vbs_backup_policy_v2" "policies" {
   name = "${var.policy_name}"
-  id = "${var.policy_id}"
+  id   = "${var.policy_id}"
 }
  ```
 

--- a/website/docs/r/as_configuration_v1.html.markdown
+++ b/website/docs/r/as_configuration_v1.html.markdown
@@ -19,13 +19,13 @@ resource "huaweicloud_as_configuration_v1" "my_as_config" {
   scaling_configuration_name = "my_as_config"
   instance_config {
     flavor = "${var.flavor}"
-    image = "${var.image_id}"
+    image  = "${var.image_id}"
     disk {
-      size = 40
+      size        = 40
       volume_type = "SATA"
-      disk_type = "SYS"
+      disk_type   = "SYS"
     }
-    key_name = "${var.keyname}"
+    key_name  = "${var.keyname}"
     user_data = "${file("userdata.txt")}"
   }
 }
@@ -38,13 +38,13 @@ resource "huaweicloud_as_configuration_v1" "my_as_config" {
   scaling_configuration_name = "my_as_config"
   instance_config {
     flavor = "${var.flavor}"
-    image = "${var.image_id}"
+    image  = "${var.image_id}"
     disk {
-      size = 40
+      size        = 40
       volume_type = "SATA"
-      disk_type = "SYS"
+      disk_type   = "SYS"
     }
-    key_name = "${var.keyname}"
+    key_name  = "${var.keyname}"
     user_data = "${file("userdata.txt")}"
     metadata = {
       some_key = "some_value"
@@ -63,7 +63,7 @@ resource "huaweicloud_as_configuration_v1" "my_as_config" {
   scaling_configuration_name = "my_as_config"
   instance_config {
     instance_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
-    key_name = "${var.keyname}"
+    key_name    = "${var.keyname}"
   }
 }
 ```

--- a/website/docs/r/as_group_v1.html.markdown
+++ b/website/docs/r/as_group_v1.html.markdown
@@ -16,16 +16,16 @@ Manages a V1 Autoscaling Group resource within HuaweiCloud.
 
 ```hcl
 resource "huaweicloud_as_group_v1" "my_as_group" {
-  scaling_group_name = "my_as_group"
+  scaling_group_name       = "my_as_group"
   scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
-  desire_instance_number = 2
-  min_instance_number = 0
-  max_instance_number = 10
-  networks = [{id = "ad091b52-742f-469e-8f3c-fd81cadf0743"}]
-  security_groups = [{id = "45e4c6de-6bf0-4843-8953-2babde3d4810"}]
-  vpc_id = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
-  delete_publicip = true
-  delete_instances = "yes"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  networks                 = [{ id = "ad091b52-742f-469e-8f3c-fd81cadf0743" }]
+  security_groups          = [{ id = "45e4c6de-6bf0-4843-8953-2babde3d4810" }]
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  delete_publicip          = true
+  delete_instances         = "yes"
 }
 ```
 
@@ -33,16 +33,16 @@ resource "huaweicloud_as_group_v1" "my_as_group" {
 
 ```hcl
 resource "huaweicloud_as_group_v1" "my_as_group_only_remove_members" {
-  scaling_group_name = "my_as_group_only_remove_members"
+  scaling_group_name       = "my_as_group_only_remove_members"
   scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
-  desire_instance_number = 2
-  min_instance_number = 0
-  max_instance_number = 10
-  networks = [{id = "ad091b52-742f-469e-8f3c-fd81cadf0743"}]
-  security_groups = [{id = "45e4c6de-6bf0-4843-8953-2babde3d4810"}]
-  vpc_id = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
-  delete_publicip = true
-  delete_instances = "no"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  networks                 = [{ id = "ad091b52-742f-469e-8f3c-fd81cadf0743" }]
+  security_groups          = [{ id = "45e4c6de-6bf0-4843-8953-2babde3d4810" }]
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  delete_publicip          = true
+  delete_instances         = "no"
 }
 ```
 
@@ -50,32 +50,32 @@ resource "huaweicloud_as_group_v1" "my_as_group_only_remove_members" {
 
 ```hcl
 resource "huaweicloud_as_group_v1" "my_as_group_with_elb" {
-  scaling_group_name = "my_as_group_with_elb"
+  scaling_group_name       = "my_as_group_with_elb"
   scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
-  desire_instance_number = 2
-  min_instance_number = 0
-  max_instance_number = 10
-  networks = [{id = "ad091b52-742f-469e-8f3c-fd81cadf0743"}]
-  security_groups = [{id = "45e4c6de-6bf0-4843-8953-2babde3d4810"}]
-  vpc_id = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
-  lb_listener_id = "${huaweicloud_elb_listener.my_listener.id}"
-  delete_publicip = true
-  delete_instances = "yes"
+  desire_instance_number   = 2
+  min_instance_number      = 0
+  max_instance_number      = 10
+  networks                 = [{ id = "ad091b52-742f-469e-8f3c-fd81cadf0743" }]
+  security_groups          = [{ id = "45e4c6de-6bf0-4843-8953-2babde3d4810" }]
+  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  lb_listener_id           = "${huaweicloud_elb_listener.my_listener.id}"
+  delete_publicip          = true
+  delete_instances         = "yes"
 }
 
 resource "huaweicloud_elb_listener" "my_listener" {
-  name = "my_listener"
-  description = "my test listener"
-  protocol = "TCP"
+  name             = "my_listener"
+  description      = "my test listener"
+  protocol         = "TCP"
   backend_protocol = "TCP"
-  port = 12345
-  backend_port = 21345
-  lb_algorithm = "roundrobin"
-  loadbalancer_id = "cba48790-baf5-4446-adb3-02069a916e97"
+  port             = 12345
+  backend_port     = 21345
+  lb_algorithm     = "roundrobin"
+  loadbalancer_id  = "cba48790-baf5-4446-adb3-02069a916e97"
   timeouts {
-        create = "5m"
-        update = "5m"
-        delete = "5m"
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 

--- a/website/docs/r/as_policy_v1.html.markdown
+++ b/website/docs/r/as_policy_v1.html.markdown
@@ -15,20 +15,20 @@ Manages a V1 AS Policy resource within HuaweiCloud.
 ### AS Recurrence Policy
 
 ```hcl
-resource "huaweicloud_as_policy_v1" "hth_aspolicy"{
+resource "huaweicloud_as_policy_v1" "hth_aspolicy" {
   scaling_policy_name = "hth_aspolicy"
-  scaling_group_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
-  cool_down_time = 900
+  scaling_group_id    = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+  cool_down_time      = 900
   scaling_policy_type = "RECURRENCE"
   scaling_policy_action {
-    operation = "ADD"
+    operation       = "ADD"
     instance_number = 1
   }
   scheduled_policy {
-    launch_time = "07:00"
+    launch_time     = "07:00"
     recurrence_type = "Daily"
-    start_time = "2017-11-30T12:00Z"
-    end_time = "2017-12-30T12:00Z"
+    start_time      = "2017-11-30T12:00Z"
+    end_time        = "2017-12-30T12:00Z"
   }
 }
 
@@ -37,13 +37,13 @@ resource "huaweicloud_as_policy_v1" "hth_aspolicy"{
 ### AS Scheduled Policy
 
 ```hcl
-resource "huaweicloud_as_policy_v1" "hth_aspolicy_1"{
+resource "huaweicloud_as_policy_v1" "hth_aspolicy_1" {
   scaling_policy_name = "hth_aspolicy_1"
-  scaling_group_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
-  cool_down_time = 900
+  scaling_group_id    = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+  cool_down_time      = 900
   scaling_policy_type = "SCHEDULED"
   scaling_policy_action {
-    operation = "REMOVE"
+    operation       = "REMOVE"
     instance_number = 1
   }
   scheduled_policy {
@@ -58,14 +58,14 @@ Please note that the `launch_time` of the `SCHEDULED` policy cannot be earlier t
 ### AS Alarm Policy
 
 ```hcl
-resource "huaweicloud_as_policy_v1" "hth_aspolicy_2"{
+resource "huaweicloud_as_policy_v1" "hth_aspolicy_2" {
   scaling_policy_name = "hth_aspolicy_2"
-  scaling_group_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
-  cool_down_time = 900
+  scaling_group_id    = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
+  cool_down_time      = 900
   scaling_policy_type = "ALARM"
-  alarm_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  alarm_id            = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
   scaling_policy_action {
-    operation = "ADD"
+    operation       = "ADD"
     instance_number = 1
   }
 }

--- a/website/docs/r/cdm_cluster_v1.html.markdown
+++ b/website/docs/r/cdm_cluster_v1.html.markdown
@@ -16,18 +16,18 @@ cdm cluster management
 
 ```hcl
 resource "huaweicloud_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "huaweicloud_cdm_cluster_v1" "cluster" {
   availability_zone = "{{ availability_zone }}"
-  flavor_id = "{{ flavor_id }}"
-  name = "terraform_test_cdm_cluster"
+  flavor_id         = "{{ flavor_id }}"
+  name              = "terraform_test_cdm_cluster"
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ network_id }}"
-  vpc_id = "{{ vpc_id }}"
-  version = "{{ version }}"
+  subnet_id         = "{{ network_id }}"
+  vpc_id            = "{{ vpc_id }}"
+  version           = "{{ version }}"
 }
 ```
 

--- a/website/docs/r/cloudtable_cluster_v2.html.markdown
+++ b/website/docs/r/cloudtable_cluster_v2.html.markdown
@@ -16,18 +16,18 @@ cloud table cluster management
 
 ```hcl
 resource "huaweicloud_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "huaweicloud_cloudtable_cluster_v2" "cluster" {
   availability_zone = "{{ availability_zone }}"
-  name = "terraform-test-cluster"
-  rs_num = 2
+  name              = "terraform-test-cluster"
+  rs_num            = 2
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ network_id }}"
-  vpc_id = "{{ vpc_id }}"
-  storage_type = "COMMON"
+  subnet_id         = "{{ network_id }}"
+  vpc_id            = "{{ vpc_id }}"
+  storage_type      = "COMMON"
 }
 ```
 

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -56,7 +56,7 @@ resource "huaweicloud_compute_instance_v2" "myinstance" {
 
 resource "huaweicloud_compute_volume_attach_v2" "attached" {
   compute_id = "${huaweicloud_compute_instance_v2.myinstance.id}"
-  volume_id = "${huaweicloud_blockstorage_volume_v2.myvol.id}"
+  volume_id  = "${huaweicloud_blockstorage_volume_v2.myvol.id}"
 }
 ```
 
@@ -205,7 +205,7 @@ resource "huaweicloud_compute_instance_v2" "multi-net" {
 resource "huaweicloud_compute_floatingip_associate_v2" "myip" {
   floating_ip = "${huaweicloud_networking_floatingip_v2.myip.address}"
   instance_id = "${huaweicloud_compute_instance_v2.multi-net.id}"
-  fixed_ip = "${huaweicloud_compute_instance_v2.multi-net.network.1.fixed_ip_v4}"
+  fixed_ip    = "${huaweicloud_compute_instance_v2.multi-net.network.1.fixed_ip_v4}"
 }
 ```
 

--- a/website/docs/r/compute_secgroup_v2.html.markdown
+++ b/website/docs/r/compute_secgroup_v2.html.markdown
@@ -100,10 +100,10 @@ When using ICMP as the `ip_protocol`, the `from_port` sets the ICMP _type_ and t
 
 ```hcl
 rule {
-  from_port = -1
-  to_port = -1
+  from_port   = -1
+  to_port     = -1
   ip_protocol = "icmp"
-  cidr = "0.0.0.0/0"
+  cidr        = "0.0.0.0/0"
 }
 ```
 

--- a/website/docs/r/cs_peering_connect_v1.html.markdown
+++ b/website/docs/r/cs_peering_connect_v1.html.markdown
@@ -25,10 +25,10 @@ resource "huaweicloud_vpc_v1" "vpc" {
 }
 
 resource "huaweicloud_vpc_subnet_v1" "subnet" {
-  name = "terraform_vpc_subnet_v1_test"
-  cidr = "192.168.0.0/16"
+  name       = "terraform_vpc_subnet_v1_test"
+  cidr       = "192.168.0.0/16"
   gateway_ip = "192.168.0.1"
-  vpc_id = "${huaweicloud_vpc_v1.vpc.id}"
+  vpc_id     = "${huaweicloud_vpc_v1.vpc.id}"
 }
 
 resource "huaweicloud_cs_peering_connect_v1" "peering" {

--- a/website/docs/r/csbs_backup_policy_v1.html.markdown
+++ b/website/docs/r/csbs_backup_policy_v1.html.markdown
@@ -13,23 +13,23 @@ Provides an HuaweiCloud Backup Policy of Resources.
 ## Example Usage
 
  ```hcl
- variable "name" { }
- variable "id" { }
- variable "resource_name" { }
- 
- resource "huaweicloud_csbs_backup_policy_v1" "backup_policy_v1" {
-   name  = "${var.name}"
-   resource {
-     id = "${var.id}"
-     type = "OS::Nova::Server"
-     name = "${var.resource_name}"
-   }
-   scheduled_operation {
-     enabled = true
-     operation_type = "backup"
-     trigger_pattern = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nRRULE:FREQ=WEEKLY;BYDAY=TH;BYHOUR=12;BYMINUTE=27\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
-   }
- }
+variable "name" {}
+variable "id" {}
+variable "resource_name" {}
+
+resource "huaweicloud_csbs_backup_policy_v1" "backup_policy_v1" {
+  name = "${var.name}"
+  resource {
+    id   = "${var.id}"
+    type = "OS::Nova::Server"
+    name = "${var.resource_name}"
+  }
+  scheduled_operation {
+    enabled         = true
+    operation_type  = "backup"
+    trigger_pattern = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nRRULE:FREQ=WEEKLY;BYDAY=TH;BYHOUR=12;BYMINUTE=27\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+  }
+}
 
  ```
 ## Argument Reference

--- a/website/docs/r/csbs_backup_v1.html.markdown
+++ b/website/docs/r/csbs_backup_v1.html.markdown
@@ -13,14 +13,14 @@ Provides an HuaweiCloud Backup of Resources.
 ## Example Usage
 
  ```hcl
- variable "backup_name" { }
- variable "resource_id" { }
- 
- resource "huaweicloud_csbs_backup_v1" "backup_v1" {
-   backup_name = "${var.backup_name}"
-   resource_id = "${var.resource_id}"
-   resource_type = "OS::Nova::Server"
- }
+variable "backup_name" {}
+variable "resource_id" {}
+
+resource "huaweicloud_csbs_backup_v1" "backup_v1" {
+  backup_name   = "${var.backup_name}"
+  resource_id   = "${var.resource_id}"
+  resource_type = "OS::Nova::Server"
+}
 
  ```
 ## Argument Reference

--- a/website/docs/r/css_cluster_v1.html.markdown
+++ b/website/docs/r/css_cluster_v1.html.markdown
@@ -16,24 +16,24 @@ cluster management
 
 ```hcl
 resource "huaweicloud_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "huaweicloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
-  name = "terraform_test_cluster"
-  engine_version = "6.2.3"
+  name            = "terraform_test_cluster"
+  engine_version  = "6.2.3"
   node_config {
     flavor = "ess.spec-2u16g"
     network_info {
       security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
-      subnet_id = "{{ network_id }}"
-      vpc_id = "{{ vpc_id }}"
+      subnet_id         = "{{ network_id }}"
+      vpc_id            = "{{ vpc_id }}"
     }
     volume {
       volume_type = "COMMON"
-      size = 40
+      size        = 40
     }
     availability_zone = "{{ availability_zone }}"
   }

--- a/website/docs/r/cts_tracker_v1.html.markdown
+++ b/website/docs/r/cts_tracker_v1.html.markdown
@@ -13,18 +13,18 @@ Allows you to collect, store, and query cloud resource operation records.
 ## Example Usage
 
  ```hcl
- variable "bucket_name" { }
- variable "topic_id" { }
- 
- resource "huaweicloud_cts_tracker_v1" "tracker_v1" {
-   bucket_name      = "${var.bucket_name}"
-   file_prefix_name      = "yO8Q"
-   is_support_smn = true
-   topic_id = "${var.topic_id}"
-   is_send_all_key_operation = false
-   operations = ["login"]
-   need_notify_user_list = ["user1"]
- }
+variable "bucket_name" {}
+variable "topic_id" {}
+
+resource "huaweicloud_cts_tracker_v1" "tracker_v1" {
+  bucket_name               = "${var.bucket_name}"
+  file_prefix_name          = "yO8Q"
+  is_support_smn            = true
+  topic_id                  = "${var.topic_id}"
+  is_send_all_key_operation = false
+  operations                = ["login"]
+  need_notify_user_list     = ["user1"]
+}
 
  ```
 ## Argument Reference

--- a/website/docs/r/dcs_instance_v1.html.markdown
+++ b/website/docs/r/dcs_instance_v1.html.markdown
@@ -15,34 +15,34 @@ Manages a DCS instance in the huaweicloud DCS Service.
 ### Automatically detect the correct network
 
 ```hcl
-       resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-         name = "secgroup_1"
-         description = "secgroup_1"
-       }
-       data "huaweicloud_dcs_az_v1" "az_1" {
-         port = "8002"
-		}
-       data "huaweicloud_dcs_product_v1" "product_1" {
-          spec_code = "dcs.master_standby"
-		}
-		resource "huaweicloud_dcs_instance_v1" "instance_1" {
-		  name  = "test_dcs_instance"
-          engine_version = "3.0.7"
-          password = "Huawei_test"
-          engine = "Redis"
-          capacity = 2
-          vpc_id = "1477393a-29c9-4de5-843f-18ef51257c7e"
-          security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup_1.id}"
-          subnet_id = "27d99e17-42f2-4751-818f-5c8c6c03ff15"
-          available_zones = ["${data.huaweicloud_dcs_az_v1.az_1.id}"]
-          product_id = "${data.huaweicloud_dcs_product_v1.product_1.id}"
-          save_days = 1
-          backup_type = "manual"
-          begin_at = "00:00-01:00"
-          period_type = "weekly"
-          backup_at = [1]
-          depends_on = ["data.huaweicloud_dcs_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
-		}
+resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "secgroup_1"
+}
+data "huaweicloud_dcs_az_v1" "az_1" {
+  port = "8002"
+}
+data "huaweicloud_dcs_product_v1" "product_1" {
+  spec_code = "dcs.master_standby"
+}
+resource "huaweicloud_dcs_instance_v1" "instance_1" {
+  name              = "test_dcs_instance"
+  engine_version    = "3.0.7"
+  password          = "Huawei_test"
+  engine            = "Redis"
+  capacity          = 2
+  vpc_id            = "1477393a-29c9-4de5-843f-18ef51257c7e"
+  security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup_1.id}"
+  subnet_id         = "27d99e17-42f2-4751-818f-5c8c6c03ff15"
+  available_zones   = ["${data.huaweicloud_dcs_az_v1.az_1.id}"]
+  product_id        = "${data.huaweicloud_dcs_product_v1.product_1.id}"
+  save_days         = 1
+  backup_type       = "manual"
+  begin_at          = "00:00-01:00"
+  period_type       = "weekly"
+  backup_at         = [1]
+  depends_on        = ["data.huaweicloud_dcs_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/dis_stream_v2.html.markdown
+++ b/website/docs/r/dis_stream_v2.html.markdown
@@ -16,7 +16,7 @@ DIS Stream management
 
 ```hcl
 resource "huaweicloud_dis_stream_v2" "stream" {
-  stream_name = "terraform_test_dis_stream"
+  stream_name     = "terraform_test_dis_stream"
   partition_count = 1
 }
 ```
@@ -25,10 +25,10 @@ resource "huaweicloud_dis_stream_v2" "stream" {
 
 ```hcl
 resource "huaweicloud_dis_stream_v2" "stream" {
-  stream_name = "terraform_test_dis_stream"
+  stream_name     = "terraform_test_dis_stream"
   partition_count = 1
-  data_type = "JSON"
-  data_schema = "{\"type\":\"record\",\"name\":\"RecordName\",\"fields\":[{\"name\":\"id\",\"type\":\"string\",\"doc\":\"Type inferred from '\\\"2017/10/11 11:11:11\\\"'\"},{\"name\":\"info\",\"type\":{\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"info\",\"fields\":[{\"name\":\"date\",\"type\":\"string\",\"doc\":\"Type inferred from '\\\"2018/10/11 11:11:11\\\"'\"}]}},\"doc\":\"Type inferred from '[{\\\"date\\\":\\\"2018/10/11 11:11:11\\\"}]'\"}]}"
+  data_type       = "JSON"
+  data_schema     = "{\"type\":\"record\",\"name\":\"RecordName\",\"fields\":[{\"name\":\"id\",\"type\":\"string\",\"doc\":\"Type inferred from '\\\"2017/10/11 11:11:11\\\"'\"},{\"name\":\"info\",\"type\":{\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"info\",\"fields\":[{\"name\":\"date\",\"type\":\"string\",\"doc\":\"Type inferred from '\\\"2018/10/11 11:11:11\\\"'\"}]}},\"doc\":\"Type inferred from '[{\\\"date\\\":\\\"2018/10/11 11:11:11\\\"}]'\"}]}"
 }
 ```
 

--- a/website/docs/r/dms_group_v1.html.markdown
+++ b/website/docs/r/dms_group_v1.html.markdown
@@ -16,15 +16,15 @@ Manages a DMS group in the huaweicloud DMS Service.
 
 ```hcl
 resource "huaweicloud_dms_group_v1" "queue_1" {
-  name  = "queue_1"
-  description  = "test create dms queue"
-  queue_mode  = "FIFO"
-  redrive_policy  = "enable"
+  name              = "queue_1"
+  description       = "test create dms queue"
+  queue_mode        = "FIFO"
+  redrive_policy    = "enable"
   max_consume_count = 80
 }
 
 resource "huaweicloud_dms_group_v1" "group_1" {
-  name = "group_1"
+  name     = "group_1"
   queue_id = "${huaweicloud_dms_queue_v1.queue_1.id}"
 }
 ```

--- a/website/docs/r/dms_instance_v1.html.markdown
+++ b/website/docs/r/dms_instance_v1.html.markdown
@@ -16,29 +16,29 @@ Manages a DMS instance in the huaweicloud DMS Service.
 
 ```hcl
 resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-  name = "secgroup_1"
+  name        = "secgroup_1"
   description = "secgroup_1"
 }
 data "huaweicloud_dms_az_v1" "az_1" {
 }
 data "huaweicloud_dms_product_v1" "product_1" {
-  engine = "rabbitmq"
+  engine        = "rabbitmq"
   instance_type = "single"
-  version = "3.7.0"
+  version       = "3.7.0"
 }
 resource "huaweicloud_dms_instance_v1" "instance_1" {
-  name  = "%s"
-  engine = "rabbitmq"
-  storage_space = "${data.huaweicloud_dms_product_v1.product_1.storage}"
-  access_user = "user"
-  password = "Dmstest@123"
-  vpc_id = "%s"
+  name              = "%s"
+  engine            = "rabbitmq"
+  storage_space     = "${data.huaweicloud_dms_product_v1.product_1.storage}"
+  access_user       = "user"
+  password          = "Dmstest@123"
+  vpc_id            = "%s"
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup_1.id}"
-  subnet_id = "%s"
-  available_zones = ["${data.huaweicloud_dms_az_v1.az_1.id}"]
-  product_id = "${data.huaweicloud_dms_product_v1.product_1.id}"
-  engine_version = "${data.huaweicloud_dms_product_v1.product_1.version}"
-  depends_on      = ["data.huaweicloud_dms_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
+  subnet_id         = "%s"
+  available_zones   = ["${data.huaweicloud_dms_az_v1.az_1.id}"]
+  product_id        = "${data.huaweicloud_dms_product_v1.product_1.id}"
+  engine_version    = "${data.huaweicloud_dms_product_v1.product_1.version}"
+  depends_on        = ["data.huaweicloud_dms_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
 }
 ```
 

--- a/website/docs/r/dms_queue_v1.html.markdown
+++ b/website/docs/r/dms_queue_v1.html.markdown
@@ -16,10 +16,10 @@ Manages a DMS queue in the huaweicloud DMS Service.
 
 ```hcl
 resource "huaweicloud_dms_queue_v1" "queue_1" {
-  name  = "queue_1"
-  description  = "test create dms queue"
-  queue_mode  = "FIFO"
-  redrive_policy  = "enable"
+  name              = "queue_1"
+  description       = "test create dms queue"
+  queue_mode        = "FIFO"
+  redrive_policy    = "enable"
   max_consume_count = 80
 }
 ```

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -16,20 +16,20 @@ Manages a DNS record set in the HuaweiCloud DNS Service.
 
 ```hcl
 resource "huaweicloud_dns_zone_v2" "example_zone" {
-  name = "example.com."
-  email = "email2@example.com"
+  name        = "example.com."
+  email       = "email2@example.com"
   description = "a zone"
-  ttl = 6000
-  zone_type = "public"
+  ttl         = 6000
+  zone_type   = "public"
 }
 
 resource "huaweicloud_dns_recordset_v2" "rs_example_com" {
-  zone_id = "${huaweicloud_dns_zone_v2.example_zone.id}"
-  name = "rs.example.com."
+  zone_id     = "${huaweicloud_dns_zone_v2.example_zone.id}"
+  name        = "rs.example.com."
   description = "An example record set"
-  ttl = 3000
-  type = "A"
-  records = ["10.0.0.1"]
+  ttl         = 3000
+  type        = "A"
+  records     = ["10.0.0.1"]
 }
 ```
 

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -16,11 +16,11 @@ Manages a DNS zone in the HuaweiCloud DNS Service.
 
 ```hcl
 resource "huaweicloud_dns_zone_v2" "my_public_zone" {
-  name = "example.com."
-  email = "jdoe@example.com"
+  name        = "example.com."
+  email       = "jdoe@example.com"
   description = "An example zone"
-  ttl = 3000
-  zone_type = "public"
+  ttl         = 3000
+  zone_type   = "public"
 }
 ```
 
@@ -28,15 +28,15 @@ resource "huaweicloud_dns_zone_v2" "my_public_zone" {
 
 ```hcl
 resource "huaweicloud_dns_zone_v2" "my_private_zone" {
-  name = "1.example.com."
-  email = "jdoe@example.com"
+  name        = "1.example.com."
+  email       = "jdoe@example.com"
   description = "An example zone"
-  ttl = 3000
-  zone_type = "private"
+  ttl         = 3000
+  zone_type   = "private"
   router = [
     {
       router_region = "cn-north-1"
-      router_id = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
+      router_id     = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
     }
   ]
 }

--- a/website/docs/r/dws_cluster.html.markdown
+++ b/website/docs/r/dws_cluster.html.markdown
@@ -16,20 +16,20 @@ cluster management
 
 ```hcl
 resource "huaweicloud_networking_secgroup_v2" "secgroup" {
-  name = "security_group_2"
+  name        = "security_group_2"
   description = "terraform security group"
 }
 
 resource "huaweicloud_dws_cluster" "cluster" {
-  node_type = "dws.m3.xlarge"
-  number_of_node = 3
-  network_id = "{{ network_id }}"
-  vpc_id = "{{ vpc_id }}"
+  node_type         = "dws.m3.xlarge"
+  number_of_node    = 3
+  network_id        = "{{ network_id }}"
+  vpc_id            = "{{ vpc_id }}"
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
   availability_zone = "{{ availability_zone }}"
-  name = "terraform_dws_cluster_test"
-  user_name = "test_cluster_admin"
-  user_pwd = "cluster123@!"
+  name              = "terraform_dws_cluster_test"
+  user_name         = "test_cluster_admin"
+  user_pwd          = "cluster123@!"
 
   timeouts {
     create = "30m"

--- a/website/docs/r/elb_backendecs.html.markdown
+++ b/website/docs/r/elb_backendecs.html.markdown
@@ -14,34 +14,34 @@ Manages an elastic loadbalancer backendecs resource within huawei cloud.
 
 ```hcl
 resource "huaweicloud_elb_loadbalancer" "elb" {
-  name = "elb"
-  type = "External"
-  description = "test elb"
-  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  name           = "elb"
+  type           = "External"
+  description    = "test elb"
+  vpc_id         = "e346dc4a-d9a6-46f4-90df-10153626076e"
   admin_state_up = 1
-  bandwidth = 5
+  bandwidth      = 5
 }
 
 resource "huaweicloud_elb_listener" "listener" {
-  name = "test-elb-listener"
-  description = "great listener"
-  protocol = "TCP"
+  name             = "test-elb-listener"
+  description      = "great listener"
+  protocol         = "TCP"
   backend_protocol = "TCP"
-  port = 12345
-  backend_port = 8080
-  lb_algorithm = "roundrobin"
-  loadbalancer_id = "${huaweicloud_elb_loadbalancer.elb.id}"
+  port             = 12345
+  backend_port     = 8080
+  lb_algorithm     = "roundrobin"
+  loadbalancer_id  = "${huaweicloud_elb_loadbalancer.elb.id}"
   timeouts {
-	create = "5m"
-	update = "5m"
-	delete = "5m"
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 
 resource "huaweicloud_elb_backendecs" "backend" {
   private_address = "192.168.0.211"
-  listener_id = "${huaweicloud_elb_listener.listener.id}"
-  server_id = "8f7a32f1-f66c-4d13-9b17-3a13f9f0bb8d"
+  listener_id     = "${huaweicloud_elb_listener.listener.id}"
+  server_id       = "8f7a32f1-f66c-4d13-9b17-3a13f9f0bb8d"
 }
 ```
 

--- a/website/docs/r/elb_healthcheck.html.markdown
+++ b/website/docs/r/elb_healthcheck.html.markdown
@@ -14,37 +14,37 @@ Manages an elastic loadbalancer healthcheck resource within huawei cloud.
 
 ```hcl
 resource "huaweicloud_elb_loadbalancer" "elb" {
-  name = "elb"
-  type = "External"
-  description = "test elb"
-  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  name           = "elb"
+  type           = "External"
+  description    = "test elb"
+  vpc_id         = "e346dc4a-d9a6-46f4-90df-10153626076e"
   admin_state_up = 1
-  bandwidth = 5
+  bandwidth      = 5
 }
 
 resource "huaweicloud_elb_listener" "listener" {
-  name = "test-elb-listener"
-  description = "great listener"
-  protocol = "TCP"
+  name             = "test-elb-listener"
+  description      = "great listener"
+  protocol         = "TCP"
   backend_protocol = "TCP"
-  port = 12345
-  backend_port = 8080
-  lb_algorithm = "roundrobin"
-  loadbalancer_id = "${huaweicloud_elb_loadbalancer.elb.id}"
+  port             = 12345
+  backend_port     = 8080
+  lb_algorithm     = "roundrobin"
+  loadbalancer_id  = "${huaweicloud_elb_loadbalancer.elb.id}"
   timeouts {
-	create = "5m"
-	update = "5m"
-	delete = "5m"
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 
 resource "huaweicloud_elb_healthcheck" "healthcheck" {
-  listener_id = "${huaweicloud_elb_listener.listener.id}"
-  healthcheck_protocol = "TCP"
+  listener_id               = "${huaweicloud_elb_listener.listener.id}"
+  healthcheck_protocol      = "TCP"
   healthcheck_connect_porta = 22
-  healthy_threshold = 5
-  healthcheck_timeout = 25
-  healthcheck_interval = 3
+  healthy_threshold         = 5
+  healthcheck_timeout       = 25
+  healthcheck_interval      = 3
   timeouts {
     create = "5m"
     update = "5m"

--- a/website/docs/r/elb_listener.html.markdown
+++ b/website/docs/r/elb_listener.html.markdown
@@ -14,27 +14,27 @@ Manages an elastic loadbalancer listener resource within huawei cloud.
 
 ```hcl
 resource "huaweicloud_elb_loadbalancer" "elb" {
-  name = "elb"
-  type = "External"
-  description = "test elb"
-  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  name           = "elb"
+  type           = "External"
+  description    = "test elb"
+  vpc_id         = "e346dc4a-d9a6-46f4-90df-10153626076e"
   admin_state_up = 1
-  bandwidth = 5
+  bandwidth      = 5
 }
 
 resource "huaweicloud_elb_listener" "listener" {
-  name = "test-elb-listener"
-  description = "great listener"
-  protocol = "TCP"
+  name             = "test-elb-listener"
+  description      = "great listener"
+  protocol         = "TCP"
   backend_protocol = "TCP"
-  port = 12345
-  backend_port = 8080
-  lb_algorithm = "roundrobin"
-  loadbalancer_id = "${huaweicloud_elb_loadbalancer.elb.id}"
+  port             = 12345
+  backend_port     = 8080
+  lb_algorithm     = "roundrobin"
+  loadbalancer_id  = "${huaweicloud_elb_loadbalancer.elb.id}"
   timeouts {
-	create = "5m"
-	update = "5m"
-	delete = "5m"
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 ```

--- a/website/docs/r/elb_loadbalancer.html.markdown
+++ b/website/docs/r/elb_loadbalancer.html.markdown
@@ -14,12 +14,12 @@ Manages an elastic loadbalancer resource within huawei cloud.
 
 ```hcl
 resource "huaweicloud_elb_loadbalancer" "elb" {
-  name = "elb"
-  type = "External"
-  description = "test elb"
-  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  name           = "elb"
+  type           = "External"
+  description    = "test elb"
+  vpc_id         = "e346dc4a-d9a6-46f4-90df-10153626076e"
   admin_state_up = 1
-  bandwidth = 5
+  bandwidth      = 5
 }
 ```
 

--- a/website/docs/r/fw_firewall_group_v2.html.markdown
+++ b/website/docs/r/fw_firewall_group_v2.html.markdown
@@ -40,7 +40,7 @@ resource "huaweicloud_fw_policy_v2" "policy_1" {
 }
 
 resource "huaweicloud_fw_firewall_group_v2" "firewall_group_1" {
-  name      = "my-firewall-group"
+  name              = "my-firewall-group"
   ingress_policy_id = "${huaweicloud_fw_policy_v2.policy_1.id}"
 }
 ```

--- a/website/docs/r/ges_graph_v1.html.markdown
+++ b/website/docs/r/ges_graph_v1.html.markdown
@@ -16,18 +16,18 @@ graph management
 
 ```hcl
 resource "huaweicloud_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "huaweicloud_ges_graph_v1" "graph" {
   availability_zone = "{{ availability_zone }}"
-  graph_size_type = 0
-  name = "terraform_ges_graph_test"
-  region = "{{ region_name }}"
+  graph_size_type   = 0
+  name              = "terraform_ges_graph_test"
+  region            = "{{ region_name }}"
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ network_id }}"
-  vpc_id = "{{ vpc_id }}"
+  subnet_id         = "{{ network_id }}"
+  vpc_id            = "{{ vpc_id }}"
 }
 ```
 

--- a/website/docs/r/iam_agency_v3.html.markdown
+++ b/website/docs/r/iam_agency_v3.html.markdown
@@ -14,8 +14,8 @@ Manages an agency resource within huawei cloud.
 
 ```hcl
 resource "huaweicloud_iam_agency_v3" "agency" {
-  name = "test_agency"
-  description = "test agency"
+  name                  = "test_agency"
+  description           = "test agency"
   delegated_domain_name = "***"
   project_role = [
     {
@@ -26,7 +26,7 @@ resource "huaweicloud_iam_agency_v3" "agency" {
     }
   ]
   domain_roles = [
-      "Anti-DDoS Administrator",
+    "Anti-DDoS Administrator",
   ]
 }
 ```

--- a/website/docs/r/identity_group_membership_v3.html.markdown
+++ b/website/docs/r/identity_group_membership_v3.html.markdown
@@ -18,27 +18,27 @@ this resource.
 
 ```hcl
 resource "huaweicloud_identity_group_v3" "group_1" {
-  name = "group1"
+  name        = "group1"
   description = "This is a test group"
 }
 
 resource "huaweicloud_identity_user_v3" "user_1" {
-      name = "user1"
-      enabled = true
-      password = "password12345!"
+  name     = "user1"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_user_v3" "user_2" {
-      name = "user2"
-      enabled = true
-      password = "password12345!"
+  name     = "user2"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_group_membership_v3" "membership_1" {
-        group = "${huaweicloud_identity_group_v3.group_1.id}"
-        users = ["${huaweicloud_identity_user_v3.user_1.id}",
-                "${huaweicloud_identity_user_v3.user_2.id}"
-                ]
+  group = "${huaweicloud_identity_group_v3.group_1.id}"
+  users = ["${huaweicloud_identity_user_v3.user_1.id}",
+    "${huaweicloud_identity_user_v3.user_2.id}"
+  ]
 }
 ```
 

--- a/website/docs/r/identity_group_v3.html.markdown
+++ b/website/docs/r/identity_group_v3.html.markdown
@@ -17,7 +17,7 @@ this resource.
 
 ```hcl
 resource "huaweicloud_identity_group_v3" "group_1" {
-  name = "group_1"
+  name        = "group_1"
   description = "This is a test group"
 }
 ```

--- a/website/docs/r/identity_project_v3.html.markdown
+++ b/website/docs/r/identity_project_v3.html.markdown
@@ -19,7 +19,7 @@ https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html)
 
 ```hcl
 resource "huaweicloud_identity_project_v3" "project_1" {
-  name = "eu-de_project1"
+  name        = "eu-de_project1"
   description = "This is a test project"
 }
 ```

--- a/website/docs/r/identity_role_assignment_v3.html.markdown
+++ b/website/docs/r/identity_role_assignment_v3.html.markdown
@@ -29,9 +29,9 @@ data "huaweicloud_identity_role_v3" "role_1" {
 }
 
 resource "huaweicloud_identity_role_assignment_v3" "role_assignment_1" {
-  group_id = "${huaweicloud_identity_group_v3.group_1.id}"
+  group_id   = "${huaweicloud_identity_group_v3.group_1.id}"
   project_id = "${huaweicloud_identity_project_v3.project_1.id}"
-  role_id = "${data.huaweicloud_identity_role_v3.role_1.id}"
+  role_id    = "${data.huaweicloud_identity_role_v3.role_1.id}"
 }
 ```
 
@@ -40,8 +40,8 @@ resource "huaweicloud_identity_role_assignment_v3" "role_assignment_1" {
 ```hcl
 
 variable "domain_id" {
-    default = "01aafcf63744d988ebef2b1e04c5c34"
-    description = "this is the domain id"
+  default     = "01aafcf63744d988ebef2b1e04c5c34"
+  description = "this is the domain id"
 }
 
 resource "huaweicloud_identity_group_v3" "group_1" {
@@ -53,10 +53,10 @@ data "huaweicloud_identity_role_v3" "role_1" {
 }
 
 resource "huaweicloud_identity_role_assignment_v3" "role_assignment_1" {
-  group_id = "${huaweicloud_identity_group_v3.group_1.id}"
+  group_id  = "${huaweicloud_identity_group_v3.group_1.id}"
   domain_id = "${var.domain_id}"
-  role_id = "${data.huaweicloud_identity_role_v3.role_1.id}"
-} 
+  role_id   = "${data.huaweicloud_identity_role_v3.role_1.id}"
+}
 
 ```
 

--- a/website/docs/r/identity_user_v3.html.markdown
+++ b/website/docs/r/identity_user_v3.html.markdown
@@ -17,9 +17,9 @@ this resource.
 
 ```hcl
 resource "huaweicloud_identity_user_v3" "user_1" {
-  name = "user_1"
+  name        = "user_1"
   description = "A user"
-  password = "password123!"
+  password    = "password123!"
 
 }
 ```

--- a/website/docs/r/images_image_v2.html.markdown
+++ b/website/docs/r/images_image_v2.html.markdown
@@ -14,11 +14,11 @@ Manages a V2 Image resource within HuaweiCloud IMS.
 
 ```hcl
 resource "huaweicloud_images_image_v2" "rancheros" {
-  name   = "RancherOS"
+  name             = "RancherOS"
   image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
   container_format = "bare"
-  disk_format = "qcow2"
-  tags = ["foo.bar", "tag.value"]
+  disk_format      = "qcow2"
+  tags             = ["foo.bar", "tag.value"]
 }
 ```
 

--- a/website/docs/r/lb_l7policy_v2.html.markdown
+++ b/website/docs/r/lb_l7policy_v2.html.markdown
@@ -14,14 +14,14 @@ Manages a Load Balancer L7 Policy resource within HuaweiCloud.
 
 ```hcl
 resource "huaweicloud_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "SUBNET_ID"
 }
 
 resource "huaweicloud_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
   loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
 }
 

--- a/website/docs/r/lb_l7rule_v2.html.markdown
+++ b/website/docs/r/lb_l7rule_v2.html.markdown
@@ -14,14 +14,14 @@ Manages a V2 L7 Rule resource within HuaweiCloud.
 
 ```hcl
 resource "huaweicloud_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "SUBNET_ID"
 }
 
 resource "huaweicloud_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
   loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
 }
 

--- a/website/docs/r/mls_instance.html.markdown
+++ b/website/docs/r/mls_instance.html.markdown
@@ -16,23 +16,23 @@ mls instance
 
 ```hcl
 resource "huaweicloud_mrs_cluster_v1" "cluster1" {
-  cluster_name = "mrs-cluster-acc"
-  region = "en-OS_REGION_NAME"
-  billing_type = 12
-  master_node_num = 2
-  core_node_num = 3
-  master_node_size = "s1.4xlarge.linux.mrs"
-  core_node_size = "s1.xlarge.linux.mrs"
-  available_zone_id = "{{ availability_zone }}"
-  vpc_id = "{{ vpc_id }}"
-  subnet_id = "{{ network_id }}"
-  cluster_version = "MRS 1.3.0"
-  volume_type = "SATA"
-  volume_size = 100
-  safe_mode = 0
-  cluster_type = 0
+  cluster_name          = "mrs-cluster-acc"
+  region                = "en-OS_REGION_NAME"
+  billing_type          = 12
+  master_node_num       = 2
+  core_node_num         = 3
+  master_node_size      = "s1.4xlarge.linux.mrs"
+  core_node_size        = "s1.xlarge.linux.mrs"
+  available_zone_id     = "{{ availability_zone }}"
+  vpc_id                = "{{ vpc_id }}"
+  subnet_id             = "{{ network_id }}"
+  cluster_version       = "MRS 1.3.0"
+  volume_type           = "SATA"
+  volume_size           = 100
+  safe_mode             = 0
+  cluster_type          = 0
   node_public_cert_name = "KeyPair-ci"
-  cluster_admin_secret = ""
+  cluster_admin_secret  = ""
   component_list {
     component_name = "Hadoop"
   }
@@ -48,12 +48,12 @@ resource "huaweicloud_mrs_cluster_v1" "cluster1" {
 }
 
 resource "huaweicloud_mls_instance" "instance" {
-  name = "terraform-mls-instancei"
+  name    = "terraform-mls-instancei"
   version = "1.5.0"
-  flavor = "mls.c2.2xlarge.common"
+  flavor  = "mls.c2.2xlarge.common"
   network {
-    vpc_id = "{{ vpc_id }}"
-    network_id = "{{ network_id }}"
+    vpc_id         = "{{ vpc_id }}"
+    network_id     = "{{ network_id }}"
     available_zone = "{{ availability_zone }}"
     public_ip {
       bind_type = "not_use"

--- a/website/docs/r/mrs_cluster_v1.html.markdown
+++ b/website/docs/r/mrs_cluster_v1.html.markdown
@@ -14,31 +14,31 @@ Manages resource cluster within HuaweiCloud MRS.
 
 ```hcl
 resource "huaweicloud_mrs_cluster_v1" "cluster1" {
-  cluster_name = "mrs-cluster"
-  region = "cn-north-1"
-  billing_type = 12
-  master_node_num = 2
-  core_node_num = 3
-  master_node_size = "c3.4xlarge.2.linux.bigdata"
-  core_node_size = "c3.xlarge.4.linux.bigdata"
-  available_zone_id = "ae04cf9d61544df3806a3feeb401b204"
-  vpc_id = "51edfb75-f9f0-4bbc-b4dc-21466b93f60d"
-  subnet_id = "1d7a8646-43ee-455a-a3ab-40da87a1304c"
-  cluster_version = "MRS 1.6.3"
-  volume_type = "SATA"
-  volume_size = 100
-  safe_mode = 0
-  cluster_type = 0
+  cluster_name          = "mrs-cluster"
+  region                = "cn-north-1"
+  billing_type          = 12
+  master_node_num       = 2
+  core_node_num         = 3
+  master_node_size      = "c3.4xlarge.2.linux.bigdata"
+  core_node_size        = "c3.xlarge.4.linux.bigdata"
+  available_zone_id     = "ae04cf9d61544df3806a3feeb401b204"
+  vpc_id                = "51edfb75-f9f0-4bbc-b4dc-21466b93f60d"
+  subnet_id             = "1d7a8646-43ee-455a-a3ab-40da87a1304c"
+  cluster_version       = "MRS 1.6.3"
+  volume_type           = "SATA"
+  volume_size           = 100
+  safe_mode             = 0
+  cluster_type          = 0
   node_public_cert_name = "KeyPair-ci"
-  cluster_admin_secret = ""
+  cluster_admin_secret  = ""
   component_list {
-      component_name = "Hadoop"
+    component_name = "Hadoop"
   }
   component_list {
-      component_name = "Spark"
+    component_name = "Spark"
   }
   component_list {
-      component_name = "Hive"
+    component_name = "Hive"
   }
 }
 ```

--- a/website/docs/r/mrs_job_v1.html.markdown
+++ b/website/docs/r/mrs_job_v1.html.markdown
@@ -15,14 +15,14 @@ Manages resource job within HuaweiCloud MRS.
 ```hcl
 
 resource "huaweicloud_mrs_job_v1" "job1" {
-  job_type = 1
-  job_name = "test_mapreduce_job1"
+  job_type   = 1
+  job_name   = "test_mapreduce_job1"
   cluster_id = "ef43d2ff-1ecf-4f13-bd0c-0004c429a058"
-  jar_path = "s3a://wordcount/program/hadoop-mapreduce-examples-2.7.5.jar"
-  input = "s3a://wordcount/input/"
-  output = "s3a://wordcount/output/"
-  job_log = "s3a://wordcount/log/"
-  arguments = "wordcount"
+  jar_path   = "s3a://wordcount/program/hadoop-mapreduce-examples-2.7.5.jar"
+  input      = "s3a://wordcount/input/"
+  output     = "s3a://wordcount/output/"
+  job_log    = "s3a://wordcount/log/"
+  arguments  = "wordcount"
 }
 
 ```

--- a/website/docs/r/nat_gateway_v2.html.markdown
+++ b/website/docs/r/nat_gateway_v2.html.markdown
@@ -14,10 +14,10 @@ Manages a V2 nat gateway resource within HuaweiCloud Nat
 
 ```hcl
 resource "huaweicloud_nat_gateway_v2" "nat_1" {
-  name   = "Terraform"
-  description = "test for terraform2"
-  spec = "3"
-  router_id = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
+  name                = "Terraform"
+  description         = "test for terraform2"
+  spec                = "3"
+  router_id           = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
   internal_network_id = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
 }
 ```

--- a/website/docs/r/nat_snat_rule_v2.html.markdown
+++ b/website/docs/r/nat_snat_rule_v2.html.markdown
@@ -15,7 +15,7 @@ Manages a V2 snat rule resource within HuaweiCloud Nat
 ```hcl
 resource "huaweicloud_nat_snat_rule_v2" "snat_1" {
   nat_gateway_id = "3c0dffda-7c76-452b-9dcc-5bce7ae56b17"
-  network_id = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  network_id     = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
   floating_ip_id = "0a166fc5-a904-42fb-b1ef-cf18afeeddca"
 }
 ```

--- a/website/docs/r/networking_floatingip_associate_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_associate_v2.html.markdown
@@ -21,7 +21,7 @@ resource "huaweicloud_networking_port_v2" "port_1" {
 
 resource "huaweicloud_networking_floatingip_associate_v2" "fip_1" {
   floating_ip = "1.2.3.4"
-  port_id = "${huaweicloud_networking_port_v2.port_1.id}"
+  port_id     = "${huaweicloud_networking_port_v2.port_1.id}"
 }
 ```
 

--- a/website/docs/r/networking_secgroup_v2.html.markdown
+++ b/website/docs/r/networking_secgroup_v2.html.markdown
@@ -61,14 +61,14 @@ separate security group rules such as the following:
 
 ```hcl
 resource "huaweicloud_networking_secgroup_rule_v2" "secgroup_rule_v4" {
-  direction = "egress"
-  ethertype = "IPv4"
+  direction         = "egress"
+  ethertype         = "IPv4"
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
 }
 
 resource "huaweicloud_networking_secgroup_rule_v2" "secgroup_rule_v6" {
-  direction = "egress"
-  ethertype = "IPv6"
+  direction         = "egress"
+  ethertype         = "IPv6"
   security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
 }
 ```

--- a/website/docs/r/rds_instance_v1.html.markdown
+++ b/website/docs/r/rds_instance_v1.html.markdown
@@ -14,10 +14,10 @@ Manages rds instance resource within HuaweiCloud
 
 ```hcl
 data "huaweicloud_rds_flavors_v1" "flavor" {
-    region = "eu-de"
-    datastore_name = "PostgreSQL"
-    datastore_version = "9.5.5"
-    speccode = "rds.pg.s1.large"
+  region            = "eu-de"
+  datastore_name    = "PostgreSQL"
+  datastore_version = "9.5.5"
+  speccode          = "rds.pg.s1.large"
 }
 
 resource "huaweicloud_compute_secgroup_v2" "secgrp_rds" {
@@ -28,7 +28,7 @@ resource "huaweicloud_compute_secgroup_v2" "secgrp_rds" {
 resource "huaweicloud_rds_instance_v1" "instance" {
   name = "rds-instance"
   datastore {
-    type = "PostgreSQL"
+    type    = "PostgreSQL"
     version = "9.5.5"
   }
   flavorref = "${data.huaweicloud_rds_flavors_v1.flavor.id}"
@@ -36,9 +36,9 @@ resource "huaweicloud_rds_instance_v1" "instance" {
     type = "COMMON"
     size = 200
   }
-  region = "eu-de"
+  region           = "eu-de"
   availabilityzone = "eu-de-01"
-  vpc = "c1095fe7-03df-4205-ad2d-6f4c181d436e"
+  vpc              = "c1095fe7-03df-4205-ad2d-6f4c181d436e"
   nics {
     subnetid = "b65f8d25-c533-47e2-8601-cfaa265a3e3e"
   }
@@ -48,11 +48,11 @@ resource "huaweicloud_rds_instance_v1" "instance" {
   dbport = "8635"
   backupstrategy {
     starttime = "04:00:00"
-    keepdays = 4
+    keepdays  = 4
   }
   dbrtpd = "Huangwei!120521"
   ha {
-    enable = true
+    enable          = true
     replicationmode = "async"
   }
   depends_on = ["huaweicloud_compute_secgroup_v2.secgrp_rds"]
@@ -62,10 +62,10 @@ resource "huaweicloud_rds_instance_v1" "instance" {
 ## Example Usage:  Creating a SQLServer RDS instance
 ```hcl
 data "huaweicloud_rds_flavors_v1" "flavor" {
-    region = "eu-de"
-    datastore_name = "SQLServer"
-    datastore_version = "2014 SP2 SE"
-    speccode = "rds.mssql.s1.2xlarge"
+  region            = "eu-de"
+  datastore_name    = "SQLServer"
+  datastore_version = "2014 SP2 SE"
+  speccode          = "rds.mssql.s1.2xlarge"
 }
 
 resource "huaweicloud_compute_secgroup_v2" "secgrp_rds" {
@@ -76,7 +76,7 @@ resource "huaweicloud_compute_secgroup_v2" "secgrp_rds" {
 resource "huaweicloud_rds_instance_v1" "instance" {
   name = "rds-instance"
   datastore {
-    type = "SQLServer"
+    type    = "SQLServer"
     version = "2014 SP2 SE"
   }
   flavorref = "${data.huaweicloud_rds_flavors_v1.flavor.id}"
@@ -84,9 +84,9 @@ resource "huaweicloud_rds_instance_v1" "instance" {
     type = "COMMON"
     size = 200
   }
-  region = "eu-de"
+  region           = "eu-de"
   availabilityzone = "eu-de-01"
-  vpc = "c1095fe7-03df-4205-ad2d-6f4c181d436e"
+  vpc              = "c1095fe7-03df-4205-ad2d-6f4c181d436e"
   nics {
     subnetid = "b65f8d25-c533-47e2-8601-cfaa265a3e3e"
   }
@@ -96,9 +96,9 @@ resource "huaweicloud_rds_instance_v1" "instance" {
   dbport = "8635"
   backupstrategy {
     starttime = "04:00:00"
-    keepdays = 4
+    keepdays  = 4
   }
-  dbrtpd = "Huangwei!120521"
+  dbrtpd     = "Huangwei!120521"
   depends_on = ["huaweicloud_compute_secgroup_v2.secgrp_rds"]
 }
 ```
@@ -106,10 +106,10 @@ resource "huaweicloud_rds_instance_v1" "instance" {
 ## Example Usage:  Creating a MySQL RDS instance
 ```hcl
 data "huaweicloud_rds_flavors_v1" "flavor" {
-    region = "eu-de"
-    datastore_name = "MySQL"
-    datastore_version = "5.6.33"
-    speccode = "rds.mysql.s1.medium"
+  region            = "eu-de"
+  datastore_name    = "MySQL"
+  datastore_version = "5.6.33"
+  speccode          = "rds.mysql.s1.medium"
 }
 
 resource "huaweicloud_compute_secgroup_v2" "secgrp_rds" {
@@ -120,7 +120,7 @@ resource "huaweicloud_compute_secgroup_v2" "secgrp_rds" {
 resource "huaweicloud_rds_instance_v1" "instance" {
   name = "rds-instance"
   datastore {
-    type = "MySQL"
+    type    = "MySQL"
     version = "5.6.33"
   }
   flavorref = "${data.huaweicloud_rds_flavors_v1.flavor.id}"
@@ -128,9 +128,9 @@ resource "huaweicloud_rds_instance_v1" "instance" {
     type = "COMMON"
     size = 200
   }
-  region = "eu-de"
+  region           = "eu-de"
   availabilityzone = "eu-de-01"
-  vpc = "c1095fe7-03df-4205-ad2d-6f4c181d436e"
+  vpc              = "c1095fe7-03df-4205-ad2d-6f4c181d436e"
   nics {
     subnetid = "b65f8d25-c533-47e2-8601-cfaa265a3e3e"
   }
@@ -140,11 +140,11 @@ resource "huaweicloud_rds_instance_v1" "instance" {
   dbport = "8635"
   backupstrategy {
     starttime = "04:00:00"
-    keepdays = 4
+    keepdays  = 4
   }
   dbrtpd = "Huangwei!120521"
   ha {
-    enable = true
+    enable          = true
     replicationmode = "async"
   }
   depends_on = ["huaweicloud_compute_secgroup_v2.secgrp_rds"]

--- a/website/docs/r/rts_software_config_v1.html.markdown
+++ b/website/docs/r/rts_software_config_v1.html.markdown
@@ -14,7 +14,7 @@ Provides an RTS software config resource.
 
  ```hcl
 variable "config_name" {}
- 
+
 resource "huaweicloud_rts_software_config_v1" "myconfig" {
   name = "${var.config_name}"
 }

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -107,7 +107,7 @@ resource "huaweicloud_s3_bucket" "bucket" {
     id      = "log"
     enabled = true
 
-    prefix  = "log/"
+    prefix = "log/"
 
     expiration {
       days = 90

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -21,7 +21,7 @@ resource "huaweicloud_s3_bucket" "b" {
 
 resource "huaweicloud_s3_bucket_policy" "b" {
   bucket = "${huaweicloud_s3_bucket.b.id}"
-  policy =<<POLICY
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "MYBUCKETPOLICY",

--- a/website/docs/r/sfs_file_system_v2.html.markdown
+++ b/website/docs/r/sfs_file_system_v2.html.markdown
@@ -13,22 +13,22 @@ Provides an Shared File System (SFS) resource.
 ## Example Usage
 
  ```hcl
-    variable "share_name" { }
+variable "share_name" {}
 
-    variable "share_description" { }
+variable "share_description" {}
 
-    variable "vpc_id" { }
+variable "vpc_id" {}
 
-    resource "huaweicloud_sfs_file_system_v2" "sfs1" {
-            size = 50
-            name = "${var.share_name}"
-            access_to = "${var.vpc_id}"
-            access_level = "rw"
-            description = "${var.share_description}"
-            metadata = {
-                "type"="nfs"
-            }
-    }
+resource "huaweicloud_sfs_file_system_v2" "sfs1" {
+  size         = 50
+  name         = "${var.share_name}"
+  access_to    = "${var.vpc_id}"
+  access_level = "rw"
+  description  = "${var.share_description}"
+  metadata = {
+    "type" = "nfs"
+  }
+}
  ```
 
 ## Argument Reference

--- a/website/docs/r/smn_subscription_v2.html.markdown
+++ b/website/docs/r/smn_subscription_v2.html.markdown
@@ -14,22 +14,22 @@ Manages a V2 subscription resource within HuaweiCloud.
 
 ```hcl
 resource "huaweicloud_smn_topic_v2" "topic_1" {
-  name		  = "topic_1"
-  display_name    = "The display name of topic_1"
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
 }
 
 resource "huaweicloud_smn_subscription_v2" "subscription_1" {
-  topic_urn       = "${huaweicloud_smn_topic_v2.topic_1.id}"
-  endpoint        = "mailtest@gmail.com"
-  protocol        = "email"
-  remark          = "O&M"
+  topic_urn = "${huaweicloud_smn_topic_v2.topic_1.id}"
+  endpoint  = "mailtest@gmail.com"
+  protocol  = "email"
+  remark    = "O&M"
 }
 
 resource "huaweicloud_smn_subscription_v2" "subscription_2" {
-  topic_urn       = "${huaweicloud_smn_topic_v2.topic_1.id}"
-  endpoint        = "13600000000"
-  protocol        = "sms"
-  remark          = "O&M"
+  topic_urn = "${huaweicloud_smn_topic_v2.topic_1.id}"
+  endpoint  = "13600000000"
+  protocol  = "sms"
+  remark    = "O&M"
 }
 ```
 

--- a/website/docs/r/smn_topic_v2.html.markdown
+++ b/website/docs/r/smn_topic_v2.html.markdown
@@ -14,8 +14,8 @@ Manages a V2 topic resource within HuaweiCloud.
 
 ```hcl
 resource "huaweicloud_smn_topic_v2" "topic_1" {
-  name            = "topic_1"
-  display_name    = "The display name of topic_1"
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
 }
 ```
 

--- a/website/docs/r/vbs_backup_policy_v2.html.markdown
+++ b/website/docs/r/vbs_backup_policy_v2.html.markdown
@@ -14,17 +14,17 @@ Provides an VBS Backup Policy resource.
 
  ```hcl
 resource "huaweicloud_vbs_backup_policy_v2" "vbs" {
-  name = "policy_002"
-  start_time  = "12:00"
-  status  = "ON"
+  name                = "policy_002"
+  start_time          = "12:00"
+  status              = "ON"
   retain_first_backup = "N"
-  rentention_num = 2
-  frequency = 1
-      tags =[
-        {
-          key = "k1"
-          value = "v1"
-          }] 
+  rentention_num      = 2
+  frequency           = 1
+  tags = [
+    {
+      key   = "k1"
+      value = "v1"
+  }]
 }
  ```
 

--- a/website/docs/r/vbs_backup_v2.html.markdown
+++ b/website/docs/r/vbs_backup_v2.html.markdown
@@ -16,10 +16,10 @@ Provides an VBS Backup resource.
 variable "backup_name" {}
 
 variable "volume_id" {}
- 
+
 resource "huaweicloud_vbs_backup_v2" "mybackup" {
   volume_id = "${var.volume_id}"
-  name = "${var.backup_name}"
+  name      = "${var.backup_name}"
 }
  ```
 

--- a/website/docs/r/vpc_eip_v1.html.markdown
+++ b/website/docs/r/vpc_eip_v1.html.markdown
@@ -18,9 +18,9 @@ resource "huaweicloud_vpc_eip_v1" "eip_1" {
     type = "5_bgp"
   }
   bandwidth {
-    name = "test"
-    size = 8
-    share_type = "PER"
+    name        = "test"
+    size        = 8
+    share_type  = "PER"
     charge_mode = "traffic"
   }
 }


### PR DESCRIPTION
Along with the release of Terraform v0.12, Terraform also introduces the officially recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. For better readability of the docs, the inline HCLs in docs should also follow that rule. 

This PR is trying to use a tool I developed to convert all the existing inline HCL codes into the canonical format.

Signed-off-by: imjoey <majunjiev@gmail.com>
