### PR TITLE
Update Authentication order

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -82,11 +82,12 @@ func (c *Config) LoadAndValidate() error {
 	if c.Token != "" {
 		err = buildClientByToken(c)
 
+	} else if c.Password != "" && (c.Username != "" || c.UserID != "") {
+		err = buildClientByPassword(c)
+
 	} else if c.AccessKey != "" && c.SecretKey != "" {
 		err = buildClientByAKSK(c)
 
-	} else if c.Password != "" && (c.Username != "" || c.UserID != "") {
-		err = buildClientByPassword(c)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
This makes username/password auth prior to ak/sk as we usually
need to set ak/sk to make obs work, so username/password will
always not take into account.