### PR TITLE
Fix example issue for compute_instance_v2

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -55,7 +55,7 @@ resource "huaweicloud_compute_instance_v2" "myinstance" {
 }
 
 resource "huaweicloud_compute_volume_attach_v2" "attached" {
-  compute_id = "${huaweicloud_compute_instance_v2.myinstance.id}"
+  instance_id = "${huaweicloud_compute_instance_v2.myinstance.id}"
   volume_id  = "${huaweicloud_blockstorage_volume_v2.myvol.id}"
 }
 ```


### PR DESCRIPTION
This fixes the wrong parameter for "Instance With Attached Volume"
on compute_instance_v2 resource docs.

fixes #218 