### PR TITLE
Add huaweicloud_lb_whitelist_v2 resource

### DIFF
--- a/huaweicloud/diff_suppress_funcs.go
+++ b/huaweicloud/diff_suppress_funcs.go
@@ -1,6 +1,10 @@
 package huaweicloud
 
 import (
+	"reflect"
+	"sort"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/jen20/awspolicyequivalence"
 )
@@ -30,4 +34,16 @@ func suppressComputedFixedWhenFloatingIp(k, old, new string, d *schema.ResourceD
 		return new == "" || old == new
 	}
 	return false
+}
+
+func suppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	old_array := strings.Split(old, ",")
+	new_array := strings.Split(new, ",")
+	sort.Strings(old_array)
+	sort.Strings(new_array)
+
+	return reflect.DeepEqual(old_array, new_array)
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -267,6 +267,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_lb_monitor_v2":                      resourceMonitorV2(),
 			"huaweicloud_lb_l7policy_v2":                     resourceL7PolicyV2(),
 			"huaweicloud_lb_l7rule_v2":                       resourceL7RuleV2(),
+			"huaweicloud_lb_whitelist_v2":                    resourceWhitelistV2(),
 			"huaweicloud_mrs_cluster_v1":                     resourceMRSClusterV1(),
 			"huaweicloud_mrs_job_v1":                         resourceMRSJobV1(),
 			"huaweicloud_networking_network_v2":              resourceNetworkingNetworkV2(),

--- a/huaweicloud/resource_huaweicloud_lb_whitelist_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_whitelist_v2.go
@@ -1,0 +1,140 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists"
+)
+
+func resourceWhitelistV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWhitelistV2Create,
+		Read:   resourceWhitelistV2Read,
+		Update: resourceWhitelistV2Update,
+		Delete: resourceWhitelistV2Delete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"listener_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"enable_whitelist": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"whitelist": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressLBWhitelistDiffs,
+			},
+		},
+	}
+}
+
+func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	enableWhitelist := d.Get("enable_whitelist").(bool)
+	createOpts := whitelists.CreateOpts{
+		TenantId:        d.Get("tenant_id").(string),
+		ListenerId:      d.Get("listener_id").(string),
+		EnableWhitelist: &enableWhitelist,
+		Whitelist:       d.Get("whitelist").(string),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	wl, err := whitelists.Create(networkingClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud Whitelist: %s", err)
+	}
+
+	d.SetId(wl.ID)
+	return resourceWhitelistV2Read(d, meta)
+}
+
+func resourceWhitelistV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	wl, err := whitelists.Get(networkingClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "whitelist")
+	}
+
+	log.Printf("[DEBUG] Retrieved whitelist %s: %#v", d.Id(), wl)
+
+	d.SetId(wl.ID)
+	d.Set("tenant_id", wl.TenantId)
+	d.Set("listener_id", wl.ListenerId)
+	d.Set("enable_whitelist", wl.EnableWhitelist)
+	d.Set("whitelist", wl.Whitelist)
+
+	return nil
+}
+
+func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	var updateOpts whitelists.UpdateOpts
+	if d.HasChange("enable_whitelist") {
+		ew := d.Get("enable_whitelist").(bool)
+		updateOpts.EnableWhitelist = &ew
+	}
+	if d.HasChange("whitelist") {
+		updateOpts.Whitelist = d.Get("whitelist").(string)
+	}
+
+	log.Printf("[DEBUG] Updating whitelist %s with options: %#v", d.Id(), updateOpts)
+	_, err = whitelists.Update(networkingClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Unable to update whitelist %s: %s", d.Id(), err)
+	}
+
+	return resourceWhitelistV2Read(d, meta)
+}
+
+func resourceWhitelistV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	log.Printf("[DEBUG] Attempting to delete whitelist %s", d.Id())
+	err = whitelists.Delete(networkingClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting HuaweiCloud whitelist: %s", err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/huaweicloud/resource_huaweicloud_lb_whitelist_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_whitelist_v2_test.go
@@ -1,0 +1,127 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists"
+)
+
+func TestAccLBV2Whitelist_basic(t *testing.T) {
+	var whitelist whitelists.Whitelist
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2WhitelistDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccLBV2WhitelistConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2WhitelistExists("huaweicloud_lb_whitelist_v2.whitelist_1", &whitelist),
+				),
+			},
+			{
+				Config: TestAccLBV2WhitelistConfig_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("huaweicloud_lb_whitelist_v2.whitelist_1", "enable_whitelist", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_lb_whitelist_v2" {
+			continue
+		}
+
+		_, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Whitelist still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckLBV2WhitelistExists(n string, whitelist *whitelists.Whitelist) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		}
+
+		found, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Whitelist not found")
+		}
+
+		*whitelist = *found
+
+		return nil
+	}
+}
+
+var TestAccLBV2WhitelistConfig_basic = fmt.Sprintf(`
+resource "huaweicloud_lb_loadbalancer_v2" "loadbalancer_1" {
+  name = "loadbalancer_1"
+  vip_subnet_id = "%s"
+}
+
+resource "huaweicloud_lb_listener_v2" "listener_1" {
+  name = "listener_1"
+  protocol = "HTTP"
+  protocol_port = 8080
+  loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
+resource "huaweicloud_lb_whitelist_v2" "whitelist_1" {
+  enable_whitelist = true
+  whitelist = "192.168.11.1,192.168.0.1/24"
+  listener_id = "${huaweicloud_lb_listener_v2.listener_1.id}"
+}
+`, OS_SUBNET_ID)
+
+var TestAccLBV2WhitelistConfig_update = fmt.Sprintf(`
+resource "huaweicloud_lb_loadbalancer_v2" "loadbalancer_1" {
+  name = "loadbalancer_1"
+  vip_subnet_id = "%s"
+}
+
+resource "huaweicloud_lb_listener_v2" "listener_1" {
+  name = "listener_1"
+  protocol = "HTTP"
+  protocol_port = 8080
+  loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
+}
+
+resource "huaweicloud_lb_whitelist_v2" "whitelist_1" {
+  enable_whitelist = true
+  whitelist = "192.168.11.1,192.168.0.1/24,192.168.201.18/8"
+  listener_id = "${huaweicloud_lb_listener_v2.listener_1.id}"
+}
+`, OS_SUBNET_ID)

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists/requests.go
@@ -1,0 +1,89 @@
+package whitelists
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// CreateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Create operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type CreateOptsBuilder interface {
+	ToWhitelistCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	TenantId        string `json:"tenant_id,omitempty"`
+	ListenerId      string `json:"listener_id" required:"true"`
+	EnableWhitelist *bool  `json:"enable_whitelist,omitempty"`
+	Whitelist       string `json:"whitelist,omitempty"`
+}
+
+// ToWhitelistCreateMap casts a CreateOpts struct to a map.
+func (opts CreateOpts) ToWhitelistCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "whitelist")
+}
+
+// Create is an operation which provisions a new whitelist based on the
+// configuration defined in the CreateOpts struct. Once the request is
+// validated and progress has started on the provisioning process, a
+// CreateResult will be returned.
+//
+// Users with an admin role can create loadbalancers on behalf of other tenants by
+// specifying a TenantID attribute different than their own.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToWhitelistCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Whitelist based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Update operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type UpdateOptsBuilder interface {
+	ToWhitelistUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	EnableWhitelist *bool  `json:"enable_whitelist,omitempty"`
+	Whitelist       string `json:"whitelist,omitempty"`
+}
+
+// ToWhitelistUpdateMap casts a UpdateOpts struct to a map.
+func (opts UpdateOpts) ToWhitelistUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "whitelist")
+}
+
+// Update is an operation which modifies the attributes of the specified Whitelist.
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToWhitelistUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular Whitelist based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists/results.go
@@ -1,0 +1,44 @@
+package whitelists
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type Whitelist struct {
+	ID              string `json:"id"`
+	TenantId        string `json:"tenant_id"`
+	ListenerId      string `json:"listener_id"`
+	EnableWhitelist bool   `json:"enable_whitelist"`
+	Whitelist       string `json:"whitelist"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+func (r commonResult) Extract() (*Whitelist, error) {
+	s := &Whitelist{}
+	return s, r.ExtractInto(s)
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "whitelist")
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/whitelists/urls.go
@@ -1,0 +1,16 @@
+package whitelists
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	rootPath     = "lbaas"
+	resourcePath = "whitelists"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}

--- a/website/docs/r/lb_whitelist_v2.html.markdown
+++ b/website/docs/r/lb_whitelist_v2.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lb_whitelist_v2"
+sidebar_current: "docs-huaweicloud-resource-lb-whitelist-v2"
+description: |-
+  Manages a Load Balancer whitelist resource within HuaweiCloud.
+---
+
+# huaweicloud\_lb\_whitelist\_v2
+
+Manages a Load Balancer whitelist resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_lb_listener_v2" "listener_1" {
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = var.loadbalancer_id
+}
+
+resource "huaweicloud_lb_whitelist_v2" "whitelist_1" {
+  enable_whitelist = true
+  whitelist        = "192.168.11.1,192.168.0.1/24,192.168.201.18/8"
+  listener_id      = huaweicloud_lb_listener_v2.listener_1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `tenant_id` - (Optional) Required for admins. The UUID of the tenant who owns
+    the whitelist. Only administrative users can specify a tenant UUID
+    other than their own. Changing this creates a new whitelist.
+
+* `listener_id` - (Required) The Listener ID that the whitelist will be associated with. Changing this creates a new whitelist.
+
+* `enable_whitelist` - (Optional) Specify whether to enable access control.
+
+* `whitelist` - (Optional) Specifies the IP addresses in the whitelist. Use commas(,) to separate
+    the multiple IP addresses.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique ID for the whitelist.
+* `tenant_id` - See Argument Reference above.
+* `listener_id` - See Argument Reference above.
+* `enable_whitelist` - See Argument Reference above.
+* `whitelist` - See Argument Reference above.

--- a/website/huaweicloud.erb
+++ b/website/huaweicloud.erb
@@ -389,6 +389,9 @@
             <li<%= sidebar_current("docs-huaweicloud-resource-lb-l7rule-v2") %>>
               <a href="/docs/providers/huaweicloud/r/lb_l7rule_v2.html">huaweicloud_lb_l7rule_v2</a>
             </li>
+            <li<%= sidebar_current("docs-huaweicloud-resource-lb-whitelist-v2") %>>
+              <a href="/docs/providers/huaweicloud/r/lb_whitelist_v2.html">huaweicloud_lb_whitelist_v2</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
The PR provides an new  resource, named huaweicloud_lb_whitelist_v2.

The result of running test case as follows:
```shell
$ make testacc TEST=./huaweicloud TESTARGS='-run=TestAccLBV2Whitelist_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccLBV2Whitelist_basic -timeout 360m
=== RUN   TestAccLBV2Whitelist_basic
--- PASS: TestAccLBV2Whitelist_basic (56.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-huaweicloud/huaweicloud	56.909s
```