### PR TITLE
Suppress diffs for snat rule floating_ip_id

### DIFF
--- a/huaweicloud/diff_suppress_funcs.go
+++ b/huaweicloud/diff_suppress_funcs.go
@@ -47,3 +47,15 @@ func suppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
 
 	return reflect.DeepEqual(old_array, new_array)
 }
+
+func suppressSnatFiplistDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	old_array := strings.Split(old, ",")
+	new_array := strings.Split(new, ",")
+	sort.Strings(old_array)
+	sort.Strings(new_array)
+
+	return reflect.DeepEqual(old_array, new_array)
+}

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
@@ -41,9 +41,10 @@ func resourceNatSnatRuleV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"floating_ip_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressSnatFiplistDiffs,
 			},
 		},
 	}


### PR DESCRIPTION
This adds a diff suppress function to avoid the floating_ip_id parameter sorted from API response.