### PR TITLE
[obs] use the region by provider if not specified

### DIFF
--- a/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -253,7 +253,8 @@ func resourceObsBucket() *schema.Resource {
 
 func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	region := GetRegion(d, config)
+	obsClient, err := config.newObjectStorageClient(region)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}
@@ -266,7 +267,7 @@ func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 		ACL:          obs.AclType(acl),
 		StorageClass: obs.StorageClassType(class),
 	}
-	opts.Location = d.Get("region").(string)
+	opts.Location = region
 	log.Printf("[DEBUG] OBS bucket create opts: %#v", opts)
 
 	_, err = obsClient.CreateBucket(opts)

--- a/website/docs/r/obs_bucket.html.markdown
+++ b/website/docs/r/obs_bucket.html.markdown
@@ -171,7 +171,7 @@ The following arguments are supported:
 
 * `force_destroy` - (Optional) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. Default to `false`.
 
-* `region` - (Optional) If specified, the region this bucket should reside in. Otherwise, the region used by the provider.
+* `region` - (Optional) Specified the region where this bucket will be created. If not specified, used the region by the provider.
 
 The `logging` object supports the following:
 
@@ -256,7 +256,7 @@ The following attributes are exported:
 
 * `id` - The name of the bucket.
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.obs.region.myhuaweicloud.com`.
-* `region` - The region this bucket resides in.
+* `region` - The region where this bucket resides in.
 
 ## Import
 


### PR DESCRIPTION
If specified the region, this bucket will be created in the specified region, otherwise used the region by the provider.

fixes #288 