### PR TITLE
[vpnaas] set admin_state_up default to true

### DIFF
--- a/huaweicloud/resource_huaweicloud_vpnaas_service_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_service_v2_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/services"
-	"strconv"
 )
 
 func TestAccVpnServiceV2_basic(t *testing.T) {
@@ -24,7 +23,7 @@ func TestAccVpnServiceV2_basic(t *testing.T) {
 					testAccCheckVpnServiceV2Exists(
 						"huaweicloud_vpnaas_service_v2.service_1", &service),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_service_v2.service_1", "router_id", &service.RouterID),
-					resource.TestCheckResourceAttr("huaweicloud_vpnaas_service_v2.service_1", "admin_state_up", strconv.FormatBool(service.AdminStateUp)),
+					resource.TestCheckResourceAttr("huaweicloud_vpnaas_service_v2.service_1", "admin_state_up", "true"),
 				),
 			},
 		},
@@ -88,7 +87,7 @@ var testAccVpnServiceV2_basic = fmt.Sprintf(`
 	  external_network_id = "%s"
 	}
 	resource "huaweicloud_vpnaas_service_v2" "service_1" {
+		name = "vpngw-acctest"
 		router_id = "${huaweicloud_networking_router_v2.router_1.id}"
-		admin_state_up = "false"
 	}
 	`, OS_EXTGW_ID)

--- a/huaweicloud/resource_huaweicloud_vpnaas_site_connection.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_site_connection.go
@@ -80,7 +80,7 @@ func resourceVpnSiteConnectionV2() *schema.Resource {
 			"admin_state_up": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"psk": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_vpnaas_site_connection_test.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_site_connection_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/vpnaas/siteconnections"
-	"strconv"
 )
 
 func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
@@ -24,7 +23,7 @@ func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 					testAccCheckSiteConnectionV2Exists(
 						"huaweicloud_vpnaas_site_connection_v2.conn_1", &conn),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_site_connection_v2.conn_1", "ikepolicy_id", &conn.IKEPolicyID),
-					resource.TestCheckResourceAttr("huaweicloud_vpnaas_site_connection_v2.conn_1", "admin_state_up", strconv.FormatBool(conn.AdminStateUp)),
+					resource.TestCheckResourceAttr("huaweicloud_vpnaas_site_connection_v2.conn_1", "admin_state_up", "true"),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_site_connection_v2.conn_1", "ipsecpolicy_id", &conn.IPSecPolicyID),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_site_connection_v2.conn_1", "vpnservice_id", &conn.VPNServiceID),
 					resource.TestCheckResourceAttrPtr("huaweicloud_vpnaas_site_connection_v2.conn_1", "local_ep_group_id", &conn.LocalEPGroupID),
@@ -110,8 +109,8 @@ var testAccSiteConnectionV2_basic = fmt.Sprintf(`
 	}
 	
 	resource "huaweicloud_vpnaas_service_v2" "service_1" {
+		name = "vpngw-acctest"
 		router_id = "${huaweicloud_networking_router_v2.router_1.id}"
-		admin_state_up = "false"
 	}
 
 	resource "huaweicloud_vpnaas_ipsec_policy_v2" "policy_1" {

--- a/website/docs/r/vpnaas_service_v2.html.markdown
+++ b/website/docs/r/vpnaas_service_v2.html.markdown
@@ -38,7 +38,8 @@ The following arguments are supported:
 * `description` - (Optional) The human-readable description for the service.
     Changing this updates the description of the existing service.
 
-* `admin_state_up` - (Optional) The administrative state of the resource. Can either be up(true) or down(false).
+* `admin_state_up` - (Optional) The administrative state of the resource.
+    Can either be up(true) or down (false). Defaults to `true`.
     Changing this updates the administrative state of the existing service.
 
 * `subnet_id` - (Optional) SubnetID is the ID of the subnet. Default is null.

--- a/website/docs/r/vpnaas_site_connection_v2.html.markdown
+++ b/website/docs/r/vpnaas_site_connection_v2.html.markdown
@@ -43,7 +43,8 @@ The following arguments are supported:
 * `description` - (Optional) The human-readable description for the connection.
     Changing this updates the description of the existing connection.
 
-* `admin_state_up` - (Optional) The administrative state of the resource. Can either be up(true) or down(false).
+* `admin_state_up` - (Optional) The administrative state of the resource.
+    Can either be up(true) or down(false). Defaults to `true`.
     Changing this updates the administrative state of the existing connection.
 
 * `ikepolicy_id` - (Required) The ID of the IKE policy. Changing this creates a new connection.


### PR DESCRIPTION
[vpnaas]set admin_state_up default to true
The admin_state_up can either be up(true) or down(false), defaults to `true`.

fix #281 