### PR TITLE
Make huaweicloud_compute_instance_v2 importable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,3 @@ require (
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-go 1.13

--- a/huaweicloud/import_huaweicloud_compute_instance_v2_test.go
+++ b/huaweicloud/import_huaweicloud_compute_instance_v2_test.go
@@ -1,0 +1,79 @@
+package huaweicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccComputeV2Instance_importBasic(t *testing.T) {
+	resourceName := "huaweicloud_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_basic,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+				},
+			},
+		},
+	})
+}
+
+func TestAccComputeV2Instance_importbootFromVolumeForceNew_1(t *testing.T) {
+	resourceName := "huaweicloud_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_bootFromVolumeForceNew_1,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+				},
+			},
+		},
+	})
+}
+func TestAccComputeV2Instance_importbootFromVolumeImage(t *testing.T) {
+	resourceName := "huaweicloud_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_bootFromVolumeImage,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+				},
+			},
+		},
+	})
+}

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -527,3 +527,16 @@ resource "huaweicloud_compute_instance_v2" "instance_1" {
   }
 }
 ```
+
+## Importing
+
+Instances can be imported by their `id`. For example,
+```
+terraform import huaweicloud_compute_instance_v2.my_instance b11b407c-e604-4e8d-8bc4-92398320b847
+```
+Note that the imported state may not be identical to your resource definition, which 
+could be because of a different network interface attachment order, missing ephemeral
+disk configuration, or some other reason. It is generally recommended running 
+`terraform plan` after importing an instance. You can then decide if changes should
+be applied to the instance, or the resource definition should be updated to align
+with the instance. 


### PR DESCRIPTION
I've ported the importer implementation for `huaweicloud_compute_instance_v2` from OpenStack, with a couple minor tweaks for unhandled errors. 

This was tested with `terraform import` without issues:
```bash
$ terraform import 'module.test.huaweicloud_compute_instance_v2.instance[0]' xxxxxxxx-xxxxxx-xxxx-xxx-xxxxxx
module.test.huaweicloud_compute_instance_v2.instance[0]: Importing from ID " xxxxxxxx-xxxxxx-xxxx-xxx-xxxxxx"...
module.test.huaweicloud_compute_instance_v2.instance[0]: Import prepared!
  Prepared huaweicloud_compute_instance_v2 for import
module.test.huaweicloud_compute_instance_v2.instance[0]: Refreshing state... [id= xxxxxxxx-xxxxxx-xxxx-xxx-xxxxxx]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.module.test
```

Note that I haven't run the acceptance tests because I don't have an account suitable for this.  Please run the tests for me if you find this PR acceptable. 

Cheers!