### PR TITLE
set sensitive flag for password parameter

### DIFF
--- a/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
@@ -47,9 +47,10 @@ func resourceDcsInstanceV1() *schema.Resource {
 				ForceNew: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+				ForceNew:  true,
 			},
 			"access_user": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_dds_instance_v3.go
@@ -90,9 +90,10 @@ func resourceDdsInstanceV3() *schema.Resource {
 				ForceNew: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Required:  true,
+				ForceNew:  true,
 			},
 			"disk_encryption_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1.go
@@ -44,8 +44,9 @@ func resourceDmsInstancesV1() *schema.Resource {
 				Required: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
 			},
 			"access_user": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_mls_instance.go
+++ b/huaweicloud/resource_huaweicloud_mls_instance.go
@@ -70,9 +70,10 @@ func resourceMlsInstance() *schema.Resource {
 							ForceNew: true,
 						},
 						"user_password": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Optional:  true,
+							ForceNew:  true,
 						},
 					},
 				},

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -63,9 +63,10 @@ func resourceRdsInstanceV3() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"password": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Required:  true,
+							ForceNew:  true,
 						},
 						"type": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
The "password" in some resources are  sensitive, and should be hidden from the terraform output.

See:
- https://www.terraform.io/docs/extend/best-practices/sensitive-state.html
- https://godoc.org/github.com/hashicorp/terraform-plugin-sdk/helper/schema#Schema.Sensitive