### PR TITLE
fix document bug for rds instance v3

### DIFF
--- a/website/docs/r/rds_instance_v3.html.markdown
+++ b/website/docs/r/rds_instance_v3.html.markdown
@@ -201,9 +201,6 @@ The `db` block supports:
   (Required)
   Specifies the DB engine. Value: MySQL, PostgreSQL, SQLServer. Changing this parameter will create a new resource.
 
-* `user_name` -
-  Indicates the default user name of database.
-
 * `version` -
   (Required)
   Specifies the database version. Changing this parameter will create a new resource.
@@ -268,6 +265,10 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `public_ips` -
   Indicates the public IP address list.
+
+* `db` - See Argument Reference above. The db block also contains:
+
+	* `user_name` - Indicates the default user name of database.
 
 The `nodes` block contains:
 


### PR DESCRIPTION
the user_name in db is an attribute which computed by the provide, so we move the description to the Attributes Reference section.