### PR TITLE
Deprecate floatingip_v2

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_floatingip_v2.go
+++ b/huaweicloud/resource_huaweicloud_compute_floatingip_v2.go
@@ -20,6 +20,7 @@ func resourceComputeFloatingIPV2() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "use huaweicloud_vpc_eip_v1 resource instead",
 
 		Schema: map[string]*schema.Schema{
 			"region": {

--- a/huaweicloud/resource_huaweicloud_networking_floatingip_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_floatingip_v2.go
@@ -27,6 +27,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "use huaweicloud_vpc_eip_v1 resource instead",
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),

--- a/website/docs/r/compute_floatingip_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_v2.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # huaweicloud\_compute\_floatingip_v2
 
+-> **NOTE:** It has been deprecated, use `huaweicloud_vpc_eip_v1` instead.
+
 Manages a V2 floating IP resource within HuaweiCloud Nova (compute)
 that can be used for compute instances.
 

--- a/website/docs/r/networking_floatingip_v2.html.markdown
+++ b/website/docs/r/networking_floatingip_v2.html.markdown
@@ -8,10 +8,9 @@ description: |-
 
 # huaweicloud\_networking\_floatingip_v2
 
+-> **NOTE:** It has been deprecated, use `huaweicloud_vpc_eip_v1` instead.
+
 Manages a V2 floating IP resource within HuaweiCloud Neutron (networking)
-that can be used for load balancers.
-These are similar to Nova (compute) floating IP resources,
-but only compute floating IPs can be used with compute instances.
 
 ## Example Usage
 


### PR DESCRIPTION
This deprecates compute/networking floatingip resource, should use vpc_eip_v1 instead.