### PR TITLE
Remove deprecated compute related resources from website

### DIFF
--- a/website/huaweicloud.erb
+++ b/website/huaweicloud.erb
@@ -415,9 +415,6 @@
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
                 <li>
-                  <a href="/docs/providers/huaweicloud/r/compute_floatingip_v2.html">huaweicloud_compute_floatingip_v2</a>
-                </li>
-                <li>
                   <a href="/docs/providers/huaweicloud/r/compute_floatingip_associate_v2.html">huaweicloud_compute_floatingip_associate_v2</a>
                 </li>
                 <li>
@@ -428,9 +425,6 @@
                 </li>
                 <li>
                   <a href="/docs/providers/huaweicloud/r/compute_keypair_v2.html">huaweicloud_compute_keypair_v2</a>
-                </li>
-                <li>
-                  <a href="/docs/providers/huaweicloud/r/compute_secgroup_v2.html">huaweicloud_compute_secgroup_v2</a>
                 </li>
                 <li>
                   <a href="/docs/providers/huaweicloud/r/compute_servergroup_v2.html">huaweicloud_compute_servergroup_v2</a>


### PR DESCRIPTION
This removes compute_floatingip_v2 and compute_secgroup_v2 from website.