### PR TITLE
update endpoint for gaussdb nosql

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -664,13 +664,6 @@ func (c *Config) RdsV3Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
-func (c *Config) GeminiDBV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewGeminiDBV3(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) CdnV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewCDNV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
@@ -697,6 +690,10 @@ func (c *Config) initServiceClient(srv, region, apiVersion string) (*golangsdk.S
 		Region: c.determineRegion(region),
 	}
 	return huaweisdk.InitServiceClientByName(c.HwClient, eo, apiVersion)
+}
+
+func (c *Config) GeminiDBV3Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.initServiceClient("gaussdb-nosql", region, "v3")
 }
 
 func (c *Config) openGaussV3Client(region string) (*golangsdk.ServiceClient, error) {


### PR DESCRIPTION
using the more general function `initServiceClient`  to get the service endpoint, so we can manage it without the https://github.com/huaweicloud.golangsdk