### PR TITLE
Add obs bucket policy resource and docs

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -402,7 +402,7 @@ func (c *Config) newObjectStorageClient(region string) (*obs.ObsClient, error) {
 		}
 	}
 
-	return obs.New(c.AccessKey, c.SecretKey, client.Endpoint)
+	return obs.New(c.AccessKey, c.SecretKey, client.Endpoint, obs.WithSignature("OBS"))
 }
 
 func (c *Config) apiGatewayV1Client(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -273,6 +273,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_s3_bucket_object":                   resourceS3BucketObject(),
 			"huaweicloud_obs_bucket":                         resourceObsBucket(),
 			"huaweicloud_obs_bucket_object":                  resourceObsBucketObject(),
+			"huaweicloud_obs_bucket_policy":                  resourceObsBucketPolicy(),
 			"huaweicloud_smn_topic_v2":                       resourceTopic(),
 			"huaweicloud_smn_subscription_v2":                resourceSubscription(),
 			"huaweicloud_rds_instance_v1":                    resourceRdsInstance(),

--- a/huaweicloud/resource_huaweicloud_obs_bucket_policy.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_policy.go
@@ -1,0 +1,95 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+func resourceObsBucketPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceObsBucketPolicyPut,
+		Read:   resourceObsBucketPolicyRead,
+		Update: resourceObsBucketPolicyPut,
+		Delete: resourceObsBucketPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+	policy := d.Get("policy").(string)
+	log.Printf("[DEBUG] OBS bucket: %s, set policy: %s", bucket, policy)
+
+	params := &obs.SetBucketPolicyInput{
+		Bucket: bucket,
+		Policy: policy,
+	}
+	if _, err := obsClient.SetBucketPolicy(params); err != nil {
+		return getObsError("Error setting OBS bucket policy", bucket, err)
+	}
+
+	d.SetId(bucket)
+	return nil
+}
+
+func resourceObsBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+	}
+
+	log.Printf("[DEBUG] read policy for obs bucket: %s", d.Id())
+	output, err := obsClient.GetBucketPolicy(d.Id())
+
+	var pol string
+	if err == nil && output.Policy != "" {
+		pol = output.Policy
+	}
+	if err := d.Set("policy", pol); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceObsBucketPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+
+	log.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
+	_, err = obsClient.DeleteBucketPolicy(bucket)
+	if err != nil {
+		return getObsError("Error deleting policy of OBS bucket %s: %s", bucket, err)
+	}
+
+	return nil
+}

--- a/huaweicloud/resource_huaweicloud_obs_bucket_policy_test.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_policy_test.go
@@ -1,0 +1,156 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccObsBucketPolicy_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+
+	expectedPolicyText := fmt.Sprintf(
+		`{"Statement":[{"Sid":"test1","Effect":"Allow","Principal":{"ID":["*"]},"Action":["GetObject"],"Resource":["%s/*"]}]}`,
+		name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckS3(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists("huaweicloud_obs_bucket.bucket"),
+					testAccCheckObsBucketHasPolicy("huaweicloud_obs_bucket.bucket", expectedPolicyText),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucketPolicy_update(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+
+	expectedPolicyText1 := fmt.Sprintf(
+		`{"Statement":[{"Sid":"test1","Effect":"Allow","Principal":{"ID":["*"]},"Action":["GetObject"],"Resource":["%s/*"]}]}`,
+		name)
+
+	expectedPolicyText2 := fmt.Sprintf(
+		`{"Statement":[{"Sid":"test2","Effect":"Allow","Principal":{"ID":["*"]},"Action":["GetObject","PutObject","DeleteObject"],"Resource":["%s/*"]}]}`,
+		name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckS3(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists("huaweicloud_obs_bucket.bucket"),
+					testAccCheckObsBucketHasPolicy("huaweicloud_obs_bucket.bucket", expectedPolicyText1),
+				),
+			},
+
+			{
+				Config: testAccObsBucketPolicyConfig_updated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists("huaweicloud_obs_bucket.bucket"),
+					testAccCheckObsBucketHasPolicy("huaweicloud_obs_bucket.bucket", expectedPolicyText2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckObsBucketHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No OBS Bucket ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		}
+
+		policy, err := obsClient.GetBucketPolicy(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("GetBucketPolicy error: %v", err)
+		}
+
+		actualPolicyText := policy.Policy
+		if actualPolicyText != expectedPolicyText {
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
+}
+
+func testAccObsBucketPolicyConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+	bucket = "%s"
+	tags = {
+	  TestName = "TestAccObsBucketPolicy_basic"
+	}
+}
+
+resource "huaweicloud_obs_bucket_policy" "policy" {
+	bucket = huaweicloud_obs_bucket.bucket.bucket
+	policy =<<POLICY
+{
+	"Statement": [{
+		"Sid": "test1",
+		"Effect": "Allow",
+		"Principal": {
+			"ID": ["*"]
+		},
+		"Action": ["GetObject"],
+		"Resource": ["%s/*"]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName)
+}
+
+func testAccObsBucketPolicyConfig_updated(bucketName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+	bucket = "%s"
+	tags = {
+	  TestName = "TestAccObsBucketPolicy_updated"
+	}
+}
+
+resource "huaweicloud_obs_bucket_policy" "policy" {
+	bucket = huaweicloud_obs_bucket.bucket.bucket
+	policy =<<POLICY
+{
+	"Statement": [{
+		"Sid": "test2",
+		"Effect": "Allow",
+		"Principal": {
+			"ID": ["*"]
+		},
+		"Action": ["GetObject", "PutObject", "DeleteObject"],
+		"Resource": ["%s/*"]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName)
+}

--- a/website/docs/r/obs_bucket.html.markdown
+++ b/website/docs/r/obs_bucket.html.markdown
@@ -159,6 +159,8 @@ The following arguments are supported:
 
 * `acl` - (Optional) Specifies the ACL policy for a bucket. The predefined common policies are as follows: "private", "public-read", "public-read-write" and "log-delivery-write". Defaults to `private`.
 
+* `policy` - (Optional) Specifies the [bucket policy](https://support.huaweicloud.com/intl/en-us/devg-obs/obs_06_0048.html) in JSON format.
+
 * `tags` - (Optional) A mapping of tags to assign to the bucket. Each tag is represented by one key-value pair.
 
 * `versioning` - (Optional) Whether enable versioning. Once you version-enable a bucket, it can never return to an unversioned state.

--- a/website/docs/r/obs_bucket_policy.html.markdown
+++ b/website/docs/r/obs_bucket_policy.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_obs_bucket_policy"
+sidebar_current: "docs-huaweicloud-resource-obs-bucket-policy"
+description: |-
+  Attaches a policy to an OBS bucket resource.
+---
+
+# huaweicloud\_obs\_bucket\_policy
+
+Attaches a policy to an OBS bucket resource.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket = "my-test-bucket"
+}
+
+resource "huaweicloud_obs_bucket_policy" "policy" {
+  bucket = huaweicloud_obs_bucket.bucket.id
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Sid": "AddPerm",
+      "Effect": "Allow",
+      "Principal": {"ID": "*"},
+      "Action": ["GetObject"],
+      "Resource": "my-test-bucket/*"
+    } 
+  ]
+}
+POLICY
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to which to apply the policy.
+* `policy` - (Required) The text of the [bucket policy](https://support.huaweicloud.com/intl/en-us/devg-obs/obs_06_0048.html) in JSON format.

--- a/website/huaweicloud.erb
+++ b/website/huaweicloud.erb
@@ -761,6 +761,9 @@
                   <a href="/docs/providers/huaweicloud/r/obs_bucket_object.html">huaweicloud_obs_bucket_object</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/huaweicloud/r/obs_bucket_policy.html">huaweicloud_obs_bucket_policy</a>
+                </li>
+                <li>
                   <a href="/docs/providers/huaweicloud/r/s3_bucket.html">huaweicloud_s3_bucket</a>
                 </li>
                 <li>


### PR DESCRIPTION
Add obs bucket policy resource and docs.
also, add `policy` parameter into obs bucket resource

fixes #382 

The result of testing as follows:
```
$ make testacc TEST=./huaweicloud TESTARGS='-run TestAccObsBucketPolicy_update'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucketPolicy_update -timeout 360m
=== RUN   TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucketPolicy_update (153.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-huaweicloud/huaweicloud       153.948s
```