### PR TITLE
support type parameter into lb certificate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20200721030010-4ccadda0c1d0
+	github.com/huaweicloud/golangsdk v0.0.0-20200721081039-51b301b04100
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20200719033133-e6883dd4cac6 h1:7gIUBTKXT
 github.com/huaweicloud/golangsdk v0.0.0-20200719033133-e6883dd4cac6/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/huaweicloud/golangsdk v0.0.0-20200721030010-4ccadda0c1d0 h1:v0WvhM9CBkbxy8kGhLc0MsQc8zzOlrgWqc/FcgvhGGk=
 github.com/huaweicloud/golangsdk v0.0.0-20200721030010-4ccadda0c1d0/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20200721081039-51b301b04100 h1:jbgMKCCuT/jb/x3peMLgcWYKRcKzWP5LUC+3uv2U8fI=
+github.com/huaweicloud/golangsdk v0.0.0-20200721081039-51b301b04100/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/diff_suppress_funcs.go
+++ b/huaweicloud/diff_suppress_funcs.go
@@ -59,3 +59,8 @@ func suppressSnatFiplistDiffs(k, old, new string, d *schema.ResourceData) bool {
 
 	return reflect.DeepEqual(old_array, new_array)
 }
+
+// Suppress changes if we get a string with or without new line
+func suppressNewLineDiffs(k, old, new string, d *schema.ResourceData) bool {
+	return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+}

--- a/huaweicloud/resource_huaweicloud_lb_certificate_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate_v2.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/certificates"
 )
@@ -42,19 +43,31 @@ func resourceCertificateV2() *schema.Resource {
 				Optional: true,
 			},
 
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "server",
+				ValidateFunc: validation.StringInSlice([]string{
+					"server", "client",
+				}, true),
+			},
+
 			"domain": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
 			"private_key": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressNewLineDiffs,
 			},
 
 			"certificate": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressNewLineDiffs,
 			},
 
 			"update_time": {
@@ -80,6 +93,7 @@ func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error
 	createOpts := certificates.CreateOpts{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
+		Type:        d.Get("type").(string),
 		Domain:      d.Get("domain").(string),
 		PrivateKey:  d.Get("private_key").(string),
 		Certificate: d.Get("certificate").(string),
@@ -112,6 +126,7 @@ func resourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", c.Name)
 	d.Set("description", c.Description)
+	d.Set("type", c.Type)
 	d.Set("domain", c.Domain)
 	d.Set("certificate", c.Certificate)
 	d.Set("private_key", c.PrivateKey)

--- a/huaweicloud/resource_huaweicloud_lb_certificate_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
@@ -12,6 +13,7 @@ import (
 
 func TestAccLBV2Certificate_basic(t *testing.T) {
 	var c certificates.Certificate
+	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,16 +21,43 @@ func TestAccLBV2Certificate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2CertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLBV2CertificateConfig_basic,
+				Config: testAccLBV2CertificateConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2CertificateExists("huaweicloud_lb_certificate_v2.certificate_1", &c),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_lb_certificate_v2.certificate_1", "name", name),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_lb_certificate_v2.certificate_1", "type", "server"),
 				),
 			},
 			{
-				Config: testAccLBV2CertificateConfig_update,
+				Config: testAccLBV2CertificateConfig_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"huaweicloud_lb_certificate_v2.certificate_1", "name", "certificate_1_updated"),
+						"huaweicloud_lb_certificate_v2.certificate_1", "name", fmt.Sprintf("%s_updated", name)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLBV2Certificate_client(t *testing.T) {
+	var c certificates.Certificate
+	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2CertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBV2CertificateConfig_client(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2CertificateExists("huaweicloud_lb_certificate_v2.certificate_client", &c),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_lb_certificate_v2.certificate_client", "name", name),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_lb_certificate_v2.certificate_client", "type", "client"),
 				),
 			},
 		},
@@ -89,9 +118,10 @@ func testAccCheckLBV2CertificateExists(
 	}
 }
 
-const testAccLBV2CertificateConfig_basic = `
+func testAccLBV2CertificateConfig_basic(name string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_lb_certificate_v2" "certificate_1" {
-  name = "certificate_1"
+  name = "%s"
   description = "terraform test certificate"
   domain = "www.elb.com"
   private_key = <<EOT
@@ -124,7 +154,7 @@ nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
 -----END RSA PRIVATE KEY-----
 EOT
 
-certificate = <<EOT
+  certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
 BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
@@ -155,11 +185,13 @@ EOT
     delete = "5m"
   }
 }
-`
+`, name)
+}
 
-const testAccLBV2CertificateConfig_update = `
+func testAccLBV2CertificateConfig_update(name string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_lb_certificate_v2" "certificate_1" {
-  name = "certificate_1_updated"
+  name = "%s_updated"
   description = "terraform test certificate"
   domain = "www.elb.com"
   private_key = <<EOT
@@ -192,7 +224,7 @@ nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
 -----END RSA PRIVATE KEY-----
 EOT
 
-certificate = <<EOT
+  certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
 BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
@@ -223,4 +255,40 @@ EOT
     delete = "5m"
   }
 }
-`
+`, name)
+}
+
+func testAccLBV2CertificateConfig_client(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lb_certificate_v2" "certificate_client" {
+  name = "%s"
+  description = "terraform CA certificate"
+  type = "client"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----
+EOT
+}
+`, name)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/certificates/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/certificates/requests.go
@@ -58,7 +58,7 @@ type CreateOpts struct {
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Domain      string `json:"domain,omitempty"`
-	PrivateKey  string `json:"private_key" required:"true"`
+	PrivateKey  string `json:"private_key,omitempty"`
 	Certificate string `json:"certificate" required:"true"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost
 github.com/hashicorp/terraform-svchost/auth
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20200721030010-4ccadda0c1d0
+# github.com/huaweicloud/golangsdk v0.0.0-20200721081039-51b301b04100
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/openstack
 github.com/huaweicloud/golangsdk/openstack/antiddos/v1/antiddos

--- a/website/docs/r/lb_certificate_v2.html.markdown
+++ b/website/docs/r/lb_certificate_v2.html.markdown
@@ -94,11 +94,18 @@ The following arguments are supported:
 
 * `description` - (Optional) Human-readable description for the Certificate.
 
-* `domain` - (Optional) The domain of the Certificate.
-
-* `private_key` - (Required) The private encrypted key of the Certificate, PEM format.
+* `type` - (Optional) Specifies the certificate type. The default value is "server".
+    The value can be one of the following:
+    - server: indicates the server certificate.
+    - client: indicates the CA certificate.
 
 * `certificate` - (Required) The public encrypted key of the Certificate, PEM format.
+
+* `private_key` - (Optional) The private encrypted key of the Certificate, PEM format.
+    This parameter is valid and mandatory only when `type` is set to "server".
+
+* `domain` - (Optional) The domain of the Certificate. The value contains a maximum of 100 characters.
+    This parameter is valid only when `type` is set to "server".
 
 ## Attributes Reference
 
@@ -107,6 +114,7 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
+* `type` - See Argument Reference above.
 * `domain` - See Argument Reference above.
 * `private_key` - See Argument Reference above.
 * `certificate` - See Argument Reference above.


### PR DESCRIPTION
we can create a CA certificate when `type` is set to "client".
fixes #410 

The testing result as follows:
```
$ make testacc TEST=./huaweicloud TESTARGS='-run TestAccLBV2Certificate_client'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Certificate_client -timeout 360m
=== RUN   TestAccLBV2Certificate_client
--- PASS: TestAccLBV2Certificate_client (120.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-huaweicloud/huaweicloud       120.689s
```