### PR TITLE
support tags and backup_strategy parameter in css cluster

### DIFF
--- a/huaweicloud/resource_huaweicloud_css_cluster_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_css_cluster_v1_test.go
@@ -34,6 +34,12 @@ func TestAccCssClusterV1_basic(t *testing.T) {
 				Config: testAccCssClusterV1_basic(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_css_cluster_v1.cluster", "expect_node_num", "1"),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_css_cluster_v1.cluster", "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_css_cluster_v1.cluster", "tags.foo", "bar"),
 				),
 			},
 		},
@@ -54,7 +60,7 @@ resource "huaweicloud_css_cluster_v1" "cluster" {
   node_config {
     flavor = "ess.spec-2u16g"
     network_info {
-      security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
+      security_group_id = huaweicloud_networking_secgroup_v2.secgroup.id
       subnet_id = "%s"
       vpc_id = "%s"
     }
@@ -63,6 +69,10 @@ resource "huaweicloud_css_cluster_v1" "cluster" {
       size = 40
     }
     availability_zone = "%s"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
   }
 }
 	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)

--- a/website/docs/r/css_cluster_v1.html.markdown
+++ b/website/docs/r/css_cluster_v1.html.markdown
@@ -3,12 +3,12 @@ layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_css_cluster_v1"
 sidebar_current: "docs-huaweicloud-resource-css-cluster-v1"
 description: |-
-  cluster management
+ CSS cluster management
 ---
 
 # huaweicloud\_css\_cluster\_v1
 
-cluster management
+CSS cluster management
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ resource "huaweicloud_networking_secgroup_v2" "secgroup" {
 resource "huaweicloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "terraform_test_cluster"
-  engine_version  = "6.2.3"
+  engine_version  = "7.1.1"
   node_config {
     flavor = "ess.spec-2u16g"
     network_info {
@@ -44,19 +44,34 @@ resource "huaweicloud_css_cluster_v1" "cluster" {
 
 The following arguments are supported:
 
-* `engine_version` -
-  (Required)
-  Engine version. Versions 5.5.1 and 6.2.3 are supported.  Changing this parameter will create a new resource.
-
 * `name` -
   (Required)
   Cluster name. It contains 4 to 32 characters. Only letters, digits,
   hyphens (-), and underscores (_) are allowed. The value must start
-  with a letter.  Changing this parameter will create a new resource.
+  with a letter. Changing this parameter will create a new resource.
+
+* `engine_type` -
+  (Optional)
+  Engine type. The default value is "elasticsearch". Currently, the value
+  can only be "elasticsearch". Changing this parameter will create a new resource.
+
+* `engine_version` -
+  (Required)
+  Engine version. Versions 5.5.1, 6.2.3, 6.5.4 and 7.1.1 are supported. Changing this parameter will create a new resource.
+
+* `expect_node_num` -
+  (Optional)
+  Number of cluster instances. The value range is 1 to 32. Defaults to 1.
 
 * `node_config` -
   (Required)
   Node configuration. Structure is documented below. Changing this parameter will create a new resource.
+
+* `backup_strategy` - (Optional) Specifies the advanced backup policy. Structure is documented below.
+  Changing this parameter will create a new resource.
+
+* `tags` - (Optional) The key/value pairs to associate with the cluster.
+  Changing this parameter will create a new resource.
 
 The `node_config` block supports:
 
@@ -66,11 +81,12 @@ The `node_config` block supports:
 
 * `flavor` -
   (Required)
-  Instance flavor name. Value range of flavor ess.spec-1u8g: 40 GB
-  to 640 GB Value range of flavor ess.spec-2u16g: 40 GB to 1280 GB
-  Value range of flavor ess.spec-4u32g: 40 GB to 2560 GB Value
-  range of flavor ess.spec-8u64g: 80 GB to 5120 GB Value range of
-  flavor ess.spec-16u128g: 160 GB to 10240 GB.  Changing this parameter will create a new resource.
+  Instance flavor name. For example: value range of flavor ess.spec-2u8g:
+  40 GB to 800 GB, value range of flavor ess.spec-4u16g: 40 GB to 1600 GB,
+  value range of flavor ess.spec-8u32g: 80 GB to 3200 GB, value range of
+  flavor ess.spec-16u64g: 100 GB to 6400 GB, value range of
+  flavor ess.spec-32u128g: 100 GB to 10240 GB.
+  Changing this parameter will create a new resource.
 
 * `network_info` -
   (Required)
@@ -82,70 +98,71 @@ The `node_config` block supports:
 
 The `network_info` block supports:
 
-* `security_group_id` -
+* `vpc_id` -
   (Required)
-  Security group ID. All instances in a cluster must have the
-  same subnets and security groups.  Changing this parameter will create a new resource.
+  VPC ID, which is used for configuring cluster network. Changing this parameter will create a new resource.
 
 * `subnet_id` -
   (Required)
-  Subnet ID. All instances in a cluster must have the same
-  subnets and security groups.  Changing this parameter will create a new resource.
+  Subnet ID. All instances in a cluster must have the same subnet which should be configured with a *DNS address*.
+  Changing this parameter will create a new resource.
 
-* `vpc_id` -
+* `security_group_id` -
   (Required)
-  VPC ID, which is used for configuring cluster network.  Changing this parameter will create a new resource.
+  Security group ID. All instances in a cluster must have the same security group.
+  Changing this parameter will create a new resource.
 
 The `volume` block supports:
 
 * `size` -
   (Required)
-  Volume size, which must be a multiple of 4 and 10.  Changing this parameter will create a new resource.
+  Specifies the volume size in GB, which must be a multiple of 10.
+  Changing this parameter will create a new resource.
 
 * `volume_type` -
   (Required)
-  COMMON: Common I/O. The SATA disk is used. HIGH: High I/O.
+  Specifies the volume type. COMMON: Common I/O. The SATA disk is used. HIGH: High I/O.
   The SAS disk is used. ULTRAHIGH: Ultra-high I/O. The
-  solid-state drive (SSD) is used.  Changing this parameter will create a new resource.
+  solid-state drive (SSD) is used. Changing this parameter will create a new resource.
 
-- - -
 
-* `engine_type` -
-  (Optional)
-  Engine type. The default value is elasticsearch. Currently, the value
-  can only be elasticsearch.  Changing this parameter will create a new resource.
+The `backup_strategy` block supports:
 
-* `expect_node_num` -
-  (Optional)
-  Number of cluster instances. The value range is 1 to 32.
+* `start_time` - (Required) Specifies the time when a snapshot is automatically
+  created everyday. Example value: "04:00 GMT+08:00".
+
+* `keep_days` - (Optional) Specifies the number of days to retain the generated
+   snapshots. Snapshots are reserved for seven days by default.
+
+* `prefix` - (Optional) Specifies the prefix of the snapshot that is automatically
+  created. The default value is "snapshot".
+
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
+* `endpoint` -
+  Indicates the IP address and port number.
+
 * `created` -
   Time when a cluster is created. The format is ISO8601:
   CCYY-MM-DDThh:mm:ss.
-
-* `endpoint` -
-  Indicates the IP address and port number.
 
 * `nodes` -
   List of node objects. Structure is documented below.
 
 The `nodes` block contains:
 
-* `id` -
-  Instance ID.
+* `id` - Instance ID.
 
-* `name` -
-  Instance name.
+* `name` - Instance name.
 
-* `type` -
-  Supported type: ess (indicating the Elasticsearch node).
+* `type` - Supported type: ess (indicating the Elasticsearch node).
 
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
+
 - `create` - Default is 30 minute.
 - `update` - Default is 30 minute.


### PR DESCRIPTION
support `tags` and `backup_strategy` parameter in CSS cluster. the testing result as follows:

```
 $ make testacc TEST=./huaweicloud TESTARGS='-run TestAccCssClusterV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCssClusterV1_basic -timeout 360m
=== RUN   TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (1064.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-huaweicloud/huaweicloud       1064.897s
```