### PR TITLE
set 'access_to' to be optional in sfs file system

### DIFF
--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
@@ -47,10 +47,6 @@ func resourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -74,8 +70,8 @@ func resourceSFSFileSystemV2() *schema.Resource {
 			},
 			"access_level": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Optional: true,
+				Default:  "rw",
 			},
 			"access_type": {
 				Type:     schema.TypeString,
@@ -84,13 +80,17 @@ func resourceSFSFileSystemV2() *schema.Resource {
 			},
 			"access_to": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"share_access_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"access_state": {
+			"access_rule_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -100,12 +100,6 @@ func resourceSFSFileSystemV2() *schema.Resource {
 			},
 			"export_location": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"export_locations": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 				Computed: true,
 			},
 		},
@@ -138,7 +132,7 @@ func resourceSFSFileSystemV2Create(d *schema.ResourceData, meta interface{}) err
 	d.SetId(create.ID)
 	log.Printf("[INFO] Share ID: %s", create.Name)
 
-	log.Printf("[DEBUG] Waiting for Huaweicloud SFS File Share (%s) to be created", create.ID)
+	log.Printf("[DEBUG] Waiting for Huaweicloud SFS File Share (%s) to be available", create.ID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating"},
@@ -149,27 +143,28 @@ func resourceSFSFileSystemV2Create(d *schema.ResourceData, meta interface{}) err
 		MinTimeout: 3 * time.Second,
 	}
 	_, StateErr := stateConf.WaitForState()
-
 	if StateErr != nil {
-		return fmt.Errorf("Error applying access rules to share file : %s", StateErr)
+		return fmt.Errorf("Error waiting for Share File (%s) to become available: %s ", d.Id(), StateErr)
 	}
 
-	grantAccessOpts := shares.GrantAccessOpts{
-		AccessLevel: d.Get("access_level").(string),
-		AccessType:  d.Get("access_type").(string),
-		AccessTo:    d.Get("access_to").(string),
+	// specified the "access_to" field, apply first access rule to share file
+	if _, ok := d.GetOk("access_to"); ok {
+		grantAccessOpts := shares.GrantAccessOpts{
+			AccessLevel: d.Get("access_level").(string),
+			AccessType:  d.Get("access_type").(string),
+			AccessTo:    d.Get("access_to").(string),
+		}
+
+		grant, accessErr := shares.GrantAccess(sfsClient, d.Id(), grantAccessOpts).ExtractAccess()
+		if accessErr != nil {
+			return fmt.Errorf("Error applying access rules to share file : %s", accessErr)
+		}
+
+		log.Printf("[DEBUG] Applied access rule (%s) to share file %s", grant.ID, d.Id())
+		d.Set("share_access_id", grant.ID)
 	}
-
-	grant, accessErr := shares.GrantAccess(sfsClient, d.Id(), grantAccessOpts).ExtractAccess()
-
-	if accessErr != nil {
-		return fmt.Errorf("Error applying access rules to share file : %s", accessErr)
-	}
-
-	log.Printf("[DEBUG] Waiting for Huaweicloud SFS File Share (%s) to become available", grant.ID)
 
 	return resourceSFSFileSystemV2Read(d, meta)
-
 }
 
 func resourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) error {
@@ -190,29 +185,15 @@ func resourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error retrieving Huaweicloud Shares: %s", err)
 	}
 
-	rules, err := shares.ListAccessRights(sfsClient, d.Id()).ExtractAccessRights()
-
-	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			d.SetId("")
-			return nil
-		}
-
-		return fmt.Errorf("Error retrieving Huaweicloud Shares: %s", err)
-	}
-
 	d.Set("name", n.Name)
 	d.Set("share_proto", n.ShareProto)
-	d.Set("status", n.Status)
 	d.Set("size", n.Size)
 	d.Set("description", n.Description)
 	d.Set("share_type", n.ShareType)
-	d.Set("volume_type", n.VolumeType)
 	d.Set("is_public", n.IsPublic)
 	d.Set("availability_zone", n.AvailabilityZone)
 	d.Set("region", GetRegion(d, config))
 	d.Set("export_location", n.ExportLocation)
-	d.Set("export_locations", n.ExportLocations)
 	d.Set("host", n.Host)
 	d.Set("links", n.Links)
 
@@ -234,14 +215,45 @@ OUTER:
 	}
 	d.Set("metadata", md)
 
-	if len(rules) > 0 {
-		rule := rules[0]
-		d.Set("share_access_id", rule.ID)
-		d.Set("access_state", rule.State)
-		d.Set("access_to", rule.AccessTo)
-		d.Set("access_type", rule.AccessType)
-		d.Set("access_level", rule.AccessLevel)
+	// list access rules
+	rules, err := shares.ListAccessRights(sfsClient, d.Id()).ExtractAccessRights()
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Huaweicloud Shares rules: %s", err)
 	}
+
+	accessID := d.Get("share_access_id").(string)
+	if accessID != "" {
+		var ruleExist bool
+
+		for _, rule := range rules {
+			// find share_access_id
+			if rule.ID == accessID {
+				d.Set("access_rule_status", rule.State)
+				d.Set("access_to", rule.AccessTo)
+				d.Set("access_type", rule.AccessType)
+				d.Set("access_level", rule.AccessLevel)
+				ruleExist = true
+				break
+			}
+		}
+
+		if !ruleExist {
+			log.Printf("[WARN] access rule (%s) of share file %s was not exist!", accessID, d.Id())
+			d.Set("share_access_id", "")
+		}
+	}
+
+	if len(rules) != 0 {
+		d.Set("status", n.Status)
+	} else {
+		// The file system is not bind with any VPC.
+		d.Set("status", "unavailable")
+	}
+
 	return nil
 }
 
@@ -259,22 +271,29 @@ func resourceSFSFileSystemV2Update(d *schema.ResourceData, meta interface{}) err
 		updateOpts.DisplayDescription = d.Get("description").(string)
 	}
 	if d.HasChange("access_to") {
-		deleteAccessOpts := shares.DeleteAccessOpts{AccessID: d.Get("share_access_id").(string)}
-		deny := shares.DeleteAccess(sfsClient, d.Id(), deleteAccessOpts)
-		if deny.Err != nil {
-			return fmt.Errorf("Error changing access rules for share file : %s", deny.Err)
+		ruleID := d.Get("share_access_id").(string)
+		if ruleID != "" {
+			deleteAccessOpts := shares.DeleteAccessOpts{AccessID: ruleID}
+			deny := shares.DeleteAccess(sfsClient, d.Id(), deleteAccessOpts)
+			if deny.Err != nil {
+				return fmt.Errorf("Error changing access rules for share file : %s", deny.Err)
+			}
+			d.Set("share_access_id", "")
 		}
 
-		grantAccessOpts := shares.GrantAccessOpts{
-			AccessLevel: d.Get("access_level").(string),
-			AccessType:  d.Get("access_type").(string),
-			AccessTo:    d.Get("access_to").(string),
-		}
+		if _, ok := d.GetOk("access_to"); ok {
+			grantAccessOpts := shares.GrantAccessOpts{
+				AccessLevel: d.Get("access_level").(string),
+				AccessType:  d.Get("access_type").(string),
+				AccessTo:    d.Get("access_to").(string),
+			}
 
-		_, accessErr := shares.GrantAccess(sfsClient, d.Id(), grantAccessOpts).ExtractAccess()
-
-		if accessErr != nil {
-			return fmt.Errorf("Error changing access rules for share file : %s", accessErr)
+			log.Printf("[DEBUG] Grant Access Rules: %#v", grantAccessOpts)
+			grant, accessErr := shares.GrantAccess(sfsClient, d.Id(), grantAccessOpts).ExtractAccess()
+			if accessErr != nil {
+				return fmt.Errorf("Error changing access rules for share file : %s", accessErr)
+			}
+			d.Set("share_access_id", grant.ID)
 		}
 	}
 

--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2_test.go
@@ -28,7 +28,7 @@ func TestAccSFSFileSystemV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"huaweicloud_sfs_file_system_v2.sfs_1", "status", "available"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_sfs_file_system_v2.sfs_1", "size", "1"),
+						"huaweicloud_sfs_file_system_v2.sfs_1", "size", "10"),
 					resource.TestCheckResourceAttr(
 						"huaweicloud_sfs_file_system_v2.sfs_1", "access_level", "rw"),
 					resource.TestCheckResourceAttr(
@@ -48,13 +48,35 @@ func TestAccSFSFileSystemV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"huaweicloud_sfs_file_system_v2.sfs_1", "status", "available"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_sfs_file_system_v2.sfs_1", "size", "2"),
+						"huaweicloud_sfs_file_system_v2.sfs_1", "size", "20"),
 					resource.TestCheckResourceAttr(
 						"huaweicloud_sfs_file_system_v2.sfs_1", "access_level", "rw"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSFSFileSystemV2_without_rule(t *testing.T) {
+	var share shares.Share
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSFileSystemV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSFileSystemV2_without_rule,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSFileSystemV2Exists("huaweicloud_sfs_file_system_v2.sfs_1", &share),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_sfs_file_system_v2.sfs_1", "access_to", OS_VPC_ID),
+						"huaweicloud_sfs_file_system_v2.sfs_1", "name", "sfs-test-no-rules"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_sfs_file_system_v2.sfs_1", "access_type", "cert"),
+						"huaweicloud_sfs_file_system_v2.sfs_1", "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_file_system_v2.sfs_1", "status", "unavailable"),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_file_system_v2.sfs_1", "size", "10"),
 				),
 			},
 		},
@@ -134,42 +156,52 @@ func testAccCheckSFSFileSystemV2Exists(n string, share *shares.Share) resource.T
 
 var testAccSFSFileSystemV2_basic = fmt.Sprintf(`
 resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="sfs-test1"
-  	availability_zone="%s"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto  = "NFS"
+  size         = 10
+  name         = "sfs-test1"
+  description  = "sfs_c2c_test-file"
+  access_to    = "%s"
+  access_type  = "cert"
+  access_level = "rw"
+  availability_zone = "%s"
 }
-`, OS_AVAILABILITY_ZONE, OS_VPC_ID)
+`, OS_VPC_ID, OS_AVAILABILITY_ZONE)
 
 var testAccSFSFileSystemV2_update = fmt.Sprintf(`
 resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=2
-	name="sfs-test2"
-  	availability_zone="%s"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto  = "NFS"
+  size         = 20
+  name         = "sfs-test2"
+  description  = "sfs_c2c_test-file"
+  access_to    = "%s"
+  access_type  = "cert"
+  access_level = "rw"
+  availability_zone = "%s"
 }
-`, OS_AVAILABILITY_ZONE, OS_VPC_ID)
+`, OS_VPC_ID, OS_AVAILABILITY_ZONE)
+
+const testAccSFSFileSystemV2_without_rule = `
+resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "sfs-test-no-rules"
+  description = "sfs_c2c_test-file"
+}
+`
 
 var testAccSFSFileSystemV2_timeout = fmt.Sprintf(`
 resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="sfs-test1"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto  = "NFS"
+  size         = 10
+  name         = "sfs-test1"
+  description  = "sfs_c2c_test-file"
+  access_to    = "%s"
+  access_type  = "cert"
+  access_level = "rw"
+  availability_zone = "%s"
 
   timeouts {
     create = "5m"
     delete = "5m"
   }
-}`, OS_VPC_ID)
+}`, OS_VPC_ID, OS_AVAILABILITY_ZONE)

--- a/website/docs/r/sfs_file_system_v2.html.markdown
+++ b/website/docs/r/sfs_file_system_v2.html.markdown
@@ -12,24 +12,20 @@ Provides an Shared File System (SFS) resource.
 
 ## Example Usage
 
- ```hcl
-variable "share_name" {}
+```hcl
+variable "share_name" { }
+variable "share_description" { }
+variable "vpc_id" { }
 
-variable "share_description" {}
-
-variable "vpc_id" {}
-
-resource "huaweicloud_sfs_file_system_v2" "sfs1" {
-  size         = 50
-  name         = "${var.share_name}"
-  access_to    = "${var.vpc_id}"
+resource "huaweicloud_sfs_file_system_v2" "share-file" {
+  name         = var.share_name
+  size         = 100
+  share_proto  = "NFS"
   access_level = "rw"
-  description  = "${var.share_description}"
-  metadata = {
-    "type" = "nfs"
-  }
+  access_to    = var.vpc_id
+  description  = var.share_description
 }
- ```
+```
 
 ## Argument Reference
 The following arguments are supported:
@@ -44,15 +40,26 @@ The following arguments are supported:
 
 * `is_public` - (Optional) The level of visibility for the shared file system.
 
-* `metadata` - (Optional) Metadata key and value pairs as a dictionary of strings.Changing this will create a new resource.
+* `metadata` - (Optional) Metadata key and value pairs as a dictionary of strings. Changing this will create a new resource.
 
-* `availability_zone` - (Optional) The availability zone name.Changing this parameter will create a new resource.
+* `availability_zone` - (Optional) The availability zone name. Changing this parameter will create a new resource.
 
-* `access_level` - (Required) The access level of the shared file system. Changing this will create a new access rule.
+* `access_level` - (Optional) Specifies the access level of the shared file system. Possible values are *ro* (read-only)
+    and *rw* (read-write). The default value is *rw* (read/write). Changing this will create a new access rule.
 
-* `access_type` - (Optional) The type of the share access rule. Changing this will create a new access rule.
+* `access_type` - (Optional) Specifies the type of the share access rule. The default value is *cert*.
+    Changing this will create a new access rule.
 
-* `access_to` - (Required) The access that the back end grants or denies. Changing this will create a new access rule
+* `access_to` - (Optional) Specifies the value that defines the access rule. The value contains 1 to 255 characters.
+    Changing this will create a new access rule. The value varies according to the scenario:
+    - Set the VPC ID in VPC authorization scenarios.
+    - Set this parameter in IP address authorization scenario.
+
+        For an NFS shared file system, the value in the format of *VPC_ID#IP_address#priority#user_permission*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
+
+        For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:
@@ -61,9 +68,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the shared file system.
 
-* `share_type` - The storage service type assigned for the shared file system, such as high-performance storage (composed of SSDs) and large-capacity storage (composed of SATA disks).
-
-* `volume_type` - The volume type.
+* `share_type` - The storage service type assigned for the shared file system, such as high-performance
+    storage (composed of SSDs) and large-capacity storage (composed of SATA disks).
 
 * `export_location` - The address for accessing the shared file system.
 
@@ -71,22 +77,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `share_access_id` - The UUID of the share access rule.
 
-* `access_rules_status` - The status of the share access rule.
+* `access_rule_status` - The status of the share access rule.
 
 ## Import
 
 SFS can be imported using the `id`, e.g.
 
 ```
-> $ terraform import huaweicloud_sfs_file_system_v2 4779ab1c-7c1a-44b1-a02e-93dfc361b32d
+$ terraform import huaweicloud_sfs_file_system_v2 4779ab1c-7c1a-44b1-a02e-93dfc361b32d
 ```
-
-
-
-
-
-
-
-
-
-   


### PR DESCRIPTION
testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSFSFileSystemV2_basic -timeout 360m
=== RUN   TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (37.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       37.719s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSFSFileSystemV2_without_rule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSFSFileSystemV2_without_rule -timeout 360m
=== RUN   TestAccSFSFileSystemV2_without_rule
--- PASS: TestAccSFSFileSystemV2_without_rule (27.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       27.512s
```