### PR TITLE
Add sfs access rule resource and docs

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -288,6 +288,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_nat_gateway_v2":                     resourceNatGatewayV2(),
 			"huaweicloud_nat_snat_rule_v2":                   resourceNatSnatRuleV2(),
 			"huaweicloud_nat_dnat_rule_v2":                   resourceNatDnatRuleV2(),
+			"huaweicloud_sfs_access_rule_v2":                 resourceSFSAccessRuleV2(),
 			"huaweicloud_sfs_file_system_v2":                 resourceSFSFileSystemV2(),
 			"huaweicloud_sfs_turbo":                          resourceSFSTurbo(),
 			"huaweicloud_rts_stack_v1":                       resourceRTSStackV1(),

--- a/huaweicloud/resource_huaweicloud_sfs_access_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_access_rule_v2.go
@@ -1,0 +1,189 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares"
+)
+
+func resourceSFSAccessRuleV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSFSAccessRuleV2Create,
+		Read:   resourceSFSAccessRuleV2Read,
+		Delete: resourceSFSAccessRuleV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceSFSAccessRuleV2Import,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"sfs_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"access_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "rw",
+			},
+			"access_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "cert",
+			},
+			"access_to": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSFSAccessRuleV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	sfsClient, err := config.sfsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud SFS Client: %s", err)
+	}
+
+	shareID := d.Get("sfs_id").(string)
+	grantAccessOpts := shares.GrantAccessOpts{
+		AccessLevel: d.Get("access_level").(string),
+		AccessType:  d.Get("access_type").(string),
+		AccessTo:    d.Get("access_to").(string),
+	}
+
+	log.Printf("[DEBUG] Applied access rule to share file %s, opts: %#v", shareID, grantAccessOpts)
+	grant, err := shares.GrantAccess(sfsClient, shareID, grantAccessOpts).ExtractAccess()
+	if err != nil {
+		return fmt.Errorf("Error creating access rule to share file: %s", err)
+	}
+
+	d.SetId(grant.ID)
+	// wait access rule to become active
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"new", "queued_to_apply", "applying"},
+		Target:     []string{"active"},
+		Refresh:    waitForSFSAccessStatus(sfsClient, shareID, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud SFS access rule: %s", err)
+	}
+
+	return resourceSFSAccessRuleV2Read(d, meta)
+}
+
+func resourceSFSAccessRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	sfsClient, err := config.sfsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud SFS Client: %s", err)
+	}
+
+	shareID := d.Get("sfs_id").(string)
+	rules, err := shares.ListAccessRights(sfsClient, shareID).ExtractAccessRights()
+	if err != nil {
+		return fmt.Errorf("Error retrieving HuaweiCloud Shares rules: %s", err)
+	}
+
+	for _, rule := range rules {
+		if rule.ID == d.Id() {
+			d.Set("access_to", rule.AccessTo)
+			d.Set("access_type", rule.AccessType)
+			d.Set("access_level", rule.AccessLevel)
+			d.Set("status", rule.State)
+			return nil
+		}
+	}
+
+	// the access rule was not found
+	log.Printf("[WARN] access rule (%s) of share file %s was not exist!", d.Id(), shareID)
+	d.SetId("")
+	return nil
+}
+
+func resourceSFSAccessRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	sfsClient, err := config.sfsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud SFS Client: %s", err)
+	}
+
+	shareID := d.Get("sfs_id").(string)
+	deleteAccessOpts := shares.DeleteAccessOpts{AccessID: d.Id()}
+	deny := shares.DeleteAccess(sfsClient, shareID, deleteAccessOpts)
+	if deny.Err != nil {
+		return CheckDeleted(d, deny.Err, "Error deleting access rule")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active", "queued_to_deny", "denying"},
+		Target:     []string{"deleted"},
+		Refresh:    waitForSFSAccessStatus(sfsClient, shareID, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error deleting HuaweiCloud SFS access rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForSFSAccessStatus(sfsClient *golangsdk.ServiceClient, shareID, ruleID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		rules, err := shares.ListAccessRights(sfsClient, shareID).ExtractAccessRights()
+		if err != nil {
+			log.Printf("[WARN] list access rules error")
+			return nil, "error", err
+		}
+
+		for _, rule := range rules {
+			if rule.ID == ruleID {
+				log.Printf("[DEBUG] find access rule %s, state: %s", ruleID, rule.State)
+				return rule, rule.State, nil
+			}
+		}
+
+		// the rule was not found, seem as deleted
+		log.Printf("[DEBUG] could not find the access rule %s", ruleID)
+		return shares.AccessRight{}, "deleted", nil
+	}
+}
+
+func resourceSFSAccessRuleV2Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	arr := strings.Split(d.Id(), "/")
+	shareID := arr[0]
+	ruleID := arr[1]
+	d.Set("sfs_id", shareID)
+	d.SetId(ruleID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/resource_huaweicloud_sfs_access_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_sfs_access_rule_v2_test.go
@@ -1,0 +1,152 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares"
+)
+
+func TestAccSFSAccessRuleV2_basic(t *testing.T) {
+	var rule shares.AccessRight
+	shareName := fmt.Sprintf("sfs-acc-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSAccessRuleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configAccSFSAccessRuleV2_basic(shareName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSAccessRuleV2Exists("huaweicloud_sfs_access_rule_v2.rule_1", &rule),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_access_rule_v2.rule_1", "access_to", OS_VPC_ID),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_access_rule_v2.rule_1", "access_level", "rw"),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_access_rule_v2.rule_1", "status", "active"),
+				),
+			},
+			{
+				Config: configAccSFSAccessRuleV2_ipAuth(shareName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSAccessRuleV2Exists("huaweicloud_sfs_access_rule_v2.rule_1", &rule),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_access_rule_v2.rule_1", "access_to",
+						strings.Join([]string{OS_VPC_ID, "192.168.10.0/24", "0", "no_all_squash,no_root_squash"}, "#")),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_sfs_access_rule_v2.rule_1", "status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSFSAccessRuleV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	sfsClient, err := config.sfsV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud sfs client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_sfs_access_rule_v2" {
+			continue
+		}
+
+		sfsID := rs.Primary.Attributes["sfs_id"]
+		if sfsID == "" {
+			return fmt.Errorf("No SFSID is set in huaweicloud_sfs_access_rule_v2")
+		}
+		rules, err := shares.ListAccessRights(sfsClient, sfsID).ExtractAccessRights()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+
+			return err
+		}
+
+		for _, v := range rules {
+			if v.ID == rs.Primary.ID {
+				return fmt.Errorf("resource huaweicloud_sfs_access_rule_v2 still exists")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSFSAccessRuleV2Exists(n string, rule *shares.AccessRight) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set in %s", n)
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		sfsClient, err := config.sfsV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud sfs client: %s", err)
+		}
+
+		sfsID := rs.Primary.Attributes["sfs_id"]
+		if sfsID == "" {
+			return fmt.Errorf("No SFSID is set in %s", n)
+		}
+
+		rules, err := shares.ListAccessRights(sfsClient, sfsID).ExtractAccessRights()
+		if err != nil {
+			return err
+		}
+
+		for _, v := range rules {
+			if v.ID == rs.Primary.ID {
+				*rule = v
+				return nil
+			}
+		}
+
+		return fmt.Errorf("sfs access rule %s was not found", n)
+	}
+}
+
+func configAccSFSAccessRuleV2_basic(sfsName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "%s"
+  description = "sfs file system created by terraform testacc"
+}
+
+resource "huaweicloud_sfs_access_rule_v2" "rule_1" {
+  sfs_id = huaweicloud_sfs_file_system_v2.sfs_1.id
+  access_to = "%s"
+}`, sfsName, OS_VPC_ID)
+}
+
+func configAccSFSAccessRuleV2_ipAuth(sfsName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "%s"
+  description = "sfs file system created by terraform testacc"
+}
+
+resource "huaweicloud_sfs_access_rule_v2" "rule_1" {
+  sfs_id = huaweicloud_sfs_file_system_v2.sfs_1.id
+  access_to = join("#", ["%s", "192.168.10.0/24", "0", "no_all_squash,no_root_squash"])
+}`, sfsName, OS_VPC_ID)
+}

--- a/website/docs/r/sfs_access_rule_v2.html.markdown
+++ b/website/docs/r/sfs_access_rule_v2.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_sfs_access_rule_v2"
+sidebar_current: "docs-huaweicloud-resource-sfs-access-rule-v2"
+description: |-
+ Provides an access rule resource of Scalable File Resource (SFS).
+---
+
+# huaweicloud_sfs_access_rule_v2
+
+Provides an access rule resource of Scalable File Resource (SFS).
+
+## Example Usage
+
+### Usage in VPC authorization scenarios
+```hcl
+variable "share_name" { }
+variable "vpc_id" { }
+
+resource "huaweicloud_sfs_file_system_v2" "share-file" {
+  name        = var.share_name
+  size        = 100
+  share_proto = "NFS"
+}
+
+resource "huaweicloud_sfs_access_rule_v2" "rule_1" {
+  sfs_id    = huaweicloud_sfs_file_system_v2.share-file.id
+  access_to = var.vpc_id
+}
+```
+
+### Usage in IP address authorization scenario
+```hcl
+variable "share_name" { }
+variable "vpc_id" { }
+
+resource "huaweicloud_sfs_file_system_v2" "share-file" {
+  name        = var.share_name
+  size        = 100
+  share_proto = "NFS"
+}
+
+resource "huaweicloud_sfs_access_rule_v2" "rule_1" {
+  sfs_id    = huaweicloud_sfs_file_system_v2.share-file.id
+  access_to = join("#", [var.vpc_id, "192.168.10.0/24", "0", "no_all_squash,no_root_squash"])
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+* `sfs_id` - (Required) Specifies the UUID of the shared file system. Changing this will create a new access rule.
+
+* `access_level` - (Optional) Specifies the access level of the shared file system. Possible values are *ro* (read-only)
+    and *rw* (read-write). The default value is *rw* (read/write). Changing this will create a new access rule.
+
+* `access_type` - (Optional) Specifies the type of the share access rule. The default value is *cert*.
+    Changing this will create a new access rule.
+
+* `access_to` - (Required) Specifies the value that defines the access rule. The value contains 1 to 255 characters.
+    Changing this will create a new access rule. The value varies according to the scenario:
+    - Set the VPC ID in VPC authorization scenarios.
+    - Set this parameter in IP address authorization scenario.
+
+        For an NFS shared file system, the value in the format of *VPC_ID#IP_address#priority#user_permission*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
+
+        For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
+
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The UUID of the share access rule.
+
+* `status` - The status of the share access rule.
+
+## Import
+
+SFS access rule can be imported by specifying the SFS ID and access rule ID separated by a slash, e.g.:
+
+```
+$ terraform import huaweicloud_sfs_access_rule_v2 <sfs_id>/<rule_id>
+```

--- a/website/docs/r/sfs_file_system_v2.html.markdown
+++ b/website/docs/r/sfs_file_system_v2.html.markdown
@@ -61,6 +61,9 @@ The following arguments are supported:
         For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
         For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
 
+-> **NOTE:** If you want to create more access rules, please using [huaweicloud_sfs_access_rule_v2](https://www.terraform.io/docs/providers/huaweicloud/r/sfs_access_rule_v2.html).
+
+
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:
 

--- a/website/huaweicloud.erb
+++ b/website/huaweicloud.erb
@@ -874,6 +874,9 @@
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
                 <li>
+                  <a href="/docs/providers/huaweicloud/r/sfs_access_rule_v2.html">huaweicloud_sfs_access_rule_v2</a>
+                </li>
+                <li>
                   <a href="/docs/providers/huaweicloud/r/sfs_file_system_v2.html">huaweicloud_sfs_file_system_v2</a>
                 </li>
                 <li>


### PR DESCRIPTION
add `huaweicloud_sfs_access_rule_v2` resource, then we can create more access rules for an SFS.
the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSFSAccessRuleV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSFSAccessRuleV2_basic -timeout 360m
=== RUN   TestAccSFSAccessRuleV2_basic
--- PASS: TestAccSFSAccessRuleV2_basic (68.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       68.302s
```