### PR TITLE
improve for cce cluster and node resources

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -62,8 +62,9 @@ func resourceCCEClusterV3() *schema.Resource {
 			},
 			"cluster_type": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  "VirtualMachine",
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -112,7 +113,7 @@ func resourceCCEClusterV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "x509",
+				Default:  "rbac",
 			},
 			"authenticating_proxy_ca": {
 				Type:     schema.TypeString,
@@ -237,13 +238,19 @@ func resourceCCEClusterV3Create(d *schema.ResourceData, meta interface{}) error 
 			Flavor:      d.Get("flavor_id").(string),
 			Version:     d.Get("cluster_version").(string),
 			Description: d.Get("description").(string),
-			HostNetwork: clusters.HostNetworkSpec{VpcId: d.Get("vpc_id").(string),
+			HostNetwork: clusters.HostNetworkSpec{
+				VpcId:         d.Get("vpc_id").(string),
 				SubnetId:      d.Get("subnet_id").(string),
-				HighwaySubnet: d.Get("highway_subnet_id").(string)},
-			ContainerNetwork: clusters.ContainerNetworkSpec{Mode: d.Get("container_network_type").(string),
-				Cidr: d.Get("container_network_cidr").(string)},
-			Authentication: clusters.AuthenticationSpec{Mode: d.Get("authentication_mode").(string),
-				AuthenticatingProxy: authenticating_proxy},
+				HighwaySubnet: d.Get("highway_subnet_id").(string),
+			},
+			ContainerNetwork: clusters.ContainerNetworkSpec{
+				Mode: d.Get("container_network_type").(string),
+				Cidr: d.Get("container_network_cidr").(string),
+			},
+			Authentication: clusters.AuthenticationSpec{
+				Mode:                d.Get("authentication_mode").(string),
+				AuthenticatingProxy: authenticating_proxy,
+			},
 			BillingMode: d.Get("billing_mode").(int),
 			ExtendParam: resourceClusterExtendParamV3(d),
 		},

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
@@ -31,7 +31,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
 					resource.TestCheckResourceAttr(resourceName, "flavor_id", "cce.s1.small"),
 					resource.TestCheckResourceAttr(resourceName, "container_network_type", "overlay_l2"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "x509"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
 				),
 			},
 			{
@@ -158,7 +158,6 @@ func testAccCCEClusterV3_basic(rName string) string {
 
 resource "huaweicloud_cce_cluster_v3" "test" {
   name                   = "%s"
-  cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
   vpc_id                 = huaweicloud_vpc_v1.test.id
   subnet_id              = huaweicloud_vpc_subnet_v1.test.id
@@ -173,7 +172,6 @@ func testAccCCEClusterV3_update(rName string) string {
 
 resource "huaweicloud_cce_cluster_v3" "test" {
   name                   = "%s"
-  cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
   vpc_id                 = huaweicloud_vpc_v1.test.id
   subnet_id              = huaweicloud_vpc_subnet_v1.test.id

--- a/website/docs/r/cce_cluster_v3.html.md
+++ b/website/docs/r/cce_cluster_v3.html.md
@@ -19,7 +19,6 @@ variable "subnet_id" { }
 
 resource "huaweicloud_cce_cluster_v3" "cluster_1" {
   name                   = "cluster"
-  cluster_type           = "VirtualMachine"
   flavor_id              = var.flavor_id
   vpc_id                 = var.vpc_id
   subnet_id              = var.subnet_id
@@ -52,7 +51,8 @@ The following arguments are supported:
 * `cluster_version` - (Optional) For the cluster version, defaults to the latest supported version. To learn which cluster
 versions are available, choose Dashboard > Buy Cluster on the CCE console. Changing this parameter will create a new cluster resource.
 
-* `cluster_type` - (Required) Cluster Type, possible values are VirtualMachine and BareMetal. Changing this parameter will create a new cluster resource.
+* `cluster_type` - (Optional) Cluster Type, possible values are VirtualMachine, BareMetal and ARM64. Defaults to *VirtualMachine*.
+  Changing this parameter will create a new cluster resource.
 
 * `description` - (Optional) The Cluster description.
 
@@ -62,7 +62,8 @@ versions are available, choose Dashboard > Buy Cluster on the CCE console. Chang
 
 * `vpc_id` - (Required) The ID of the VPC used to create the node. Changing this parameter will create a new cluster resource.
 
-* `subnet_id` - (Required) The ID of the subnet used to create the node. Changing this parameter will create a new cluster resource.
+* `subnet_id` - (Required) The ID of the subnet used to create the node  which should be configured with a *DNS address*.
+  Changing this parameter will create a new cluster resource.
 
 * `highway_subnet_id` - (Optional) The ID of the high speed network used to create bare metal nodes. Changing this parameter will create a new cluster resource.
 
@@ -74,7 +75,7 @@ versions are available, choose Dashboard > Buy Cluster on the CCE console. Chang
 
 * `container_network_cidr` - (Optional) Container network segment. Changing this parameter will create a new cluster resource.
 
-* `authentication_mode` - (Optional) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to x509.
+* `authentication_mode` - (Optional) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to *rbac*.
     Changing this parameter will create a new cluster resource.
 
 * `authenticating_proxy_ca` - (Optional) CA root certificate provided in the authenticating_proxy mode. The CA root certificate

--- a/website/docs/r/cce_node_v3.html.md
+++ b/website/docs/r/cce_node_v3.html.md
@@ -20,7 +20,7 @@ resource "huaweicloud_cce_node_v3" "node_1" {
   cluster_id        = var.cluster_id
   availability_zone = var.availability_zone
   name              = "test"
-  flavor_id         = "s1.medium"
+  flavor_id         = "s6.large.2"
   key_pair          = var.ssh_key
 
   root_volume {
@@ -49,8 +49,9 @@ The following arguments are supported:
  
 * `availability_zone` - (Required) specify the name of the available partition (AZ). Changing this parameter will create a new resource.
 
-* `os` - (Optional) Operating System of the node, possible values are EulerOS 2.2 and CentOS 7.1. Defaults to EulerOS 2.2.
-    Changing this parameter will create a new resource.
+* `os` - (Optional) Operating System of the node. Changing this parameter will create a new resource.
+    - For VM nodes, clusters of v1.13 and later support *EulerOS 2.5* and *CentOS 7.6*.
+    - For BMS nodes purchased in the yearly/monthly billing mode, only *EulerOS 2.3* is supported.
 
 * `key_pair` - (Optional) Key pair name when logging in to select the key pair mode. This parameter and `password` are alternative.
     Changing this parameter will create a new resource.
@@ -62,12 +63,13 @@ The following arguments are supported:
 
 * `eip_id` - (Optional) The ID of the EIP. Changing this parameter will create a new resource.
 
-* `eip_ids` - (Deprecated) This has been deprecated, use eip_id instead. List of existing elastic IP IDs. Changing this parameter will create a new resource.
+* `eip_ids` - (Deprecated) This has been deprecated, use eip_id instead. List of existing elastic IP IDs.
+    Changing this parameter will create a new resource.
 
-**Note:**
-If the eip_id parameter is configured, you do not need to configure the bandwidth parameters: iptype, bandwidth_charge_mode, bandwidth_size and share_type.
+-> **Note:** If the eip_id parameter is configured, you do not need to configure the bandwidth parameters:
+  `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
 
-* `iptype` - (Optional) Elastic IP type. Default is 5_bgp. Changing this parameter will create a new resource.
+* `iptype` - (Optional) Elastic IP type. Changing this parameter will create a new resource.
 
 * `bandwidth_charge_mode` - (Optional) Bandwidth billing type. Changing this parameter will create a new resource.
 


### PR DESCRIPTION
fixes #434 

* make `cluster_type` to be optional, and defaults to "VirtualMachine";
* change the default value of `authentication_mode` to "rbac";
* [cce node] set `eip_id` or `eip_ids`  conflicts with `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
