### PR TITLE
Fix standard resource check

### DIFF
--- a/huaweicloud/config_test.go
+++ b/huaweicloud/config_test.go
@@ -35,6 +35,7 @@ func testRequestRetry(t *testing.T, count int) {
 			info.mut.RLock()
 			info.retries += 1
 			info.mut.RUnlock()
+			//lintignore:R009
 			panic(err) // simulate EOF
 		}
 		w.WriteHeader(500)

--- a/huaweicloud/data_source_huaweicloud_images_image_v2.go
+++ b/huaweicloud/data_source_huaweicloud_images_image_v2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"time"
 
 	"github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images"
 
@@ -218,8 +219,8 @@ func dataSourceImagesImageV2Attributes(d *schema.ResourceData, image *images.Ima
 	if err := d.Set("metadata", image.Metadata); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving metadata to state for HuaweiCloud image (%s): %s", d.Id(), err)
 	}
-	d.Set("created_at", image.CreatedAt)
-	d.Set("updated_at", image.UpdatedAt)
+	d.Set("created_at", image.CreatedAt.Format(time.RFC3339))
+	d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339))
 	d.Set("file", image.File)
 	d.Set("schema", image.Schema)
 

--- a/huaweicloud/data_source_huaweicloud_kms_data_key_v1.go
+++ b/huaweicloud/data_source_huaweicloud_kms_data_key_v1.go
@@ -58,6 +58,7 @@ func resourceKmsDataKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	//lintignore:R017
 	d.SetId(time.Now().UTC().String())
 	d.Set("plain_text", v.PlainText)
 	d.Set("cipher_text", v.CipherText)

--- a/huaweicloud/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_port_v2.go
@@ -68,7 +68,7 @@ func dataSourceNetworkingPortV2() *schema.Resource {
 			"fixed_ip": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.SingleIP(),
+				ValidateFunc: validation.IsIPAddress,
 			},
 
 			"status": {

--- a/huaweicloud/resource_huaweicloud_as_group_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_group_v1.go
@@ -590,7 +590,6 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
-	d.Partial(true)
 	var desireNum int
 	minNum := d.Get("min_instance_number").(int)
 	maxNum := d.Get("max_instance_number").(int)
@@ -599,7 +598,7 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		desireNum = minNum
 	}
-	if d.HasChange("min_instance_number") || d.HasChange("max_instance_number") || d.HasChange("desire_instance_number") {
+	if d.HasChanges("min_instance_number", "max_instance_number", "desire_instance_number") {
 		log.Printf("[DEBUG] Min instance number is: %#v", minNum)
 		log.Printf("[DEBUG] Max instance number is: %#v", maxNum)
 		log.Printf("[DEBUG] Desire instance number is: %#v", desireNum)
@@ -661,7 +660,6 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	d.Partial(false)
 	return resourceASGroupRead(d, meta)
 }
 

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule.go
@@ -336,6 +336,7 @@ func resourceAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating %s %s with options: %#v", nameCESAR, arId, updateOpts)
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := alarmrule.Update(client, arId, updateOpts).ExtractErr()
 		if err != nil {
@@ -361,6 +362,7 @@ func resourceAlarmRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting %s %s", nameCESAR, arId)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := alarmrule.Delete(client, arId).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_compute_instance_v2.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_v2.go
@@ -853,7 +853,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if d.HasChange("flavor_id") || d.HasChange("flavor_name") {
+	if d.HasChanges("flavor_id", "flavor_name") {
 		var newFlavorId string
 		var err error
 		if d.HasChange("flavor_id") {

--- a/huaweicloud/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_peering_connect_v1.go
@@ -430,6 +430,7 @@ func setCsPeeringConnectV1States(d *schema.ResourceData, opts map[string]interfa
 	return nil
 }
 
+//lintignore:R014
 func actionCsPeeringConnectV1AcceptPeering(d *schema.ResourceData, result interface{}, client *golangsdk.ServiceClient) error {
 	pathParameters := map[string][]string{
 		"peering_id": []string{"peering", "id"},

--- a/huaweicloud/resource_huaweicloud_ecs_auto_recovery_v1.go
+++ b/huaweicloud/resource_huaweicloud_ecs_auto_recovery_v1.go
@@ -41,6 +41,7 @@ func setAutoRecoveryForInstance(d *schema.ResourceData, meta interface{}, instan
 	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	log.Printf("[DEBUG] Setting ECS-AutoRecovery for instance:%s with options: %#v", rId, updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := auto_recovery.Update(client, rId, updateOpts)
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_elb_backendecs.go
+++ b/huaweicloud/resource_huaweicloud_elb_backendecs.go
@@ -180,6 +180,7 @@ func resourceELBBackendECSDelete(d *schema.ResourceData, meta interface{}) error
 	var job *elb.Job
 	timeout := d.Timeout(schema.TimeoutDelete)
 	lId := d.Get("listener_id").(string)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		j, err := backendecs.Delete(networkingClient, lId, deleteOpts).Extract()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_elb_healthcheck.go
+++ b/huaweicloud/resource_huaweicloud_elb_healthcheck.go
@@ -182,6 +182,7 @@ func resourceELBHealthCheckUpdate(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Updating healthcheck %s(%s) with options: %#v", nameELBHC, hcId, updateOpts)
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err := healthcheck.Update(networkingClient, hcId, updateOpts).Extract()
 		if err != nil {
@@ -207,6 +208,7 @@ func resourceELBHealthCheckDelete(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Deleting %s %s", nameELBHC, hcId)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := healthcheck.Delete(networkingClient, hcId).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_elb_listener.go
+++ b/huaweicloud/resource_huaweicloud_elb_listener.go
@@ -377,6 +377,7 @@ func resourceELBListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating %s %s with options: %#v", nameELBListener, lId, opts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err := listeners.Update(networkingClient, lId, opts, not_pass_params).Extract()
 		if err != nil {
@@ -402,6 +403,7 @@ func resourceELBListenerDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting %s %s", nameELBListener, lId)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := listeners.Delete(networkingClient, lId).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
@@ -282,6 +282,7 @@ func resourceELBLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Updating %s %s with options: %#v", nameELBLB, lbId, updateOpts)
 	var job *elb.Job
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		j, err := loadbalancers.Update(networkingClient, lbId, updateOpts, not_pass_param).Extract()
 		if err != nil {
@@ -315,6 +316,7 @@ func resourceELBLoadBalancerDelete(d *schema.ResourceData, meta interface{}) err
 
 	var job *elb.Job
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		j, err := loadbalancers.Delete(networkingClient, lbId).Extract()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_iam_agency_v3.go
+++ b/huaweicloud/resource_huaweicloud_iam_agency_v3.go
@@ -446,13 +446,14 @@ func resourceIAMAgencyV3Update(d *schema.ResourceData, meta interface{}) error {
 
 	aID := d.Id()
 
-	if d.HasChange("delegated_domain_name") || d.HasChange("description") {
+	if d.HasChanges("delegated_domain_name", "description") {
 		updateOpts := agency.UpdateOpts{
 			DelegatedDomain: d.Get("delegated_domain_name").(string),
 			Description:     d.Get("description").(string),
 		}
 		log.Printf("[DEBUG] Updating IAM-Agency %s with options: %#v", aID, updateOpts)
 		timeout := d.Timeout(schema.TimeoutUpdate)
+		//lintignore:R006
 		err = resource.Retry(timeout, func() *resource.RetryError {
 			_, err := agency.Update(client, aID, updateOpts).Extract()
 			if err != nil {
@@ -467,7 +468,7 @@ func resourceIAMAgencyV3Update(d *schema.ResourceData, meta interface{}) error {
 
 	domainID := ""
 	var roles map[string]string
-	if d.HasChange("project_role") || d.HasChange("domain_roles") {
+	if d.HasChanges("project_role", "domain_roles") {
 		domainID, err = getDomainID(config, client)
 		if err != nil {
 			return fmt.Errorf("Error getting the domain id, err=%s", err)
@@ -569,6 +570,7 @@ func resourceIAMAgencyV3Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting IAM-Agency %s", rID)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := agency.Delete(client, rID).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_identity_group_membership_v3.go
+++ b/huaweicloud/resource_huaweicloud_identity_group_membership_v3.go
@@ -49,6 +49,7 @@ func resourceIdentityGroupMembershipV3Create(d *schema.ResourceData, meta interf
 		return err
 	}
 
+	//lintignore:R015
 	d.SetId(resource.UniqueId())
 
 	return resourceIdentityGroupMembershipV3Read(d, meta)

--- a/huaweicloud/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/resource_huaweicloud_images_image_v2.go
@@ -193,8 +193,6 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		createOpts.Tags = resourceImagesImageV2BuildTags(tags)
 	}
 
-	d.Partial(true)
-
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	newImg, err := images.Create(imageClient, createOpts).Extract()
 	if err != nil {
@@ -241,8 +239,6 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error waiting for Image: %s", err)
 	}
 
-	d.Partial(false)
-
 	return resourceImagesImageV2Read(d, meta)
 }
 
@@ -269,8 +265,8 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("metadata", img.Metadata); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving metadata to state for HuaweiCloud image (%s): %s", d.Id(), err)
 	}
-	d.Set("created_at", img.CreatedAt)
-	d.Set("update_at", img.UpdatedAt)
+	d.Set("created_at", img.CreatedAt.Format(time.RFC3339))
+	d.Set("update_at", img.UpdatedAt.Format(time.RFC3339))
 	d.Set("container_format", img.ContainerFormat)
 	d.Set("disk_format", img.DiskFormat)
 	d.Set("min_disk_gb", img.MinDiskGigabytes)

--- a/huaweicloud/resource_huaweicloud_lb_certificate_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate_v2.go
@@ -165,6 +165,7 @@ func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Updating certificate %s with options: %#v", d.Id(), updateOpts)
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err := certificates.Update(networkingClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -188,6 +189,7 @@ func resourceCertificateV2Delete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Deleting certificate %s", d.Id())
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := certificates.Delete(networkingClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_l7policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7policy_v2.go
@@ -165,6 +165,7 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Attempting to create L7 Policy")
 	var l7Policy *l7policies.L7Policy
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		l7Policy, err = l7policies.Create(lbClient, createOpts).Extract()
 		if err != nil {
@@ -293,6 +294,7 @@ func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating L7 Policy %s with options: %#v", d.Id(), updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = l7policies.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -343,6 +345,7 @@ func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Attempting to delete L7 Policy %s", d.Id())
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = l7policies.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_l7rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7rule_v2.go
@@ -164,6 +164,7 @@ func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Attempting to create L7 Rule")
 	var l7Rule *l7policies.Rule
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		l7Rule, err = l7policies.CreateRule(lbClient, l7policyID, createOpts).Extract()
 		if err != nil {
@@ -283,6 +284,7 @@ func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating L7 Rule %s with options: %#v", d.Id(), updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err := l7policies.UpdateRule(lbClient, l7policyID, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -341,6 +343,7 @@ func resourceL7RuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Attempting to delete L7 Rule %s", d.Id())
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = l7policies.DeleteRule(lbClient, l7policyID, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_listener_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_listener_v2.go
@@ -161,6 +161,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Attempting to create listener")
 	var listener *listeners.Listener
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		listener, err = listeners.Create(lbClient, createOpts).Extract()
 		if err != nil {
@@ -261,6 +262,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating listener %s with options: %#v", d.Id(), updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = listeners.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -299,6 +301,7 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Deleting listener %s", d.Id())
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = listeners.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer_v2.go
@@ -221,6 +221,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Updating loadbalancer %s with options: %#v", d.Id(), updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = loadbalancers.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -259,6 +260,7 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleting loadbalancer %s", d.Id())
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = loadbalancers.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_member_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_member_v2.go
@@ -125,6 +125,7 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Attempting to create member")
 	var member *pools.Member
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		member, err = pools.CreateMember(lbClient, poolID, createOpts).Extract()
 		if err != nil {
@@ -202,6 +203,7 @@ func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating member %s with options: %#v", d.Id(), updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = pools.UpdateMember(lbClient, poolID, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -238,6 +240,7 @@ func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Attempting to delete member %s", d.Id())
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = pools.DeleteMember(lbClient, poolID, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_monitor_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor_v2.go
@@ -130,6 +130,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	log.Printf("[DEBUG] Attempting to create monitor")
 	var monitor *monitors.Monitor
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		monitor, err = monitors.Create(lbClient, createOpts).Extract()
 		if err != nil {
@@ -222,7 +223,7 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = monitors.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -258,7 +259,7 @@ func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = monitors.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_pool_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool_v2.go
@@ -196,6 +196,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Attempting to create pool")
 	var pool *pools.Pool
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		pool, err = pools.Create(lbClient, createOpts).Extract()
 		if err != nil {
@@ -285,6 +286,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating pool %s with options: %#v", d.Id(), updateOpts)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		_, err = pools.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
@@ -328,6 +330,7 @@ func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Attempting to delete pool %s", d.Id())
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err = pools.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_mrs_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_mrs_cluster_v1.go
@@ -563,9 +563,9 @@ func resourceClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	chargingStartTimeTm := time.Unix(chargingStartTime, 0)
 
-	d.Set("update_at", updateAtTm)
-	d.Set("create_at", createAtTm)
-	d.Set("charging_start_time", chargingStartTimeTm)
+	d.Set("update_at", updateAtTm.Format(time.RFC3339))
+	d.Set("create_at", createAtTm.Format(time.RFC3339))
+	d.Set("charging_start_time", chargingStartTimeTm.Format(time.RFC3339))
 	d.Set("component_list", clusterGet.Duration)
 
 	components := make([]map[string]interface{}, len(clusterGet.Componentlist))

--- a/huaweicloud/resource_huaweicloud_mrs_job_v1.go
+++ b/huaweicloud/resource_huaweicloud_mrs_job_v1.go
@@ -225,6 +225,7 @@ func resourceMRSJobV1Delete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting MRS Job %s", rId)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := job.Delete(client, rId).ExtractErr()
 		if err != nil {

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -342,7 +342,7 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("flavor") {
-		_, nflavor := d.GetChange("flavor")
+		nflavor := d.Get("flavor")
 		client, err := config.RdsV1Client(GetRegion(d, config))
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud rds v1 client: %s ", err)
@@ -419,7 +419,7 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud rds v1 client: %s ", err)
 		}
-		_, nvolume := d.GetChange("volume")
+		nvolume := d.Get("volume")
 		var updateOpts instances.UpdateOps
 		volume := make(map[string]interface{})
 		volumeRaw := nvolume.([]interface{})

--- a/huaweicloud/resource_huaweicloud_s3_bucket_policy.go
+++ b/huaweicloud/resource_huaweicloud_s3_bucket_policy.go
@@ -55,7 +55,7 @@ func resourceS3BucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
 		Bucket: aws.String(bucket),
 		Policy: aws.String(policy),
 	}
-
+	//lintignore:R006
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		if _, err := s3conn.PutBucketPolicy(params); err != nil {
 			if awserr, ok := err.(awserr.Error); ok {

--- a/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -261,9 +261,8 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 		updateOpts.ScheduledPolicy.WeekFrequency = weeks
 	}
 
-	if d.HasChange("name") || d.HasChange("start_time") || d.HasChange("retain_first_backup") ||
-		d.HasChange("rentention_num") || d.HasChange("rentention_day") || d.HasChange("status") ||
-		d.HasChange("frequency") || d.HasChange("week_frequency") {
+	if d.HasChanges("name", "start_time", "retain_first_backup", "rentention_num",
+		"rentention_day", "status", "frequency", "week_frequency") {
 		if d.HasChange("name") {
 			updateOpts.Name = d.Get("name").(string)
 		}


### PR DESCRIPTION
Fix lint:
R004: ResourceData.Set() incompatible value type: struct{wall uint64; ext int64; loc *time.Location}
R005: multiple ResourceData.HasChange() calls can be combined with single HasChanges() call
R006: RetryFunc should include RetryableError() handling or be removed
R007: deprecated d.Partial(true)
R009: avoid panic() usage
R010: prefer d.Get() over d.GetChange() when only using second return value
R014: interface{} parameter of CreateFunc, ReadFunc, UpdateFunc, or DeleteFunc should be named meta
R015: schema attributes should be stable across Terraform runs
R017: schema attributes should be stable across Terraform runs

Test result:
make testacc TEST=./huaweicloud/ TESTARGS='-run TestAccImagesImageV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccImagesImageV2_basic -timeout 360m
=== RUN   TestAccImagesImageV2_basic
--- PASS: TestAccImagesImageV2_basic (411.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       411.694s
make testacc TEST=./huaweicloud/ TESTARGS='-run TestAccMRSV1Cluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccMRSV1Cluster_basic -timeout 360m
=== RUN   TestAccMRSV1Cluster_basic
    provider_test.go:117: This environment does not support MRS tests
--- SKIP: TestAccMRSV1Cluster_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.035s