### PR TITLE
Fix standard schema check

### DIFF
--- a/huaweicloud/data_source_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/data_source_huaweicloud_csbs_backup_policy_v1.go
@@ -45,6 +45,7 @@ func dataSourceCSBSBackupPolicyV1() *schema.Resource {
 			"common": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"resource": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/data_source_huaweicloud_iam_role_v3.go
+++ b/huaweicloud/data_source_huaweicloud_iam_role_v3.go
@@ -17,18 +17,22 @@ func dataSourceIAMRoleV3() *schema.Resource {
 			"projects": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"domains": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"project_domains": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"others": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/data_source_huaweicloud_images_image_v2.go
+++ b/huaweicloud/data_source_huaweicloud_images_image_v2.go
@@ -26,38 +26,32 @@ func dataSourceImagesImageV2() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"visibility": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: dataSourceImagesImageV2Visibility,
 			},
 
 			"owner": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"size_min": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"size_max": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"sort_key": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Default:      "name",
 				ValidateFunc: dataSourceImagesImageV2SortKey,
 			},
@@ -65,7 +59,6 @@ func dataSourceImagesImageV2() *schema.Resource {
 			"sort_direction": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Default:      "asc",
 				ValidateFunc: dataSourceImagesImageV2SortDirection,
 			},
@@ -73,14 +66,12 @@ func dataSourceImagesImageV2() *schema.Resource {
 			"tag": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"most_recent": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
 			},
 
 			// Computed values
@@ -122,6 +113,7 @@ func dataSourceImagesImageV2() *schema.Resource {
 			"metadata": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"updated_at": {

--- a/huaweicloud/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_port_v2.go
@@ -74,7 +74,6 @@ func dataSourceNetworkingPortV2() *schema.Resource {
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"security_group_ids": {

--- a/huaweicloud/data_source_huaweicloud_rts_software_config_v1.go
+++ b/huaweicloud/data_source_huaweicloud_rts_software_config_v1.go
@@ -35,12 +35,18 @@ func dataSourceRtsSoftwareConfigV1() *schema.Resource {
 			"input_values": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
 			},
 			"output_values": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
 			},
 			"config": {
 				Type:     schema.TypeString,
@@ -49,6 +55,7 @@ func dataSourceRtsSoftwareConfigV1() *schema.Resource {
 			"options": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/data_source_huaweicloud_rts_stack_v1.go
+++ b/huaweicloud/data_source_huaweicloud_rts_stack_v1.go
@@ -38,10 +38,12 @@ func dataSourceRTSStackV1() *schema.Resource {
 			"outputs": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"parameters": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"timeout_mins": {
 				Type:     schema.TypeInt,

--- a/huaweicloud/data_source_huaweicloud_s3_bucket_object.go
+++ b/huaweicloud/data_source_huaweicloud_s3_bucket_object.go
@@ -74,6 +74,7 @@ func dataSourceS3BucketObject() *schema.Resource {
 			"metadata": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"range": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/data_source_huaweicloud_sfs_file_system_v2.go
@@ -75,6 +75,7 @@ func dataSourceSFSFileSystemV2() *schema.Resource {
 			"metadata": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"export_locations": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/resource_huaweicloud_as_configuration_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_configuration_v1.go
@@ -166,6 +166,7 @@ func resourceASConfiguration() *schema.Resource {
 						"metadata": {
 							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},

--- a/huaweicloud/resource_huaweicloud_as_group_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_group_v1.go
@@ -198,6 +198,7 @@ func resourceASGroup() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_blockstorage_volume_v2.go
+++ b/huaweicloud/resource_huaweicloud_blockstorage_volume_v2.go
@@ -61,8 +61,8 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 			"metadata": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: false,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"snapshot_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -43,11 +43,13 @@ func resourceCCEClusterV3() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"annotations": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"flavor_id": {
 				Type:     schema.TypeString,
@@ -97,6 +99,7 @@ func resourceCCEClusterV3() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"container_network_type": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -48,11 +48,13 @@ func resourceCCENodeV3() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"annotations": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"flavor_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -170,6 +170,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 				ForceNew:      false,
 				ConflictsWith: []string{"system_disk_type", "system_disk_size", "data_disks"},
 				Deprecated:    "use tags instead",
+				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
 			"admin_pass": {
 				Type:      schema.TypeString,
@@ -355,11 +356,13 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:         schema.TypeMap,
 				Optional:     true,
 				ValidateFunc: validateECSTagValue,
+				Elem:         &schema.Schema{Type: schema.TypeString},
 			},
 			"all_metadata": {
 				Type:       schema.TypeMap,
 				Computed:   true,
 				Deprecated: "use tags instead",
+				Elem:       &schema.Schema{Type: schema.TypeString},
 			},
 			"volume_attached": {
 				Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_compute_keypair_v2.go
+++ b/huaweicloud/resource_huaweicloud_compute_keypair_v2.go
@@ -39,6 +39,7 @@ func resourceComputeKeypairV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_compute_servergroup_v2.go
+++ b/huaweicloud/resource_huaweicloud_compute_servergroup_v2.go
@@ -46,6 +46,7 @@ func resourceComputeServerGroupV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/resource_huaweicloud_csbs_backup_policy_v1.go
@@ -54,9 +54,10 @@ func resourceCSBSBackupPolicyV1() *schema.Resource {
 			"common": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"scheduled_operation": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -328,7 +329,7 @@ func waitForVBSPolicyDelete(policyClient *golangsdk.ServiceClient, policyID stri
 }
 
 func resourceCSBSScheduleV1(d *schema.ResourceData) []policies.ScheduledOperation {
-	scheduledOperations := d.Get("scheduled_operation").(*schema.Set).List()
+	scheduledOperations := d.Get("scheduled_operation").([]interface{})
 	so := make([]policies.ScheduledOperation, len(scheduledOperations))
 	for i, raw := range scheduledOperations {
 		rawMap := raw.(map[string]interface{})
@@ -370,8 +371,8 @@ func resourceCSBSResourceV1(d *schema.ResourceData) []policies.Resource {
 func resourceCSBScheduleUpdateV1(d *schema.ResourceData) []policies.ScheduledOperationToUpdate {
 
 	oldSORaw, newSORaw := d.GetChange("scheduled_operation")
-	oldSOList := oldSORaw.(*schema.Set).List()
-	newSOSetList := newSORaw.(*schema.Set).List()
+	oldSOList := oldSORaw.([]interface{})
+	newSOSetList := newSORaw.([]interface{})
 
 	schedule := make([]policies.ScheduledOperationToUpdate, len(newSOSetList))
 	for i, raw := range newSOSetList {

--- a/huaweicloud/resource_huaweicloud_css_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_css_cluster_v1.go
@@ -155,6 +155,7 @@ func resourceCssClusterV1() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"created": {

--- a/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2.go
@@ -56,6 +56,7 @@ func resourceDNSPtrRecordV2() *schema.Resource {
 				Optional:     true,
 				ForceNew:     false,
 				ValidateFunc: validateECSTagValue,
+				Elem:         &schema.Schema{Type: schema.TypeString},
 			},
 			"address": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -76,6 +76,7 @@ func resourceDNSRecordSetV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_dns_zone_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2.go
@@ -92,6 +92,7 @@ func resourceDNSZoneV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
@@ -194,6 +194,7 @@ func resourceEcsInstanceV1() *schema.Resource {
 				Type:         schema.TypeMap,
 				Optional:     true,
 				ValidateFunc: validateECSTagValue,
+				Elem:         &schema.Schema{Type: schema.TypeString},
 			},
 			"auto_recovery": {
 				Type:     schema.TypeBool,

--- a/huaweicloud/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/resource_huaweicloud_evs_volume.go
@@ -85,6 +85,7 @@ func resourceEvsStorageVolumeV3() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"attachment": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/resource_huaweicloud_fw_firewall_group_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_firewall_group_v2.go
@@ -73,6 +73,7 @@ func resourceFWFirewallGroupV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_fw_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_policy_v2.go
@@ -64,6 +64,7 @@ func resourceFWPolicyV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_fw_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_rule_v2.go
@@ -79,6 +79,7 @@ func resourceFWRuleV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/resource_huaweicloud_images_image_v2.go
@@ -94,6 +94,7 @@ func resourceImagesImageV2() *schema.Resource {
 			"metadata": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"min_disk_gb": {

--- a/huaweicloud/resource_huaweicloud_networking_floatingip_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_floatingip_v2.go
@@ -74,6 +74,7 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_networking_network_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_network_v2.go
@@ -88,6 +88,7 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_port_v2.go
@@ -152,6 +152,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"all_fixed_ips": {
 				Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_networking_router_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_router_v2.go
@@ -92,6 +92,7 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_subnet_v2.go
@@ -142,6 +142,7 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -244,6 +244,7 @@ func resourceObsBucket() *schema.Resource {
 			"tags": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"force_destroy": {

--- a/huaweicloud/resource_huaweicloud_rds_configuration_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_configuration_v3.go
@@ -40,6 +40,7 @@ func resourceRdsConfigurationV3() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"datastore": {
 				Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_rts_software_config_v1.go
+++ b/huaweicloud/resource_huaweicloud_rts_software_config_v1.go
@@ -50,18 +50,25 @@ func resourceSoftwareConfigV1() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"input_values": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
 			},
 			"output_values": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Elem: &schema.Schema{Type: schema.TypeString},
+				},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_rts_stack_v1.go
+++ b/huaweicloud/resource_huaweicloud_rts_stack_v1.go
@@ -59,6 +59,7 @@ func resourceRTSStackV1() *schema.Resource {
 			"files": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"environment": {
 				Type:         schema.TypeString,
@@ -73,6 +74,7 @@ func resourceRTSStackV1() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"timeout_mins": {
 				Type:     schema.TypeInt,
@@ -95,6 +97,7 @@ func resourceRTSStackV1() *schema.Resource {
 			"outputs": {
 				Type:     schema.TypeMap,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"capabilities": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
@@ -61,6 +61,7 @@ func resourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_vpc_eip_v1.go
+++ b/huaweicloud/resource_huaweicloud_vpc_eip_v1.go
@@ -107,6 +107,7 @@ func resourceVpcEIPV1() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_vpnaas_endpoint_group_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_endpoint_group_v2.go
@@ -64,6 +64,7 @@ func resourceVpnEndpointGroupV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_vpnaas_ike_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_ike_policy_v2.go
@@ -94,6 +94,7 @@ func resourceVpnIKEPolicyV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
@@ -95,6 +95,7 @@ func resourceVpnIPSecPolicyV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_vpnaas_service_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_service_v2.go
@@ -61,7 +61,6 @@ func resourceVpnServiceV2() *schema.Resource {
 			"router_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				Computed: false,
 				ForceNew: true,
 			},
 			"status": {
@@ -80,6 +79,7 @@ func resourceVpnServiceV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_vpnaas_site_connection.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_site_connection.go
@@ -135,6 +135,7 @@ func resourceVpnSiteConnectionV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/huaweicloud/tags.go
+++ b/huaweicloud/tags.go
@@ -11,6 +11,7 @@ func tagsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
 }
 


### PR DESCRIPTION
Fix lint:
S006: schema of TypeMap should include Elem
S018: schema should use TypeList with MaxItems 1
S019: schema should omit Computed, Optional, or Required set to false
S024: ForceNew is extraneous in data source schema attributes

Test result:
make testacc TEST=./huaweicloud/ TESTARGS='-run TestAccNetworkingV2Network_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccNetworkingV2Network_basic -timeout 360m
=== RUN   TestAccNetworkingV2Network_basic
    provider_test.go:62: This environment does not support deprecated tests
--- SKIP: TestAccNetworkingV2Network_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.034s

make testacc TEST=./huaweicloud/ TESTARGS='-run TestAccHuaweiCloudImagesV2ImageDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccHuaweiCloudImagesV2ImageDataSource_basic -timeout 360m
=== RUN   TestAccHuaweiCloudImagesV2ImageDataSource_basic
--- PASS: TestAccHuaweiCloudImagesV2ImageDataSource_basic (429.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       429.815s