### PR TITLE
Fix standard validation checks

### DIFF
--- a/huaweicloud/resource_huaweicloud_as_configuration_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_configuration_v1.go
@@ -440,6 +440,7 @@ func resourceASConfigurationValidateVolumeType(v interface{}, k string) (ws []st
 	return
 }
 
+//lintignore:V001
 func resourceASConfigurationValidateName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 64 || len(value) < 1 {

--- a/huaweicloud/resource_huaweicloud_as_group_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_group_v1.go
@@ -771,6 +771,7 @@ func resourceASGroupValidateHealthAuditTime(v interface{}, k string) (ws []strin
 	return
 }
 
+//lintignore:V001
 func resourceASGroupValidateGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 64 || len(value) < 1 {

--- a/huaweicloud/resource_huaweicloud_as_policy_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_policy_v1.go
@@ -353,6 +353,7 @@ func resourceASPolicyValidatePolicyType(v interface{}, k string) (ws []string, e
 	return
 }
 
+//lintignore:V001
 func resourceASPolicyValidateName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 64 || len(value) < 1 {

--- a/huaweicloud/resource_huaweicloud_elb_healthcheck.go
+++ b/huaweicloud/resource_huaweicloud_elb_healthcheck.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/healthcheck"
 )
 
@@ -47,14 +48,8 @@ func resourceELBHealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					vv := regexp.MustCompile("^/[a-zA-Z0-9-/.%?#&_=]{0,79}$")
-					if !vv.MatchString(value) {
-						errors = append(errors, fmt.Errorf("%s is a string of 1 to 80 characters that must start with a slash (/) and can only contain letters, digits, and special characters such as -/.%%?#&_=", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^/[a-zA-Z0-9-/.%?#&_=]{0,79}$"),
+					"Input is a string of 1 to 80 characters that must start with a slash (/) and can only contain letters, digits, and special characters such as -/.%%?#&_="),
 			},
 
 			"healthcheck_connect_port": {

--- a/huaweicloud/resource_huaweicloud_elb_listener.go
+++ b/huaweicloud/resource_huaweicloud_elb_listener.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/listeners"
 )
 
@@ -32,28 +33,16 @@ func resourceELBListener() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					vv := regexp.MustCompile("^[a-zA-Z0-9-_]{1,64}$")
-					if !vv.MatchString(value) {
-						errors = append(errors, fmt.Errorf("%s is a string of 1 to 64 characters that consist of letters, digits, underscores (_), and hyphens (-)", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9-_]{1,64}$"),
+					"Input is a string of 1 to 64 characters that consist of letters, digits, underscores (_), and hyphens (-)"),
 			},
 
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					vv := regexp.MustCompile("^[^<>]{0,128}$")
-					if !vv.MatchString(value) {
-						errors = append(errors, fmt.Errorf("%s is a string of 0 to 128 characters and cannot contain angle brackets (<>)", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{0,128}$"),
+					"Input is a string of 0 to 128 characters and cannot contain angle brackets (<>)"),
 			},
 
 			"loadbalancer_id": {

--- a/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/loadbalancers"
 )
@@ -33,28 +34,16 @@ func resourceELBLoadBalancer() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					vv := regexp.MustCompile("^[a-zA-Z0-9-_]{1,64}$")
-					if !vv.MatchString(value) {
-						errors = append(errors, fmt.Errorf("%s is a string of 1 to 64 characters that consist of letters, digits, underscores (_), and hyphens (-)", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9-_]{1,64}$"),
+					"Input is a string of 1 to 64 characters that consist of letters, digits, underscores (_), and hyphens (-)"),
 			},
 
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					vv := regexp.MustCompile("^[^<>]{0,128}$")
-					if !vv.MatchString(value) {
-						errors = append(errors, fmt.Errorf("%s is a string of 0 to 128 characters and cannot contain angle brackets (<>)", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{0,128}$"),
+					"Input is a string of 0 to 128 characters and cannot contain angle brackets (<>)"),
 			},
 
 			"vpc_id": {
@@ -139,14 +128,8 @@ func resourceELBLoadBalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					vv := regexp.MustCompile("^[a-zA-Z0-9-]{1,200}$")
-					if !vv.MatchString(value) {
-						errors = append(errors, fmt.Errorf("%s is a string of 1 to 200 characters that consists of uppercase and lowercase letters, digits, and hyphens (-)", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9-]{1,200}$"),
+					"Input is a string of 1 to 200 characters that consists of uppercase and lowercase letters, digits, and hyphens (-)"),
 			},
 
 			"vip_address": {

--- a/huaweicloud/validators.go
+++ b/huaweicloud/validators.go
@@ -108,6 +108,7 @@ func validateStackTemplate(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+//lintignore:V001
 func validateName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 64 {
@@ -154,6 +155,7 @@ func validateIP(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+//lintignore:V001
 func validateVBSPolicyName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if strings.HasPrefix(strings.ToLower(value), "default") {
@@ -210,6 +212,7 @@ func validateVBSPolicyRetainBackup(v interface{}, k string) (ws []string, errors
 	return
 }
 
+//lintignore:V001
 func validateVBSTagKey(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
@@ -226,6 +229,7 @@ func validateVBSTagKey(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+//lintignore:V001
 func validateVBSTagValue(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
@@ -242,6 +246,7 @@ func validateVBSTagValue(v interface{}, k string) (ws []string, errors []error) 
 	return
 }
 
+//lintignore:V001
 func validateVBSBackupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if strings.HasPrefix(strings.ToLower(value), "autobk") {
@@ -262,6 +267,7 @@ func validateVBSBackupName(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+//lintignore:V001
 func validateVBSBackupDescription(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 64 {
@@ -277,6 +283,7 @@ func validateVBSBackupDescription(v interface{}, k string) (ws []string, errors 
 	return
 }
 
+//lintignore:V001
 func validateECSTagValue(v interface{}, k string) (ws []string, errors []error) {
 	tagmap := v.(map[string]interface{})
 	vv := regexp.MustCompile(`^[0-9a-zA-Z-_]+$`)


### PR DESCRIPTION
Fix lint:
V001: custom SchemaValidateFunc should be replaced with validation.StringMatch() or validation.StringDoesNotMatch()
