### PR TITLE
Add data source of obs bucket object

### DIFF
--- a/huaweicloud/data_source_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/data_source_huaweicloud_obs_bucket_object.go
@@ -1,0 +1,119 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+func dataSourceObsBucketObject() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceObsBucketObjectRead,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"storage_class": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"content_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"version_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// Attribute parameters are not returned in one interface.
+// Two interfaces need to be called to get all parameters.
+func dataSourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+	key := d.Get("key").(string)
+
+	objects, err := obsClient.ListObjects(&obs.ListObjectsInput{
+		Bucket: bucket,
+		ListObjsInput: obs.ListObjsInput{
+			Prefix: key,
+		},
+	})
+	if err != nil {
+		return getObsError("Error listing objects of OBS bucket", bucket, err)
+	}
+
+	var exist bool
+	var objectContent obs.Content
+	for _, content := range objects.Contents {
+		if key == content.Key {
+			exist = true
+			objectContent = content
+			break
+		}
+	}
+	if !exist {
+		d.SetId("")
+		return fmt.Errorf("object %s not found in bucket %s", key, bucket)
+	}
+
+	log.Printf("[DEBUG] Data Source Reading OBS Bucket Object %s: %#v", key, objectContent)
+
+	object, err := obsClient.GetObject(&obs.GetObjectInput{
+		GetObjectMetadataInput: obs.GetObjectMetadataInput{
+			Bucket: bucket,
+			Key:    key,
+		},
+	})
+	if err != nil {
+		return getObsError("Error get object info of OBS bucket", bucket, err)
+	}
+
+	log.Printf("[DEBUG] Data Source Reading OBS Bucket Object : %#v", object)
+
+	d.SetId(key)
+	d.Set("size", objectContent.Size)
+	d.Set("etag", strings.Trim(objectContent.ETag, `"`))
+	d.Set("version_id", object.VersionId)
+	d.Set("content_type", object.ContentType)
+
+	class := string(objectContent.StorageClass)
+	if class == "" {
+		d.Set("storage_class", "STANDARD")
+	} else {
+		d.Set("storage_class", normalizeStorageClass(class))
+	}
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/data_source_huaweicloud_obs_bucket_object_test.go
@@ -1,0 +1,226 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/obs"
+)
+
+func TestAccHuaweiCloudObsBucketObjectDataSource_content(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceConf, dataSourceConf := testAccHuaweiCloudObsBucketObjectDataSource_content(rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheckS3(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("huaweicloud_obs_bucket_object.object"),
+				),
+			},
+			{
+				Config: dataSourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHuaweiCloudObsBucketObjectDataSource_source(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	rInt := acctest.RandInt()
+
+	// write test data to the tempfile
+	for i := 0; i < 1024; i++ {
+		_, err := tmpFile.WriteString("test obs object file storage")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	tmpFile.Close()
+
+	resourceConf, dataSourceConf := testAccHuaweiCloudObsBucketObjectDataSource_source(rInt, tmpFile.Name())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheckS3(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("huaweicloud_obs_bucket_object.object"),
+				),
+			},
+			{
+				Config: dataSourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHuaweiCloudObsBucketObjectDataSource_allParams(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceConf, dataSourceConf := testAccHuaweiCloudObsBucketObjectDataSource_allParams(rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheckS3(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("huaweicloud_obs_bucket_object.object"),
+				),
+			},
+			{
+				Config: dataSourceConf,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "application/unknown"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "body", "\t{\"msg\": \"Hi there!\"}\n"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Obs object data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Obs object data source ID not set")
+		}
+
+		bucket := rs.Primary.Attributes["bucket"]
+		key := rs.Primary.Attributes["key"]
+
+		config := testAccProvider.Meta().(*Config)
+		obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		}
+
+		respList, err := obsClient.ListObjects(&obs.ListObjectsInput{
+			Bucket: bucket,
+			ListObjsInput: obs.ListObjsInput{
+				Prefix: key,
+			},
+		})
+		if err != nil {
+			return getObsError("Error listing objects of OBS bucket", bucket, err)
+		}
+
+		var exist bool
+		for _, content := range respList.Contents {
+			if key == content.Key {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			return fmt.Errorf("object %s not found in bucket %s", key, bucket)
+		}
+
+		return nil
+	}
+}
+
+func testAccHuaweiCloudObsBucketObjectDataSource_content(randInt int) (string, string) {
+	resource := fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+resource "huaweicloud_obs_bucket_object" "object" {
+	bucket = huaweicloud_obs_bucket.object_bucket.bucket
+	key = "test-key-%d"
+	content = "some_bucket_content"
+}
+`, randInt, randInt)
+
+	dataSource := fmt.Sprintf(`%s
+data "huaweicloud_obs_bucket_object" "obj" {
+	bucket = "tf-object-test-bucket-%d"
+	key = "test-key-%d"
+}`, resource, randInt, randInt)
+
+	return resource, dataSource
+}
+
+func testAccHuaweiCloudObsBucketObjectDataSource_source(randInt int, source string) (string, string) {
+	resource := fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+resource "huaweicloud_obs_bucket_object" "object" {
+	bucket = huaweicloud_obs_bucket.object_bucket.bucket
+	key = "test-key-%d"
+	source = "%s"
+	content_type = "binary/octet-stream"
+}
+`, randInt, randInt, source)
+
+	dataSource := fmt.Sprintf(`%s
+data "huaweicloud_obs_bucket_object" "obj" {
+	bucket = "tf-object-test-bucket-%d"
+	key = "test-key-%d"
+}`, resource, randInt, randInt)
+
+	return resource, dataSource
+}
+
+func testAccHuaweiCloudObsBucketObjectDataSource_allParams(randInt int) (string, string) {
+	resource := fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "object_bucket" {
+	bucket = "tf-object-test-bucket-%d"
+}
+resource "huaweicloud_obs_bucket_object" "object" {
+	bucket = huaweicloud_obs_bucket.object_bucket.bucket
+	key = "test-key-%d"
+	content = <<CONTENT
+	{"msg": "Hi there!"}
+CONTENT
+	acl = "private"
+	content_type = "application/unknown"
+	storage_class = "STANDARD"
+	encryption = true
+}
+`, randInt, randInt)
+
+	dataSource := fmt.Sprintf(`%s
+data "huaweicloud_obs_bucket_object" "obj" {
+	bucket = "tf-object-test-bucket-%d"
+	key = "test-key-%d"
+}`, resource, randInt, randInt)
+
+	return resource, dataSource
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -199,6 +199,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_kms_data_key":           dataSourceKmsDataKeyV1(),
 			"huaweicloud_networking_port":        dataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":    dataSourceNetworkingSecGroupV2(),
+			"huaweicloud_obs_bucket_object":      dataSourceObsBucketObject(),
 			"huaweicloud_rds_flavors":            dataSourceRdsFlavorV3(),
 			"huaweicloud_sfs_file_system":        dataSourceSFSFileSystemV2(),
 			"huaweicloud_vpc":                    dataSourceVirtualPrivateCloudVpcV1(),

--- a/website/docs/d/obs_bucket_object.html.markdown
+++ b/website/docs/d/obs_bucket_object.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_obs_bucket_object"
+sidebar_current: "docs-huaweicloud-datasource-obs-bucket-object"
+description: |-
+    Provides metadata and optionally content of an Obs object
+---
+
+# huaweicloud\_obs\_bucket\_object
+
+Use this data source to get info of special HuaweiCloud obs object.
+
+```hcl
+data "huaweicloud_obs_bucket_object" "object" {
+  bucket = "my-test-bucket"
+  key    = "new-key"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to put the file in.
+
+* `key` - (Required) The name of the object once it is in the bucket.
+
+## Attributes Reference
+
+The following attributes are exported
+
+* `id` - the `key` of the resource supplied above.
+* `bucket` -  the name of the bucket to put the file in.
+* `key` - the name of the object once it is in the bucket.
+* `etag` - the ETag generated for the object (an MD5 sum of the object content).
+  When the object is encrypted on the server side, the ETag value is not the MD5 value of the object,
+  but the unique identifier calculated through the server-side encryption.
+* `size` - the size of the object in bytes.
+* `version_id` - a unique version ID value for the object, if bucket versioning is enabled.
+* `storage_class` - specifies the storage class of the object.
+* `content_type` - a standard MIME type describing the format of the object data, e.g. application/octet-stream.
+  All Valid MIME Types are valid for this input.

--- a/website/huaweicloud.erb
+++ b/website/huaweicloud.erb
@@ -744,6 +744,14 @@
           <a href="#">Object Storage Service (OBS)</a>
           <ul class="nav">
             <li>
+              <a href="#">Data Sources</a>
+              <ul class="nav nav-auto-expand">
+                <li>
+                  <a href="/docs/providers/huaweicloud/d/obs_bucket_object.html">huaweicloud_obs_bucket_object</a>
+                </li>
+              </ul>
+            </li>
+            <li>
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
                 <li>


### PR DESCRIPTION
make testacc TEST=./huaweicloud/ TESTARGS='-run TestAccDataSourceAWSObsBucketObject_allParams'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccDataSourceAWSObsBucketObject_allParams -timeout 360m
=== RUN   TestAccDataSourceAWSObsBucketObject_allParams
--- PASS: TestAccDataSourceAWSObsBucketObject_allParams (17.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       17.662s

 make testacc TEST=./huaweicloud/ TESTARGS='-run TestAccDataSourceObsBucketObject_source'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccDataSourceObsBucketObject_source -timeout 360m
=== RUN   TestAccDataSourceObsBucketObject_source
--- PASS: TestAccDataSourceObsBucketObject_source (17.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       17.761s