### PR TITLE
Add network acl resource and docs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20200828025748-cf0b1095edc4
+	github.com/huaweicloud/golangsdk v0.0.0-20200829051431-68dcb72fe133
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20200828025748-cf0b1095edc4 h1:ChlNphU5JsSQv+JO17JT/Gt/Tz0/HbyuSIpB5fQoSmw=
 github.com/huaweicloud/golangsdk v0.0.0-20200828025748-cf0b1095edc4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20200829051431-68dcb72fe133 h1:Z8PaF9gDdps1sbGVc4cynRPzXIEI1WHk0irU25/JBTw=
+github.com/huaweicloud/golangsdk v0.0.0-20200829051431-68dcb72fe133/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -327,6 +327,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_nat_dnat_rule":                   resourceNatDnatRuleV2(),
 			"huaweicloud_nat_gateway":                     resourceNatGatewayV2(),
 			"huaweicloud_nat_snat_rule":                   resourceNatSnatRuleV2(),
+			"huaweicloud_network_acl":                     resourceNetworkACL(),
 			"huaweicloud_network_acl_rule":                resourceNetworkACLRule(),
 			"huaweicloud_networking_eip_associate":        resourceNetworkingFloatingIPAssociateV2(),
 			"huaweicloud_networking_port":                 resourceNetworkingPortV2(),

--- a/huaweicloud/resource_huaweicloud_network_acl.go
+++ b/huaweicloud/resource_huaweicloud_network_acl.go
@@ -1,0 +1,484 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/firewall_groups"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/policies"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/routerinsertion"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
+)
+
+func resourceNetworkACL() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkACLCreate,
+		Read:   resourceNetworkACLRead,
+		Update: resourceNetworkACLUpdate,
+		Delete: resourceNetworkACLDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"inbound_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 10,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"outbound_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 10,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"subnets": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"inbound_policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"outbound_policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ports": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkACLCreate(d *schema.ResourceData, meta interface{}) error {
+	var err error
+	var portIds []string
+	var inboundPolicyID, outboundPolicyID string
+
+	config := meta.(*Config)
+	fwClient, err := config.fwV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
+	}
+
+	defer func() {
+		// delete firewall policies when encounter errors
+		if err != nil && inboundPolicyID != "" {
+			deleteErr := policies.Delete(fwClient, inboundPolicyID).Err
+			if deleteErr != nil {
+				log.Printf("[WARN] Error deleting inbound firewall policy %s: %s", inboundPolicyID, deleteErr)
+			}
+		}
+
+		if err != nil && outboundPolicyID != "" {
+			deleteErr := policies.Delete(fwClient, outboundPolicyID).Err
+			if deleteErr != nil {
+				log.Printf("[WARN] Error deleting outbound firewall policy %s: %s", outboundPolicyID, deleteErr)
+			}
+		}
+	}()
+
+	// get port Ids from subnets
+	subnetsRaw := d.Get("subnets").(*schema.Set).List()
+	if len(subnetsRaw) > 0 {
+		for _, v := range subnetsRaw {
+			port, err := getGWPortFromSubnet(config, v.(string))
+			if err != nil {
+				return err
+			}
+			portIds = append(portIds, port)
+		}
+		log.Printf("[DEBUG] Will attempt to associate Firewall group with subnets: %+v", subnetsRaw)
+	}
+
+	groupName := d.Get("name").(string)
+	// create inbound policy
+	inboundRaw := d.Get("inbound_rules").([]interface{})
+	if len(inboundRaw) > 0 {
+		inboundRules := make([]string, len(inboundRaw))
+		for i, r := range inboundRaw {
+			inboundRules[i] = r.(string)
+		}
+
+		policyName := "inbound_policy_for_" + groupName
+		policyOpts := policies.CreateOpts{
+			Name:  policyName,
+			Rules: inboundRules,
+		}
+
+		log.Printf("[DEBUG] Create inbound firewall policy: %#v", policyOpts)
+		policy, err := policies.Create(fwClient, policyOpts).Extract()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Firewall inbound policy created: %#v", policy)
+		inboundPolicyID = policy.ID
+	}
+
+	// create outbound policy
+	outboundRaw := d.Get("outbound_rules").([]interface{})
+	if len(outboundRaw) > 0 {
+		outboundRules := make([]string, len(outboundRaw))
+		for i, r := range outboundRaw {
+			outboundRules[i] = r.(string)
+		}
+
+		policyName := "outbound_policy_for_" + groupName
+		policyOpts := policies.CreateOpts{
+			Name:  policyName,
+			Rules: outboundRules,
+		}
+
+		log.Printf("[DEBUG] Create outbound firewall policy: %#v", policyOpts)
+		policy, err := policies.Create(fwClient, policyOpts).Extract()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Firewall outbound policy created: %#v", policy)
+		outboundPolicyID = policy.ID
+	}
+
+	var createOpts firewall_groups.CreateOptsBuilder
+	createOpts = &firewall_groups.CreateOpts{
+		Name:            groupName,
+		Description:     d.Get("description").(string),
+		IngressPolicyID: inboundPolicyID,
+		EgressPolicyID:  outboundPolicyID,
+	}
+
+	if len(portIds) > 0 {
+		createOpts = &routerinsertion.CreateOptsExt{
+			CreateOptsBuilder: createOpts,
+			PortIDs:           portIds,
+		}
+	}
+
+	log.Printf("[DEBUG] Create firewall group: %#v", createOpts)
+	group, err := firewall_groups.Create(fwClient, createOpts).Extract()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(group.ID)
+	log.Printf("[DEBUG] waiting for Firewall group (%s) to become ACTIVE", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		// if none subnets was associated with the firewall group, the state will be "INACTIVE"
+		// so we seems the "INACTIVE" as a target state.
+		Pending:    []string{"PENDING_CREATE"},
+		Target:     []string{"ACTIVE", "INACTIVE"},
+		Refresh:    waitForFirewallGroupActive(fwClient, group.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      2,
+		MinTimeout: 2 * time.Second,
+	}
+	_, stateErr := stateConf.WaitForState()
+	if stateErr != nil {
+		return fmt.Errorf("Error waiting for Firewall group (%s) to become ACTIVE: %s",
+			d.Id(), stateErr)
+	}
+
+	log.Printf("[DEBUG] Firewall group (%s) is active.", group.ID)
+	return resourceNetworkACLRead(d, meta)
+}
+
+func resourceNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	fwClient, err := config.fwV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
+	}
+
+	var fwGroup FirewallGroup
+	err = firewall_groups.Get(fwClient, d.Id()).ExtractInto(&fwGroup)
+	if err != nil {
+		return CheckDeleted(d, err, "firewall")
+	}
+
+	log.Printf("[DEBUG] Read HuaweiCloud Firewall group %s: %#v", d.Id(), fwGroup)
+
+	d.Set("name", fwGroup.Name)
+	d.Set("status", fwGroup.Status)
+	d.Set("description", fwGroup.Description)
+	d.Set("inbound_policy_id", fwGroup.IngressPolicyID)
+	d.Set("outbound_policy_id", fwGroup.EgressPolicyID)
+	if err := d.Set("ports", fwGroup.PortIDs); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving ports to state for HuaweiCloud firewall group (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceNetworkACLUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	fwClient, err := config.fwV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
+	}
+
+	// first of all, inbound_policy/rules and outbound_policy/rules should be updated
+	if d.HasChange("inbound_rules") {
+		err := updateNetworkACLPolicyRules(d, fwClient, "inbind")
+		if err != nil {
+			return err
+		}
+	}
+	if d.HasChange("outbound_rules") {
+		err := updateNetworkACLPolicyRules(d, fwClient, "outbind")
+		if err != nil {
+			return err
+		}
+	}
+
+	// update other parameters
+	var changed bool
+	opts := firewall_groups.UpdateOpts{}
+	if d.HasChanges("name", "description") {
+		changed = true
+		opts.Name = d.Get("name").(string)
+		opts.Description = d.Get("description").(string)
+	}
+
+	var updateOpts firewall_groups.UpdateOptsBuilder
+	var portIds []string
+	if d.HasChange("subnets") {
+		changed = true
+
+		// get port Ids from subnets
+		subnetsRaw := d.Get("subnets").(*schema.Set).List()
+		for _, v := range subnetsRaw {
+			port, err := getGWPortFromSubnet(config, v.(string))
+			if err != nil {
+				return err
+			}
+			portIds = append(portIds, port)
+		}
+		log.Printf("[DEBUG] Will attempt to associate Firewall group with subnets: %+v", subnetsRaw)
+
+		updateOpts = routerinsertion.UpdateOptsExt{
+			UpdateOptsBuilder: opts,
+			PortIDs:           portIds,
+		}
+	} else {
+		updateOpts = opts
+	}
+
+	if changed {
+		log.Printf("[DEBUG] Updating firewall with id %s: %#v", d.Id(), updateOpts)
+		err = firewall_groups.Update(fwClient, d.Id(), updateOpts).Err
+		if err != nil {
+			return err
+		}
+
+		// if none subnets was associated with the firewall group, the state will be "INACTIVE"
+		// so we seems the "INACTIVE" as a target state.
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
+			Target:     []string{"ACTIVE", "INACTIVE"},
+			Refresh:    waitForFirewallGroupActive(fwClient, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      2,
+			MinTimeout: 2 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf("Error updating firewall group (%s): %s", d.Id(), err)
+		}
+	}
+
+	return resourceNetworkACLRead(d, meta)
+}
+
+func resourceNetworkACLDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Destroy firewall group: %s", d.Id())
+
+	config := meta.(*Config)
+	fwClient, err := config.fwV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
+	}
+
+	inboundPolicyID := d.Get("inbound_policy_id").(string)
+	outboundPolicyID := d.Get("outbound_policy_id").(string)
+
+	err = firewall_groups.Delete(fwClient, d.Id()).Err
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"DELETING"},
+		Target:     []string{"DELETED"},
+		Refresh:    waitForFirewallGroupDeletion(fwClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      2,
+		MinTimeout: 2 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error deleting firewall group (%s): %s", d.Id(), err)
+	}
+
+	// delete firewall policies after the firewall group
+	if inboundPolicyID != "" {
+		deleteErr := policies.Delete(fwClient, inboundPolicyID).Err
+		if deleteErr != nil {
+			log.Printf("[WARN] Error deleting inbound firewall policy %s: %s", inboundPolicyID, deleteErr)
+		}
+	}
+
+	if outboundPolicyID != "" {
+		deleteErr := policies.Delete(fwClient, outboundPolicyID).Err
+		if deleteErr != nil {
+			log.Printf("[WARN] Error deleting outbound firewall policy %s: %s", outboundPolicyID, deleteErr)
+		}
+	}
+
+	d.SetId("")
+	return err
+}
+
+func getGWPortFromSubnet(config *Config, subnetID string) (string, error) {
+	var gatewayIP string
+	var gatewayPort string
+
+	subnetClient, err := config.networkingV1Client(config.Region)
+	if err != nil {
+		return "", fmt.Errorf("Error creating Huaweicloud vpc client: %s", err)
+	}
+	networkingClient, err := config.networkingV2Client(config.Region)
+	if err != nil {
+		return "", fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	// get Gateway IP
+	n, err := subnets.Get(subnetClient, subnetID).Extract()
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving Huaweicloud subnet %s: %s", subnetID, err)
+	}
+	gatewayIP = n.GatewayIP
+	log.Printf("[DEBUG] the gateway IP address of subnet %s is %s", subnetID, gatewayIP)
+
+	// list all ports in the subnet
+	listOpts := ports.ListOpts{
+		NetworkID: subnetID,
+		//Status:    "ACTIVE",
+	}
+	allPages, err := ports.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return "", fmt.Errorf("Unable to list Huaweicloud ports of %s: %s", subnetID, err)
+	}
+
+	var allPorts []ports.Port
+	err = ports.ExtractPortsInto(allPages, &allPorts)
+	if err != nil {
+		return "", fmt.Errorf("Unable to retrieve Huaweicloud ports of %s: %s", subnetID, err)
+	}
+
+	if len(allPorts) == 0 {
+		return "", fmt.Errorf("No ports was found in %s", subnetID)
+	}
+
+	// Filter IPs by the gatewayIP
+	var isExist bool
+	for _, p := range allPorts {
+		for _, ipObject := range p.FixedIPs {
+			if ipObject.IPAddress == gatewayIP {
+				isExist = true
+				gatewayPort = p.ID
+				log.Printf("[DEBUG] the gateway port of subnet %s is %s", subnetID, gatewayPort)
+				break
+			}
+		}
+		if isExist {
+			break
+		}
+	}
+	if !isExist {
+		return "", fmt.Errorf("No gateway port was found in %s", subnetID)
+	}
+
+	return gatewayPort, nil
+}
+
+func updateNetworkACLPolicyRules(d *schema.ResourceData, client *golangsdk.ServiceClient, direct string) error {
+	var policyKey, rulesKey string
+
+	if direct == "inbind" {
+		policyKey = "inbound_policy_id"
+		rulesKey = "inbound_rules"
+	} else {
+		policyKey = "outbound_policy_id"
+		rulesKey = "outbound_rules"
+	}
+
+	groupName := d.Get("name").(string)
+	policyID := d.Get(policyKey).(string)
+	policyName := direct + "_policy_for_" + groupName
+
+	v := d.Get(rulesKey).([]interface{})
+	rulesList := make([]string, len(v))
+	for i, v := range v {
+		rulesList[i] = v.(string)
+	}
+
+	if policyID != "" {
+		// update the firewall policy, even if the rules are empty
+		policyOpts := policies.UpdateOpts{
+			Name:  policyName,
+			Rules: rulesList,
+		}
+
+		log.Printf("[DEBUG] updating firewall policy with id %s: %#v", policyID, policyOpts)
+		err := policies.Update(client, policyID, policyOpts).Err
+		if err != nil {
+			return fmt.Errorf("Error updating firewall policy %s: %s", policyID, err)
+		}
+	} else {
+		// create new firewall policy
+		policyOpts := policies.CreateOpts{
+			Name:  policyName,
+			Rules: rulesList,
+		}
+
+		log.Printf("[DEBUG] Create firewall policy: %#v", policyOpts)
+		policy, err := policies.Create(client, policyOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error creating firewall policy: %s", err)
+		}
+
+		d.Set(policyKey, policy.ID)
+	}
+
+	return nil
+}

--- a/huaweicloud/resource_huaweicloud_network_acl_test.go
+++ b/huaweicloud/resource_huaweicloud_network_acl_test.go
@@ -1,0 +1,240 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/firewall_groups"
+)
+
+func TestAccNetworkACL_basic(t *testing.T) {
+	rName := fmt.Sprintf("acc-fw-%s", acctest.RandString(5))
+	resourceKey := "huaweicloud_network_acl.fw_1"
+	var fwGroup FirewallGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkACL_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLExists(resourceKey, &fwGroup),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName),
+					resource.TestCheckResourceAttr(resourceKey, "description", "created by terraform test acc"),
+					resource.TestCheckResourceAttr(resourceKey, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet(resourceKey, "inbound_policy_id"),
+					testAccCheckFWFirewallPortCount(&fwGroup, 1),
+				),
+			},
+			{
+				Config: testAccNetworkACL_basic_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLExists("huaweicloud_network_acl.fw_1", &fwGroup),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceKey, "description", "updated by terraform test acc"),
+					resource.TestCheckResourceAttr(resourceKey, "status", "ACTIVE"),
+					testAccCheckFWFirewallPortCount(&fwGroup, 2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkACL_no_subnets(t *testing.T) {
+	rName := fmt.Sprintf("acc-fw-%s", acctest.RandString(5))
+	resourceKey := "huaweicloud_network_acl.fw_1"
+	var fwGroup FirewallGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkACL_no_subnets(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLExists(resourceKey, &fwGroup),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName),
+					resource.TestCheckResourceAttr(resourceKey, "description", "network acl without subents"),
+					resource.TestCheckResourceAttr(resourceKey, "status", "INACTIVE"),
+					testAccCheckFWFirewallPortCount(&fwGroup, 0),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkACL_remove(t *testing.T) {
+	rName := fmt.Sprintf("acc-fw-%s", acctest.RandString(5))
+	resourceKey := "huaweicloud_network_acl.fw_1"
+	var fwGroup FirewallGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkACL_basic_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLExists("huaweicloud_network_acl.fw_1", &fwGroup),
+					resource.TestCheckResourceAttr(resourceKey, "status", "ACTIVE"),
+					testAccCheckFWFirewallPortCount(&fwGroup, 2),
+				),
+			},
+			{
+				Config: testAccNetworkACL_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLExists("huaweicloud_network_acl.fw_1", &fwGroup),
+					resource.TestCheckResourceAttr(resourceKey, "status", "ACTIVE"),
+					testAccCheckFWFirewallPortCount(&fwGroup, 1),
+				),
+			},
+			{
+				Config: testAccNetworkACL_no_subnets(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLExists(resourceKey, &fwGroup),
+					resource.TestCheckResourceAttr(resourceKey, "status", "INACTIVE"),
+					testAccCheckFWFirewallPortCount(&fwGroup, 0),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkACLDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	fwClient, err := config.fwV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_network_acl" {
+			continue
+		}
+
+		_, err = firewall_groups.Get(fwClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Firewall group (%s) still exists.", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckNetworkACLExists(n string, fwGroup *FirewallGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set in %s", n)
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		fwClient, err := config.fwV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
+		}
+
+		var found FirewallGroup
+		err = firewall_groups.Get(fwClient, rs.Primary.ID).ExtractInto(&found)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Firewall group not found")
+		}
+
+		*fwGroup = found
+
+		return nil
+	}
+}
+
+const testAccNetworkACLRules = `
+resource "huaweicloud_vpc_v1" "vpc_1" {
+  name = "acc_vpc_test"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet_v1" "subnet_1" {
+  name = "acc_subnet_1"
+  cidr = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id = huaweicloud_vpc_v1.vpc_1.id
+}
+
+resource "huaweicloud_vpc_subnet_v1" "subnet_2" {
+	name = "acc_subnet_2"
+	cidr = "192.168.10.0/24"
+	gateway_ip = "192.168.10.1"
+	vpc_id = huaweicloud_vpc_v1.vpc_1.id
+  }
+
+resource "huaweicloud_network_acl_rule" "rule_1" {
+  name             = "my-rule-1"
+  description      = "drop TELNET traffic"
+  action           = "deny"
+  protocol         = "tcp"
+  destination_port = "23"
+}
+
+resource "huaweicloud_network_acl_rule" "rule_2" {
+  name             = "my-rule-2"
+  description      = "drop NTP traffic"
+  action           = "deny"
+  protocol         = "udp"
+  destination_port = "123"
+}
+`
+
+func testAccNetworkACL_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_network_acl" "fw_1" {
+  name        = "%s"
+  description = "created by terraform test acc"
+
+  inbound_rules = [huaweicloud_network_acl_rule.rule_1.id]
+  subnets = [huaweicloud_vpc_subnet_v1.subnet_1.id]
+}
+`, testAccNetworkACLRules, name)
+}
+
+func testAccNetworkACL_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_network_acl" "fw_1" {
+  name        = "%s_update"
+  description = "updated by terraform test acc"
+
+  inbound_rules = [huaweicloud_network_acl_rule.rule_1.id,
+      huaweicloud_network_acl_rule.rule_2.id]
+  subnets = [huaweicloud_vpc_subnet_v1.subnet_1.id,
+      huaweicloud_vpc_subnet_v1.subnet_2.id]
+}
+`, testAccNetworkACLRules, name)
+}
+
+func testAccNetworkACL_no_subnets(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_network_acl" "fw_1" {
+  name        = "%s"
+  description = "network acl without subents"
+}
+`, name)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/policies/requests.go
@@ -111,7 +111,7 @@ type UpdateOpts struct {
 	Description string   `json:"description,omitempty"`
 	Shared      *bool    `json:"shared,omitempty"`
 	Audited     *bool    `json:"audited,omitempty"`
-	Rules       []string `json:"firewall_rules,omitempty"`
+	Rules       []string `json:"firewall_rules"`
 }
 
 // ToFirewallPolicyUpdateMap casts a CreateOpts struct to a map.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20200828025748-cf0b1095edc4
+# github.com/huaweicloud/golangsdk v0.0.0-20200829051431-68dcb72fe133
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_network_acl"
+sidebar_current: "docs-huaweicloud-resource-network-acl"
+description: |-
+  Manages a network ACL resource within HuaweiCloud.
+---
+
+# huaweicloud\_network\_acl
+
+Manages a network ACL resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_vpc_subnet_v1" "subnet" {
+  name = "my_subnet"
+}
+
+resource "huaweicloud_network_acl_rule" "rule_1" {
+  name             = "my-rule-1"
+  description      = "drop TELNET traffic"
+  action           = "deny"
+  protocol         = "tcp"
+  destination_port = "23"
+  enabled          = "true"
+}
+
+resource "huaweicloud_network_acl_rule" "rule_2" {
+  name             = "my-rule-2"
+  description      = "drop NTP traffic"
+  action           = "deny"
+  protocol         = "udp"
+  destination_port = "123"
+  enabled          = "false"
+}
+
+resource "huaweicloud_network_acl" "fw_acl" {
+  name          = "my-fw-acl"
+  subnets       = [data.huaweicloud_vpc_subnet_v1.subnet.id]
+  inbound_rules = [huaweicloud_network_acl_rule.rule_1.id,
+    huaweicloud_network_acl_rule.rule_2.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the network ACL name. This parameter can contain a maximum of 64 characters,
+    which may consist of letters, digits, underscores (_), and hyphens (-).
+
+* `description` - (Optional) Specifies the supplementary information about the network ACL.
+    This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
+
+* `inbound_rules` - (Optional)  A list of the IDs of ingress rules associated with the network ACL. 
+
+* `outbound_rules` - (Optional) A list of the IDs of egress rules associated with the network ACL. 
+
+* `subnets` - (Optional) A list of the IDs of networks associated with the network ACL. 
+
+## Attributes Reference
+
+All of the argument attributes are also exported as result attributes:
+
+* `id` - The ID of the network ACL.
+* `inbound_policy_id` - The ID of the ingress firewall policy for the network ACL.
+* `outbound_policy_id` - The ID of the egress firewall policy for the network ACL.
+* `ports` - A list of the port IDs of the subnet gateway.
+* `status` - The status of the network ACL. 

--- a/website/huaweicloud.erb
+++ b/website/huaweicloud.erb
@@ -716,6 +716,9 @@
               <a href="#">Resources</a>
               <ul class="nav nav-auto-expand">
                 <li>
+                  <a href="/docs/providers/huaweicloud/r/network_acl.html">huaweicloud_network_acl</a>
+                </li>
+                <li>
                   <a href="/docs/providers/huaweicloud/r/network_acl_rule.html">huaweicloud_network_acl_rule</a>
                 </li>
                 <li>


### PR DESCRIPTION
support the network acl resource, the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkACL_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkACL_basic -timeout 360m
=== RUN   TestAccNetworkACL_basic
--- PASS: TestAccNetworkACL_basic (68.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       69.020s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkACL_remove'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkACL_remove -timeout 360m
=== RUN   TestAccNetworkACL_remove
--- PASS: TestAccNetworkACL_remove (142.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       142.090s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkACL_no_subnets'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkACL_no_subnets -timeout 360m
=== RUN   TestAccNetworkACL_no_subnets
--- PASS: TestAccNetworkACL_no_subnets (6.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       6.703s
```