### PR TITLE
precheck OS_USERGROUP_NAME environment for iam acctest

### DIFF
--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -64,9 +64,9 @@ func testAccPreCheckDeprecated(t *testing.T) {
 }
 
 func testAccPreCheckAdminOnly(t *testing.T) {
-	v := os.Getenv("OS_USERNAME")
+	v := os.Getenv("OS_USERGROUP_NAME")
 	if v != "admin" {
-		t.Skip("Skipping test because it requires the admin user")
+		t.Skip("Skipping test because it requires the admin user group")
 	}
 }
 


### PR DESCRIPTION
we must set `OS_USERGROUP_NAME` to admin before testing iam resources.