### PR TITLE
Add a Sleep to GaussDB after creation

### DIFF
--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -327,6 +327,9 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
+	// This is a workaround to avoid db connection issue
+	time.Sleep(360 * time.Second)
+
 	return resourceGeminiDBInstanceV3Read(d, meta)
 }
 

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -313,6 +313,9 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	// This is a workaround to avoid db connection issue
+	time.Sleep(360 * time.Second)
+
 	return resourceGaussDBInstanceRead(d, meta)
 }
 

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -389,6 +389,9 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 			id, err)
 	}
 
+	// This is a workaround to avoid db connection issue
+	time.Sleep(360 * time.Second)
+
 	return resourceOpenGaussInstanceRead(d, meta)
 }
 


### PR DESCRIPTION
This adds a sleep to avoid db connection issue after creation.