### PR TITLE
Add NewServiceClient as a common method to create service client

### DIFF
--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_configuration.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_configuration.go
@@ -36,7 +36,7 @@ func dataSourceGaussdbMysqlConfigurations() *schema.Resource {
 func dataSourceGaussdbMysqlConfigurationsRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	client, err := config.initServiceClient("gaussdb", GetRegion(d, config), "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 	}

--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
@@ -62,7 +62,7 @@ func dataSourceGaussdbMysqlFlavors() *schema.Resource {
 func dataSourceGaussdbMysqlFlavorsRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	client, err := config.initServiceClient("gaussdb", GetRegion(d, config), "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 	}

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -1,0 +1,59 @@
+package huaweicloud
+
+// ServiceCatalog defines a struct which was used to generate a service client for huaweicloud.
+// the endpoint likes https://{Name}.{Region}.myhuaweicloud.com/{Version}/{project_id}/{ResourceBase}
+// For more information, please refer to Config.NewServiceClient
+type ServiceCatalog struct {
+	Name             string
+	Version          string
+	Scope            string
+	ResourceBase     string
+	WithOutProjectID bool
+}
+
+var allServiceCatalog = map[string]ServiceCatalog{
+	"ecs": ServiceCatalog{
+		Name:    "ecs",
+		Version: "v1",
+	},
+	"compute": ServiceCatalog{
+		Name:    "ecs",
+		Version: "v2.1",
+	},
+	"network": ServiceCatalog{
+		Name:    "vpc",
+		Version: "v2.0",
+	},
+	"vpc": ServiceCatalog{
+		Name:    "vpc",
+		Version: "v1",
+	},
+	"volumev2": ServiceCatalog{
+		Name:    "evs",
+		Version: "v2",
+	},
+	"volumev3": ServiceCatalog{
+		Name:    "evs",
+		Version: "v3",
+	},
+	"sfs-turbo": ServiceCatalog{
+		Name:    "sfs-turbo",
+		Version: "v1",
+	},
+	"dcsv2": ServiceCatalog{
+		Name:    "dcs",
+		Version: "v2",
+	},
+	"cassandra": ServiceCatalog{
+		Name:    "gaussdb-nosql",
+		Version: "v3",
+	},
+	"gaussdb": ServiceCatalog{
+		Name:    "gaussdb",
+		Version: "mysql/v3",
+	},
+	"opengauss": ServiceCatalog{
+		Name:    "gaussdb",
+		Version: "opengauss/v3",
+	},
+}

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -79,10 +79,10 @@ func TestAccServiceEndpoints(t *testing.T) {
 	if actualURL != expectedURL {
 		t.Fatalf("GeminiDB endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
-	t.Logf("GeminiDB endpoint:\t %s", actualURL)
+	t.Logf("GeminiDB/Cassandra endpoint:\t %s", actualURL)
 
 	// test the endpoint of gaussdb service
-	serviceClient, err = config.initServiceClient("gaussdb", OS_REGION_NAME, "mysql/v3")
+	serviceClient, err = config.NewServiceClient("gaussdb", OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud gaussdb client: %s", err)
 	}
@@ -106,7 +106,7 @@ func TestAccServiceEndpoints(t *testing.T) {
 	t.Logf("openGauss endpoint:\t %s", actualURL)
 
 	// test the endpoint of DCS v2 service
-	serviceClient, err = config.initServiceClient("dcs", OS_REGION_NAME, "v2")
+	serviceClient, err = config.NewServiceClient("dcsv2", OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud dcs v2 client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
@@ -313,7 +313,7 @@ func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(v.InstanceID)
 
 	// set whitelist
-	dcsV2Client, err := config.initServiceClient("dcs", GetRegion(d, config), "v2")
+	dcsV2Client, err := config.NewServiceClient("dcsv2", GetRegion(d, config))
 	whitelistOpts := getDcsInstanceWhitelist(d)
 	log.Printf("[DEBUG] Create whitelist options: %#v", whitelistOpts)
 
@@ -369,7 +369,7 @@ func resourceDcsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("maintain_end", v.MaintainEnd)
 	d.Set("access_user", v.AccessUser)
 
-	dcsV2Client, err := config.initServiceClient("dcs", GetRegion(d, config), "v2")
+	dcsV2Client, err := config.NewServiceClient("dcsv2", GetRegion(d, config))
 	object, err := whitelists.Get(dcsV2Client, d.Id()).Extract()
 
 	enable := object.Enable
@@ -411,7 +411,7 @@ func resourceDcsInstancesV1Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("whitelists") {
-		dcsV2Client, err := config.initServiceClient("dcs", GetRegion(d, config), "v2")
+		dcsV2Client, err := config.NewServiceClient("dcsv2", GetRegion(d, config))
 		whitelistOpts := getDcsInstanceWhitelist(d)
 		log.Printf("[DEBUG] update whitelist options: %#v", whitelistOpts)
 

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -239,7 +239,7 @@ func GaussDBInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID
 
 func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.initServiceClient("gaussdb", GetRegion(d, config), "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s ", err)
 	}
@@ -322,7 +322,7 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 func resourceGaussDBInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	client, err := config.initServiceClient("gaussdb", region, "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", region)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 	}
@@ -419,7 +419,7 @@ func resourceGaussDBInstanceRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceGaussDBInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.initServiceClient("gaussdb", GetRegion(d, config), "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s ", err)
 	}
@@ -554,7 +554,7 @@ func resourceGaussDBInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 func resourceGaussDBInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.initServiceClient("gaussdb", GetRegion(d, config), "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s ", err)
 	}

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -34,7 +34,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 
 func testAccCheckGaussDBInstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.initServiceClient("gaussdb", OS_REGION_NAME, "mysql/v3")
+	client, err := config.NewServiceClient("gaussdb", OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 	}
@@ -65,7 +65,7 @@ func testAccCheckGaussDBInstanceExists(n string, instance *instances.TaurusDBIns
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.initServiceClient("gaussdb", OS_REGION_NAME, "mysql/v3")
+		client, err := config.NewServiceClient("gaussdb", OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -34,7 +34,7 @@ func TestAccOpenGaussInstance_basic(t *testing.T) {
 
 func testAccCheckOpenGaussInstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.initServiceClient("gaussdb", OS_REGION_NAME, "opengauss/v3")
+	client, err := config.openGaussV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 	}
@@ -65,7 +65,7 @@ func testAccCheckOpenGaussInstanceExists(n string, instance *instances.GaussDBIn
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.initServiceClient("gaussdb", OS_REGION_NAME, "opengauss/v3")
+		client, err := config.openGaussV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 		}


### PR DESCRIPTION
`NewServiceClient` can create a ServiceClient which was assembled from ServiceCatalog.
If you want to add new ServiceClient, please make sure the catalog was already in allServiceCatalog.
the endpoint likes https://{Name}.{Region}.myhuaweicloud.com/{Version}/{project_id}/{ResourceBase}