### PR TITLE
Add RegionClient to Config

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -49,7 +49,8 @@ type Config struct {
 	DelegatedProject string
 	Cloud            string
 	MaxRetries       int
-	terraformVersion string
+	TerraformVersion string
+	RegionClient     bool
 
 	HwClient *golangsdk.ProviderClient
 	s3sess   *session.Session
@@ -131,7 +132,7 @@ func genClient(c *Config, ao golangsdk.AuthOptionsProvider) (*golangsdk.Provider
 	}
 
 	// Set UserAgent
-	client.UserAgent.Prepend(httpclient.TerraformUserAgent(c.terraformVersion))
+	client.UserAgent.Prepend(httpclient.TerraformUserAgent(c.TerraformVersion))
 
 	config, err := generateTLSConfig(c)
 	if err != nil {
@@ -473,15 +474,23 @@ func (c *Config) computeV2Client(region string) (*golangsdk.ServiceClient, error
 }
 
 func (c *Config) dnsV2Client(region string) (*golangsdk.ServiceClient, error) {
+	region = ""
+	if c.RegionClient {
+		region = c.determineRegion(region)
+	}
 	return huaweisdk.NewDNSV2(c.HwClient, golangsdk.EndpointOpts{
-		Region:       "",
+		Region:       region,
 		Availability: c.getHwEndpointType(),
 	})
 }
 
 func (c *Config) identityV3Client(region string) (*golangsdk.ServiceClient, error) {
+	region = ""
+	if c.RegionClient {
+		region = c.determineRegion(region)
+	}
 	return huaweisdk.NewIdentityV3(c.DomainClient, golangsdk.EndpointOpts{
-		//Region:       c.determineRegion(region),
+		Region:       region,
 		Availability: c.getHwEndpointType(),
 	})
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -580,7 +580,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		DelegatedProject: delegated_project,
 		Cloud:            d.Get("cloud").(string),
 		MaxRetries:       d.Get("max_retries").(int),
-		terraformVersion: terraformVersion,
+		TerraformVersion: terraformVersion,
 	}
 
 	if err := config.LoadAndValidate(); err != nil {


### PR DESCRIPTION
This adds RegionClient to Config to determine whether use a global
client or not for DNS and IAM.