### PR TITLE
improve for iam agency resource

### DIFF
--- a/docs/resources/iam_agency_v3.md
+++ b/docs/resources/iam_agency_v3.md
@@ -13,14 +13,13 @@ resource "huaweicloud_iam_agency_v3" "agency" {
   name                  = "test_agency"
   description           = "test agency"
   delegated_domain_name = "***"
-  project_role = [
-    {
-      project = "cn-north-1"
-      roles = [
-        "Tenant Administrator",
-      ]
-    }
-  ]
+
+  project_role {
+    project = "cn-north-1"
+    roles = [
+      "Tenant Administrator",
+    ]
+  }
   domain_roles = [
     "Anti-DDoS Administrator",
   ]
@@ -62,6 +61,7 @@ creating an agency.
 
 The following attributes are exported:
 
+* `id` - The agency ID.
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `delegated_domain_name` - See Argument Reference above.
@@ -69,6 +69,5 @@ The following attributes are exported:
 * `domain_roles` - See Argument Reference above.
 * `duration` - Validity period of an agency. The default value is null,
     indicating that the agency is permanently valid.
-* `expire_time` - The expiration time of agency
+* `expire_time` - The expiration time of agency.
 * `create_time` - The time when the agency was created.
-* `id` - The agency ID.

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -461,12 +461,12 @@ func (c *Config) getHwEndpointType() golangsdk.Availability {
 }
 
 // ********** client for Global Service **********
-func (c *Config) loadIAMV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewIdentityV3(c.DomainClient, golangsdk.EndpointOpts{})
+func (c *Config) IAMV3Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("iam", region)
 }
 
 func (c *Config) IdentityV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("iam", region)
+	return c.NewServiceClient("identity", region)
 }
 
 func (c *Config) DnsV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -14,9 +14,18 @@ type ServiceCatalog struct {
 
 var allServiceCatalog = map[string]ServiceCatalog{
 	// catalog for global service
-	"iam": ServiceCatalog{
+	// identity is used for openstack keystone APIs
+	"identity": ServiceCatalog{
 		Name:             "iam",
 		Version:          "v3",
+		Scope:            "global",
+		Admin:            true,
+		WithOutProjectID: true,
+	},
+	// iam is used for huaweicloud IAM APIs
+	"iam": ServiceCatalog{
+		Name:             "iam",
+		Version:          "v3.0",
 		Scope:            "global",
 		Admin:            true,
 		WithOutProjectID: true,

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -50,16 +50,28 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	config := testProvider.Meta().(*Config)
 
 	// test the endpoint of IAM service
-	serviceClient, err = config.IdentityV3Client(OS_REGION_NAME)
+	serviceClient, err = config.IAMV3Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud IAM client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://iam.%s/v3/", config.Cloud)
+	expectedURL = fmt.Sprintf("https://iam.%s/v3.0/", config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("IAM endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
 	t.Logf("IAM endpoint:\t %s", actualURL)
+
+	// test the endpoint of identity service
+	serviceClient, err = config.IdentityV3Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud identity client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://iam.%s/v3/", config.Cloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("Identity endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("Identity endpoint:\t %s", actualURL)
 
 	// test the endpoint of CDN service
 	serviceClient, err = config.CdnV1Client(OS_REGION_NAME)


### PR DESCRIPTION
add new catalog `iam`  for IAM service

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIAMRoleV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIAMRoleV3DataSource_basic -timeout 360m
=== RUN   TestAccIAMRoleV3DataSource_basic
--- PASS: TestAccIAMRoleV3DataSource_basic (14.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       14.331s
```