### PR TITLE
improve for elb, maas and rts client

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -516,11 +516,11 @@ func (c *Config) FgsV2Client(region string) (*golangsdk.ServiceClient, error) {
 
 // ********** client for Storage **********
 func (c *Config) blockStorageV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("blockstoragev2", region)
+	return c.NewServiceClient("volumev2", region)
 }
 
 func (c *Config) blockStorageV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("blockstoragev3", region)
+	return c.NewServiceClient("volumev3", region)
 }
 
 func (c *Config) sfsV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -542,7 +542,7 @@ func (c *Config) vbsV2Client(region string) (*golangsdk.ServiceClient, error) {
 
 // ********** client for Network **********
 func (c *Config) NetworkingV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("network", region)
+	return c.NewServiceClient("vpc", region)
 }
 
 func (c *Config) NetworkingV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -553,8 +553,8 @@ func (c *Config) natV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("natv2", region)
 }
 
-func (c *Config) loadElasticLoadBalancerClient(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("loadelasticloadbalancer", region)
+func (c *Config) elasticLBClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("elb", region)
 }
 
 func (c *Config) fwV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -566,7 +566,7 @@ func (c *Config) ctsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("cts", region)
 }
 
-func (c *Config) loadCESClient(region string) (*golangsdk.ServiceClient, error) {
+func (c *Config) newCESClient(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("ces", region)
 }
 
@@ -636,17 +636,11 @@ func (c *Config) BssV1Client(region string) (*golangsdk.ServiceClient, error) {
 }
 
 func (c *Config) maasV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.MAASV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
+	return c.NewServiceClient("oms", region)
 }
 
 func (c *Config) orchestrationV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewOrchestrationV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
+	return c.NewServiceClient("rts", region)
 }
 
 func (c *Config) sdkClient(region, serviceType string, level string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/elb_utils.go
+++ b/huaweicloud/elb_utils.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/listeners"
@@ -98,14 +97,6 @@ func waitForELBResource(networkingClient *golangsdk.ServiceClient, name string, 
 	}
 
 	return o, nil
-}
-
-func chooseELBClient(d *schema.ResourceData, config *Config) (*golangsdk.ServiceClient, error) {
-	return config.loadElasticLoadBalancerClient(GetRegion(d, config))
-}
-
-func chooseCESClient(d *schema.ResourceData, config *Config) (*golangsdk.ServiceClient, error) {
-	return config.loadCESClient(GetRegion(d, config))
 }
 
 func isResourceNotFound(err error) bool {

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -42,7 +42,8 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Scope:            "global",
 		WithOutProjectID: true,
 	},
-	// ******* client for Compute start *******
+
+	// ******* catalog for Compute *******
 	"ecs": ServiceCatalog{
 		Name:    "ecs",
 		Version: "v1",
@@ -82,20 +83,23 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "functiongraph",
 		Version: "v2",
 	},
-	// ******* client for Compute end  *******//
 
-	// ******* client for storage start ******//
-	"blockstoragev2": ServiceCatalog{
+	// ******* catalog for storage ******
+	"volumev2": ServiceCatalog{
 		Name:    "evs",
 		Version: "v2",
 	},
-	"blockstoragev3": ServiceCatalog{
+	"volumev3": ServiceCatalog{
 		Name:    "evs",
 		Version: "v3",
 	},
 	"sfsv2": ServiceCatalog{
 		Name:    "sfs",
 		Version: "v2",
+	},
+	"sfs-turbo": ServiceCatalog{
+		Name:    "sfs-turbo",
+		Version: "v1",
 	},
 	"csbsv1": ServiceCatalog{
 		Name:    "csbs",
@@ -105,10 +109,9 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "vbs",
 		Version: "v2",
 	},
-	// ******* client for storage end   ******//
 
-	// ******* client for network start ******//
-	"network": ServiceCatalog{
+	// ******* catalog for network ******
+	"vpc": ServiceCatalog{
 		Name:             "vpc",
 		Version:          "v1",
 		WithOutProjectID: true,
@@ -123,7 +126,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v2.0",
 		WithOutProjectID: true,
 	},
-	"loadelasticloadbalancer": ServiceCatalog{
+	"elb": ServiceCatalog{
 		Name:             "elb",
 		Version:          "v1.0",
 		WithOutProjectID: true,
@@ -132,29 +135,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:             "vpc",
 		Version:          "v2.0",
 		WithOutProjectID: true,
-	},
-	// ******* client for network end   ******//
-
-	"vpc": ServiceCatalog{
-		Name:             "vpc",
-		Version:          "v1",
-		WithOutProjectID: true,
-	},
-	"volumev2": ServiceCatalog{
-		Name:    "evs",
-		Version: "v2",
-	},
-	"volumev3": ServiceCatalog{
-		Name:    "evs",
-		Version: "v3",
-	},
-	"sfs-turbo": ServiceCatalog{
-		Name:    "sfs-turbo",
-		Version: "v1",
-	},
-	"dcsv2": ServiceCatalog{
-		Name:    "dcs",
-		Version: "v2",
 	},
 
 	// catalog for database
@@ -182,11 +162,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "gaussdb",
 		Version: "opengauss/v3",
 	},
-	"bss": ServiceCatalog{
-		Name:             "bss",
-		Version:          "v1.0",
-		WithOutProjectID: true,
-	},
+
 	// catalog for management service
 	"ces": ServiceCatalog{
 		Name:    "ces",
@@ -234,8 +210,28 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dcs",
 		Version: "v1.0",
 	},
+	"dcsv2": ServiceCatalog{
+		Name:    "dcs",
+		Version: "v2",
+	},
 	"dms": ServiceCatalog{
 		Name:    "dms",
 		Version: "v1.0",
+	},
+
+	// catalog for Others
+	"bss": ServiceCatalog{
+		Name:             "bss",
+		Version:          "v1.0",
+		WithOutProjectID: true,
+	},
+	"rts": ServiceCatalog{
+		Name:    "rts",
+		Version: "v1",
+	},
+	"oms": ServiceCatalog{
+		Name:    "oms",
+		Version: "v1",
+		Scope:   "global",
 	},
 }

--- a/huaweicloud/lb_v2_shared.go
+++ b/huaweicloud/lb_v2_shared.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/l7policies"
@@ -251,10 +250,6 @@ func waitForLBV2viaPool(networkingClient *golangsdk.ServiceClient, id string, ta
 
 	// got a pool but no LB - this is wrong
 	return fmt.Errorf("No Load Balancer on pool %s", id)
-}
-
-func chooseLBV2Client(d *schema.ResourceData, config *Config) (*golangsdk.ServiceClient, error) {
-	return config.NetworkingV2Client(GetRegion(d, config))
 }
 
 func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *golangsdk.ServiceClient, lbID, resourceType, resourceID string) resource.StateRefreshFunc {

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule.go
@@ -246,7 +246,7 @@ func getAlarmAction(d *schema.ResourceData, name string) []alarmrule.ActionOpts 
 
 func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := chooseCESClient(d, config)
+	client, err := config.newCESClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -290,7 +290,7 @@ func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := chooseCESClient(d, config)
+	client, err := config.newCESClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -321,7 +321,7 @@ func resourceAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := chooseCESClient(d, config)
+	client, err := config.newCESClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -353,7 +353,7 @@ func resourceAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := chooseCESClient(d, config)
+	client, err := config.newCESClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule_test.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule_test.go
@@ -37,7 +37,7 @@ func TestAccCESAlarmRule_basic(t *testing.T) {
 
 func testCESAlarmRuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.loadCESClient(OS_REGION_NAME)
+	networkingClient, err := config.newCESClient(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud ces client: %s", err)
 	}
@@ -69,7 +69,7 @@ func testCESAlarmRuleExists(n string, ar *alarmrule.AlarmRule) resource.TestChec
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.loadCESClient(OS_REGION_NAME)
+		networkingClient, err := config.newCESClient(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud ces client: %s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_elb_healthcheck.go
+++ b/huaweicloud/resource_huaweicloud_elb_healthcheck.go
@@ -112,7 +112,7 @@ func resourceELBHealthCheck() *schema.Resource {
 
 func resourceELBHealthCheckCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := chooseELBClient(d, config)
+	elbClient, err := config.elasticLBClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -124,7 +124,7 @@ func resourceELBHealthCheckCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 	log.Printf("[DEBUG] Create %s Options: %#v", nameELBHC, createOpts)
 
-	hc, err := healthcheck.Create(networkingClient, createOpts).Extract()
+	hc, err := healthcheck.Create(elbClient, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating %s: %s", nameELBHC, err)
 	}
@@ -138,12 +138,12 @@ func resourceELBHealthCheckCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceELBHealthCheckRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := chooseELBClient(d, config)
+	elbClient, err := config.elasticLBClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
 
-	hc, err := healthcheck.Get(networkingClient, d.Id()).Extract()
+	hc, err := healthcheck.Get(elbClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "healthcheck")
 	}
@@ -154,7 +154,7 @@ func resourceELBHealthCheckRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceELBHealthCheckUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := chooseELBClient(d, config)
+	elbClient, err := config.elasticLBClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -179,7 +179,7 @@ func resourceELBHealthCheckUpdate(d *schema.ResourceData, meta interface{}) erro
 	timeout := d.Timeout(schema.TimeoutUpdate)
 	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		_, err := healthcheck.Update(networkingClient, hcId, updateOpts).Extract()
+		_, err := healthcheck.Update(elbClient, hcId, updateOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -194,7 +194,7 @@ func resourceELBHealthCheckUpdate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceELBHealthCheckDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := chooseELBClient(d, config)
+	elbClient, err := config.elasticLBClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -205,7 +205,7 @@ func resourceELBHealthCheckDelete(d *schema.ResourceData, meta interface{}) erro
 	timeout := d.Timeout(schema.TimeoutDelete)
 	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		err := healthcheck.Delete(networkingClient, hcId).ExtractErr()
+		err := healthcheck.Delete(elbClient, hcId).ExtractErr()
 		if err != nil {
 			return checkForRetryableError(err)
 		}

--- a/huaweicloud/resource_huaweicloud_lb_listener_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_listener_v2.go
@@ -117,7 +117,7 @@ func resourceListenerV2() *schema.Resource {
 
 func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -186,7 +186,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -216,7 +216,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -287,7 +287,7 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer_v2.go
@@ -101,7 +101,7 @@ func resourceLoadBalancerV2() *schema.Resource {
 
 func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -154,7 +154,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -196,7 +196,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 
 func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -253,7 +253,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_member_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_member_v2.go
@@ -93,7 +93,7 @@ func resourceMemberV2() *schema.Resource {
 
 func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -151,7 +151,7 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -177,7 +177,7 @@ func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -226,7 +226,7 @@ func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_monitor_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor_v2.go
@@ -100,7 +100,7 @@ func resourceMonitorV2() *schema.Resource {
 
 func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -155,7 +155,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -184,7 +184,7 @@ func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -247,7 +247,7 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_pool_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool_v2.go
@@ -130,7 +130,7 @@ func resourcePoolV2() *schema.Resource {
 
 func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -227,7 +227,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -253,7 +253,7 @@ func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -314,7 +314,7 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := chooseLBV2Client(d, config)
+	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_rts_software_config_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_rts_software_config_v1_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccRtsSoftwareConfigV1_basic(t *testing.T) {
 	var config softwareconfig.SoftwareConfig
+	resourceName := "huaweicloud_rts_software_config_v1.config_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,15 +22,15 @@ func TestAccRtsSoftwareConfigV1_basic(t *testing.T) {
 			{
 				Config: testAccRtsSoftwareConfigV1_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRtsSoftwareConfigV1Exists("huaweicloud_rts_software_config_v1.config_1", &config),
+					testAccCheckRtsSoftwareConfigV1Exists(resourceName, &config),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_software_config_v1.config_1", "name", "huaweicloud-config"),
+						resourceName, "name", "huaweicloud-config"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_software_config_v1.config_1", "group", "script"),
+						resourceName, "group", "script"),
 				),
 			},
 			{
-				ResourceName:      "huaweicloud_rts_software_config_v1.config_1",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -39,6 +40,7 @@ func TestAccRtsSoftwareConfigV1_basic(t *testing.T) {
 
 func TestAccRtsSoftwareConfigV1_timeout(t *testing.T) {
 	var config softwareconfig.SoftwareConfig
+	resourceName := "huaweicloud_rts_software_config_v1.config_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -48,7 +50,7 @@ func TestAccRtsSoftwareConfigV1_timeout(t *testing.T) {
 			{
 				Config: testAccRtsSoftwareConfigV1_timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRtsSoftwareConfigV1Exists("huaweicloud_rts_software_config_v1.config_1", &config),
+					testAccCheckRtsSoftwareConfigV1Exists(resourceName, &config),
 				),
 			},
 		},

--- a/huaweicloud/resource_huaweicloud_rts_stack_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_rts_stack_v1_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccRTSStackV1_basic(t *testing.T) {
 	var stacks stacks.RetrievedStack
+	resourceName := "huaweicloud_rts_stack_v1.stack_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,32 +22,32 @@ func TestAccRTSStackV1_basic(t *testing.T) {
 			{
 				Config: testAccRTSStackV1_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRTSStackV1Exists("huaweicloud_rts_stack_v1.stack_1", &stacks),
+					testAccCheckRTSStackV1Exists(resourceName, &stacks),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "name", "terraform_provider_stack"),
+						resourceName, "name", "terraform_provider_stack"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "status", "CREATE_COMPLETE"),
+						resourceName, "status", "CREATE_COMPLETE"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "disable_rollback", "true"),
+						resourceName, "disable_rollback", "true"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "timeout_mins", "60"),
+						resourceName, "timeout_mins", "60"),
 				),
 			},
 			{
-				ResourceName:      "huaweicloud_rts_software_config_v1.config_1",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccRTSStackV1_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRTSStackV1Exists("huaweicloud_rts_stack_v1.stack_1", &stacks),
+					testAccCheckRTSStackV1Exists(resourceName, &stacks),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "disable_rollback", "false"),
+						resourceName, "disable_rollback", "false"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "timeout_mins", "50"),
+						resourceName, "timeout_mins", "50"),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_rts_stack_v1.stack_1", "status", "UPDATE_COMPLETE"),
+						resourceName, "status", "UPDATE_COMPLETE"),
 				),
 			},
 		},
@@ -55,6 +56,7 @@ func TestAccRTSStackV1_basic(t *testing.T) {
 
 func TestAccRTSStackV1_timeout(t *testing.T) {
 	var stacks stacks.RetrievedStack
+	resourceName := "huaweicloud_rts_stack_v1.stack_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -64,7 +66,7 @@ func TestAccRTSStackV1_timeout(t *testing.T) {
 			{
 				Config: testAccRTSStackV1_timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRTSStackV1Exists("huaweicloud_rts_stack_v1.stack_1", &stacks),
+					testAccCheckRTSStackV1Exists(resourceName, &stacks),
 				),
 			},
 		},


### PR DESCRIPTION
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccServiceEndpoints_Others'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_Others -timeout 360m
=== RUN   TestAccServiceEndpoints_Others
...
    endpoints_test.go:657: BSS v1 endpoint:      https://bss.cn-north-1.myhuaweicloud.com/v1.0/
    endpoints_test.go:669: MAAS endpoint:        https://oms.myhuaweicloud.com/v1/e71eaa2d4efc4567abf35458e0f504da/
    endpoints_test.go:681: RTS endpoint:         https://rts.cn-north-1.myhuaweicloud.com/v1/e71eaa2d4efc4567abf35458e0f504da/
--- PASS: TestAccServiceEndpoints_Others (3.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       3.980s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccRTSStackV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccRTSStackV1_basic -timeout 360m
=== RUN   TestAccRTSStackV1_basic
--- PASS: TestAccRTSStackV1_basic (37.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       37.754s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCESAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCESAlarmRule_basic -timeout 360m
=== RUN   TestAccCESAlarmRule_basic
--- PASS: TestAccCESAlarmRule_basic (212.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       212.904s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2LoadBalancer_secGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2LoadBalancer_secGroup -timeout 360m
=== RUN   TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_secGroup (73.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       73.178s
```