### PR TITLE
Update resource_huaweicloud_nat_gateway_v2.go

### DIFF
--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -61,8 +61,8 @@ func resourceNatGatewayV2() *schema.Resource {
 			},
 			"internal_network_id": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Required: false,
+				ForceNew: false,
 			},
 		},
 	}


### PR DESCRIPTION
According to the documentation in the terraform.io this item shows optional, but it is required.

internal_network_id - (Optional) ID of the network this nat gateway connects to. Changing this creates a new nat gateway.

I also suggest to improve the documentaiton with more comments and examples.