### PR TITLE
improve on CSS instance resource

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -55,11 +55,22 @@ The following arguments are supported:
 
 * `engine_version` -
   (Required)
-  Engine version. Versions 5.5.1, 6.2.3, 6.5.4 and 7.1.1 are supported. Changing this parameter will create a new resource.
+  Engine version. Versions 5.5.1, 6.2.3, 6.5.4, 7.1.1 and 7.6.2 are supported. Changing this parameter will create a new resource.
 
 * `expect_node_num` -
   (Optional)
   Number of cluster instances. The value range is 1 to 32. Defaults to 1.
+
+* `security_mode` - (Optional) Whether to enable communication encryption and security authentication.
+  Available values include *true* and *false*. security_mode is disabled by default.
+  Changing this parameter will create a new resource.
+
+* `password` - (Optional) Password of the cluster administrator admin in security mode.
+  This parameter is mandatory only when security_mode is set to true. Changing this parameter will create a new resource.
+  The administrator password must meet the following requirements:
+  - The password can contain 8 to 32 characters.
+  - The password must contain at least 3 of the following character types: uppercase letters, lowercase letters,
+    digits, and special characters (~!@#$%^&*()-_=+\\|[{}];:,<.>/?).
 
 * `node_config` -
   (Required)

--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -21,15 +21,16 @@ resource "huaweicloud_css_cluster" "cluster" {
   expect_node_num = 1
   name            = "terraform_test_cluster"
   engine_version  = "7.1.1"
+
   node_config {
-    flavor = "ess.spec-2u16g"
+    flavor = "ess.spec-4u16g"
     network_info {
       security_group_id = huaweicloud_networking_secgroup.secgroup.id
       subnet_id         = "{{ network_id }}"
       vpc_id            = "{{ vpc_id }}"
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 40
     }
     availability_zone = "{{ availability_zone }}"
@@ -67,7 +68,6 @@ The following arguments are supported:
 * `backup_strategy` - (Optional) Specifies the advanced backup policy. Structure is documented below.
 
 * `tags` - (Optional) The key/value pairs to associate with the cluster.
-  Changing this parameter will create a new resource.
 
 The `node_config` block supports:
 

--- a/huaweicloud/resource_huaweicloud_css_cluster_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_css_cluster_v1_test.go
@@ -25,57 +25,35 @@ import (
 )
 
 func TestAccCssClusterV1_basic(t *testing.T) {
+	randName := acctest.RandString(6)
+	resourceName := "huaweicloud_css_cluster_v1.cluster"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCssClusterV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCssClusterV1_basic(acctest.RandString(10)),
+				Config: testAccCssClusterV1_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_css_cluster_v1.cluster", "expect_node_num", "1"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_css_cluster_v1.cluster", "engine_type", "elasticsearch"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_css_cluster_v1.cluster", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_cluster%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "expect_node_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccCssClusterV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterV1Exists(),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCssClusterV1_basic(val string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group%s"
-  description = "terraform security group acceptance test"
-}
-
-resource "huaweicloud_css_cluster_v1" "cluster" {
-  expect_node_num = 1
-  name = "terraform_test_cluster%s"
-  engine_version = "6.2.3"
-  node_config {
-    flavor = "ess.spec-2u16g"
-    network_info {
-      security_group_id = huaweicloud_networking_secgroup_v2.secgroup.id
-      subnet_id = "%s"
-      vpc_id = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size = 40
-    }
-    availability_zone = "%s"
-  }
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
-}
-	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
 }
 
 func testAccCheckCssClusterV1Destroy(s *terraform.State) error {
@@ -135,4 +113,70 @@ func testAccCheckCssClusterV1Exists() resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func testAccCssClusterV1_basic(val string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_networking_secgroup_v2" "secgroup" {
+  name = "terraform_test_security_group%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "huaweicloud_css_cluster_v1" "cluster" {
+  name = "terraform_test_cluster%s"
+  engine_version  = "7.1.1"
+  expect_node_num = 1
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = huaweicloud_networking_secgroup_v2.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "HIGH"
+      size = 40
+    }
+    availability_zone = "%s"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1_update(val string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_networking_secgroup_v2" "secgroup" {
+  name = "terraform_test_security_group%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "huaweicloud_css_cluster_v1" "cluster" {
+  name = "terraform_test_cluster%s"
+  engine_version  = "7.1.1"
+  expect_node_num = 1
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = huaweicloud_networking_secgroup_v2.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "HIGH"
+      size = 40
+    }
+    availability_zone = "%s"
+  }
+  tags = {
+    foo = "bar_update"
+    key_update = "value"
+  }
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
 }


### PR DESCRIPTION
- enable the backup function only when the strategy was configured
- make tags of css cluster to be update-able
- support security mode for css cluster

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCssClusterV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCssClusterV1_basic -timeout 360m
=== RUN   TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (927.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       927.495s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCssClusterV1_security'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCssClusterV1_security -timeout 360m
=== RUN   TestAccCssClusterV1_security
--- PASS: TestAccCssClusterV1_security (918.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       918.338s
```