### PR TITLE
support tags for dns and vpn resource

### DIFF
--- a/docs/resources/dns_recordset.md
+++ b/docs/resources/dns_recordset.md
@@ -34,7 +34,7 @@ resource "huaweicloud_dns_recordset" "rs_example_com" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 DNS client.
+* `region` - (Optional) The region in which to obtain the DNS client.
     If omitted, the `region` argument of the provider is used.
     Changing this creates a new DNS record set.
 
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `records` - (Required) An array of DNS records.
 
+* `tags` - (Optional) The key/value pairs to associate with the zone.
+
 * `value_specs` - (Optional) Map of additional options. Changing this creates a
   new record set.
 
@@ -68,6 +70,7 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `records` - See Argument Reference above.
 * `zone_id` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
 
 ## Import
@@ -76,5 +79,5 @@ This resource can be imported by specifying the zone ID and recordset ID,
 separated by a forward slash.
 
 ```
-$ terraform import huaweicloud_dns_recordset.recordset_1 <zone_id>/<recordset_id>
+$ terraform import huaweicloud_dns_recordset.recordset_1 < zone_id >/< recordset_id >
 ```

--- a/docs/resources/vpnaas_site_connection_v2.md
+++ b/docs/resources/vpnaas_site_connection_v2.md
@@ -92,6 +92,8 @@ The following arguments are supported:
 
 * `value_specs` - (Optional) Map of additional options.
 
+* `tags` - (Optional) The key/value pairs to associate with the connection.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -114,6 +116,7 @@ The following attributes are exported:
 * `vpnservice_id` - See Argument Reference above.
 * `ikepolicy_id` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 
 ## Import
 

--- a/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2_test.go
@@ -18,6 +18,7 @@ func randomPtrName() string {
 func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 	var ptrrecord ptrrecords.Ptr
 	ptrName := randomPtrName()
+	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckDNS(t) },
@@ -27,17 +28,16 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 			{
 				Config: testAccDNSV2PtrRecord_basic(ptrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists("huaweicloud_dns_ptrrecord_v2.ptr_1", &ptrrecord),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dns_ptrrecord_v2.ptr_1", "description", "a ptr record"),
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "description", "a ptr record"),
 				),
 			},
 			{
 				Config: testAccDNSV2PtrRecord_update(ptrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists("huaweicloud_dns_ptrrecord_v2.ptr_1", &ptrrecord),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dns_ptrrecord_v2.ptr_1", "description", "ptr record updated"),
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "description", "ptr record updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 		},
@@ -52,7 +52,7 @@ func testAccCheckDNSV2PtrRecordDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_dns_ptrrecord_v2" {
+		if rs.Type != "huaweicloud_dns_ptrrecord" {
 			continue
 		}
 
@@ -99,31 +99,32 @@ func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resou
 
 func testAccDNSV2PtrRecord_basic(ptrName string) string {
 	return fmt.Sprintf(`
-		resource "huaweicloud_networking_floatingip_v2" "fip_1" {
-		}
+resource "huaweicloud_networking_floatingip_v2" "fip_1" {
+}
 
-		resource "huaweicloud_dns_ptrrecord_v2" "ptr_1" {
-			name = "%s"
-			description = "a ptr record"
-			floatingip_id = "${huaweicloud_networking_floatingip_v2.fip_1.id}"
-			ttl = 6000
-		}
-	`, ptrName)
+resource "huaweicloud_dns_ptrrecord" "ptr_1" {
+  name = "%s"
+  description = "a ptr record"
+  floatingip_id = huaweicloud_networking_floatingip_v2.fip_1.id
+  ttl = 6000
+}
+`, ptrName)
 }
 
 func testAccDNSV2PtrRecord_update(ptrName string) string {
 	return fmt.Sprintf(`
-		resource "huaweicloud_networking_floatingip_v2" "fip_1" {
-		}
+resource "huaweicloud_networking_floatingip_v2" "fip_1" {
+}
 
-		resource "huaweicloud_dns_ptrrecord_v2" "ptr_1" {
-			name = "%s"
-			description = "ptr record updated"
-			floatingip_id = "${huaweicloud_networking_floatingip_v2.fip_1.id}"
-			ttl = 6000
-			tags = {
-				foo = "bar"
-			}
-		}
-	`, ptrName)
+resource "huaweicloud_dns_ptrrecord" "ptr_1" {
+  name = "%s"
+  description = "ptr record updated"
+  floatingip_id = huaweicloud_networking_floatingip_v2.fip_1.id
+  ttl = 6000
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, ptrName)
 }


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2PtrRecord_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2PtrRecord_basic -timeout 360m
=== RUN   TestAccDNSV2PtrRecord_basic
--- PASS: TestAccDNSV2PtrRecord_basic (50.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       50.303s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2RecordSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2RecordSet_basic -timeout 360m
=== RUN   TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (61.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       61.781s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpnSiteConnectionV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpnSiteConnectionV2_basic -timeout 360m
=== RUN   TestAccVpnSiteConnectionV2_basic
--- PASS: TestAccVpnSiteConnectionV2_basic (287.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       287.648s
```