### PR TITLE
Make name argument to support Chinese character in vpc, subnet and peering

### DIFF
--- a/huaweicloud/data_source_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_peering_connection.go
@@ -26,7 +26,7 @@ func dataSourceVpcPeeringConnectionV2() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateName,
+				ValidateFunc: validateString64WithChinese,
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vpc_peering_connection_test.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_peering_connection_test.go
@@ -63,12 +63,12 @@ func testAccCheckVpcPeeringConnectionV2DataSourceID(n string) resource.TestCheck
 func testAccDataSourceVpcPeeringConnectionV2Config(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "vpc_1" {
-  name = "%s"
+  name = "%s_1"
   cidr = "192.168.0.0/16"
 }
 
 resource "huaweicloud_vpc" "vpc_2" {
-  name = "%s"
+  name = "%s_2"
   cidr = "192.168.0.0/16"
 }
 
@@ -94,5 +94,5 @@ data "huaweicloud_vpc_peering_connection" "by_vpc_ids" {
   vpc_id      = huaweicloud_vpc_peering_connection.peering_1.vpc_id
   peer_vpc_id = huaweicloud_vpc_peering_connection.peering_1.peer_vpc_id
 }
-`, rName, rName+"2", rName)
+`, rName, rName, rName)
 }

--- a/huaweicloud/resource_huaweicloud_vpc.go
+++ b/huaweicloud/resource_huaweicloud_vpc.go
@@ -39,7 +39,7 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     false,
-				ValidateFunc: validateName,
+				ValidateFunc: validateString64WithChinese,
 			},
 			"cidr": {
 				Type:         schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/resource_huaweicloud_vpc_peering_connection.go
@@ -36,11 +36,7 @@ func ResourceVpcPeeringConnectionV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     false,
-				ValidateFunc: validateName,
-			},
-			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				ValidateFunc: validateString64WithChinese,
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,
@@ -56,6 +52,10 @@ func ResourceVpcPeeringConnectionV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/huaweicloud/resource_huaweicloud_vpc_peering_connection_test.go
+++ b/huaweicloud/resource_huaweicloud_vpc_peering_connection_test.go
@@ -102,12 +102,12 @@ func testAccCheckVpcPeeringConnectionV2Exists(n string, peering *peerings.Peerin
 func testAccVpcPeeringConnectionV2_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
-  name = "%s"
+  name = "%s_1"
   cidr = "192.168.0.0/16"
 }
 
 resource "huaweicloud_vpc" "test2" {
-  name = "%s"
+  name = "%s_2"
   cidr = "192.168.0.0/16"
 }
 
@@ -116,5 +116,5 @@ resource "huaweicloud_vpc_peering_connection" "test" {
   vpc_id      = huaweicloud_vpc.test.id
   peer_vpc_id = huaweicloud_vpc.test2.id
 }
-`, rName, rName+"2", rName)
+`, rName, rName, rName)
 }

--- a/huaweicloud/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/resource_huaweicloud_vpc_subnet.go
@@ -48,7 +48,7 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     false,
-				ValidateFunc: validateName,
+				ValidateFunc: validateString64WithChinese,
 			},
 			"cidr": {
 				Type:         schema.TypeString,

--- a/huaweicloud/validators.go
+++ b/huaweicloud/validators.go
@@ -126,6 +126,23 @@ func validateName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+func validateString64WithChinese(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+
+	pattern := "^[\\-._A-Za-z0-9\u4e00-\u9fa5]+$"
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
 func validateCIDR(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, ipnet, err := net.ParseCIDR(value)


### PR DESCRIPTION
we can create a vpc, subnet and vpc peering with specified name including Chinese character.