### PR TITLE
Add CSS snapshot resource and docs

### DIFF
--- a/docs/resources/css_snapshot.md
+++ b/docs/resources/css_snapshot.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# huaweicloud\_css\_snapshot
+
+CSS cluster snapshot management
+
+## Example Usage
+
+### create a snapshot
+
+```hcl
+resource "huaweicloud_css_snapshot" "snapshot" {
+  name        = "snapshot_001"
+  description = "a snapshot created by manual" 
+  cluster_id  = var.css_cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the snapshot name. The snapshot name must
+  start with a letter and contains 4 to 64 characters consisting of only
+  lowercase letters, digits, hyphens (-), and underscores (_).
+  Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required) Specifies ID of the CSS cluster where index data is to be backed up.
+  Changing this parameter will create a new resource.
+
+* `index` - (Optional) Specifies the name of the index to be backed up. Multiple index names
+  are separated by commas (,). By default, data of all indices is backed up. You can use the
+  asterisk (*) to back up data of certain indices. For example, if you enter 2020-06*, then
+  data of indices with the name prefix of 2020-06 will be backed up.
+  The value contains 0 to 1024 characters. Uppercase letters, spaces, and certain special
+  characters (including "\<|>/?) are not allowed.
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional) Specifies the description of a snapshot.
+  The value contains 0 to 256 characters, and angle brackets (<) and (>) are not allowed.
+  Changing this parameter will create a new resource.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `status` - Indicates the snapshot status.
+
+* `cluster_name` - Indicates the CSS cluster name.
+
+* `backup_type` - Indicates the snapshot creation mode, the value should be "manual" or "automated".
+
+
+## Import
+
+This resource can be imported by specifying the CSS cluster ID and snapshot ID
+separated by a slash, e.g.:
+
+```
+$ terraform import huaweicloud_css_snapshot.snapshot_1 < cluster_id >/< snapshot_id >
+```

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -23,10 +23,8 @@ import (
 )
 
 const (
-	serviceProjectLevel string = "project"
-	serviceDomainLevel  string = "domain"
-	obsLogFile          string = "./.obs-sdk.log"
-	obsLogFileSize10MB  int64  = 1024 * 1024 * 10
+	obsLogFile         string = "./.obs-sdk.log"
+	obsLogFileSize10MB int64  = 1024 * 1024 * 10
 )
 
 type Config struct {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -301,6 +301,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_csbs_backup":                     resourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy":              resourceCSBSBackupPolicyV1(),
 			"huaweicloud_css_cluster":                     resourceCssClusterV1(),
+			"huaweicloud_css_snapshot":                    resourceCssSnapshot(),
 			"huaweicloud_cts_tracker":                     resourceCTSTrackerV1(),
 			"huaweicloud_dcs_instance":                    resourceDcsInstanceV1(),
 			"huaweicloud_dds_instance":                    resourceDdsInstanceV3(),

--- a/huaweicloud/resource_huaweicloud_css_snapshot.go
+++ b/huaweicloud/resource_huaweicloud_css_snapshot.go
@@ -1,0 +1,219 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/css/v1/snapshots"
+)
+
+func resourceCssSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCssSnapshotCreate,
+		Read:   resourceCssSnapshotRead,
+		Delete: resourceCssSnapshotDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceCssSnapshotImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"index": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCssSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	cssClient, err := config.cssV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CSS client: %s", err)
+	}
+
+	clusterID := d.Get("cluster_id").(string)
+	createOpts := &snapshots.CreateOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Indices:     d.Get("index").(string),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	snap, err := snapshots.Create(cssClient, createOpts, clusterID).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CSS snapshot: %s", err)
+	}
+
+	// Store the snapshot ID
+	d.SetId(snap.ID)
+
+	log.Printf("[DEBUG] Waiting for snapshot (%s) to complete", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"BUILDING"},
+		Target:     []string{"COMPLETED"},
+		Refresh:    cssSnapshotStateRefreshFunc(cssClient, clusterID, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for snapshot (%s) to complete: %s",
+			d.Id(), err)
+	}
+
+	return resourceCssSnapshotRead(d, meta)
+}
+
+func resourceCssSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	cssClient, err := config.cssV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CSS client: %s", err)
+	}
+
+	clusterID := d.Get("cluster_id").(string)
+	snapList, err := snapshots.List(cssClient, clusterID).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "snapshot")
+	}
+
+	// find the snapshot by ID
+	var snap snapshots.Snapshot
+	for _, v := range snapList {
+		if v.ID == d.Id() {
+			snap = v
+			break
+		}
+	}
+	if snap.ID == "" {
+		log.Printf("[INFO] the snapshot %s does not exist", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Retrieved the sanpshot %s: %+v", d.Id(), snap)
+
+	d.Set("name", snap.Name)
+	d.Set("description", snap.Description)
+	d.Set("status", snap.Status)
+	d.Set("index", snap.Indices)
+	d.Set("cluster_id", snap.ClusterID)
+	d.Set("cluster_name", snap.ClusterName)
+	// Method is more suitable for backup_type
+	d.Set("backup_type", snap.Method)
+
+	return nil
+}
+
+func resourceCssSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	cssClient, err := config.cssV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CSS storage client: %s", err)
+	}
+
+	clusterID := d.Get("cluster_id").(string)
+	if err := snapshots.Delete(cssClient, clusterID, d.Id()).ExtractErr(); err != nil {
+		return CheckDeleted(d, err, "snapshot")
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// cssSnapshotStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// an CSS cluster snapshot.
+func cssSnapshotStateRefreshFunc(client *golangsdk.ServiceClient, clusterID, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		snapList, err := snapshots.List(client, clusterID).Extract()
+		if err != nil {
+			return nil, "FAILED", err
+		}
+
+		// find the snapshot by ID
+		var snap snapshots.Snapshot
+		for _, v := range snapList {
+			if v.ID == id {
+				snap = v
+				break
+			}
+		}
+
+		if snap.ID == "" {
+			return nil, "NOTEXIST", fmt.Errorf("The specified snapshot %s not exist", id)
+		}
+
+		return snap, snap.Status, nil
+	}
+}
+
+func resourceCssSnapshotImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmt.Errorf("Invalid format specified for CSS snapshot. Format must be <cluster id>/<snapshot id>")
+		return nil, err
+	}
+	clusterID := parts[0]
+	snapshotID := parts[1]
+
+	config := meta.(*Config)
+	client, err := config.cssV1Client(GetRegion(d, config))
+	if err != nil {
+		return nil, fmt.Errorf("Error creating css client, err=%s", err)
+	}
+
+	// check the css cluster whether exists
+	d.SetId(clusterID)
+	if _, err := sendCssClusterV1ReadRequest(d, client); err != nil {
+		return nil, err
+	}
+
+	d.Set("cluster_id", clusterID)
+	d.SetId(snapshotID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/resource_huaweicloud_css_snapshot_test.go
+++ b/huaweicloud/resource_huaweicloud_css_snapshot_test.go
@@ -1,0 +1,136 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/css/v1/snapshots"
+)
+
+func TestAccCssSnapshot_basic(t *testing.T) {
+	rand := acctest.RandString(5)
+	resourceName := "huaweicloud_css_snapshot.snapshot"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCssSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssSnapshot_basic(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssSnapshotExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("snapshot-%s", rand)),
+					resource.TestCheckResourceAttr(resourceName, "status", "COMPLETED"),
+					resource.TestCheckResourceAttr(resourceName, "backup_type", "manual"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCssSnapshotDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	client, err := config.cssV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating css client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_css_snapshot" {
+			continue
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		snapList, err := snapshots.List(client, clusterID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+
+			return err
+		}
+
+		for _, v := range snapList {
+			if v.ID == rs.Primary.ID {
+				return fmt.Errorf("huaweicloud css snapshot %s still exists", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCssSnapshotExists() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		client, err := config.cssV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating css client, err=%s", err)
+		}
+
+		rs, ok := s.RootModule().Resources["huaweicloud_css_snapshot.snapshot"]
+		if !ok {
+			return fmt.Errorf("Error checking huaweicloud css snapshot.snapshot exist, err=not found this resource")
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		snapList, err := snapshots.List(client, clusterID).Extract()
+		if err != nil {
+			return err
+		}
+
+		for _, v := range snapList {
+			if v.ID == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("huaweicloud css snapshot %s is not exist", rs.Primary.ID)
+	}
+}
+
+func testAccCssSnapshot_basic(val string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_networking_secgroup" "secgroup" {
+  name = "terraform_test_sg-%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "huaweicloud_css_cluster" "cluster" {
+  name = "tf-css-cluster-%s"
+  engine_version  = "7.1.1"
+  expect_node_num = 1
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = huaweicloud_networking_secgroup.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "HIGH"
+      size = 40
+    }
+    availability_zone = "%s"
+  }
+
+  backup_strategy {
+    start_time = "00:00 GMT+03:00"
+    prefix     = "snapshot"
+    keep_days  = 14
+  }
+}
+
+resource "huaweicloud_css_snapshot" "snapshot" {
+  name        = "snapshot-%s"
+  description = "a snapshot created by terraform acctest"
+  cluster_id  = huaweicloud_css_cluster.cluster.id
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE, val)
+}


### PR DESCRIPTION
Support CSS snapshot resource, the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCssSnapshot_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCssSnapshot_basic -timeout 360m
=== RUN   TestAccCssSnapshot_basic
--- PASS: TestAccCssSnapshot_basic (951.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       951.266s
```