### PR TITLE
add enterprise_project_id to secgroup

### DIFF
--- a/docs/resources/networking_secgroup.md
+++ b/docs/resources/networking_secgroup.md
@@ -32,6 +32,8 @@ The following arguments are supported:
     egress security rules. This is `false` by default. See the below note
     for more information.
 
+* `enterprise_project_id` - (Optional) The enterprise project id of the security group. Changing this creates a new security group.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201021110706-4cb6032799d8
+	github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20201021110706-4cb6032799d8 h1:x028T/6qFLr/WXVVqHShpnIgFz9U8NmfjZVag3zvFF8=
-github.com/huaweicloud/golangsdk v0.0.0-20201021110706-4cb6032799d8/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3 h1:OM0O1p/gea9E3fQGca1gBrM/f10IZQ38w4MGhupar8c=
+github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -529,6 +529,10 @@ func (c *Config) NetworkingV1Client(region string) (*golangsdk.ServiceClient, er
 	return c.NewServiceClient("vpc", region)
 }
 
+func (c *Config) SecurityGroupV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("security_group", region)
+}
+
 func (c *Config) NetworkingV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("networkv2", region)
 }

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -121,6 +121,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v2.0",
 		WithOutProjectID: true,
 	},
+	"security_group": ServiceCatalog{
+		Name:    "vpc",
+		Version: "v1",
+	},
 	"natv2": ServiceCatalog{
 		Name:             "nat",
 		Version:          "v2.0",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -581,6 +581,16 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "nat", "v2", t)
 
+	// test endpoint of secgroup v1
+	serviceClient, err = nil, nil
+	serviceClient, err = config.SecurityGroupV1Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud security_group v1 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	compareURL(expectedURL, actualURL, "vpc", "v1", t)
+
 	// test endpoint of loadElasticLoadBalancer v1.0
 	serviceClient, err = nil, nil
 	serviceClient, err = config.elasticLBClient(OS_REGION_NAME)

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_v2_test.go
@@ -22,12 +22,12 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Config: testAccNetworkingV2SecGroup_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
-						"huaweicloud_networking_secgroup_v2.secgroup_1", &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 2),
+						"huaweicloud_networking_secgroup.secgroup_1", &security_group),
+					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 6),
 				),
 			},
 			{
-				ResourceName:      "huaweicloud_networking_secgroup_v2.secgroup_1",
+				ResourceName:      "huaweicloud_networking_secgroup.secgroup_1",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -35,9 +35,30 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Config: testAccNetworkingV2SecGroup_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPtr(
-						"huaweicloud_networking_secgroup_v2.secgroup_1", "id", &security_group.ID),
+						"huaweicloud_networking_secgroup.secgroup_1", "id", &security_group.ID),
 					resource.TestCheckResourceAttr(
-						"huaweicloud_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
+						"huaweicloud_networking_secgroup.secgroup_1", "name", "security_group_2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroup_withEpsId(t *testing.T) {
+	var security_group groups.SecGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroup_epsId(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SecGroupExists(
+						"huaweicloud_networking_secgroup.secgroup_1", &security_group),
+					resource.TestCheckResourceAttr(
+						"huaweicloud_networking_secgroup.secgroup_1", "enterprise_project_id", OS_ENTERPRISE_PROJECT_ID),
 				),
 			},
 		},
@@ -56,7 +77,7 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 				Config: testAccNetworkingV2SecGroup_noDefaultRules,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
-						"huaweicloud_networking_secgroup_v2.secgroup_1", &security_group),
+						"huaweicloud_networking_secgroup.secgroup_1", &security_group),
 					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
 				),
 			},
@@ -76,7 +97,7 @@ func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 				Config: testAccNetworkingV2SecGroup_timeout,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
-						"huaweicloud_networking_secgroup_v2.secgroup_1", &security_group),
+						"huaweicloud_networking_secgroup.secgroup_1", &security_group),
 				),
 			},
 		},
@@ -91,7 +112,7 @@ func testAccCheckNetworkingV2SecGroupDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_networking_secgroup_v2" {
+		if rs.Type != "huaweicloud_networking_secgroup" {
 			continue
 		}
 
@@ -149,21 +170,31 @@ func testAccCheckNetworkingV2SecGroupRuleCount(
 }
 
 const testAccNetworkingV2SecGroup_basic = `
-resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
   name = "security_group"
   description = "terraform security group acceptance test"
 }
 `
 
+func testAccNetworkingV2SecGroup_epsId() string {
+	return fmt.Sprintf(`
+	resource "huaweicloud_networking_secgroup" "secgroup_1" {
+	  name = "security_group"
+	  description = "terraform security group acceptance test"
+	  enterprise_project_id = "%s"
+	}
+	`, OS_ENTERPRISE_PROJECT_ID)
+}
+
 const testAccNetworkingV2SecGroup_update = `
-resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
   name = "security_group_2"
   description = "terraform security group acceptance test"
 }
 `
 
 const testAccNetworkingV2SecGroup_noDefaultRules = `
-resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
 	name = "security_group_1"
 	description = "terraform security group acceptance test"
 	delete_default_rules = true
@@ -171,7 +202,7 @@ resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
 `
 
 const testAccNetworkingV2SecGroup_timeout = `
-resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
   name = "security_group"
   description = "terraform security group acceptance test"
 

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups/requests.go
@@ -1,0 +1,108 @@
+package securitygroups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type CreateOpts struct {
+
+	// Specifies the security group name.
+	Name string `json:"name" required:"true"`
+
+	// Specifies the enterprise project ID. This field can be used to
+	// filter out the VPCs associated with a specified enterprise project.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+
+	// Specifies the resource ID of the VPC to which the security
+	// group belongs.
+	VpcId string `json:"vpc_id,omitempty"`
+
+	// Specifies the default security group rule, which ensures that
+	//// hosts in the security group can communicate with one another.
+	//SecurityGroupRules []SecurityGroupRule `json:"security_group_rules"`
+
+	Description string `json:"description,omitempty"`
+}
+
+type CreateOptsBuilder interface {
+	ToSecuritygroupsCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToSecuritygroupsCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "security_group")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSecuritygroupsCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(CreateURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+func Delete(client *golangsdk.ServiceClient, securityGroupId string) (r DeleteResult) {
+	url := DeleteURL(client, securityGroupId)
+	_, r.Err = client.Delete(url, nil)
+	return
+}
+
+func Get(client *golangsdk.ServiceClient, securityGroupId string) (r GetResult) {
+	url := GetURL(client, securityGroupId)
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+type ListOpts struct {
+
+	// Specifies the resource ID of pagination query. If the parameter
+	// is left blank, only resources on the first page are queried.
+	Marker string `q:"marker"`
+
+	// Specifies the number of records returned on each page.
+	Limit int `q:"limit"`
+
+	// Specifies the VPC ID used as the query filter.
+	VpcId string `q:"vpc_id"`
+
+	// enterprise_project_id
+	// Specifies the enterprise_project_id used as the query filter.
+	EnterpriseProjectId string `q:"enterprise_project_id"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := ListURL(client)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url,
+		func(r pagination.PageResult) pagination.Page {
+			return SecurityGroupPage{pagination.LinkedPageBase{PageResult: r}}
+
+		})
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups/results.go
@@ -1,0 +1,138 @@
+package securitygroups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type SecurityGroup struct {
+	// Specifies the security group name.
+	Name string `json:"name"`
+
+	// Provides supplementary information about the security group.
+	Description string `json:"description"`
+
+	// Specifies the security group ID, which uniquely identifies the
+	// security group.
+	ID string `json:"id"`
+
+	// Specifies the resource ID of the VPC to which the security
+	// group belongs.
+	VpcId string `json:"vpc_id"`
+
+	// Specifies the default security group rule, which ensures that
+	// hosts in the security group can communicate with one another.
+	SecurityGroupRules []SecurityGroupRule `json:"security_group_rules"`
+
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+}
+
+type SecurityGroupRule struct {
+	// Specifies the security group rule ID.
+	ID string `json:"id,omitempty"`
+
+	// Specifies the description.
+	Description string `json:"description,omitempty"`
+
+	// Specifies the security group ID.
+	SecurityGroupId string `json:"security_group_id,omitempty"`
+
+	// Specifies the direction of access control. The value can
+	// be?egress?or?ingress.
+	Direction string `json:"direction,omitempty"`
+
+	// Specifies the version of the Internet Protocol. The value can
+	// be?IPv4?or?IPv6.
+	Ethertype string `json:"ethertype,omitempty"`
+
+	// Specifies the protocol type. If the parameter is left blank,
+	// the security group supports all types of protocols. The value can be?icmp,?tcp,
+	// or?udp.
+	Protocol string `json:"protocol,omitempty"`
+
+	// Specifies the start port. The value ranges from 1 to 65,535.
+	// The value must be less than or equal to the value of?port_range_max. An empty value
+	// indicates all ports. If?protocol?is?icmp, the value range is determined by the
+	// ICMP-port range relationship table provided in Appendix A.2.
+	PortRangeMin *int `json:"port_range_min,omitempty"`
+
+	// Specifies the end port. The value ranges from 1 to 65,535. The
+	// value must be greater than or equal to the value of?port_range_min. An empty value
+	// indicates all ports. If?protocol?is?icmp, the value range is determined by the
+	// ICMP-port range relationship table provided in Appendix A.2.
+	PortRangeMax *int `json:"port_range_max,omitempty"`
+
+	// Specifies the remote IP address. If the access control
+	// direction is set to?egress, the parameter specifies the source IP address. If the
+	// access control direction is set to?ingress, the parameter specifies the destination
+	// IP address. The parameter is exclusive with parameter?remote_group_id. The value can
+	// be in the CIDR format or IP addresses.
+	RemoteIpPrefix string `json:"remote_ip_prefix,omitempty"`
+
+	// Specifies the ID of the peer security group. The value is
+	// exclusive with parameter?remote_ip_prefix.
+	RemoteGroupId string `json:"remote_group_id,omitempty"`
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (*SecurityGroup, error) {
+	var entity SecurityGroup
+	err := r.ExtractIntoStructPtr(&entity, "security_group")
+	return &entity, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r GetResult) Extract() (*SecurityGroup, error) {
+	var entity SecurityGroup
+	err := r.ExtractIntoStructPtr(&entity, "security_group")
+	return &entity, err
+}
+
+type ListResult struct {
+	commonResult
+}
+
+func (r ListResult) Extract() (*[]SecurityGroup, error) {
+	var list []SecurityGroup
+	err := r.ExtractIntoSlicePtr(&list, "security_groups")
+	return &list, err
+}
+
+func (r SecurityGroupPage) IsEmpty() (bool, error) {
+	list, err := ExtractSecurityGroups(r)
+	return len(list) == 0, err
+}
+
+type SecurityGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+func ExtractSecurityGroups(r pagination.Page) ([]SecurityGroup, error) {
+	var s struct {
+		SecurityGroups []SecurityGroup `json:"security_groups"`
+	}
+	err := r.(SecurityGroupPage).ExtractInto(&s)
+	return s.SecurityGroups, err
+}
+
+func (r SecurityGroupPage) NextPageURL() (string, error) {
+	s, err := ExtractSecurityGroups(r)
+	if err != nil {
+		return "", err
+	}
+	return r.WrapNextPageURL(s[len(s)-1].ID)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups/urls.go
@@ -1,0 +1,21 @@
+package securitygroups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+func CreateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("security-groups")
+}
+
+func DeleteURL(c *golangsdk.ServiceClient, securityGroupId string) string {
+	return c.ServiceURL("security-groups", securityGroupId)
+}
+
+func GetURL(c *golangsdk.ServiceClient, securityGroupId string) string {
+	return c.ServiceURL("security-groups", securityGroupId)
+}
+
+func ListURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("security-groups")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups/requests.go
@@ -88,7 +88,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Describes the security group.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToSecGroupUpdateMap builds a request body from UpdateOpts.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201021110706-4cb6032799d8
+# github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -274,6 +274,7 @@ github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster
 github.com/huaweicloud/golangsdk/openstack/mrs/v1/job
 github.com/huaweicloud/golangsdk/openstack/networking/v1/bandwidths
 github.com/huaweicloud/golangsdk/openstack/networking/v1/eips
+github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups
 github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets
 github.com/huaweicloud/golangsdk/openstack/networking/v1/vpcs
 github.com/huaweicloud/golangsdk/openstack/networking/v2/bandwidths


### PR DESCRIPTION
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2SecGroup_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2SecGroup_withEpsId -timeout 360m
=== RUN   TestAccNetworkingV2SecGroup_withEpsId
--- PASS: TestAccNetworkingV2SecGroup_withEpsId (18.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       18.992s