### PR TITLE
support tags for dms instance resource

### DIFF
--- a/docs/resources/dms_instance.md
+++ b/docs/resources/dms_instance.md
@@ -12,29 +12,31 @@ This is an alternative to `huaweicloud_dms_instance_v1`
 ### Automatically detect the correct network
 
 ```hcl
-resource "huaweicloud_networking_secgroup" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
 data "huaweicloud_dms_az" "az_1" {
 }
 data "huaweicloud_dms_product" "product_1" {
   engine        = "rabbitmq"
   instance_type = "single"
-  version       = "3.7.0"
+  version       = "3.7.17"
+}
+
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "secgroup_1"
 }
 resource "huaweicloud_dms_instance" "instance_1" {
-  name              = "%s"
+  name              = var.instance_name
   engine            = "rabbitmq"
-  storage_space     = data.huaweicloud_dms_product.product_1.storage
   access_user       = "user"
   password          = "Dmstest@123"
-  vpc_id            = "%s"
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
   security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
-  subnet_id         = "%s"
   available_zones   = [data.huaweicloud_dms_az.az_1.id]
   product_id        = data.huaweicloud_dms_product.product_1.id
   engine_version    = data.huaweicloud_dms_product.product_1.version
+  storage_space     = data.huaweicloud_dms_product.product_1.storage
+  storage_spec_code = data.huaweicloud_dms_product.product_1.storage_spec_code
 }
 ```
 
@@ -56,20 +58,31 @@ The following arguments are supported:
     Indicates the baseline bandwidth of a Kafka instance, that is, the maximum amount
 	of data transferred per unit time. Unit: byte/s. Options: 300 MB, 600 MB, 1200 MB.
 
-* `storage_space` - (Required) Indicates the message storage space.
-    Value range:
-    Single-node RabbitMQ instance: 100–90000 GB
-    Cluster RabbitMQ instance: 100 GB x Number of nodes to 90000 GB, 200 GB x Number of
+* `storage_space` - (Required) Indicates the message storage space. Value range:
+    - Single-node RabbitMQ instance: 100–90000 GB
+    - Cluster RabbitMQ instance: 100 GB x Number of nodes to 90000 GB, 200 GB x Number of
 	nodes to 90000 GB, 300 GB x Number of nodes to 90000 GB
-    Kafka instance with specification being 300 MB: 1200–90000 GB
-    Kafka instance with specification being 600 MB: 2400–90000 GB
-    Kafka instance with specification being 1200 MB: 4800–90000 GB
+    - Kafka instance with specification being 300 MB: 1200–90000 GB
+    - Kafka instance with specification being 600 MB: 2400–90000 GB
+    - Kafka instance with specification being 1200 MB: 4800–90000 GB
+
+* `storage_spec_code` - (Required) Indicates the storage I/O specification. Value range:
+
+    Options for a RabbitMQ instance:
+    - dms.physical.storage.normal
+    - dms.physical.storage.high
+    - dms.physical.storage.ultra
+
+    Options for a Kafka instance:
+    - When specification is 300 MB: dms.physical.storage.high or dms.physical.storage.ultra
+    - When specification is 600 MB: dms.physical.storage.ultra
+    - When specification is 1200 MB: dms.physical.storage.ultra
 
 * `partition_num` - (Optional) This parameter is mandatory when a Kafka instance is created.
     Indicates the maximum number of topics in a Kafka instance.
-    When specification is 300 MB: 900
-    When specification is 600 MB: 1800
-    When specification is 1200 MB: 1800
+    - When specification is 300 MB: 900
+    - When specification is 600 MB: 1800
+    - When specification is 1200 MB: 1800
 
 * `access_user` - (Optional) Indicates a username. If the engine is rabbitmq, this
     parameter is mandatory. If the engine is kafka, this parameter is optional.
@@ -85,9 +98,9 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) Indicates the ID of a VPC.
 
-* `security_group_id` - (Required) Indicates the ID of a security group.
-
 * `subnet_id` - (Required) Indicates the ID of a subnet.
+
+* `security_group_id` - (Required) Indicates the ID of a security group.
 
 * `available_zones` - (Required) Indicates the ID of an AZ. The parameter value can not be
     left blank or an empty array. For details, see section Querying AZ Information.
@@ -119,21 +132,12 @@ The following arguments are supported:
 * `publicip_id` - (Optional) Indicates the ID of the elastic IP address (EIP) bound to a RabbitMQ instance.
     This parameter is mandatory if public access is enabled (that is, enable_publicip is set to true).
 
-* `storage_spec_code` - (Optional) Indicates the storage I/O specification. For details on how to
-    select a disk type, see Disk Types and Disk Performance. Options for a RabbitMQ instance:
-    dms.physical.storage.normal
-    dms.physical.storage.high
-    dms.physical.storage.ultra
-    Options for a Kafka instance:
-    When specification is 300 MB: dms.physical.storage.high or dms.physical.storage.ultra
-    When specification is 600 MB: dms.physical.storage.ultra
-    When specification is 1200 MB: dms.physical.storage.ultra
+* `tags` - (Optional) The key/value pairs to associate with the instance.
 
 
 ## Attributes Reference
 
 The following attributes are exported:
-
 
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
@@ -157,6 +161,7 @@ The following attributes are exported:
 * `enable_publicip` - See Argument Reference above.
 * `publicip_id` - See Argument Reference above.
 * `storage_spec_code` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 * `used_storage_space` - Indicates the used message storage space. Unit: GB
 * `connect_address` - Indicates the IP address of an instance.
 * `port` - Indicates the port number of an instance.

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -633,6 +633,10 @@ func (c *Config) dmsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dms", region)
 }
 
+func (c *Config) dmsV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("dmsv2", region)
+}
+
 // ********** client for Database **********
 func (c *Config) RdsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("rdsv1", region)

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -258,6 +258,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dms",
 		Version: "v1.0",
 	},
+	"dmsv2": ServiceCatalog{
+		Name:    "dms",
+		Version: "v2",
+	},
 
 	// catalog for Others
 	"bss": ServiceCatalog{

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -328,14 +328,26 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	// test the endpoint of DMS service
 	serviceClient, err = config.dmsV1Client(OS_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud DMS client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud DMS v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://dms.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
-		t.Fatalf("DMS endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+		t.Fatalf("DMS v1 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
-	t.Logf("DMS endpoint:\t %s", actualURL)
+	t.Logf("DMS v1 endpoint:\t %s", actualURL)
+
+	// test the endpoint of DMS v2 service
+	serviceClient, err = config.dmsV2Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud DMS v2 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://dms.%s.%s/v2/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("DMS v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("DMS v2 endpoint:\t %s", actualURL)
 }
 
 // TestAccServiceEndpoints_Compute test for endpoints of the clients used in ecs

--- a/huaweicloud/resource_huaweicloud_dms_instance_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1_test.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/dms/v1/instances"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccDmsInstancesV1_basic(t *testing.T) {
+func TestAccDmsInstancesV1_Rabbitmq(t *testing.T) {
 	var instance instances.Instance
 	var instanceName = fmt.Sprintf("dms_instance_%s", acctest.RandString(5))
 	var instanceUpdate = fmt.Sprintf("dms_instance_update_%s", acctest.RandString(5))
+	resourceName := "huaweicloud_dms_instance.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckDms(t) },
@@ -24,30 +24,31 @@ func TestAccDmsInstancesV1_basic(t *testing.T) {
 			{
 				Config: testAccDmsV1Instance_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDmsV1InstanceExists("huaweicloud_dms_instance_v1.instance_1", instance),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dms_instance_v1.instance_1", "name", instanceName),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dms_instance_v1.instance_1", "engine", "rabbitmq"),
+					testAccCheckDmsV1InstanceExists(resourceName, instance),
+					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "rabbitmq"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
 				Config: testAccDmsV1Instance_update(instanceUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDmsV1InstanceExists("huaweicloud_dms_instance_v1.instance_1", instance),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dms_instance_v1.instance_1", "name", instanceUpdate),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dms_instance_v1.instance_1", "description", "instance update description"),
+					testAccCheckDmsV1InstanceExists(resourceName, instance),
+					resource.TestCheckResourceAttr(resourceName, "name", instanceUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "instance update description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDmsInstancesV1_KafkaInstance(t *testing.T) {
+func TestAccDmsInstancesV1_Kafka(t *testing.T) {
 	var instance instances.Instance
 	var instanceName = fmt.Sprintf("dms_instance_%s", acctest.RandString(5))
+	resourceName := "huaweicloud_dms_instance.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckDms(t) },
@@ -57,9 +58,10 @@ func TestAccDmsInstancesV1_KafkaInstance(t *testing.T) {
 			{
 				Config: testAccDmsV1Instance_KafkaInstance(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDmsV1InstanceExists("huaweicloud_dms_instance_v1.instance_1", instance),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_dms_instance_v1.instance_1", "name", instanceName),
+					testAccCheckDmsV1InstanceExists(resourceName, instance),
+					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 		},
@@ -74,7 +76,7 @@ func testAccCheckDmsV1InstanceDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_dms_instance_v1" {
+		if rs.Type != "huaweicloud_dms_instance" {
 			continue
 		}
 
@@ -118,92 +120,109 @@ func testAccCheckDmsV1InstanceExists(n string, instance instances.Instance) reso
 
 func testAccDmsV1Instance_basic(instanceName string) string {
 	return fmt.Sprintf(`
-       resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-         name = "secgroup_1"
-         description = "secgroup_1"
-       }
-       data "huaweicloud_dms_az_v1" "az_1" {
-		}
-       data "huaweicloud_dms_product_v1" "product_1" {
-          engine = "rabbitmq"
-          instance_type = "single"
-          version = "3.7.0"
-		}
-		resource "huaweicloud_dms_instance_v1" "instance_1" {
-			name  = "%s"
-          engine = "rabbitmq"
-          storage_space = "${data.huaweicloud_dms_product_v1.product_1.storage}"
-          access_user = "user"
-          password = "Dmstest@123"
-          vpc_id = "%s"
-          security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup_1.id}"
-          subnet_id = "%s"
-          available_zones = ["${data.huaweicloud_dms_az_v1.az_1.id}"]
-          product_id = "${data.huaweicloud_dms_product_v1.product_1.id}"
-          engine_version = "${data.huaweicloud_dms_product_v1.product_1.version}"
-          depends_on      = ["data.huaweicloud_dms_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
-		}
+data "huaweicloud_dms_az" "az_1" {
+}
+data "huaweicloud_dms_product" "product_1" {
+  engine        = "rabbitmq"
+  instance_type = "single"
+  version       = "3.7.17"
+}
+
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "secgroup_1"
+}
+resource "huaweicloud_dms_instance" "instance_1" {
+  name              = "%s"
+  engine            = "rabbitmq"
+  access_user       = "user"
+  password          = "Dmstest@123"
+  vpc_id            = "%s"
+  subnet_id         = "%s"
+  security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
+  available_zones   = [data.huaweicloud_dms_az.az_1.id]
+  product_id        = data.huaweicloud_dms_product.product_1.id
+  engine_version    = data.huaweicloud_dms_product.product_1.version
+  storage_space     = data.huaweicloud_dms_product.product_1.storage
+  storage_spec_code = data.huaweicloud_dms_product.product_1.storage_spec_code
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
 	`, instanceName, OS_VPC_ID, OS_NETWORK_ID)
 }
 
 func testAccDmsV1Instance_update(instanceUpdate string) string {
 	return fmt.Sprintf(`
-       resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-         name = "secgroup_1"
-         description = "secgroup_1"
-       }
-       data "huaweicloud_dms_az_v1" "az_1" {
-		}
-       data "huaweicloud_dms_product_v1" "product_1" {
-          engine = "rabbitmq"
-          instance_type = "single"
-          version = "3.7.0"
-		}
-		resource "huaweicloud_dms_instance_v1" "instance_1" {
-			name  = "%s"
-          description = "instance update description"
-          engine = "rabbitmq"
-          storage_space = "${data.huaweicloud_dms_product_v1.product_1.storage}"
-          access_user = "user"
-          password = "Dmstest@123"
-          vpc_id = "%s"
-          security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup_1.id}"
-          subnet_id = "%s"
-          available_zones = ["${data.huaweicloud_dms_az_v1.az_1.id}"]
-          product_id = "${data.huaweicloud_dms_product_v1.product_1.id}"
-          engine_version = "${data.huaweicloud_dms_product_v1.product_1.version}"
-          depends_on      = ["data.huaweicloud_dms_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
-		}
+data "huaweicloud_dms_az" "az_1" {
+}
+data "huaweicloud_dms_product" "product_1" {
+  engine        = "rabbitmq"
+  instance_type = "single"
+  version       = "3.7.17"
+}
+
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "secgroup_1"
+}
+resource "huaweicloud_dms_instance" "instance_1" {
+  name              = "%s"
+  description       = "instance update description"
+  engine            = "rabbitmq"
+  access_user       = "user"
+  password          = "Dmstest@123"
+  vpc_id            = "%s"
+  subnet_id         = "%s"
+  security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
+  available_zones   = [data.huaweicloud_dms_az.az_1.id]
+  product_id        = data.huaweicloud_dms_product.product_1.id
+  engine_version    = data.huaweicloud_dms_product.product_1.version
+  storage_space     = data.huaweicloud_dms_product.product_1.storage
+  storage_spec_code = data.huaweicloud_dms_product.product_1.storage_spec_code
+
+  tags = {
+    key1  = "value"
+    owner = "terraform_update"
+  }
+}
 	`, instanceUpdate, OS_VPC_ID, OS_NETWORK_ID)
 }
 
 func testAccDmsV1Instance_KafkaInstance(instanceName string) string {
 	return fmt.Sprintf(`
-       resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-         name = "secgroup_1"
-         description = "secgroup_1"
-       }
-       data "huaweicloud_dms_az_v1" "az_1" {
-		}
-       data "huaweicloud_dms_product_v1" "product_1" {
-          engine = "kafka"
-          instance_type = "cluster"
-          version = "1.1.0"
-		}
-		resource "huaweicloud_dms_instance_v1" "instance_1" {
-			name  = "%s"
-          engine = "kafka"
-          partition_num = "${data.huaweicloud_dms_product_v1.product_1.partition_num}"
-          storage_space = "${data.huaweicloud_dms_product_v1.product_1.storage}"
-          specification = "${data.huaweicloud_dms_product_v1.product_1.bandwidth}"
-          vpc_id = "%s"
-          security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup_1.id}"
-          subnet_id = "%s"
-          available_zones = ["${data.huaweicloud_dms_az_v1.az_1.id}"]
-          product_id = "${data.huaweicloud_dms_product_v1.product_1.id}"
-          engine_version = "${data.huaweicloud_dms_product_v1.product_1.version}"
-          storage_spec_code = "${data.huaweicloud_dms_product_v1.product_1.storage_spec_code}"
-          depends_on      = ["data.huaweicloud_dms_product_v1.product_1", "huaweicloud_networking_secgroup_v2.secgroup_1"]
-		}
+data "huaweicloud_dms_az" "az_1" {
+}
+data "huaweicloud_dms_product" "product_1" {
+  engine        = "kafka"
+  instance_type = "cluster"
+  version       = "1.1.0"
+}
+
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "secgroup_1"
+}
+resource "huaweicloud_dms_instance" "instance_1" {
+  name              = "%s"
+  engine            = "kafka"
+  vpc_id            = "%s"
+  subnet_id         = "%s"
+  security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
+  available_zones   = [data.huaweicloud_dms_az.az_1.id]
+  product_id        = data.huaweicloud_dms_product.product_1.id
+  engine_version    = data.huaweicloud_dms_product.product_1.version
+  specification     = data.huaweicloud_dms_product.product_1.bandwidth
+  partition_num     = data.huaweicloud_dms_product.product_1.partition_num
+  storage_space     = data.huaweicloud_dms_product.product_1.storage
+  storage_spec_code = data.huaweicloud_dms_product.product_1.storage_spec_code
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
 	`, instanceName, OS_VPC_ID, OS_NETWORK_ID)
 }


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDmsInstancesV1_Rabbitmq'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDmsInstancesV1_Rabbitmq -timeout 360m
=== RUN   TestAccDmsInstancesV1_Rabbitmq
--- PASS: TestAccDmsInstancesV1_Rabbitmq (415.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       415.048s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDmsInstancesV1_Kafka'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDmsInstancesV1_Kafka -timeout 360m
=== RUN   TestAccDmsInstancesV1_Kafka
--- PASS: TestAccDmsInstancesV1_Kafka (424.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       424.967s
```