### PR TITLE
support tags for elb loadbalancer and listener resource

### DIFF
--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -13,6 +13,10 @@ resource "huaweicloud_lb_listener_v2" "listener_1" {
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+
+  tags = {
+    key = "value"
+  }
 }
 ```
 
@@ -63,6 +67,8 @@ The following arguments are supported:
 * `admin_state_up` - (Optional) The administrative state of the Listener.
     A valid value is true (UP) or false (DOWN).
 
+* `tags` - (Optional) The key/value pairs to associate with the listener.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -79,3 +85,4 @@ The following attributes are exported:
 * `default_tls_container_ref` - See Argument Reference above.
 * `sni_container_refs` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
+* `tags` - See Argument Reference above.

--- a/docs/resources/lb_loadbalancer_v2.md
+++ b/docs/resources/lb_loadbalancer_v2.md
@@ -13,6 +13,10 @@ Manages a V2 loadbalancer resource within HuaweiCloud.
 ```hcl
 resource "huaweicloud_lb_loadbalancer_v2" "lb_1" {
   vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+
+  tags = {
+    key = "value"
+  }
 }
 ```
 
@@ -33,21 +37,23 @@ resource "huaweicloud_networking_eip_associate" "eip_1" {
 
 The following arguments are supported:
 
-* `name` - (Optional) Human-readable name for the Loadbalancer. Does not have
+* `name` - (Optional) Human-readable name for the loadbalancer. Does not have
     to be unique.
 
-* `description` - (Optional) Human-readable description for the Loadbalancer.
+* `description` - (Optional) Human-readable description for the loadbalancer.
 
 * `vip_subnet_id` - (Required) The network on which to allocate the
-    Loadbalancer's address. A tenant can only create Loadbalancers on networks
+    loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
     are shared).  Changing this creates a new loadbalancer.
 
 * `vip_address` - (Optional) The ip address of the load balancer.
     Changing this creates a new loadbalancer.
 
-* `admin_state_up` - (Optional) The administrative state of the Loadbalancer.
+* `admin_state_up` - (Optional) The administrative state of the loadbalancer.
     A valid value is true (UP) or false (DOWN).
+
+* `tags` - (Optional) The key/value pairs to associate with the loadbalancer.
 
 ## Attributes Reference
 
@@ -59,4 +65,5 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `vip_address` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 * `vip_port_id` - The Port ID of the Load Balancer IP.

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -549,6 +549,10 @@ func (c *Config) elasticLBClient(region string) (*golangsdk.ServiceClient, error
 	return c.NewServiceClient("elb", region)
 }
 
+func (c *Config) elbV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("elbv2", region)
+}
+
 func (c *Config) fwV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("networkv2", region)
 }

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -139,6 +139,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v1.0",
 		WithOutProjectID: true,
 	},
+	"elbv2": ServiceCatalog{
+		Name:    "elb",
+		Version: "v2.0",
+	},
 	"fwv2": ServiceCatalog{
 		Name:             "vpc",
 		Version:          "v2.0",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -603,15 +603,25 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "vpc", "v1", t)
 
-	// test endpoint of loadElasticLoadBalancer v1.0
+	// test endpoint of elb v1.0
 	serviceClient, err = nil, nil
 	serviceClient, err = config.elasticLBClient(OS_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud loadElasticLoadBalancer v1.0 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud ELB v1.0 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://elb.%s.%s/v1.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "elb", "v1.0", t)
+
+	// test endpoint of elb v2.0
+	serviceClient, err = nil, nil
+	serviceClient, err = config.elbV2Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud ELB v2.0 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	compareURL(expectedURL, actualURL, "elb", "v2.0", t)
 
 	// test the endpoint of fw v2 service
 	serviceClient, err = config.fwV2Client(OS_REGION_NAME)

--- a/huaweicloud/resource_huaweicloud_lb_listener_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_listener_v2_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccLBV2Listener_basic(t *testing.T) {
 	var listener listeners.Listener
+	resourceName := "huaweicloud_lb_listener_v2.listener_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckULB(t) },
@@ -20,20 +21,19 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 			{
 				Config: TestAccLBV2ListenerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2ListenerExists("huaweicloud_lb_listener_v2.listener_1", &listener),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_lb_listener_v2.listener_1", "name", "listener_1"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_lb_listener_v2.listener_1", "connection_limit", "-1"),
+					testAccCheckLBV2ListenerExists(resourceName, &listener),
+					resource.TestCheckResourceAttr(resourceName, "name", "listener_1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "connection_limit", "-1"),
 				),
 			},
 			{
 				Config: TestAccLBV2ListenerConfig_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"huaweicloud_lb_listener_v2.listener_1", "name", "listener_1_updated"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_lb_listener_v2.listener_1", "name", "listener_1_updated"),
+					resource.TestCheckResourceAttr(resourceName, "name", "listener_1_updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
 			},
 		},
@@ -103,13 +103,12 @@ resource "huaweicloud_lb_listener_v2" "listener_1" {
   name = "listener_1"
   protocol = "HTTP"
   protocol_port = 8080
-  loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
+  loadbalancer_id = huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id
 
-	timeouts {
-		create = "5m"
-		update = "5m"
-		delete = "5m"
-	}
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
 }
 `, OS_SUBNET_ID)
 
@@ -124,12 +123,11 @@ resource "huaweicloud_lb_listener_v2" "listener_1" {
   protocol = "HTTP"
   protocol_port = 8080
   admin_state_up = "true"
-  loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
+  loadbalancer_id = huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id
 
-	timeouts {
-		create = "5m"
-		update = "5m"
-		delete = "5m"
-	}
+  tags = {
+    foo   = "bar"
+    owner = "terraform_update"
+  }
 }
 `, OS_SUBNET_ID)


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2LoadBalancer_basic -timeout 360m
=== RUN   TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (48.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       48.835s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Listener_basic -timeout 360m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (82.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       82.970s
```