### PR TITLE
Add the feature of resource-level region[1/2]

### DIFF
--- a/huaweicloud/data_source_huaweicloud_antiddos_v1.go
+++ b/huaweicloud/data_source_huaweicloud_antiddos_v1.go
@@ -17,7 +17,6 @@ func dataSourceAntiDdosV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"floating_ip_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_availability_zones.go
+++ b/huaweicloud/data_source_huaweicloud_availability_zones.go
@@ -14,6 +14,11 @@ func dataSourceAvailabilityZones() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAvailabilityZonesRead,
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"names": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/huaweicloud/data_source_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_cluster_v3.go
@@ -17,7 +17,6 @@ func dataSourceCCEClusterV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_v3.go
@@ -17,7 +17,6 @@ func dataSourceCCENodeV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"cluster_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_cdm_flavors_v1.go
+++ b/huaweicloud/data_source_huaweicloud_cdm_flavors_v1.go
@@ -16,7 +16,6 @@ func dataSourceCdmFlavorV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"version": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_csbs_backup_policy_v1.go
+++ b/huaweicloud/data_source_huaweicloud_csbs_backup_policy_v1.go
@@ -17,7 +17,6 @@ func dataSourceCSBSBackupPolicyV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_csbs_backup_v1.go
+++ b/huaweicloud/data_source_huaweicloud_csbs_backup_v1.go
@@ -17,7 +17,6 @@ func dataSourceCSBSBackupV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/data_source_huaweicloud_cts_tracker_v1.go
@@ -17,7 +17,6 @@ func dataSourceCTSTrackerV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_dcs_az_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_az_v1.go
@@ -13,6 +13,11 @@ func dataSourceDcsAZV1() *schema.Resource {
 		Read: dataSourceDcsAZV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_dcs_maintainwindow_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_maintainwindow_v1.go
@@ -14,6 +14,11 @@ func dataSourceDcsMaintainWindowV1() *schema.Resource {
 		Read: dataSourceDcsMaintainWindowV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"seq": {
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_dcs_product_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_product_v1.go
@@ -13,6 +13,11 @@ func dataSourceDcsProductV1() *schema.Resource {
 		Read: dataSourceDcsProductV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"spec_code": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_dis_partition_v2.go
+++ b/huaweicloud/data_source_huaweicloud_dis_partition_v2.go
@@ -12,6 +12,11 @@ func dataSourceDisPartitionV2() *schema.Resource {
 		Read: dataSourceDisPartitionV2Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"stream_name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/data_source_huaweicloud_dms_az_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dms_az_v1.go
@@ -13,6 +13,11 @@ func dataSourceDmsAZV1() *schema.Resource {
 		Read: dataSourceDmsAZV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_dms_maintainwindow_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dms_maintainwindow_v1.go
@@ -14,6 +14,11 @@ func dataSourceDmsMaintainWindowV1() *schema.Resource {
 		Read: dataSourceDmsMaintainWindowV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"seq": {
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_dms_product_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dms_product_v1.go
@@ -13,6 +13,11 @@ func dataSourceDmsProductV1() *schema.Resource {
 		Read: dataSourceDmsProductV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"engine": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_configuration.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_configuration.go
@@ -13,6 +13,11 @@ func dataSourceGaussdbMysqlConfigurations() *schema.Resource {
 		Read: dataSourceGaussdbMysqlConfigurationsRead,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
@@ -12,6 +12,11 @@ func dataSourceGaussdbMysqlFlavors() *schema.Resource {
 		Read: dataSourceGaussdbMysqlFlavorsRead,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"engine": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_identity_role_v3.go
+++ b/huaweicloud/data_source_huaweicloud_identity_role_v3.go
@@ -28,7 +28,6 @@ func DataSourceIdentityRoleV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/huaweicloud/data_source_huaweicloud_images_image_v2.go
+++ b/huaweicloud/data_source_huaweicloud_images_image_v2.go
@@ -20,7 +20,6 @@ func dataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"name": {

--- a/huaweicloud/data_source_huaweicloud_kms_data_key_v1.go
+++ b/huaweicloud/data_source_huaweicloud_kms_data_key_v1.go
@@ -14,6 +14,11 @@ func dataSourceKmsDataKeyV1() *schema.Resource {
 		Read: resourceKmsDataKeyV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"key_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1.go
@@ -14,6 +14,11 @@ func dataSourceKmsKeyV1() *schema.Resource {
 		Read: dataSourceKmsKeyV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"key_alias": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
@@ -13,6 +13,11 @@ func dataSourceNatGatewayV2() *schema.Resource {
 		Read: dataSourceNatGatewayV2Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/data_source_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/data_source_huaweicloud_obs_bucket_object.go
@@ -14,6 +14,11 @@ func dataSourceObsBucketObject() *schema.Resource {
 		Read: dataSourceObsBucketObjectRead,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"bucket": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/data_source_huaweicloud_rds_flavors_v3.go
+++ b/huaweicloud/data_source_huaweicloud_rds_flavors_v3.go
@@ -12,6 +12,11 @@ func dataSourceRdsFlavorV3() *schema.Resource {
 		Read: dataSourceRdsFlavorV3Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"db_type": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/data_source_huaweicloud_rts_software_config_v1.go
+++ b/huaweicloud/data_source_huaweicloud_rts_software_config_v1.go
@@ -18,7 +18,6 @@ func dataSourceRtsSoftwareConfigV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_rts_stack_resource_v1.go
+++ b/huaweicloud/data_source_huaweicloud_rts_stack_resource_v1.go
@@ -16,7 +16,6 @@ func dataSourceRTSStackResourcesV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"stack_name": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_rts_stack_v1.go
+++ b/huaweicloud/data_source_huaweicloud_rts_stack_v1.go
@@ -20,7 +20,6 @@ func dataSourceRTSStackV1() *schema.Resource {
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"status": {

--- a/huaweicloud/data_source_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/data_source_huaweicloud_sfs_file_system_v2.go
@@ -18,7 +18,6 @@ func dataSourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/data_source_huaweicloud_vbs_backup_policy_v2.go
@@ -18,7 +18,6 @@ func dataSourceVBSBackupPolicyV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vbs_backup_v2.go
+++ b/huaweicloud/data_source_huaweicloud_vbs_backup_v2.go
@@ -17,7 +17,6 @@ func dataSourceVBSBackupV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/data_source_huaweicloud_vpc.go
@@ -18,7 +18,6 @@ func DataSourceVirtualPrivateCloudVpcV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_bandwidth.go
@@ -13,6 +13,11 @@ func dataSourceBandWidth() *schema.Resource {
 		Read: dataSourceBandWidthRead,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_ids.go
@@ -13,6 +13,11 @@ func dataSourceVirtualPrivateCloudVpcIdsV1() *schema.Resource {
 		Read: dataSourceVirtualPrivateCloudIdsV1Read,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"ids": {
 				Type:     schema.TypeSet,
 				Computed: true,

--- a/huaweicloud/data_source_huaweicloud_vpc_route.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_route.go
@@ -18,7 +18,6 @@ func DataSourceVPCRouteV2() *schema.Resource {
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"type": {

--- a/huaweicloud/data_source_huaweicloud_vpc_route_ids.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_route_ids.go
@@ -17,7 +17,6 @@ func dataSourceVPCRouteIdsV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_subnet.go
@@ -18,7 +18,6 @@ func DataSourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/data_source_huaweicloud_vpc_subnet_ids.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_subnet_ids.go
@@ -17,7 +17,6 @@ func DataSourceVpcSubnetIdsV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1,6 +1,8 @@
 package huaweicloud
 
 import (
+	"sync"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -594,10 +596,16 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		MaxRetries:          d.Get("max_retries").(int),
 		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
 		TerraformVersion:    terraformVersion,
+		RegionProjectIDMap:  make(map[string]string),
+		RPLock:              new(sync.Mutex),
 	}
 
 	if err := config.LoadAndValidate(); err != nil {
 		return nil, err
+	}
+
+	if config.HwClient != nil && config.HwClient.ProjectID != "" {
+		config.RegionProjectIDMap[config.Region] = config.HwClient.ProjectID
 	}
 
 	return &config, nil

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -24,6 +24,7 @@ var (
 	OS_SUBNET_ID              = os.Getenv("OS_SUBNET_ID")
 	OS_POOL_NAME              = os.Getenv("OS_POOL_NAME")
 	OS_REGION_NAME            = os.Getenv("OS_REGION_NAME")
+	OS_CUSTOM_REGION_NAME     = os.Getenv("OS_CUSTOM_REGION_NAME")
 	OS_ACCESS_KEY             = os.Getenv("OS_ACCESS_KEY")
 	OS_SECRET_KEY             = os.Getenv("OS_SECRET_KEY")
 	OS_SRC_ACCESS_KEY         = os.Getenv("OS_SRC_ACCESS_KEY")
@@ -56,6 +57,12 @@ func testAccPreCheck(t *testing.T) {
 	// Do not run the test if this is a deprecated testing environment.
 	if OS_DEPRECATED_ENVIRONMENT != "" {
 		t.Skip("This environment only runs deprecated tests")
+	}
+}
+
+func testAccPrecheckCustomRegion(t *testing.T) {
+	if OS_CUSTOM_REGION_NAME == "" {
+		t.Skip("This environment does not support custom region tests")
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_api_gateway_api.go
+++ b/huaweicloud/resource_huaweicloud_api_gateway_api.go
@@ -26,6 +26,12 @@ func resourceAPIGatewayAPI() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"group_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_api_gateway_group.go
+++ b/huaweicloud/resource_huaweicloud_api_gateway_group.go
@@ -25,6 +25,12 @@ func resourceAPIGatewayGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cce_addon_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_addon_v3.go
@@ -24,6 +24,12 @@ func resourceCCEAddonV3() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{ // request and response parameters
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -25,6 +25,12 @@ func resourceCCENodePool() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cci_network_v1.go
+++ b/huaweicloud/resource_huaweicloud_cci_network_v1.go
@@ -24,6 +24,12 @@ func resourceCCINetworkV1() *schema.Resource {
 
 		//request and response parameters
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cdm_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_cdm_cluster_v1.go
@@ -36,6 +36,12 @@ func resourceCdmClusterV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule.go
@@ -26,6 +26,12 @@ func resourceAlarmRule() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"alarm_name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cloudtable_cluster_v2.go
+++ b/huaweicloud/resource_huaweicloud_cloudtable_cluster_v2.go
@@ -35,6 +35,12 @@ func resourceCloudtableClusterV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cs_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_cluster_v1.go
@@ -37,6 +37,12 @@ func resourceCsClusterV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_peering_connect_v1.go
@@ -36,6 +36,12 @@ func resourceCsPeeringConnectV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_cs_route_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_route_v1.go
@@ -30,6 +30,12 @@ func resourceCsRouteV1() *schema.Resource {
 		Delete: resourceCsRouteV1Delete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_css_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_css_cluster_v1.go
@@ -39,6 +39,12 @@ func resourceCssClusterV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
@@ -26,6 +26,12 @@ func resourceDcsInstanceV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dis_stream_v2.go
+++ b/huaweicloud/resource_huaweicloud_dis_stream_v2.go
@@ -31,6 +31,12 @@ func resourceDisStreamV2() *schema.Resource {
 		Delete: resourceDisStreamV2Delete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"partition_count": {
 				Type:     schema.TypeInt,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dli_queue_v1.go
+++ b/huaweicloud/resource_huaweicloud_dli_queue_v1.go
@@ -30,6 +30,12 @@ func resourceDliQueueV1() *schema.Resource {
 		Delete: resourceDliQueueV1Delete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"cu_count": {
 				Type:     schema.TypeInt,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dms_group_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_group_v1.go
@@ -18,6 +18,12 @@ func resourceDmsGroupsV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1.go
@@ -24,6 +24,12 @@ func resourceDmsInstancesV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dms_queue_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_queue_v1.go
@@ -18,6 +18,12 @@ func resourceDmsQueuesV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/resource_huaweicloud_dws_cluster.go
@@ -44,6 +44,7 @@ func resourceDwsCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"name": {

--- a/huaweicloud/resource_huaweicloud_evs_snapshot.go
+++ b/huaweicloud/resource_huaweicloud_evs_snapshot.go
@@ -27,6 +27,12 @@ func resourceEvsSnapshotV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"volume_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/resource_huaweicloud_evs_volume.go
@@ -33,6 +33,12 @@ func resourceEvsStorageVolumeV3() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"backup_id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/resource_huaweicloud_fgs_function_v2.go
+++ b/huaweicloud/resource_huaweicloud_fgs_function_v2.go
@@ -25,6 +25,12 @@ func resourceFgsFunctionV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_ges_graph_v1.go
+++ b/huaweicloud/resource_huaweicloud_ges_graph_v1.go
@@ -56,8 +56,9 @@ func resourceGesGraphV1() *schema.Resource {
 
 			"region": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 
 			"security_group_id": {

--- a/huaweicloud/resource_huaweicloud_iam_agency_v3.go
+++ b/huaweicloud/resource_huaweicloud_iam_agency_v3.go
@@ -38,6 +38,7 @@ func resourceIAMAgencyV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1.go
@@ -27,6 +27,12 @@ func resourceKmsKeyV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"key_alias": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_lb_whitelist_v2.go
+++ b/huaweicloud/resource_huaweicloud_lb_whitelist_v2.go
@@ -23,6 +23,12 @@ func resourceWhitelistV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/resource_huaweicloud_lts_group.go
+++ b/huaweicloud/resource_huaweicloud_lts_group.go
@@ -19,6 +19,12 @@ func resourceLTSGroupV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"group_name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/resource_huaweicloud_lts_stream.go
@@ -18,6 +18,12 @@ func resourceLTSStreamV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"group_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_mls_instance.go
+++ b/huaweicloud/resource_huaweicloud_mls_instance.go
@@ -44,6 +44,7 @@ func resourceMlsInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"flavor": {

--- a/huaweicloud/resource_huaweicloud_mrs_job_v1.go
+++ b/huaweicloud/resource_huaweicloud_mrs_job_v1.go
@@ -31,6 +31,7 @@ func resourceMRSJobV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"job_type": {
 				Type:     schema.TypeInt,

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -34,6 +34,12 @@ func resourceNatDnatRuleV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"floating_ip_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_network_acl.go
+++ b/huaweicloud/resource_huaweicloud_network_acl.go
@@ -30,6 +30,12 @@ func resourceNetworkACL() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_network_acl_rule.go
+++ b/huaweicloud/resource_huaweicloud_network_acl_rule.go
@@ -22,6 +22,12 @@ func resourceNetworkACLRule() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/resource_huaweicloud_networking_vip_associate_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_associate_v2.go
@@ -16,6 +16,12 @@ func resourceNetworkingVIPAssociateV2() *schema.Resource {
 		Delete: resourceNetworkingVIPAssociateV2Delete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"vip_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_networking_vip_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_v2.go
@@ -18,6 +18,12 @@ func resourceNetworkingVIPV2() *schema.Resource {
 		Delete: resourceNetworkingVIPV2Delete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"network_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -264,6 +264,7 @@ func resourceObsBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"enterprise_project_id": {

--- a/huaweicloud/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_object.go
@@ -20,6 +20,12 @@ func resourceObsBucketObject() *schema.Resource {
 		Delete: resourceObsBucketObjectDelete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"bucket": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_obs_bucket_policy.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_policy.go
@@ -21,6 +21,12 @@ func resourceObsBucketPolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"bucket": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_oms_task_v1.go
+++ b/huaweicloud/resource_huaweicloud_oms_task_v1.go
@@ -27,6 +27,12 @@ func resourceMaasTaskV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/huaweicloud/resource_huaweicloud_rds_configuration_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_configuration_v3.go
@@ -26,6 +26,12 @@ func resourceRdsConfigurationV3() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -47,6 +47,12 @@ func resourceRdsInstanceV3() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"availability_zone": {
 				Type:     schema.TypeList,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_sfs_access_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_access_rule_v2.go
@@ -28,6 +28,12 @@ func resourceSFSAccessRuleV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"sfs_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_smn_subscription_v2.go
+++ b/huaweicloud/resource_huaweicloud_smn_subscription_v2.go
@@ -16,6 +16,12 @@ func resourceSubscription() *schema.Resource {
 		Delete: resourceSubscriptionDelete,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"topic_urn": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_smn_topic_v2.go
+++ b/huaweicloud/resource_huaweicloud_smn_topic_v2.go
@@ -19,6 +19,12 @@ func resourceTopic() *schema.Resource {
 		Update: resourceTopicUpdate,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -27,6 +27,12 @@ func resourceVBSBackupPolicyV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,

--- a/huaweicloud/resource_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/resource_huaweicloud_vpc_bandwidth.go
@@ -30,6 +30,12 @@ func resourceVpcBandWidthV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,


### PR DESCRIPTION
#### Intro
Based on provider-level region, this commit add an optional param named `region` in each resource and datasource.
User can manage cloud-resources in different regions just in a single `tf` file by confing `region` param in resource or datasource.
But, plase read the following attentions:
1. **Resource-level region only supports AK/SK authentication**.
2. **If you set `region` in resource or datasource but authed by user-name/pwd or token, then the resource-level region must be the same with the provider-level region. Or you will get an error.**
 
#### Test
Have commited a test case in `resource_huaweicloud_vpc_test.go` , named `TestAccVpcV1_WithCustomRegion`, and there is the test script and result.
```go
func tesstAccVpcV1_WithCustomRegion(name1 string, name2 string, region string) string {
	return fmt.Sprintf(`
resource "huaweicloud_vpc" "test1" {
  name = "%s"
  cidr = "192.168.0.0/16"
}

resource "huaweicloud_vpc" "test2" {    
  name = "%s"
  region = "%s"
  cidr = "192.168.0.0/16"
}
`, name1, name2, region)
}
```

```bash
root@ecs-yuqizi:~/go/src/github.com/terraform-provider-huaweicloud# make testacc TEST='./huaweicloud/' TESTARGS='-run TestAccVpcV1_WithCustomRegion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccVpcV1_WithCustomRegion -timeout 360m
=== RUN   TestAccVpcV1_WithCustomRegion
--- PASS: TestAccVpcV1_WithCustomRegion (53.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       53.722s
```