### PR TITLE
add data source enterprise project support

### DIFF
--- a/docs/data-sources/eps.md
+++ b/docs/data-sources/eps.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# huaweicloud\_enterprise\_project
+
+Use this data source to get an enterprise project from HuaweiCloud
+
+## Example Usage
+
+```hcl
+data "huaweicloud_enterprise_project" "test" {
+  name = "test"
+}
+```
+
+## Resources Supported Currently:
+Service Name | Resource Name
+---- | ---
+VPC | huaweicloud_vpc<br>huaweicloud_vpc_eip<br>huaweicloud_vpc_bandwidth<br>huaweicloud_networking_secgroup
+ECS | huaweicloud_compute_instance
+CCE | huaweicloud_cce_cluster
+RDS | huaweicloud_rds_instance
+OBS | hauweicloud_obs_bucket
+SFS | hauweicloud_sfs_file_system
+DCS | huaweicloud_dcs_instance
+NAT | huaweicloud_nat_gateway
+CDM | huaweicloud_cdm_cluster
+CDN | huaweicloud_cdn_domain
+GaussDB | huaweicloud_gaussdb_cassandra_instance<br>huaweicloud_gaussdb_mysql_instance<br>huaweicloud_gaussdb_opengauss_instance
+
+## Argument Reference
+
+* `name` - (Optional) Specifies the enterprise project name. Fuzzy search is supported.
+
+* `id` - (Optional) Specifies the ID of an enterprise project. The value 0 indicates enterprise project default.
+
+* `status` - (Optional) Specifies the status of an enterprise project.
+    - 1 indicates Enabled.
+    - 2 indicates Disabled.
+
+## Attributes Reference
+
+All above argument parameters can be exported as attribute parameters along with attribute reference:
+
+* `description` - Provides supplementary information about the enterprise project.
+
+* `created_at` - Specifies the time (UTC) when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - Specifies the time (UTC) when the enterprise project was modified. Example: 2018-05-28T02:21:36Z
+

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3
+	github.com/huaweicloud/golangsdk v0.0.0-20201030072716-cb31520416ba
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3 h1:OM0O1p/gea9E3fQGca1gBrM/f10IZQ38w4MGhupar8c=
-github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20201030072716-cb31520416ba h1:HYHfyOIFOG8Y3y1XZoiyFhsTUxkg56IxPn+D9ME60pE=
+github.com/huaweicloud/golangsdk v0.0.0-20201030072716-cb31520416ba/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -461,6 +461,10 @@ func (c *Config) CdnV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("cdn", region)
 }
 
+func (c *Config) EnterpriseProjectClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("eps", region)
+}
+
 // ********** client for Compute **********
 func (c *Config) computeV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("ecs", region)

--- a/huaweicloud/data_source_enterprise_project.go
+++ b/huaweicloud/data_source_enterprise_project.go
@@ -1,0 +1,84 @@
+package huaweicloud
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects"
+)
+
+func DataSourceEnterpriseProject() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceEnterpriseProjectRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEnterpriseProjectRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	epsClient, err := config.EnterpriseProjectClient(region)
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud eps client %s", err)
+	}
+
+	listOpts := enterpriseprojects.ListOpts{
+		Name:   d.Get("name").(string),
+		ID:     d.Get("id").(string),
+		Status: d.Get("status").(int),
+	}
+	projects, err := enterpriseprojects.List(epsClient, listOpts).Extract()
+
+	if err != nil {
+		return fmt.Errorf("Error retriving enterprise projects %s", err)
+	}
+
+	if len(projects) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(projects) > 1 {
+		return fmt.Errorf("Your query returned more than one result." +
+			" Please try a more specific search criteria")
+	}
+
+	project := projects[0]
+
+	d.SetId(project.ID)
+	d.Set("name", project.Name)
+	d.Set("description", project.Description)
+	d.Set("status", project.Status)
+	d.Set("created_at", project.CreatedAt)
+	d.Set("updated_at", project.UpdatedAt)
+
+	return nil
+}

--- a/huaweicloud/data_source_enterprise_project_test.go
+++ b/huaweicloud/data_source_enterprise_project_test.go
@@ -1,0 +1,49 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccEnterpriseProjectDataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_enterprise_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProjectDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnterpriseProjectDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "id", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEnterpriseProjectDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find enterprise project data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("enterprise project data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+const testAccEnterpriseProjectDataSource_basic = `
+data "huaweicloud_enterprise_project" "test" {
+  name = "default"
+}
+`

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -42,6 +42,13 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Scope:            "global",
 		WithOutProjectID: true,
 	},
+	"eps": ServiceCatalog{
+		Name:             "eps",
+		Version:          "v1.0",
+		Scope:            "global",
+		Admin:            true,
+		WithOutProjectID: true,
+	},
 
 	// ******* catalog for Compute *******
 	"ecs": ServiceCatalog{

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -207,6 +207,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_dms_az":                      dataSourceDmsAZV1(),
 			"huaweicloud_dms_product":                 dataSourceDmsProductV1(),
 			"huaweicloud_dms_maintainwindow":          dataSourceDmsMaintainWindowV1(),
+			"huaweicloud_enterprise_project":          DataSourceEnterpriseProject(),
 			"huaweicloud_gaussdb_mysql_configuration": dataSourceGaussdbMysqlConfigurations(),
 			"huaweicloud_gaussdb_mysql_flavors":       dataSourceGaussdbMysqlFlavors(),
 			"huaweicloud_iam_role":                    dataSourceIAMRoleV3(),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/flavors/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/flavors/results.go
@@ -82,6 +82,12 @@ type OsExtraSpecs struct {
 
 	// Indicates the model and quantity of passthrough-enabled GPUs on P1 ECSs.
 	PciPassthroughAlias string `json:"pci_passthrough:alias"`
+
+	// Indicates the status of the flavor in region level.
+	OperationStatus string `json:"cond:operation:status"`
+
+	// Indicates the status of the flavor in az level.
+	OperationAz string `json:"cond:operation:az"`
 }
 
 // FlavorsPage is the page returned by a pager when traversing over a

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects/requests.go
@@ -1,0 +1,34 @@
+package enterpriseprojects
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type ListOpts struct {
+	Name   string `q:"name"`
+	ID     string `q:"id"`
+	Status int    `q:"status"`
+}
+
+func (opts ListOpts) ToEnterpriseProjectListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+type ListOptsBuilder interface {
+	ToEnterpriseProjectListQuery() (string, error)
+}
+
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) (r ListResult) {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToEnterpriseProjectListQuery()
+		if err != nil {
+			r.Err = err
+		}
+		url += query
+	}
+
+	_, r.Err = c.Get(url, &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects/results.go
@@ -1,0 +1,30 @@
+package enterpriseprojects
+
+import "github.com/huaweicloud/golangsdk"
+
+type Project struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Status      int    `json:"status"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	Type        string `json:"type"`
+}
+
+type Projects struct {
+	EnterpriseProjects []Project `json:"enterprise_projects"`
+	TotalCount         int       `json:"total_count"`
+}
+
+type ListResult struct {
+	golangsdk.Result
+}
+
+func (r ListResult) Extract() ([]Project, error) {
+	var a struct {
+		EnterpriseProjects []Project `json:"enterprise_projects"`
+	}
+	err := r.Result.ExtractInto(&a)
+	return a.EnterpriseProjects, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects/urls.go
@@ -1,0 +1,9 @@
+package enterpriseprojects
+
+import "github.com/huaweicloud/golangsdk"
+
+const resourcePath = "enterprise-projects"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201027014306-5ff7dac952b3
+# github.com/huaweicloud/golangsdk v0.0.0-20201030072716-cb31520416ba
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -248,6 +248,7 @@ github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/flavors
+github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects
 github.com/huaweicloud/golangsdk/openstack/evs/v2/snapshots
 github.com/huaweicloud/golangsdk/openstack/evs/v2/tags
 github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes


### PR DESCRIPTION
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccEnterpriseProjectDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccEnterpriseProjectDataSource_basic -timeout 360m
=== RUN   TestAccEnterpriseProjectDataSource_basic
--- PASS: TestAccEnterpriseProjectDataSource_basic (10.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       11.001s