### PR TITLE
Fix some errors in docs

### DIFF
--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -129,7 +129,6 @@ The `backup_strategy` block supports:
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `status` - Indicates the DB instance status.
-* `region` - Indicates the region where the DB instance is deployed.
 * `port` - Indicates the database port.
 * `mode` - Indicates the instance type.
 * `db_user_name` - Indicates the default username.

--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -115,7 +115,6 @@ The `backup_strategy` block supports:
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `status` - Indicates the DB instance status.
-* `region` - Indicates the region where the DB instance is deployed.
 * `port` - Indicates the database port.
 * `mode` - Indicates the instance mode.
 * `db_user_name` - Indicates the default username.

--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -138,7 +138,6 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `id` - Indicates the DB instance ID.
 * `status` - Indicates the DB instance status.
-* `region` - Indicates the region where the DB instance is deployed.
 * `type` - Indicates the database type.
 * `port` - Indicates the database port.
 * `private_ips` - Indicates the private IP address of the DB instance.

--- a/docs/resources/lb_l7policy_v2.md
+++ b/docs/resources/lb_l7policy_v2.md
@@ -43,7 +43,7 @@ resource "huaweicloud_lb_l7policy_v2" "l7policy_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
+    A Networking client is needed to create a L7 Policy resource. If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     L7 Policy.
 

--- a/docs/resources/lb_l7rule_v2.md
+++ b/docs/resources/lb_l7rule_v2.md
@@ -50,7 +50,7 @@ resource "huaweicloud_lb_l7rule_v2" "l7rule_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
+    A Networking client is needed to create a L7 Rule resource. If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     L7 Rule.
 

--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -25,7 +25,7 @@ resource "huaweicloud_lb_listener_v2" "listener_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
+    A Networking client is needed to create a V2 listener resource. If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     Listener.
 

--- a/docs/resources/lb_member_v2.md
+++ b/docs/resources/lb_member_v2.md
@@ -22,7 +22,7 @@ resource "huaweicloud_lb_member_v2" "member_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
+    A Networking client is needed to create a V2 member resource. If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     member.
 

--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -23,7 +23,7 @@ resource "huaweicloud_lb_monitor_v2" "monitor_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
+    A Networking client is needed to create a V2 monitor resource. If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     monitor.
 

--- a/docs/resources/lb_pool_v2.md
+++ b/docs/resources/lb_pool_v2.md
@@ -26,7 +26,7 @@ resource "huaweicloud_lb_pool_v2" "pool_1" {
 The following arguments are supported:
 
 * `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
+    A Networking client is needed to create a V2 pool resource. If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     pool.
 


### PR DESCRIPTION
Fix errors or remove redundant `region` in the following files:
* docs/resources/gaussdb_cassandra_instance.md
* docs/resources/gaussdb_mysql_instance.md
* docs/resources/gaussdb_opengauss_instance.md
* docs/resources/lb_l7policy_v2.md
* docs/resources/lb_l7rule_v2.md
* docs/resources/lb_listener_v2.md
* docs/resources/lb_member_v2.md
* docs/resources/lb_monitor_v2.md
* docs/resources/lb_pool_v2.md