### PR TITLE
Update nat_dnat_rule.md

### DIFF
--- a/docs/resources/nat_dnat_rule.md
+++ b/docs/resources/nat_dnat_rule.md
@@ -32,7 +32,7 @@ The following arguments are supported:
   Changing this creates a new resource.
 
 * `internal_service_port` - (Required) Specifies port used by ECSs or BMSs
-  to provide services for external systems. Changing this creates a new resource.
+  to provide services for internal systems. Changing this creates a new resource.
 
 * `nat_gateway_id` - (Required) ID of the nat gateway this dnat rule belongs to.
    Changing this creates a new dnat rule.


### PR DESCRIPTION
## Argument Reference
internal_service_port: "Specifies port used by ECSs or BMSs to provide services for external systems."

Revise:
'external' should be update to 'internal'.