### PR TITLE
support importing and add status attribute for nat gateway and snat rule

### DIFF
--- a/docs/resources/nat_dnat_rule.md
+++ b/docs/resources/nat_dnat_rule.md
@@ -16,8 +16,8 @@ resource "huaweicloud_nat_dnat_rule" "dnat_1" {
   floating_ip_id        = "2bd659ab-bbf7-43d7-928b-9ee6a10de3ef"
   nat_gateway_id        = "bf99c679-9f41-4dac-8513-9c9228e713e1"
   private_ip            = "10.0.0.12"
-  internal_service_port = 993
   protocol              = "tcp"
+  internal_service_port = 993
   external_service_port = 242
 }
 ```

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -12,7 +12,7 @@ This is an alternative to `huaweicloud_nat_gateway_v2`
 ```hcl
 resource "huaweicloud_nat_gateway" "nat_1" {
   name                = "Terraform"
-  description         = "test for terraform2"
+  description         = "test for terraform"
   spec                = "3"
   router_id           = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
   internal_network_id = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
@@ -55,3 +55,11 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `router_id` - See Argument Reference above.
 * `internal_network_id` - See Argument Reference above.
+
+## Import
+
+Nat gateway can be imported using the following format:
+
+```
+$ terraform import huaweicloud_nat_gateway.nat_1 d126fb87-43ce-4867-a2ff-cf34af3765d9
+```

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -55,6 +55,7 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `router_id` - See Argument Reference above.
 * `internal_network_id` - See Argument Reference above.
+* `status` - The status of the nat gateway.
 
 ## Import
 

--- a/docs/resources/nat_snat_rule.md
+++ b/docs/resources/nat_snat_rule.md
@@ -40,3 +40,11 @@ The following attributes are exported:
 * `nat_gateway_id` - See Argument Reference above.
 * `network_id` - See Argument Reference above.
 * `floating_ip_id` - See Argument Reference above.
+
+## Import
+
+Snat can be imported using the following format:
+
+```
+$ terraform import huaweicloud_nat_snat_rule.snat_1 9e0713cb-0a2f-484e-8c7d-daecbb61dbe4
+```

--- a/docs/resources/nat_snat_rule.md
+++ b/docs/resources/nat_snat_rule.md
@@ -40,6 +40,8 @@ The following attributes are exported:
 * `nat_gateway_id` - See Argument Reference above.
 * `network_id` - See Argument Reference above.
 * `floating_ip_id` - See Argument Reference above.
+* `floating_ip_address` - The actual floating IP address.
+* `status` - The status of the snat rule.
 
 ## Import
 

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -19,6 +19,10 @@ func resourceNatGatewayV2() *schema.Resource {
 		Update: resourceNatGatewayV2Update,
 		Delete: resourceNatGatewayV2Delete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -74,6 +74,10 @@ func resourceNatGatewayV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -139,7 +143,7 @@ func resourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("router_id", natGateway.RouterID)
 	d.Set("internal_network_id", natGateway.InternalNetworkID)
 	d.Set("tenant_id", natGateway.TenantID)
-
+	d.Set("status", natGateway.Status)
 	d.Set("region", GetRegion(d, config))
 	d.Set("enterprise_project_id", natGateway.EnterpriseProjectID)
 

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
@@ -50,6 +50,14 @@ func resourceNatSnatRuleV2() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: suppressSnatFiplistDiffs,
 			},
+			"floating_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -108,7 +116,8 @@ func resourceNatSnatRuleV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("nat_gateway_id", snatRule.NatGatewayID)
 	d.Set("network_id", snatRule.NetworkID)
 	d.Set("floating_ip_id", snatRule.FloatingIPID)
-
+	d.Set("floating_ip_address", snatRule.FloatingIPAddress)
+	d.Set("status", snatRule.Status)
 	d.Set("region", GetRegion(d, config))
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
@@ -18,6 +18,10 @@ func resourceNatSnatRuleV2() *schema.Resource {
 		Read:   resourceNatSnatRuleV2Read,
 		Delete: resourceNatSnatRuleV2Delete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),


### PR DESCRIPTION
This PR including:
- support import for nat gateway and snat rule resources
- add status attribute nat gateway and snat rule resources
- update test cases for nat resources

and the testing results as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatGateway_basic -timeout 360m
=== RUN   TestAccNatGateway_basic
--- PASS: TestAccNatGateway_basic (117.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       117.738s
$
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatSnatRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatSnatRule_basic -timeout 360m
=== RUN   TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (116.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       116.465s
$
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatDnat_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatDnat_basic -timeout 360m
=== RUN   TestAccNatDnat_basic
--- PASS: TestAccNatDnat_basic (182.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       182.826s
```