### PR TITLE
deprecate lb_listener_id in as group and update docs

### DIFF
--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -79,66 +79,26 @@ resource "huaweicloud_as_group" "my_as_group_only_remove_members" {
 }
 ```
 
-### Autoscaling Group With ELB Listener
-
-```hcl
-resource "huaweicloud_as_group" "my_as_group_with_elb" {
-  scaling_group_name       = "my_as_group_with_elb"
-  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
-  desire_instance_number   = 2
-  min_instance_number      = 0
-  max_instance_number      = 10
-  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
-  lb_listener_id           = huaweicloud_elb_listener.my_listener.id
-  delete_publicip          = true
-  delete_instances         = "yes"
-
-  networks {
-    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  }
-  security_groups {
-    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
-  }
-}
-
-resource "huaweicloud_elb_listener" "my_listener" {
-  name             = "my_listener"
-  description      = "my test listener"
-  protocol         = "TCP"
-  backend_protocol = "TCP"
-  port             = 12345
-  backend_port     = 21345
-  lb_algorithm     = "roundrobin"
-  loadbalancer_id  = "cba48790-baf5-4446-adb3-02069a916e97"
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
-}
-
-```
-
 ### Autoscaling Group With Enhanced Load Balancer Listener
 
 ```hcl
-resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
+resource "huaweicloud_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "loadbalancer_1"
   vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
 }
 
-resource "huaweicloud_lb_listener" "listener_1" {
+resource "huaweicloud_lb_listener_v2" "listener_1" {
   name            = "listener_1"
   protocol        = "HTTP"
   protocol_port   = 8080
-  loadbalancer_id = huaweicloud_lb_loadbalancer.loadbalancer_1.id
+  loadbalancer_id = huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
-resource "huaweicloud_lb_pool" "pool_1" {
+resource "huaweicloud_lb_pool_v2" "pool_1" {
   name        = "pool_1"
   protocol    = "HTTP"
   lb_method   = "ROUND_ROBIN"
-  listener_id = huaweicloud_lb_listener.listener_1.id
+  listener_id = huaweicloud_lb_listener_v2.listener_1.id
 }
 
 resource "huaweicloud_as_group" "my_as_group_with_enhanced_lb" {
@@ -156,8 +116,8 @@ resource "huaweicloud_as_group" "my_as_group_with_enhanced_lb" {
     id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
   }
   lbaas_listeners {
-    pool_id       = huaweicloud_lb_pool.pool_1.id
-    protocol_port = huaweicloud_lb_listener.listener_1.protocol_port
+    pool_id       = huaweicloud_lb_pool_v2.pool_1.id
+    protocol_port = huaweicloud_lb_listener_v2.listener_1.protocol_port
   }
 }
 ```
@@ -189,13 +149,9 @@ The following arguments are supported:
 * `cool_down_time` - (Optional) The cooling duration (in seconds). The value ranges
     from 0 to 86400, and is 300 by default.
 
-* `lb_listener_id` - (Optional) The ELB listener IDs. The system supports up to
-    three ELB listeners, the IDs of which are separated using a comma (,).
-
 * `lbaas_listeners` - (Optional) An array of one or more enhanced load balancer.
-    The system supports the binding of up to three load balancers. The field is
-    alternative to lb_listener_id.  The lbaas_listeners object structure is
-    documented below.
+    The system supports the binding of up to six load balancers.
+    The object structure is documented below.
 
 * `available_zones` - (Optional) The availability zones in which to create
     the instances in the autoscaling group.

--- a/huaweicloud/resource_huaweicloud_as_group_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_group_v1.go
@@ -77,11 +77,14 @@ func resourceASGroup() *schema.Resource {
 				Optional:     true,
 				ForceNew:     false,
 				ValidateFunc: resourceASGroupValidateListenerId,
-				Description:  "The system supports the binding of up to three ELB listeners, the IDs of which are separated using a comma.",
+				Description:  "The system supports the binding of up to six ELB listeners, the IDs of which are separated using a comma.",
+				Deprecated:   "use lbaas_listeners instead",
 			},
 			"lbaas_listeners": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      6,
+				ConflictsWith: []string{"lb_listener_id"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pool_id": {
@@ -99,7 +102,6 @@ func resourceASGroup() *schema.Resource {
 						},
 					},
 				},
-				ForceNew: false,
 			},
 			"available_zones": {
 				Type:     schema.TypeList,
@@ -739,10 +741,10 @@ func resourceASGroupValidateCoolDownTime(v interface{}, k string) (ws []string, 
 func resourceASGroupValidateListenerId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	split := strings.Split(value, ",")
-	if len(split) <= 3 {
+	if len(split) <= 6 {
 		return
 	}
-	errors = append(errors, fmt.Errorf("%q supports binding up to 3 ELB listeners which are separated by a comma.", k))
+	errors = append(errors, fmt.Errorf("%q supports binding up to 6 ELB listeners which are separated by a comma.", k))
 	return
 }
 

--- a/huaweicloud/resource_huaweicloud_as_group_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_as_group_v1_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccASV1Group_basic(t *testing.T) {
 	var asGroup groups.Group
+	resourceName := "huaweicloud_as_group.hth_as_group"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccAsConfigPreCheck(t) },
@@ -22,13 +23,10 @@ func TestAccASV1Group_basic(t *testing.T) {
 			{
 				Config: testASV1Group_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckASV1GroupExists("huaweicloud_as_group_v1.hth_as_group", &asGroup),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_as_group_v1.hth_as_group", "lbaas_listeners.0.protocol_port", "8080"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_as_group_v1.hth_as_group", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_as_group_v1.hth_as_group", "tags.key", "value"),
+					testAccCheckASV1GroupExists(resourceName, &asGroup),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 		},
@@ -43,7 +41,7 @@ func testAccCheckASV1GroupDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_as_group_v1" {
+		if rs.Type != "huaweicloud_as_group" {
 			continue
 		}
 
@@ -91,65 +89,66 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 }
 
 var testASV1Group_basic = fmt.Sprintf(`
-resource "huaweicloud_networking_secgroup_v2" "secgroup" {
+resource "huaweicloud_networking_secgroup" "secgroup" {
   name        = "terraform"
   description = "This is a terraform test security group"
 }
 
-resource "huaweicloud_compute_keypair_v2" "hth_key" {
-  name = "as_key"
+resource "huaweicloud_compute_keypair" "hth_key" {
+  name       = "as_key"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
 
 resource "huaweicloud_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "%s"
 }
 
 resource "huaweicloud_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "huaweicloud_lb_pool_v2" "pool_1" {
-  name = "pool_1"
-  protocol = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  listener_id = "${huaweicloud_lb_listener_v2.listener_1.id}"
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = huaweicloud_lb_listener_v2.listener_1.id
 }
 
-resource "huaweicloud_as_configuration_v1" "hth_as_config"{
+resource "huaweicloud_as_configuration" "hth_as_config"{
   scaling_configuration_name = "hth_as_config"
   instance_config {
-    image = "%s"
+    image    = "%s"
+    key_name = huaweicloud_compute_keypair.hth_key.id
     disk {
-      size = 40
+      size        = 40
       volume_type = "SATA"
-      disk_type = "SYS"
+      disk_type   = "SYS"
     }
-    key_name = "${huaweicloud_compute_keypair_v2.hth_key.id}"
   }
 }
 
-resource "huaweicloud_as_group_v1" "hth_as_group"{
-  scaling_group_name = "hth_as_group"
-  scaling_configuration_id = "${huaweicloud_as_configuration_v1.hth_as_config.id}"
+resource "huaweicloud_as_group" "hth_as_group"{
+  scaling_group_name       = "hth_as_group"
+  scaling_configuration_id = huaweicloud_as_configuration.hth_as_config.id
+  vpc_id                   = "%s"
+
   networks {
     id = "%s"
   }
   security_groups {
-    id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
+    id = huaweicloud_networking_secgroup.secgroup.id
   }
   lbaas_listeners {
-    pool_id = "${huaweicloud_lb_pool_v2.pool_1.id}"
-    protocol_port = "${huaweicloud_lb_listener_v2.listener_1.protocol_port}"
+    pool_id       = huaweicloud_lb_pool_v2.pool_1.id
+    protocol_port = huaweicloud_lb_listener_v2.listener_1.protocol_port
   }
-  vpc_id = "%s"
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, OS_SUBNET_ID, OS_IMAGE_ID, OS_NETWORK_ID, OS_VPC_ID)
+`, OS_SUBNET_ID, OS_IMAGE_ID, OS_VPC_ID, OS_NETWORK_ID)


### PR DESCRIPTION
The testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccASV1Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccASV1Group_basic -timeout 360m
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (95.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       95.661s
```