### PR TITLE
Change the method of getting master node

### DIFF
--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -370,11 +370,18 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 
 	nodes := v.([]interface{})
 	if len(nodes) > 0 {
-		node_id = nodes[0].(map[string]interface{})["id"].(string)
+		for _, node := range nodes {
+			n := node.(map[string]interface{})
+			if n["role"] == "master" {
+				node_id = n["id"].(string)
+				break
+			}
+		}
 	} else {
 		log.Printf("[WARN] Error setting nodes of instance:%s", d.Id())
 		return nil
 	}
+	log.Printf("[DEBUG] get master node id: %s", node_id)
 
 	if d.HasChange("flavor") {
 		nflavor := d.Get("flavor")


### PR DESCRIPTION
Change the method of getting master node when updating rds instance. There might be getting a wrong node by getting `node[0]` in previous version.
The test result as following:
```bash
root@ecs-yuqizi:~/go/src/github.com/terraform-provider-huaweicloud# make testacc TEST=./huaweicloud/ TESTARGS="-run TestAccRdsInstanceV3_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccRdsInstanceV3_basic -timeout 360m
=== RUN   TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (657.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       657.132s
```