### PR TITLE
make subnet_id be optional and name be updatable for vip

### DIFF
--- a/docs/resources/networking_vip.md
+++ b/docs/resources/networking_vip.md
@@ -5,7 +5,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 # huaweicloud\_networking\_vip
 
 Manages a Vip resource within HuaweiCloud.
-This is an alternative to `huaweicloud_networking_vip`
+This is an alternative to `huaweicloud_networking_vip_v2`
 
 ## Example Usage
 
@@ -16,7 +16,6 @@ data "huaweicloud_vpc_subnet" "mynet" {
 
 resource "huaweicloud_networking_vip" "myvip" {
   network_id = data.huaweicloud_vpc_subnet.mynet.id
-  subnet_id  = data.huaweicloud_vpc_subnet.mynet.subnet_id
 }
 ```
 
@@ -24,29 +23,29 @@ resource "huaweicloud_networking_vip" "myvip" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the vip resource. If omitted, the provider-level region will work as default. Changing this creates a new vip resource.
+* `region` - (Optional, ForceNew) The region in which to obtain the vip resource.
+    If omitted, the provider-level region will work as default.
 
-* `network_id` - (Required) The Network ID of the VPC subnet to attach the vip to.
-    Changing this creates a new vip.
+* `network_id` - (Required, ForceNew) Specifies the ID of the network to which the vip belongs.
 
-* `subnet_id` - (Required) Subnet in which to allocate IP address for this vip.
-    Changing this creates a new vip.
+* `subnet_id` - (Optional, ForceNew) Specifies the subnet in which to allocate IP address for this vip.
 
-* `ip_address` - (Optional) IP address desired in the subnet for this vip.
+* `ip_address` - (Optional, ForceNew) Specifies the IP address desired in the subnet for this vip.
     If you don't specify `ip_address`, an available IP address from
     the specified subnet will be allocated to this vip.
 
-* `name` - (Optional) A unique name for the vip.
+* `name` - (Optional) Specifies a unique name for the vip.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `id` - The ID of the vip.
+* `name` - See Argument Reference above.
 * `network_id` - See Argument Reference above.
 * `subnet_id` - See Argument Reference above.
 * `ip_address` - See Argument Reference above.
-* `name` - See Argument Reference above.
+* `mac_address` - The MAC address of the vip.
 * `status` - The status of vip.
-* `id` - The ID of the vip.
 * `tenant_id` - The tenant ID of the vip.
 * `device_owner` - The device owner of the vip.

--- a/examples/vpc/vip/main.tf
+++ b/examples/vpc/vip/main.tf
@@ -51,7 +51,6 @@ data "huaweicloud_networking_port" "port_1" {
 
 resource "huaweicloud_networking_vip" "vip_1" {
   network_id = huaweicloud_vpc_subnet.subnet_1.id
-  subnet_id  = huaweicloud_vpc_subnet.subnet_1.subnet_id
 }
 
 # associate ports to the vip


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run  TestAccNetworkingV2VIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run  TestAccNetworkingV2VIP_basic -timeout 360m
=== RUN   TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (90.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       90.522s
```