### PR TITLE
support to update port_ids for vip associate

### DIFF
--- a/docs/resources/networking_vip_associate.md
+++ b/docs/resources/networking_vip_associate.md
@@ -16,7 +16,6 @@ data "huaweicloud_vpc_subnet" "mynet" {
 
 resource "huaweicloud_networking_vip" "myvip" {
   network_id = data.huaweicloud_vpc_subnet.mynet.id
-  subnet_id  = data.huaweicloud_vpc_subnet.mynet.subnet_id
 }
 
 resource "huaweicloud_networking_vip_associate" "vip_associated" {
@@ -29,13 +28,12 @@ resource "huaweicloud_networking_vip_associate" "vip_associated" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the vip associate resource. If omitted, the provider-level region will work as default. Changing this creates a new vip associate resource.
+* `region` - (Optional, ForceNew) The region in which to obtain the vip associate resource.
+    If omitted, the provider-level region will work as default.
 
-* `vip_id` - (Required) The ID of vip to attach the port to.
-    Changing this creates a new vip associate.
+* `vip_id` - (Required, ForceNew) The ID of vip to attach the ports to.
 
 * `port_ids` - (Required) An array of one or more IDs of the ports to attach the vip to.
-    Changing this creates a new vip associate.
 
 ## Attributes Reference
 
@@ -45,3 +43,4 @@ The following attributes are exported:
 * `port_ids` - See Argument Reference above.
 * `vip_subnet_id` - The ID of the subnet this vip connects to.
 * `vip_ip_address` - The IP address in the subnet for this vip.
+* `ip_addresses` - The IP addresses of ports to attach the vip to.

--- a/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestAccNetworkingV2VIPAssociate_basic(t *testing.T) {
+	rand := acctest.RandString(5)
 	var vip ports.Port
 	var port1 ports.Port
 	var port2 ports.Port
@@ -22,13 +24,13 @@ func TestAccNetworkingV2VIPAssociate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2VIPAssociateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccNetworkingV2VIPAssociateConfig_basic,
+				Config: testAccNetworkingV2VIPAssociateConfig_basic(rand),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2PortExists("huaweicloud_networking_port_v2.port_1", &port1),
-					testAccCheckNetworkingV2PortExists("huaweicloud_networking_port_v2.port_2", &port2),
-					testAccCheckNetworkingV2VIPExists("huaweicloud_networking_vip_v2.vip_1", &vip),
-					testAccCheckNetworkingV2VIPAssociateAssociated(&port1, &vip),
-					testAccCheckNetworkingV2VIPAssociateAssociated(&port2, &vip),
+					testAccCheckNetworkingV2PortExists("huaweicloud_networking_port.port_1", &port1),
+					testAccCheckNetworkingV2PortExists("huaweicloud_networking_port.port_2", &port2),
+					testAccCheckNetworkingV2VIPExists("huaweicloud_networking_vip.vip_1", &vip),
+					testAccCheckNetworkingV2VIPAssociated(&port1, &vip),
+					testAccCheckNetworkingV2VIPAssociated(&port2, &vip),
 				),
 			},
 		},
@@ -43,16 +45,12 @@ func testAccCheckNetworkingV2VIPAssociateDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_networking_vip_associate_v2" {
+		if rs.Type != "huaweicloud_networking_vip_associate" {
 			continue
 		}
 
-		vipid, portids, err := parseNetworkingVIPAssociateID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		vipport, err := ports.Get(networkingClient, vipid).Extract()
+		vipID := rs.Primary.Attributes["vip_id"]
+		_, err = ports.Get(networkingClient, vipID).Extract()
 		if err != nil {
 			// If the error is a 404, then the vip port does not exist,
 			// and therefore the floating IP cannot be associated to it.
@@ -61,35 +59,13 @@ func testAccCheckNetworkingV2VIPAssociateDestroy(s *terraform.State) error {
 			}
 			return err
 		}
-
-		// port by port
-		for _, portid := range portids {
-			p, err := ports.Get(networkingClient, portid).Extract()
-			if err != nil {
-				// If the error is a 404, then the port does not exist,
-				// and therefore the floating IP cannot be associated to it.
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return nil
-				}
-				return err
-			}
-
-			// But if the port and vip still exists
-			for _, ip := range p.FixedIPs {
-				for _, addresspair := range vipport.AllowedAddressPairs {
-					if ip.IPAddress == addresspair.IPAddress {
-						return fmt.Errorf("VIP %s is still associated to port %s", vipid, portid)
-					}
-				}
-			}
-		}
 	}
 
 	log.Printf("[DEBUG] testAccCheckNetworkingV2VIPAssociateDestroy success!")
 	return nil
 }
 
-func testAccCheckNetworkingV2VIPAssociateAssociated(p *ports.Port, vip *ports.Port) resource.TestCheckFunc {
+func testAccCheckNetworkingV2VIPAssociated(p *ports.Port, vip *ports.Port) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
@@ -120,7 +96,7 @@ func testAccCheckNetworkingV2VIPAssociateAssociated(p *ports.Port, vip *ports.Po
 		for _, ip := range p.FixedIPs {
 			for _, addresspair := range vipport.AllowedAddressPairs {
 				if ip.IPAddress == addresspair.IPAddress {
-					log.Printf("[DEBUG] testAccCheckNetworkingV2VIPAssociateAssociated success!")
+					log.Printf("[DEBUG] testAccCheckNetworkingV2VIPAssociated success!")
 					return nil
 				}
 			}
@@ -130,76 +106,45 @@ func testAccCheckNetworkingV2VIPAssociateAssociated(p *ports.Port, vip *ports.Po
 	}
 }
 
-var TestAccNetworkingV2VIPAssociateConfig_basic = fmt.Sprintf(`
-resource "huaweicloud_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+func testAccNetworkingV2VIPAssociateConfig_basic(rand string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "vpc_1" {
+  name = "acc-test-vpc-%s"
+  cidr = "192.168.0.0/16"
 }
 
-resource "huaweicloud_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
-  ip_version = 4
-  network_id = "${huaweicloud_networking_network_v2.network_1.id}"
+resource "huaweicloud_vpc_subnet" "subnet_1" {
+  vpc_id     = huaweicloud_vpc.vpc_1.id
+  name       = "acc-test-subnet-%s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
 }
 
-resource "huaweicloud_networking_router_interface_v2" "router_interface_1" {
-  router_id = "${huaweicloud_networking_router_v2.router_1.id}"
-  subnet_id = "${huaweicloud_networking_subnet_v2.subnet_1.id}"
-}
+resource "huaweicloud_networking_port" "port_1" {
+  name       = "port_1"
+  network_id = huaweicloud_vpc_subnet.subnet_1.id
 
-resource "huaweicloud_networking_router_v2" "router_1" {
-  name = "router_1"
-  external_network_id = "%s"
-}
-
-resource "huaweicloud_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${huaweicloud_networking_network_v2.network_1.id}"
-  
   fixed_ip {
-    subnet_id =  "${huaweicloud_networking_subnet_v2.subnet_1.id}"
+    subnet_id = huaweicloud_vpc_subnet.subnet_1.subnet_id
   }
 }
 
-resource "huaweicloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
-  availability_zone = "%s"
-	  
-  network {
-    port = "${huaweicloud_networking_port_v2.port_1.id}"
-  }
-}
+resource "huaweicloud_networking_port" "port_2" {
+  name       = "port_2"
+  network_id = huaweicloud_vpc_subnet.subnet_1.id
 
-resource "huaweicloud_networking_port_v2" "port_2" {
-  name = "port_2"
-  admin_state_up = "true"
-  network_id = "${huaweicloud_networking_network_v2.network_1.id}"
-  
   fixed_ip {
-    subnet_id =  "${huaweicloud_networking_subnet_v2.subnet_1.id}"
+    subnet_id = huaweicloud_vpc_subnet.subnet_1.subnet_id
   }
 }
 
-resource "huaweicloud_compute_instance_v2" "instance_2" {
-  name = "instance_2"
-  security_groups = ["default"]
-  availability_zone = "%s"
-	  
-  network {
-    port = "${huaweicloud_networking_port_v2.port_2.id}"
-  }
+resource "huaweicloud_networking_vip" "vip_1" {
+  network_id = huaweicloud_vpc_subnet.subnet_1.id
 }
 
-resource "huaweicloud_networking_vip_v2" "vip_1" {
-  network_id = "${huaweicloud_networking_network_v2.network_1.id}"
-  subnet_id = "${huaweicloud_networking_subnet_v2.subnet_1.id}"
+resource "huaweicloud_networking_vip_associate" "vip_associate_1" {
+  vip_id   = huaweicloud_networking_vip.vip_1.id
+  port_ids = [huaweicloud_networking_port.port_1.id, huaweicloud_networking_port.port_2.id]
 }
-
-resource "huaweicloud_networking_vip_associate_v2" "vip_associate_1" {
-  vip_id = "${huaweicloud_networking_vip_v2.vip_1.id}"
-  port_ids = ["${huaweicloud_networking_port_v2.port_1.id}", "${huaweicloud_networking_port_v2.port_2.id}"]
+	`, rand, rand)
 }
-`, OS_EXTGW_ID, OS_AVAILABILITY_ZONE, OS_AVAILABILITY_ZONE)


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2VIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2VIPAssociate_basic -timeout 360m
=== RUN   TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (88.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       88.988s
```