### PR TITLE
improve on dns resources

### DIFF
--- a/docs/resources/dns_ptrrecord.md
+++ b/docs/resources/dns_ptrrecord.md
@@ -10,14 +10,24 @@ This is an alternative to `huaweicloud_dns_ptrrecord_v2`
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_networking_floatingip_v2" "fip_1" {
+resource "huaweicloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
 }
 
 resource "huaweicloud_dns_ptrrecord" "ptr_1" {
   name          = "ptr.example.com."
   description   = "An example PTR record"
-  floatingip_id = huaweicloud_networking_floatingip_v2.fip_1.id
+  floatingip_id = huaweicloud_vpc_eip.eip_1.id
   ttl           = 3000
+
   tags = {
     foo = "bar"
   }
@@ -27,6 +37,10 @@ resource "huaweicloud_dns_ptrrecord" "ptr_1" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the PTR record.
+    If omitted, the `region` argument of the provider will be used.
+    Changing this creates a new PTR record.
 
 * `name` - (Required) Domain name of the PTR record. A domain name is case insensitive.
   Uppercase letters will also be converted into lowercase letters.

--- a/docs/resources/dns_recordset.md
+++ b/docs/resources/dns_recordset.md
@@ -34,8 +34,8 @@ resource "huaweicloud_dns_recordset" "rs_example_com" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the DNS client.
-    If omitted, the `region` argument of the provider is used.
+* `region` - (Optional) The region in which to create the DNS record set.
+    If omitted, the `region` argument of the provider will be used.
     Changing this creates a new DNS record set.
 
 * `zone_id` - (Required) The ID of the zone in which to create the record set.

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -30,9 +30,9 @@ resource "huaweicloud_dns_zone" "my_private_zone" {
   description = "An example zone"
   ttl         = 3000
   zone_type   = "private"
+
   router {
-    router_region = "cn-north-1"
-    router_id     = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
+    router_id = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
   }
 }
 ```
@@ -40,11 +40,14 @@ resource "huaweicloud_dns_zone" "my_private_zone" {
 ## Argument Reference
 
 The following arguments are supported:
+* `region` - (Optional) The region in which to create the DNS zone.
+    If omitted, the `region` argument of the provider will be used.
+    Changing this creates a new DNS zone.
 
 * `name` - (Required) The name of the zone. Note the `.` at the end of the name.
   Changing this creates a new DNS zone.
 
-* `email` - (Optional) The email contact for the zone record.
+* `email` - (Optional) The email address of the administrator managing the zone.
 
 * `zone_type` - (Optional) The type of zone. Can either be `public` or `private`.
   Changing this creates a new DNS zone.
@@ -61,9 +64,9 @@ The following arguments are supported:
 
 The `router` block supports:
 
-* `router_id` - (Required) The router UUID.
+* `router_id` - (Required) ID of the associated VPC.
 
-* `router_region` - (Required) The region of the router.
+* `router_region` - (Optional) The region of the VPC.
 
 ## Attributes Reference
 

--- a/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2.go
@@ -31,6 +31,12 @@ func ResourceDNSPtrRecordV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2_test.go
@@ -99,28 +99,46 @@ func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resou
 
 func testAccDNSV2PtrRecord_basic(ptrName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_networking_floatingip_v2" "fip_1" {
+resource "huaweicloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
 }
 
 resource "huaweicloud_dns_ptrrecord" "ptr_1" {
-  name = "%s"
-  description = "a ptr record"
-  floatingip_id = huaweicloud_networking_floatingip_v2.fip_1.id
-  ttl = 6000
+  name          = "%s"
+  description   = "a ptr record"
+  floatingip_id = huaweicloud_vpc_eip.eip_1.id
+  ttl           = 6000
 }
 `, ptrName)
 }
 
 func testAccDNSV2PtrRecord_update(ptrName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_networking_floatingip_v2" "fip_1" {
+resource "huaweicloud_vpc_eip" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
 }
 
 resource "huaweicloud_dns_ptrrecord" "ptr_1" {
-  name = "%s"
-  description = "ptr record updated"
-  floatingip_id = huaweicloud_networking_floatingip_v2.fip_1.id
-  ttl = 6000
+  name          = "%s"
+  description   = "ptr record updated"
+  floatingip_id = huaweicloud_vpc_eip.eip_1.id
+  ttl           = 6000
 
   tags = {
     foo = "bar"

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/common/tags"
@@ -69,10 +70,12 @@ func ResourceDNSRecordSetV2() *schema.Resource {
 				ValidateFunc: resourceValidateTTL,
 			},
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: resourceRecordsetValidateType,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"A", "AAAA", "MX", "CNAME", "TXT", "NS", "SRV", "PTR",
+				}, false),
 			},
 			"value_specs": {
 				Type:     schema.TypeMap,
@@ -352,20 +355,6 @@ func resourceValidateDescription(v interface{}, k string) (ws []string, errors [
 	if len(value) > 255 {
 		errors = append(errors, fmt.Errorf("%q must less than 255 characters", k))
 	}
-
-	return
-}
-
-var recordSetTypes = [8]string{"A", "AAAA", "MX", "CNAME", "TXT", "NS", "SRV", "PTR"}
-
-func resourceRecordsetValidateType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	for i := range recordSetTypes {
-		if value == recordSetTypes[i] {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf("%q must be one of %v", k, recordSetTypes))
 
 	return
 }

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2_test.go
@@ -77,26 +77,6 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 	})
 }
 
-func TestAccDNSV2RecordSet_timeout(t *testing.T) {
-	var recordset recordsets.RecordSet
-	zoneName := randomZoneName()
-	resourceName := "huaweicloud_dns_recordset.recordset_1"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSV2RecordSet_timeout(zoneName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2RecordSetExists(resourceName, &recordset),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
@@ -163,19 +143,19 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 func testAccDNSV2RecordSet_basic(zoneName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_zone" "zone_1" {
-  name = "%s"
-  email = "email2@example.com"
+  name        = "%s"
+  email       = "email2@example.com"
   description = "a zone"
-  ttl = 6000
+  ttl         = 6000
 }
 
 resource "huaweicloud_dns_recordset" "recordset_1" {
-  zone_id = huaweicloud_dns_zone.zone_1.id
-  name = "%s"
-  type = "A"
+  zone_id     = huaweicloud_dns_zone.zone_1.id
+  name        = "%s"
+  type        = "A"
   description = "a record set"
-  ttl = 3000
-  records = ["10.1.0.0"]
+  ttl         = 3000
+  records     = ["10.1.0.0"]
 
   tags = {
     foo = "bar"
@@ -188,19 +168,19 @@ resource "huaweicloud_dns_recordset" "recordset_1" {
 func testAccDNSV2RecordSet_update(zoneName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_zone" "zone_1" {
-  name = "%s"
-  email = "email2@example.com"
+  name        = "%s"
+  email       = "email2@example.com"
   description = "an updated zone"
-  ttl = 6000
+  ttl         = 6000
 }
 
 resource "huaweicloud_dns_recordset" "recordset_1" {
-  zone_id = huaweicloud_dns_zone.zone_1.id
-  name = "%s"
-  type = "A"
+  zone_id     = huaweicloud_dns_zone.zone_1.id
+  name        = "%s"
+  type        = "A"
   description = "an updated record set"
-  ttl = 6000
-  records = ["10.1.0.1"]
+  ttl         = 6000
+  records     = ["10.1.0.1"]
 
   tags = {
     foo = "bar"
@@ -213,42 +193,17 @@ resource "huaweicloud_dns_recordset" "recordset_1" {
 func testAccDNSV2RecordSet_readTTL(zoneName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_zone" "zone_1" {
-  name = "%s"
-  email = "email2@example.com"
+  name        = "%s"
+  email       = "email2@example.com"
   description = "a zone"
-  ttl = 6000
+  ttl         = 6000
 }
 
 resource "huaweicloud_dns_recordset" "recordset_1" {
   zone_id = huaweicloud_dns_zone.zone_1.id
-  name = "%s"
-  type = "A"
+  name    = "%s"
+  type    = "A"
   records = ["10.1.0.2"]
-}
-`, zoneName, zoneName)
-}
-
-func testAccDNSV2RecordSet_timeout(zoneName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_dns_zone" "zone_1" {
-  name = "%s"
-  email = "email2@example.com"
-  description = "a zone"
-  ttl = 6000
-}
-
-resource "huaweicloud_dns_recordset" "recordset_1" {
-  zone_id = huaweicloud_dns_zone.zone_1.id
-  name = "%s"
-  type = "A"
-  ttl = 3000
-  records = ["10.1.0.3"]
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, zoneName, zoneName)
 }


### PR DESCRIPTION
- make router.router_region be optional in dns zone
- clean up some codes
- update test cases and docs

the testting result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2Zone_basic' ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2Zone_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (37.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       37.942s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2Zone_private' ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2Zone_private -timeout 360m -parallel 4
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_private (30.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       30.651s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2PtrRecord_basic' ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2PtrRecord_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSV2PtrRecord_basic
=== PAUSE TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2PtrRecord_basic
--- PASS: TestAccDNSV2PtrRecord_basic (68.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       68.119s
```