### PR TITLE
Add DNS region client and select the client by zone type

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -519,10 +519,6 @@ func (c *Config) IdentityV3Client(region string) (*golangsdk.ServiceClient, erro
 	return c.NewServiceClient("identity", region)
 }
 
-func (c *Config) DnsV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("dns", region)
-}
-
 func (c *Config) CdnV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("cdn", region)
 }
@@ -625,6 +621,14 @@ func (c *Config) elbV2Client(region string) (*golangsdk.ServiceClient, error) {
 
 func (c *Config) fwV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("networkv2", region)
+}
+
+func (c *Config) DnsV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("dns", region)
+}
+
+func (c *Config) DnsWithRegionClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("dns_region", region)
 }
 
 // ********** client for Management **********

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -36,12 +36,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Scope:            "global",
 		WithOutProjectID: true,
 	},
-	"dns": ServiceCatalog{
-		Name:             "dns",
-		Version:          "v2",
-		Scope:            "global",
-		WithOutProjectID: true,
-	},
 	"eps": ServiceCatalog{
 		Name:             "eps",
 		Version:          "v1.0",
@@ -159,6 +153,17 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"fwv2": ServiceCatalog{
 		Name:             "vpc",
 		Version:          "v2.0",
+		WithOutProjectID: true,
+	},
+	"dns": ServiceCatalog{
+		Name:             "dns",
+		Version:          "v2",
+		Scope:            "global",
+		WithOutProjectID: true,
+	},
+	"dns_region": ServiceCatalog{
+		Name:             "dns",
+		Version:          "v2",
 		WithOutProjectID: true,
 	},
 

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -85,18 +85,6 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	}
 	t.Logf("CDN endpoint:\t %s", actualURL)
 
-	// test the endpoint of DNS service
-	serviceClient, err = config.DnsV2Client(OS_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud DNS client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://dns.%s/v2/", config.Cloud)
-	actualURL = serviceClient.ResourceBaseURL()
-	if actualURL != expectedURL {
-		t.Fatalf("DNS endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
-	}
-	t.Logf("DNS endpoint:\t %s", actualURL)
-
 	// test the endpoint of bss v1 service
 	serviceClient, err = config.BssV1Client(OS_REGION_NAME)
 	if err != nil {
@@ -643,6 +631,30 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v2.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "fw", "v2.0", t)
+
+	// test the endpoint of DNS service
+	serviceClient, err = config.DnsV2Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud DNS client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://dns.%s/v2/", config.Cloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("DNS endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("DNS endpoint:\t %s", actualURL)
+
+	// test the endpoint of DNS service (with region)
+	serviceClient, err = config.DnsWithRegionClient(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud DNS region client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://dns.%s.%s/v2/", OS_REGION_NAME, config.Cloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("DNS region endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("DNS region endpoint:\t %s", actualURL)
 }
 
 func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -89,10 +89,10 @@ func ResourceDNSRecordSetV2() *schema.Resource {
 }
 
 func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
+	zoneID := d.Get("zone_id").(string)
+	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return err
 	}
 
 	recordsraw := d.Get("records").([]interface{})
@@ -111,8 +111,6 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 		},
 		MapValueSpecs(d),
 	}
-
-	zoneID := d.Get("zone_id").(string)
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	n, err := recordsets.Create(dnsClient, zoneID, createOpts).Extract()
@@ -144,7 +142,7 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
-		resourceType, err := getDNSRecordSetResourceType(dnsClient, zoneID)
+		resourceType, err := getDNSRecordSetResourceType(zoneType)
 		if err != nil {
 			return fmt.Errorf("Error getting resource type of DNS record set %s: %s", n.ID, err)
 		}
@@ -161,13 +159,13 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
-	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
-	}
-
 	// Obtain relevant info from parsing the ID
 	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
 		return err
 	}
@@ -191,7 +189,7 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("zone_id", zoneID)
 
 	// save tags
-	resourceType, err := getDNSRecordSetResourceType(dnsClient, zoneID)
+	resourceType, err := getDNSRecordSetResourceType(zoneType)
 	if err != nil {
 		return fmt.Errorf("Error getting resource type of DNS record set %s: %s", recordsetID, err)
 	}
@@ -209,10 +207,15 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
+	// Obtain relevant info from parsing the ID
+	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return err
+	}
+
+	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
+	if err != nil {
+		return err
 	}
 
 	var updateOpts recordsets.UpdateOpts
@@ -231,12 +234,6 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 
 	if d.HasChange("description") {
 		updateOpts.Description = d.Get("description").(string)
-	}
-
-	// Obtain relevant info from parsing the ID
-	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
-	if err != nil {
-		return err
 	}
 
 	log.Printf("[DEBUG] Updating  record set %s with options: %#v", recordsetID, updateOpts)
@@ -264,7 +261,7 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// update tags
-	resourceType, err := getDNSRecordSetResourceType(dnsClient, zoneID)
+	resourceType, err := getDNSRecordSetResourceType(zoneType)
 	if err != nil {
 		return fmt.Errorf("Error getting resource type of DNS record set %s: %s", d.Id(), err)
 	}
@@ -278,14 +275,13 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
-	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
-	}
-
 	// Obtain relevant info from parsing the ID
 	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dnsClient, _, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
 		return err
 	}
@@ -368,18 +364,46 @@ func resourceValidateTTL(v interface{}, k string) (ws []string, errors []error) 
 	return
 }
 
-// get resource type of DNS record set from zone_id
-func getDNSRecordSetResourceType(client *golangsdk.ServiceClient, zone_id string) (string, error) {
-	zone, err := zones.Get(client, zone_id).Extract()
-	if err != nil {
-		return "", err
-	}
-
-	zoneType := zone.ZoneType
+// get resource type of DNS record set by zoneType
+func getDNSRecordSetResourceType(zoneType string) (string, error) {
 	if zoneType == "public" {
 		return "DNS-public_recordset", nil
 	} else if zoneType == "private" {
 		return "DNS-private_recordset", nil
 	}
 	return "", fmt.Errorf("invalid zone type: %s", zoneType)
+}
+
+func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interface{}) (*golangsdk.ServiceClient, string, error) {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+
+	var client *golangsdk.ServiceClient
+	var zoneInfo *zones.Zone
+	// Firstly, try to ues the DNS global endpoint
+	client, err := config.DnsV2Client(region)
+	if err != nil {
+		return nil, "", fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+	}
+
+	// get zone with DNS global endpoint
+	zoneInfo, err = zones.Get(client, zoneID).Extract()
+	if err != nil {
+		log.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
+
+		// try to ues the DNS region endpoint
+		client, clientErr := config.DnsWithRegionClient(region)
+		if clientErr != nil {
+			// it looks tricky as we return the fetching error rather than clientErr
+			return nil, "", err
+		}
+
+		// get zone with DNS region endpoint
+		zoneInfo, err = zones.Get(client, zoneID).Extract()
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	return client, zoneInfo.ZoneType, nil
 }

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2_test.go
@@ -77,6 +77,32 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 	})
 }
 
+func TestAccDNSV2RecordSet_private(t *testing.T) {
+	var recordset recordsets.RecordSet
+	zoneName := randomZoneName()
+	resourceName := "huaweicloud_dns_recordset.recordset_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckDNS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2RecordSet_private(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2RecordSetExists(resourceName, &recordset),
+					resource.TestCheckResourceAttr(resourceName, "name", zoneName),
+					resource.TestCheckResourceAttr(resourceName, "description", "a private record set"),
+					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "records.0", "10.1.0.3"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
@@ -204,6 +230,39 @@ resource "huaweicloud_dns_recordset" "recordset_1" {
   name    = "%s"
   type    = "A"
   records = ["10.1.0.2"]
+}
+`, zoneName, zoneName)
+}
+
+func testAccDNSV2RecordSet_private(zoneName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_vpc" "default" {
+  name = "vpc-default"
+}
+
+resource "huaweicloud_dns_zone" "zone_1" {
+  name        = "%s"
+  email       = "email@example.com"
+  description = "a private zone"
+  zone_type   = "private"
+
+  router {
+    router_id = data.huaweicloud_vpc.default.id
+  }
+}
+
+resource "huaweicloud_dns_recordset" "recordset_1" {
+  zone_id     = huaweicloud_dns_zone.zone_1.id
+  name        = "%s"
+  type        = "A"
+  description = "a private record set"
+  ttl         = 3000
+  records     = ["10.1.0.3"]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, zoneName, zoneName)
 }

--- a/huaweicloud/resource_huaweicloud_dns_zone_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2.go
@@ -122,6 +122,8 @@ func resourceDNSRouter(d *schema.ResourceData, region string) map[string]string 
 func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
+	var dnsClient *golangsdk.ServiceClient
+
 	dnsClient, err := config.DnsV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
@@ -134,6 +136,11 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 	if zone_type == "private" {
 		if len(router) < 1 {
 			return fmt.Errorf("The argument (router) is required when creating HuaweiCloud DNS private zone")
+		}
+		// update the endpoint with region when creating private zone
+		dnsClient, err = config.DnsWithRegionClient(GetRegion(d, config))
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud DNS region client: %s", err)
 		}
 	}
 	vs := MapResourceProp(d, "value_specs")
@@ -219,27 +226,42 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
+
+	// we can not get the corresponding client by zone type in import scene
 	dnsClient, err := config.DnsV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}
 
-	n, err := zones.Get(dnsClient, d.Id()).Extract()
+	var zoneInfo *zones.Zone
+	zoneInfo, err = zones.Get(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "zone")
+		log.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
+		// an error occurred while fetching the zone with DNS global endpoint
+		// try to fetch it again with DNS region endpoint
+		dnsClient, clientErr := config.DnsWithRegionClient(GetRegion(d, config))
+		if clientErr != nil {
+			// it looks tricky as we return the fetching error rather than clientErr
+			return CheckDeleted(d, err, "zone")
+		}
+
+		zoneInfo, err = zones.Get(dnsClient, d.Id()).Extract()
+		if err != nil {
+			return CheckDeleted(d, err, "zone")
+		}
 	}
 
-	log.Printf("[DEBUG] Retrieved Zone %s: %#v", d.Id(), n)
+	log.Printf("[DEBUG] Retrieved Zone %s: %#v", d.Id(), zoneInfo)
 
-	d.Set("name", n.Name)
-	d.Set("email", n.Email)
-	d.Set("description", n.Description)
-	d.Set("ttl", n.TTL)
-	if err = d.Set("masters", n.Masters); err != nil {
+	d.Set("name", zoneInfo.Name)
+	d.Set("email", zoneInfo.Email)
+	d.Set("description", zoneInfo.Description)
+	d.Set("ttl", zoneInfo.TTL)
+	if err = d.Set("masters", zoneInfo.Masters); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving masters to state for HuaweiCloud DNS zone (%s): %s", d.Id(), err)
 	}
 	d.Set("region", region)
-	d.Set("zone_type", n.ZoneType)
+	d.Set("zone_type", zoneInfo.ZoneType)
 
 	return nil
 }
@@ -247,6 +269,8 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
+	var dnsClient *golangsdk.ServiceClient
+
 	dnsClient, err := config.DnsV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
@@ -259,6 +283,11 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 	if zone_type == "private" {
 		if len(router) < 1 {
 			return fmt.Errorf("The argument (router) is required when updating HuaweiCloud DNS private zone")
+		}
+		// update the endpoint with region when creating private zone
+		dnsClient, err = config.DnsWithRegionClient(GetRegion(d, config))
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud DNS region client: %s", err)
 		}
 	}
 
@@ -361,7 +390,16 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
+	var dnsClient *golangsdk.ServiceClient
+	var err error
+
+	zoneType := d.Get("zone_type").(string)
+	// update the endpoint with region when creating private zone
+	if zoneType == "private" {
+		dnsClient, err = config.DnsWithRegionClient(GetRegion(d, config))
+	} else {
+		dnsClient, err = config.DnsV2Client(GetRegion(d, config))
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}


### PR DESCRIPTION
the issue was encountered in "sa-brazil-1" region, we should manage DNS public zone and record set with global endpoint while managing DNS private zone and record set with region endpoint.

the testing result as follows:
```
$ make testacc ACCTEST_PARALLELISM=4 TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2Zone_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2Zone_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (36.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       36.870s
 $
 $ make testacc ACCTEST_PARALLELISM=4 TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2Zone_private'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2Zone_private -timeout 360m -parallel 4
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_private (28.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       28.908s
$
$ make testacc ACCTEST_PARALLELISM=4 TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2RecordSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2RecordSet_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (70.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.371s
 $
$ make testacc ACCTEST_PARALLELISM=4 TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2RecordSet_private'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2RecordSet_private -timeout 360m -parallel 4
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_private
--- PASS: TestAccDNSV2RecordSet_private (47.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       47.836s
```