### PR TITLE
using elbV2Client to update endpoint in lb resources

### DIFF
--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -153,8 +153,9 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		WithOutProjectID: true,
 	},
 	"elbv2": ServiceCatalog{
-		Name:    "elb",
-		Version: "v2.0",
+		Name:             "elb",
+		Version:          "v2.0",
+		WithOutProjectID: true,
 	},
 	"fwv2": ServiceCatalog{
 		Name:             "vpc",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -613,7 +613,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	}
 	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "vpc", "v1", t)
+	compareURL(expectedURL, actualURL, "security group", "v1", t)
 
 	// test endpoint of elb v1.0
 	serviceClient, err = nil, nil
@@ -631,7 +631,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud ELB v2.0 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "elb", "v2.0", t)
 

--- a/huaweicloud/resource_huaweicloud_lb_certificate.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate.go
@@ -85,9 +85,9 @@ func resourceCertificateV2() *schema.Resource {
 
 func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	createOpts := certificates.CreateOpts{
@@ -100,7 +100,7 @@ func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	c, err := certificates.Create(networkingClient, createOpts).Extract()
+	c, err := certificates.Create(elbClient, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating Certificate: %s", err)
 	}
@@ -113,12 +113,12 @@ func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error
 
 func resourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
-	c, err := certificates.Get(networkingClient, d.Id()).Extract()
+	c, err := certificates.Get(elbClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "certificate")
 	}
@@ -140,9 +140,9 @@ func resourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	var updateOpts certificates.UpdateOpts
@@ -167,7 +167,7 @@ func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error
 	timeout := d.Timeout(schema.TimeoutUpdate)
 	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		_, err := certificates.Update(networkingClient, d.Id(), updateOpts).Extract()
+		_, err := certificates.Update(elbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -182,16 +182,16 @@ func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error
 
 func resourceCertificateV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting certificate %s", d.Id())
 	timeout := d.Timeout(schema.TimeoutDelete)
 	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		err := certificates.Delete(networkingClient, d.Id()).ExtractErr()
+		err := certificates.Delete(elbClient, d.Id()).ExtractErr()
 		if err != nil {
 			return checkForRetryableError(err)
 		}

--- a/huaweicloud/resource_huaweicloud_lb_certificate_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate_test.go
@@ -63,9 +63,9 @@ func TestAccLBV2Certificate_client(t *testing.T) {
 
 func testAccCheckLBV2CertificateDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -73,7 +73,7 @@ func testAccCheckLBV2CertificateDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := certificates.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Certificate still exists: %s", rs.Primary.ID)
 		}
@@ -95,12 +95,12 @@ func testAccCheckLBV2CertificateExists(
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
-		found, err := certificates.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/huaweicloud/resource_huaweicloud_lb_l7policy.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7policy.go
@@ -101,9 +101,9 @@ func resourceL7PolicyV2() *schema.Resource {
 
 func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	// Assign some required variables for use in creation.
@@ -191,9 +191,9 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	l7Policy, err := l7policies.Get(lbClient, d.Id()).Extract()
@@ -218,9 +218,9 @@ func resourceL7PolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	// Assign some required variables for use in updating.
@@ -318,9 +318,9 @@ func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
@@ -368,9 +368,9 @@ func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return nil, fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	l7Policy, err := l7policies.Get(lbClient, d.Id()).Extract()

--- a/huaweicloud/resource_huaweicloud_lb_l7policy_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7policy_test.go
@@ -38,7 +38,7 @@ func TestAccLBV2L7Policy_basic(t *testing.T) {
 
 func testAccCheckLBV2L7PolicyDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	lbClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
 	}
@@ -69,7 +69,7 @@ func testAccCheckLBV2L7PolicyExists(n string, l7Policy *l7policies.L7Policy) res
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		lbClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_lb_l7rule.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7rule.go
@@ -102,9 +102,9 @@ func resourceL7RuleV2() *schema.Resource {
 
 func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	// Assign some required variables for use in creation.
@@ -191,9 +191,9 @@ func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7RuleV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	l7policyID := d.Get("l7policy_id").(string)
@@ -218,9 +218,9 @@ func resourceL7RuleV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	// Assign some required variables for use in updating.
@@ -308,9 +308,9 @@ func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7RuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
@@ -372,9 +372,9 @@ func resourceL7RuleV2Import(d *schema.ResourceData, meta interface{}) ([]*schema
 	}
 
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return nil, fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	listenerID := ""

--- a/huaweicloud/resource_huaweicloud_lb_l7rule_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7rule_test.go
@@ -49,7 +49,7 @@ func TestAccLBV2L7Rule_basic(t *testing.T) {
 
 func testAccCheckLBV2L7RuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	lbClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
 	}
@@ -92,7 +92,7 @@ func testAccCheckLBV2L7RuleExists(n string, l7rule *l7rules.Rule) resource.TestC
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		lbClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_lb_listener_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_listener_test.go
@@ -42,9 +42,9 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 
 func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -52,7 +52,7 @@ func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := listeners.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Listener still exists: %s", rs.Primary.ID)
 		}
@@ -73,12 +73,12 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
-		found, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := listeners.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer_test.go
@@ -98,9 +98,9 @@ func TestAccLBV2LoadBalancer_secGroup(t *testing.T) {
 
 func testAccCheckLBV2LoadBalancerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -108,7 +108,7 @@ func testAccCheckLBV2LoadBalancerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := loadbalancers.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := loadbalancers.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("LoadBalancer still exists: %s", rs.Primary.ID)
 		}
@@ -130,12 +130,12 @@ func testAccCheckLBV2LoadBalancerExists(
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 		}
 
-		found, err := loadbalancers.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := loadbalancers.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ func testAccCheckLBV2LoadBalancerHasSecGroup(
 
 var testAccLBV2LoadBalancerConfig_basic = fmt.Sprintf(`
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "%s"
 
   tags = {
@@ -194,9 +194,9 @@ resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
 
 var testAccLBV2LoadBalancerConfig_update = fmt.Sprintf(`
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
-  name = "loadbalancer_1_updated"
+  name           = "loadbalancer_1_updated"
   admin_state_up = "true"
-  vip_subnet_id = "%s"
+  vip_subnet_id  = "%s"
 
   tags = {
     key1  = "value1"
@@ -213,61 +213,61 @@ resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
 
 var testAccLBV2LoadBalancer_secGroup = fmt.Sprintf(`
 resource "huaweicloud_networking_secgroup" "secgroup_1" {
-  name = "secgroup_1"
+  name        = "secgroup_1"
   description = "secgroup_1"
 }
 
 resource "huaweicloud_networking_secgroup" "secgroup_2" {
-  name = "secgroup_2"
+  name        = "secgroup_2"
   description = "secgroup_2"
 }
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
-    name = "loadbalancer_1"
-    vip_subnet_id = "%s"
-    security_group_ids = [
-      huaweicloud_networking_secgroup.secgroup_1.id
-    ]
+  name               = "loadbalancer_1"
+  vip_subnet_id      = "%s"
+  security_group_ids = [
+    huaweicloud_networking_secgroup.secgroup_1.id
+  ]
 }
 `, OS_SUBNET_ID)
 
 var testAccLBV2LoadBalancer_secGroup_update1 = fmt.Sprintf(`
 resource "huaweicloud_networking_secgroup" "secgroup_1" {
-  name = "secgroup_1"
+  name        = "secgroup_1"
   description = "secgroup_1"
 }
 
 resource "huaweicloud_networking_secgroup" "secgroup_2" {
-  name = "secgroup_2"
+  name        = "secgroup_2"
   description = "secgroup_2"
 }
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
-    name = "loadbalancer_1"
-    vip_subnet_id = "%s"
-    security_group_ids = [
-      huaweicloud_networking_secgroup.secgroup_1.id,
-      huaweicloud_networking_secgroup.secgroup_2.id
-    ]
+  name               = "loadbalancer_1"
+  vip_subnet_id      = "%s"
+  security_group_ids = [
+    huaweicloud_networking_secgroup.secgroup_1.id,
+    huaweicloud_networking_secgroup.secgroup_2.id
+  ]
 }
 `, OS_SUBNET_ID)
 
 var testAccLBV2LoadBalancer_secGroup_update2 = fmt.Sprintf(`
 resource "huaweicloud_networking_secgroup" "secgroup_1" {
-  name = "secgroup_1"
+  name        = "secgroup_1"
   description = "secgroup_1"
 }
 
 resource "huaweicloud_networking_secgroup" "secgroup_2" {
-  name = "secgroup_2"
+  name        = "secgroup_2"
   description = "secgroup_2"
 }
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
-    name = "loadbalancer_1"
-    vip_subnet_id = "%s"
-    security_group_ids = [
-      huaweicloud_networking_secgroup.secgroup_2.id
-    ]
+  name               = "loadbalancer_1"
+  vip_subnet_id      = "%s"
+  security_group_ids = [
+    huaweicloud_networking_secgroup.secgroup_2.id
+  ]
 }
 `, OS_SUBNET_ID)

--- a/huaweicloud/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/resource_huaweicloud_lb_member.go
@@ -93,9 +93,9 @@ func resourceMemberV2() *schema.Resource {
 
 func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	adminStateUp := d.Get("admin_state_up").(bool)
@@ -151,9 +151,9 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	member, err := pools.GetMember(lbClient, d.Get("pool_id").(string), d.Id()).Extract()
@@ -177,9 +177,9 @@ func resourceMemberV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	var updateOpts pools.UpdateMemberOpts
@@ -226,9 +226,9 @@ func resourceMemberV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMemberV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	// Wait for Pool to become active before continuing

--- a/huaweicloud/resource_huaweicloud_lb_member_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_member_test.go
@@ -40,9 +40,9 @@ func TestAccLBV2Member_basic(t *testing.T) {
 
 func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -51,7 +51,7 @@ func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
-		_, err := pools.GetMember(networkingClient, poolId, rs.Primary.ID).Extract()
+		_, err := pools.GetMember(elbClient, poolId, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Member still exists: %s", rs.Primary.ID)
 		}
@@ -72,13 +72,13 @@ func testAccCheckLBV2MemberExists(n string, member *pools.Member) resource.TestC
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
-		found, err := pools.GetMember(networkingClient, poolId, rs.Primary.ID).Extract()
+		found, err := pools.GetMember(elbClient, poolId, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/huaweicloud/resource_huaweicloud_lb_monitor.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor.go
@@ -100,9 +100,9 @@ func resourceMonitorV2() *schema.Resource {
 
 func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	adminStateUp := d.Get("admin_state_up").(bool)
@@ -155,9 +155,9 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	monitor, err := monitors.Get(lbClient, d.Id()).Extract()
@@ -184,9 +184,9 @@ func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	var updateOpts monitors.UpdateOpts
@@ -247,9 +247,9 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceMonitorV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting monitor %s", d.Id())

--- a/huaweicloud/resource_huaweicloud_lb_monitor_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor_test.go
@@ -41,9 +41,9 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 
 func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -51,7 +51,7 @@ func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := monitors.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Monitor still exists: %s", rs.Primary.ID)
 		}
@@ -72,12 +72,12 @@ func testAccCheckLBV2MonitorExists(n string, monitor *monitors.Monitor) resource
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
-		found, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := monitors.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/huaweicloud/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool.go
@@ -130,9 +130,9 @@ func resourcePoolV2() *schema.Resource {
 
 func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	adminStateUp := d.Get("admin_state_up").(bool)
@@ -227,9 +227,9 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	pool, err := pools.Get(lbClient, d.Id()).Extract()
@@ -253,9 +253,9 @@ func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	var updateOpts pools.UpdateOpts
@@ -314,9 +314,9 @@ func resourcePoolV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePoolV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	lbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	// Wait for LoadBalancer to become active before continuing

--- a/huaweicloud/resource_huaweicloud_lb_pool_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool_test.go
@@ -39,9 +39,9 @@ func TestAccLBV2Pool_basic(t *testing.T) {
 
 func testAccCheckLBV2PoolDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -49,7 +49,7 @@ func testAccCheckLBV2PoolDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := pools.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := pools.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Pool still exists: %s", rs.Primary.ID)
 		}
@@ -70,12 +70,12 @@ func testAccCheckLBV2PoolExists(n string, pool *pools.Pool) resource.TestCheckFu
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
-		found, err := pools.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := pools.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/huaweicloud/resource_huaweicloud_lb_whitelist.go
+++ b/huaweicloud/resource_huaweicloud_lb_whitelist.go
@@ -58,9 +58,9 @@ func resourceWhitelistV2() *schema.Resource {
 
 func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	enableWhitelist := d.Get("enable_whitelist").(bool)
@@ -72,7 +72,7 @@ func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	wl, err := whitelists.Create(networkingClient, createOpts).Extract()
+	wl, err := whitelists.Create(elbClient, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud Whitelist: %s", err)
 	}
@@ -83,12 +83,12 @@ func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceWhitelistV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
-	wl, err := whitelists.Get(networkingClient, d.Id()).Extract()
+	wl, err := whitelists.Get(elbClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "whitelist")
 	}
@@ -106,9 +106,9 @@ func resourceWhitelistV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	var updateOpts whitelists.UpdateOpts
@@ -121,7 +121,7 @@ func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating whitelist %s with options: %#v", d.Id(), updateOpts)
-	_, err = whitelists.Update(networkingClient, d.Id(), updateOpts).Extract()
+	_, err = whitelists.Update(elbClient, d.Id(), updateOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Unable to update whitelist %s: %s", d.Id(), err)
 	}
@@ -131,13 +131,13 @@ func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceWhitelistV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Attempting to delete whitelist %s", d.Id())
-	err = whitelists.Delete(networkingClient, d.Id()).ExtractErr()
+	err = whitelists.Delete(elbClient, d.Id()).ExtractErr()
 	if err != nil {
 		return fmt.Errorf("Error deleting HuaweiCloud whitelist: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_whitelist_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_whitelist_test.go
@@ -36,9 +36,9 @@ func TestAccLBV2Whitelist_basic(t *testing.T) {
 
 func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.elbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -46,7 +46,7 @@ func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := whitelists.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Whitelist still exists: %s", rs.Primary.ID)
 		}
@@ -67,12 +67,12 @@ func testAccCheckLBV2WhitelistExists(n string, whitelist *whitelists.Whitelist) 
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.elbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
-		found, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := whitelists.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
we can update endpoint in lb resources with elbV2Client, the endpoint of elbV2Client: `https://elb.{region}.myhuaweicloud.com/v2.0/`

all of the test cases have passed.