### PR TITLE
Set prefix of environment variables to HW

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,8 @@ provider "huaweicloud" {
 
 ### Environment variables
 
-You can provide your credentials via the `OS_ACCESS_KEY` and
-`OS_SECRET_KEY`, environment variables, representing your Huawei
+You can provide your credentials via the `HW_ACCESS_KEY` and
+`HW_SECRET_KEY` environment variables, representing your Huawei
 Cloud Access Key and Secret Key, respectively.
 
 ```hcl
@@ -67,10 +67,10 @@ provider "huaweicloud" {}
 Usage:
 
 ```sh
-$ export OS_ACCESS_KEY="anaccesskey"
-$ export OS_SECRET_KEY="asecretkey"
-$ export OS_REGION_NAME="cn-north-1"
-$ export OS_DOMAIN_NAME="account-name"
+$ export HW_ACCESS_KEY="anaccesskey"
+$ export HW_SECRET_KEY="asecretkey"
+$ export HW_REGION_NAME="cn-north-1"
+$ export HW_DOMAIN_NAME="account-name"
 $ terraform plan
 ```
 
@@ -79,38 +79,39 @@ $ terraform plan
 The following arguments are supported:
 
 * `region` - (Required) This is the Huawei Cloud region. It must be provided,
-  but it can also be sourced from the `OS_REGION_NAME` environment variables.
+  but it can also be sourced from the `HW_REGION_NAME` environment variables.
 
 * `domain_name` - (Optional, Required for IAM and prePaid resources) The
   [Account name](https://support.huaweicloud.com/en-us/usermanual-iam/iam_01_0552.html)
-  of IAM to scope to. If omitted, the `OS_DOMAIN_NAME` environment variable is used.
+  of IAM to scope to. If omitted, the `HW_DOMAIN_NAME` environment variable is used.
 
 * `access_key` - (Optional) The access key of the HuaweiCloud to use.
-  If omitted, the `OS_ACCESS_KEY` environment variable is used.
+  If omitted, the `HW_ACCESS_KEY` environment variable is used.
 
 * `secret_key` - (Optional) The secret key of the HuaweiCloud to use.
-  If omitted, the `OS_SECRET_KEY` environment variable is used.
+  If omitted, the `HW_SECRET_KEY` environment variable is used.
 
 * `project_name` - (Optional) The Name of the project to login with.
-  If omitted, the `OS_PROJECT_NAME` environment variable or `region` is used.
+  If omitted, the `HW_PROJECT_NAME` environment variable or `region` is used.
 
 * `auth_url` - (Optional, Required before 1.14.0) The Identity authentication URL. If omitted, the
-  `OS_AUTH_URL` environment variable is used. This is not required if you use Huawei Cloud.
+  `HW_AUTH_URL` environment variable is used. This is not required if you use Huawei Cloud.
 
 * `cloud` - (Optional) The endpoint of the cloud provider. If omitted, the
-  `OS_CLOUD` environment variable is used. Defaults to `myhuaweicloud.com`.
+  `HW_CLOUD` environment variable is used. Defaults to `myhuaweicloud.com`.
 
 * `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
-  `OS_INSECURE` environment variable is used.
+  `HW_INSECURE` environment variable is used.
 
 * `max_retries` - (Optional) This is the maximum number of times an API
   call is retried, in the case where requests are being throttled or
   experiencing transient failures. The delay between the subsequent API
-  calls increases exponentially. If omitted, default value is `5`.
+  calls increases exponentially. The default value is `5`.
+  If omitted, the `HW_MAX_RETRIES` environment variable is used.
 
 * `enterprise_project_id` - (Optional) Default Enterprise Project ID for supported resources.
   Please see the documentation at [EPS](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs/data-sources/eps).
-  If omitted, the `OS_ENTERPRISE_PROJECT_ID` environment variable is used.
+  If omitted, the `HW_ENTERPRISE_PROJECT_ID` environment variable is used.
 
 
 ## Testing and Development
@@ -118,11 +119,11 @@ The following arguments are supported:
 In order to run the Acceptance Tests for development, the following environment
 variables must also be set:
 
-* `OS_REGION_NAME` - The region in which to create the resources.
+* `HW_REGION_NAME` - The region in which to create the resources.
 
-* `OS_ACCESS_KEY` - The access key of the HuaweiCloud to use.
+* `HW_ACCESS_KEY` - The access key of the HuaweiCloud to use.
 
-* `OS_SECRET_KEY` - The secret key of the HuaweiCloud to use.
+* `HW_SECRET_KEY` - The secret key of the HuaweiCloud to use.
 
 
 You should be able to use any HuaweiCloud environment to develop on as long as the

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -15,129 +15,146 @@ var osMutexKV = mutexkv.NewMutexKV()
 func Provider() terraform.ResourceProvider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  descriptions["region"],
+				InputDefault: "cn-north-1",
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_REGION_NAME",
+					"OS_REGION_NAME",
+				}, nil),
+			},
+
 			"access_key": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("OS_ACCESS_KEY", nil),
 				Description:  descriptions["access_key"],
 				RequiredWith: []string{"secret_key"},
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_ACCESS_KEY",
+					"OS_ACCESS_KEY",
+				}, nil),
 			},
 
 			"secret_key": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("OS_SECRET_KEY", nil),
 				Description:  descriptions["secret_key"],
 				RequiredWith: []string{"access_key"},
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_SECRET_KEY",
+					"OS_SECRET_KEY",
+				}, nil),
 			},
 
-			"auth_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.EnvDefaultFunc(
-					"OS_AUTH_URL", "https://iam.myhuaweicloud.com:443/v3"),
-				Description: descriptions["auth_url"],
+			"domain_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["domain_id"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_DOMAIN_ID",
+					"OS_DOMAIN_ID",
+					"OS_USER_DOMAIN_ID",
+					"OS_PROJECT_DOMAIN_ID",
+				}, ""),
 			},
 
-			"region": {
-				Type:         schema.TypeString,
-				Required:     true,
-				Description:  descriptions["region"],
-				DefaultFunc:  schema.EnvDefaultFunc("OS_REGION_NAME", nil),
-				InputDefault: "cn-north-1",
+			"domain_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["domain_name"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_DOMAIN_NAME",
+					"OS_DOMAIN_NAME",
+					"OS_USER_DOMAIN_NAME",
+					"OS_PROJECT_DOMAIN_NAME",
+				}, ""),
 			},
 
 			"user_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USERNAME", ""),
 				Description: descriptions["user_name"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_USER_NAME",
+					"OS_USERNAME",
+				}, ""),
 			},
 
 			"user_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_USER_ID", ""),
-				Description: descriptions["user_name"],
-			},
-
-			"project_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_ID", nil),
-				Description: descriptions["project_id"],
-			},
-
-			"project_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PROJECT_NAME", nil),
-				Description: descriptions["project_name"],
-			},
-
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: descriptions["user_id"],
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_TENANT_ID",
-					"OS_PROJECT_ID",
+					"HW_USER_ID",
+					"OS_USER_ID",
 				}, ""),
-				Description: descriptions["tenant_id"],
-			},
-
-			"tenant_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_TENANT_NAME",
-					"OS_PROJECT_NAME",
-				}, ""),
-				Description: descriptions["tenant_name"],
 			},
 
 			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_PASSWORD", ""),
 				Description: descriptions["password"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_USER_PASSWORD",
+					"OS_PASSWORD",
+				}, ""),
+			},
+
+			"project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["project_id"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_PROJECT_ID",
+					"OS_PROJECT_ID",
+				}, nil),
+			},
+
+			"project_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["project_name"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_PROJECT_NAME",
+					"OS_PROJECT_NAME",
+				}, nil),
+			},
+
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["tenant_id"],
+				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_ID", ""),
+			},
+
+			"tenant_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["tenant_name"],
+				DefaultFunc: schema.EnvDefaultFunc("OS_TENANT_NAME", ""),
 			},
 
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_TOKEN", ""),
 				Description: descriptions["token"],
-			},
-
-			"domain_id": {
-				Type:     schema.TypeString,
-				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_USER_DOMAIN_ID",
-					"OS_PROJECT_DOMAIN_ID",
-					"OS_DOMAIN_ID",
+					"HW_AUTH_TOKEN",
+					"OS_AUTH_TOKEN",
 				}, ""),
-				Description: descriptions["domain_id"],
-			},
-
-			"domain_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"OS_USER_DOMAIN_NAME",
-					"OS_PROJECT_DOMAIN_NAME",
-					"OS_DOMAIN_NAME",
-					"OS_DEFAULT_DOMAIN",
-				}, ""),
-				Description: descriptions["domain_name"],
 			},
 
 			"insecure": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_INSECURE", false),
 				Description: descriptions["insecure"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_INSECURE",
+					"OS_INSECURE",
+				}, false),
 			},
 
 			"cacert_file": {
@@ -176,6 +193,7 @@ func Provider() terraform.ResourceProvider {
 				Description:  descriptions["agency_domain_name"],
 				RequiredWith: []string{"agency_name"},
 			},
+
 			"delegated_project": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -183,25 +201,36 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["delegated_project"],
 			},
 
+			"auth_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["auth_url"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"HW_AUTH_URL",
+					"OS_AUTH_URL",
+				}, "https://iam.myhuaweicloud.com:443/v3"),
+			},
+
 			"cloud": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DefaultFunc: schema.EnvDefaultFunc(
-					"OS_CLOUD", "myhuaweicloud.com"),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: descriptions["cloud"],
+				DefaultFunc: schema.EnvDefaultFunc(
+					"HW_CLOUD", "myhuaweicloud.com"),
+			},
+
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["enterprise_project_id"],
+				DefaultFunc: schema.EnvDefaultFunc("HW_ENTERPRISE_PROJECT_ID", ""),
 			},
 
 			"max_retries": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     5,
 				Description: descriptions["max_retries"],
-			},
-			"enterprise_project_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_ENTERPRISE_PROJECT_ID", ""),
-				Description: descriptions["enterprise_project_id"],
+				DefaultFunc: schema.EnvDefaultFunc("HW_MAX_RETRIES", 5),
 			},
 		},
 
@@ -542,19 +571,17 @@ func init() {
 
 		"project_name": "The name of the project to login with.",
 
-		"tenant_id": "The ID of the Tenant (Identity v2) or Project (Identity v3)\n" +
-			"to login with.",
+		"tenant_id": "The ID of the Tenant (Identity v2) to login with.",
 
-		"tenant_name": "The name of the Tenant (Identity v2) or Project (Identity v3)\n" +
-			"to login with.",
+		"tenant_name": "The name of the Tenant (Identity v2) to login with.",
 
 		"password": "Password to login with.",
 
 		"token": "Authentication token to use as an alternative to username/password.",
 
-		"domain_id": "The ID of the Domain to scope to (Identity v3).",
+		"domain_id": "The ID of the Domain to scope to.",
 
-		"domain_name": "The name of the Domain to scope to (Identity v3).",
+		"domain_name": "The name of the Domain to scope to.",
 
 		"insecure": "Trust self-signed certificates.",
 


### PR DESCRIPTION
We modify the prefix of environment variables from "OS_" to "HW_" which indicates Huaweicloud.
To keep the compatibility, the environment variables which begin with "OS_" are also supportted.

You can provide your credentials via the `HW_ACCESS_KEY` and `HW_SECRET_KEY` environment variables, representing your Huawei
Cloud Access Key and Secret Key, respectively.