### PR TITLE
[makefile] add TEST_PARALLELISM args to support parallel and defaults to 4

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,5 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
+TEST_PARALLELISM?=4
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=huaweicloud
 
@@ -14,10 +15,10 @@ sweep:
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=$(TEST_PARALLELISM)
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 360m -parallel $(ACCTEST_PARALLELISM)
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 360m -parallel $(TEST_PARALLELISM)
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
`TEST_PARALLELISM` defaults to 4, if you want to change it, please export it as an environment variable or add it in the command line.

```
$ export TEST_PARALLELISM=2
$ make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
        xargs -t -n4 go test  -timeout=30s -parallel=2
go test -timeout=30s -parallel=2 github.com/huaweicloud/terraform-provider-huaweicloud github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud
?       github.com/huaweicloud/terraform-provider-huaweicloud   [no test files]
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       8.147s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Certificate_client'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Certificate_client -timeout 360m -parallel 2
=== RUN   TestAccLBV2Certificate_client
=== PAUSE TestAccLBV2Certificate_client
=== CONT  TestAccLBV2Certificate_client
--- PASS: TestAccLBV2Certificate_client (29.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       29.872s

$ make test TEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
        xargs -t -n4 go test  -timeout=30s -parallel=3
go test -timeout=30s -parallel=3 github.com/huaweicloud/terraform-provider-huaweicloud github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud
?       github.com/huaweicloud/terraform-provider-huaweicloud   [no test files]
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       8.144s
```