### PR TITLE
Ignore error when fetching tags for dcs instance

### DIFF
--- a/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
@@ -378,7 +378,7 @@ func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 	if len(tagRaw) > 0 {
 		taglist := expandResourceTags(tagRaw)
 		if tagErr := tags.Create(dcsV2Client, "dcs", v.InstanceID, taglist).ExtractErr(); tagErr != nil {
-			return fmt.Errorf("Error setting tags of DCS instance %s: %s", v.InstanceID, tagErr)
+			log.Printf("[WARN] fetching tags of DCS instance failed: %s", tagErr)
 		}
 	}
 


### PR DESCRIPTION
This tries to make it compatible with regions that doens't have tags API.