### PR TITLE
Deprecate networking_port

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud\_networking\_port


### PR DESCRIPTION
This tries to deprecate networing_port, as we suggest to use VPC instead.