### PR TITLE
wait for a while after creating or deleting a dnat rule

### DIFF
--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
@@ -238,6 +239,9 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(id.(string))
 
+	// wait for a while to become ACTIVE
+	time.Sleep(3 * time.Second)
+
 	return resourceNatDnatRuleRead(d, meta)
 }
 
@@ -434,5 +438,7 @@ func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting Dnat %q: %s", d.Id(), r.Err)
 	}
 
+	// wait for a while to become DELETED
+	time.Sleep(3 * time.Second)
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2_test.go
@@ -39,6 +39,7 @@ func TestAccNatDnat_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatDnatExists(),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 				),
 			},
 			{


### PR DESCRIPTION
The API of creating and deleting a dnat rule actually is asynchronous.
The best way to process the async API is using `WaitForState()`, but the code is automatically generated by tools, so we just wait for 3 seconds to avoid the pending state.

the test result as follows:
```
$ make testacc TEST="./huaweicloud" TESTARGS="-run TestAccNatDnat_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatDnat_basic -timeout 360m -parallel 4
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== CONT  TestAccNatDnat_basic

--- PASS: TestAccNatDnat_basic (167.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       167.685s

```