### PR TITLE
add compute instance data source and docs

### DIFF
--- a/docs/data-sources/compute_instance.md
+++ b/docs/data-sources/compute_instance.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Elastic Cloud Server (ECS)"
+---
+
+# huaweicloud\_compute\_instance
+
+Use this data source to get the details of a specified compute instance.
+
+## Example Usage
+
+```hcl
+variable "ecs_name" { }
+
+data "huaweicloud_compute_instance" "demo" {
+  name = var.ecs_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the instance.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the ECS name, which can be queried with a regular expression.
+
+* `fixed_ip_v4` - (Optional, String)  Specifies the IPv4 addresses of the ECS.
+
+* `flavor_id` - (Optional, String) Specifies the flavor ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The instance ID in UUID format.
+* `availability_zone` - The availability zone where the instance is located.
+* `image_id` - The image ID of the instance.
+* `image_name` - The image name of the instance.
+* `flavor_name` - The flavor name of the instance.
+* `key_pair` - The key pair that is used to authenticate the instance.
+* `public_ip` - The EIP address that is associted to the instance.
+* `system_disk_id` - The system disk voume ID.
+* `security_groups` - An array of one or more security group names
+    to associate with the instance.
+* `network` - An array of one or more networks to attach to the instance.
+    The network object structure is documented below.
+* `volume_attached` - An array of one or more disks to attach to the instance.
+    The volume_attached object structure is documented below.
+* `scheduler_hints` - The scheduler with hints on how the instance should be launched.
+    The available hints are described below.
+* `tags` - The key/value pairs to associate with the instance.
+* `status` - The status of the instance.
+
+The `network` block supports:
+
+* `uuid` - The network UUID to attach to the server.
+* `port` - The port ID corresponding to the IP address on that network.
+* `mac` - The MAC address of the NIC on that network.
+* `fixed_ip_v4` - The fixed IPv4 address of the instance on this network.
+* `fixed_ip_v6` - The Fixed IPv6 address of the instance on that network.
+
+The `volume_attached` block supports:
+
+* `volume_id` - The volume id on that attachment.
+* `boot_index` - The volume boot index on that attachment.
+* `size` - The volume size on that attachment.
+* `pci_address` - The volume pci address on that attachment.
+
+The `scheduler_hints` block supports:
+
+* `group` - The UUID of a Server Group where the instance will be placed into.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201215030452-b7832cdb7620
+	github.com/huaweicloud/golangsdk v0.0.0-20201215110352-8d6995f79c49
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20201215030452-b7832cdb7620 h1:6TfT03T9JDbyWY05nFhYnvDAicISLR7COWDgSuMLo90=
 github.com/huaweicloud/golangsdk v0.0.0-20201215030452-b7832cdb7620/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20201215110352-8d6995f79c49 h1:ntGZja5Z4XPTGYGDp7RJPQCTlkMIU5A/PlvYDRvqFtM=
+github.com/huaweicloud/golangsdk v0.0.0-20201215110352-8d6995f79c49/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/data_source_huaweicloud_compute_instance.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance.go
@@ -1,0 +1,329 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices"
+	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
+)
+
+func DataSourceComputeInstance() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComputeInstanceRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fixed_ip_v4": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_pair": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"system_disk_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ip_v4": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ip_v6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mac": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"volume_attached": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"volume_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"boot_index": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pci_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"scheduler_hints": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ecsClient, err := config.ComputeV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud ECS client: %s", err)
+	}
+
+	epsID := GetEnterpriseProjectID(d, config)
+	listOpts := &cloudservers.ListOpts{
+		Name:                d.Get("name").(string),
+		Flavor:              d.Get("flavor_id").(string),
+		IP:                  d.Get("fixed_ip_v4").(string),
+		EnterpriseProjectID: epsID,
+	}
+
+	pages, err := cloudservers.List(ecsClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allServers, err := cloudservers.ExtractServers(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve cloud servers: %s ", err)
+	}
+
+	if len(allServers) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+	if len(allServers) > 1 {
+		return fmt.Errorf("Your query returned more than one result. " +
+			"Please try a more specific search criteria.")
+	}
+
+	server := allServers[0]
+	log.Printf("[DEBUG] fetching the ecs instance: %#v", server)
+
+	d.SetId(server.ID)
+	d.Set("region", GetRegion(d, config))
+	d.Set("availability_zone", server.AvailabilityZone)
+	d.Set("name", server.Name)
+	d.Set("status", server.Status)
+
+	flavorInfo := server.Flavor
+	d.Set("flavor_id", flavorInfo.ID)
+	d.Set("flavor_name", flavorInfo.Name)
+	d.Set("image_id", server.Image.ID)
+
+	metaData := server.Metadata
+	if metaData.ImageName != "" {
+		d.Set("image_name", metaData.ImageName)
+	}
+	if server.KeyName != "" {
+		d.Set("key_pair", server.KeyName)
+	}
+	if server.UserData != "" {
+		d.Set("user_data", server.UserData)
+	}
+	if epsID != "" {
+		d.Set("enterprise_project_id", epsID)
+	}
+
+	// set security groups
+	secGrpNames := make([]string, len(server.SecurityGroups))
+	for i, sg := range server.SecurityGroups {
+		secGrpNames[i] = sg.Name
+	}
+	d.Set("security_groups", secGrpNames)
+
+	// set os:scheduler_hints
+	osHints := server.OsSchedulerHints
+	if len(osHints.Group) > 0 {
+		schedulerHints := make([]map[string]interface{}, len(osHints.Group))
+		for i, v := range osHints.Group {
+			schedulerHints[i] = map[string]interface{}{
+				"group": v,
+			}
+		}
+		d.Set("scheduler_hints", schedulerHints)
+	}
+
+	// Set the instance network and address information
+	networks, eip := flattenComputeNetworks(d, meta, &server)
+	if err := d.Set("network", networks); err != nil {
+		log.Printf("[WARN] Error setting network of ecs instance %s: %s", d.Id(), err)
+	}
+	if eip != "" {
+		d.Set("public_ip", eip)
+	}
+
+	// Set volume attached
+	instanceVolumes := []map[string]interface{}{}
+	if len(server.VolumeAttached) > 0 {
+		for _, b := range server.VolumeAttached {
+			va, err := block_devices.Get(ecsClient, d.Id(), b.ID).Extract()
+			if err != nil {
+				return err
+			}
+			log.Printf("[DEBUG] Retrieved volume attachment %s: %#v", d.Id(), va)
+			v := map[string]interface{}{
+				"volume_id":   b.ID,
+				"boot_index":  va.BootIndex,
+				"size":        va.Size,
+				"pci_address": va.PciAddress,
+			}
+			instanceVolumes = append(instanceVolumes, v)
+			if va.BootIndex == 0 {
+				d.Set("system_disk_id", b.ID)
+			}
+		}
+		d.Set("volume_attached", instanceVolumes)
+	}
+
+	// Set instance tags
+	resourceTags, err := tags.Get(ecsClient, "cloudservers", d.Id()).Extract()
+	if err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		d.Set("tags", tagmap)
+	} else {
+		log.Printf("[WARN] Error fetching tags of ecs instance %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+// flattenComputeNetworks collects instance network information
+func flattenComputeNetworks(
+	d *schema.ResourceData, meta interface{}, server *cloudservers.CloudServer) ([]map[string]interface{}, string) {
+
+	config := meta.(*Config)
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		log.Printf("[ERROR] failed to create HuaweiCloud networking client: %s", err)
+		return nil, ""
+	}
+
+	publicIP := ""
+	networks := []map[string]interface{}{}
+
+	for _, addresses := range server.Addresses {
+		for _, addr := range addresses {
+			if addr.Type == "floating" {
+				publicIP = addr.Addr
+				continue
+			}
+
+			// get networkID
+			var networkID string
+			p, err := ports.Get(networkingClient, addr.PortID).Extract()
+			if err != nil {
+				networkID = ""
+				log.Printf("[DEBUG] failed to fetch port %s", addr.PortID)
+			} else {
+				networkID = p.NetworkID
+			}
+
+			v := map[string]interface{}{
+				"uuid": networkID,
+				"port": addr.PortID,
+				"mac":  addr.MacAddr,
+			}
+			if addr.Version == "6" {
+				v["fixed_ip_v6"] = addr.Addr
+			} else {
+				v["fixed_ip_v4"] = addr.Addr
+			}
+
+			networks = append(networks, v)
+		}
+	}
+
+	log.Printf("[DEBUG] flatten Instance Networks: %#v", networks)
+	return networks, publicIP
+}

--- a/huaweicloud/data_source_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance_test.go
@@ -1,0 +1,75 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"
+)
+
+func TestAccComputeInstanceDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("ecs-data-test-%s", acctest.RandString(5))
+	resourceName := "data.huaweicloud_compute_instance.this"
+	var instance servers.Server
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
+					testAccCheckComputeInstanceDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeInstanceDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find compute instance data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Compute instance data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeInstanceDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_compute_instance" "test" {
+  name              = "%s"
+  image_id          = data.huaweicloud_images_image.test.id
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  security_groups   = ["default"]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = data.huaweicloud_vpc_subnet.test.id
+  }
+}
+
+data "huaweicloud_compute_instance" "this" {
+  name = huaweicloud_compute_instance.test.name
+}
+`, testAccCompute_data, rName)
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -251,6 +251,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_cce_node":                    dataSourceCCENodeV3(),
 			"huaweicloud_cdm_flavors":                 dataSourceCdmFlavorV1(),
 			"huaweicloud_compute_flavors":             DataSourceEcsFlavors(),
+			"huaweicloud_compute_instance":            DataSourceComputeInstance(),
 			"huaweicloud_csbs_backup":                 dataSourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy":          dataSourceCSBSBackupPolicyV1(),
 			"huaweicloud_cts_tracker":                 dataSourceCTSTrackerV1(),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/urls.go
@@ -14,6 +14,10 @@ func getURL(sc *golangsdk.ServiceClient, serverID string) string {
 	return sc.ServiceURL("cloudservers", serverID)
 }
 
+func listDetailURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("cloudservers", "detail")
+}
+
 func jobURL(sc *golangsdk.ServiceClient, jobId string) string {
 	return sc.ServiceURL("jobs", jobId)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201215030452-b7832cdb7620
+# github.com/huaweicloud/golangsdk v0.0.0-20201215110352-8d6995f79c49
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
The testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (171.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       171.756s
```