### PR TITLE
Add time_zone to RDS instance_v3

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -33,7 +33,7 @@ resource "huaweicloud_rds_instance" "instance" {
     type = "ULTRAHIGH"
     size = 100
   }
-  flavor = "rds.pg.c2.medium"
+  flavor = "rds.pg.c2.large"
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
@@ -65,7 +65,7 @@ resource "huaweicloud_rds_instance" "instance" {
     type = "ULTRAHIGH"
     size = 100
   }
-  flavor              = "rds.pg.s1.medium.ha"
+  flavor              = "rds.pg.s1.large.ha"
   ha_replication_mode = "async"
   backup_strategy {
     start_time = "08:00-09:00"
@@ -105,7 +105,7 @@ resource "huaweicloud_rds_instance" "instance" {
     type               = "ULTRAHIGH"
     size               = 100
   }
-  flavor = "rds.pg.c2.medium"
+  flavor = "rds.pg.c2.large"
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
@@ -151,10 +151,16 @@ The following arguments are supported:
 
 * `param_group_id` - (Optional, String, ForceNew) Specifies the parameter group ID. Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the RDS instance. Changing this creates a new RDS instance.
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the RDS instance. Changing this parameter creates a new RDS instance.
 
 * `tags` - (Optional, Map) A mapping of tags to assign to the RDS instance.
   Each tag is represented by one key-value pair.
+  
+* `time_zone` - (Optional, String, ForceNew) Specifies the UTC time zone. 
+  For MySQL and PostgreSQL Chinese mainland site and international site use UTC by default. 
+  The value ranges from UTC-12:00 to UTC+12:00 at the full hour. 
+  For Microsoft SQL Server international site use UTC by default and Chinese mainland site use China Standard Time. 
+  The time zone is expressed as a character string, refer to Document [table 10](https://support.huaweicloud.com/intl/en-us/api-rds/rds_01_0002.html#rds_01_0002__table613473883617).
 
 The `db` block supports:
 

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -248,6 +248,11 @@ func resourceRdsInstanceV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"time_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -266,6 +271,7 @@ func resourceRdsInstanceV3UserInputParams(d *schema.ResourceData) map[string]int
 		"subnet_id":               d.Get("subnet_id"),
 		"volume":                  d.Get("volume"),
 		"vpc_id":                  d.Get("vpc_id"),
+		"time_zone":               d.Get("time_zone"),
 	}
 }
 
@@ -737,6 +743,16 @@ func buildRdsInstanceV3CreateParameters(opts map[string]interface{}, arrayIndex 
 		params["vpc_id"] = v
 	}
 
+	v, err = navigateValue(opts, []string{"time_zone"}, arrayIndex)
+	if err != nil {
+		return nil, err
+	}
+	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
+		return nil, err
+	} else if !e {
+		params["time_zone"] = v
+	}
+
 	return params, nil
 }
 
@@ -1135,6 +1151,14 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	}
 	if err = d.Set("tags", v); err != nil {
 		return fmt.Errorf("Error setting Instance:tags, err: %s", err)
+	}
+
+	v, err = navigateValue(response, []string{"list", "time_zone"}, nil)
+	if err != nil {
+		return fmt.Errorf("Error reading Instance:time_zone, err: %s", err)
+	}
+	if err = d.Set("time_zone", v); err != nil {
+		return fmt.Errorf("Error setting Instance:time_zone, err: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -252,6 +252,7 @@ func resourceRdsInstanceV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
@@ -42,6 +42,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+10:00"),
 				),
 			},
 			{
@@ -108,11 +109,12 @@ resource "huaweicloud_networking_secgroup" "secgroup_1" {
 
 resource "huaweicloud_rds_instance" "instance" {
   name = "terraform_test_rds_instance%s"
-  flavor = "rds.pg.c2.medium"
+  flavor = "rds.pg.c2.large"
   availability_zone = ["%s"]
   security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
   subnet_id = huaweicloud_vpc_subnet.test.id
   vpc_id = huaweicloud_vpc.test.id
+  time_zone = "UTC+10:00"
 
   db {
     password = "Huangwei!120521"
@@ -160,11 +162,12 @@ resource "huaweicloud_networking_secgroup" "secgroup_1" {
 
 resource "huaweicloud_rds_instance" "instance" {
   name = "terraform_test_rds_instance%s"
-  flavor = "rds.pg.c2.medium"
+  flavor = "rds.pg.c2.large"
   availability_zone = ["%s"]
   security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
   subnet_id = huaweicloud_vpc_subnet.test.id
   vpc_id = huaweicloud_vpc.test.id
+  time_zone = "UTC+10:00"
 
   db {
     password = "Huangwei!120521"


### PR DESCRIPTION
Change List:
1. Add 'time_zone' to resource_huaweicloud_rds_instance_v3.go;
2. Update resource_huaweicloud_rds_instance_v3_test.go accroding to new args 'time_zone'.