### PR TITLE
Add IEC data source and resource docs 

### DIFF
--- a/docs/data-sources/iec_flavors.md
+++ b/docs/data-sources/iec_flavors.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_flavors
+
+Use this data source to get the available of HuaweiCloud IEC flavors.
+
+## Example Usage
+
+```hcl
+variable "flavor_name" {
+  default = "iec-flavor-test"
+}
+
+data "huaweicloud_iec_flavors" "iec_flavor" {
+  name   = var.flavor_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` -  (Optional, String) Specifies the flavor name, which can be queried 
+    with a regular expression.
+ 
+* `site_ids` - (Optional, String) Specifies the list of edge service site.
+
+* `area` - (Optional, String) Specifies the province of the iec instance located.
+
+* `province` - (Optional, String) Specifies the province of the iec instance located.
+
+* `city` - (Optional, String) Specifies the province of the iec instance located.
+
+* `operator` - (Optional, String) Specifies the operator supported of the iec instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `flavors` - An array of one or more flavors.
+    The flavors object structure is documented below.
+
+The `flavors` block supports:
+
+* `id` - The id of the iec flavor.
+* `name` - The name of the iec flavor.
+* `vcpus` - The vcpus of the iec flavor.
+* `memory` - The memory of the iec flavor.

--- a/docs/data-sources/iec_images.md
+++ b/docs/data-sources/iec_images.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_images
+
+Use this data source to get the available of HuaweiCloud IEC images.
+
+## Example Usage
+
+```hcl
+variable "image_name" {
+  default = "iec-image-test"
+}
+
+data "huaweicloud_iec_images" "iec_image" {
+  name    = var.image_name
+  os_type = "Linux"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` -  (Optional, String) Specifies the image Name, which can be queried 
+    with a regular expression.
+ 
+* `os_type` - (Optional, String) Specifies the os type of the iec image. 
+    "Linux", "Windows" and "Other" are supported.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `images` - An array of one or more image.
+    The images object structure is documented below.
+
+The `images` block supports:
+
+* `id` - The id of the iec images.
+* `name` - The name of the iec images.
+* `status` - The status of the iec images. Images has four states: "saving", 
+    "deleted", "killed" and "active",
+* `os_type` - The os_type of the iec images.

--- a/docs/data-sources/iec_sites.md
+++ b/docs/data-sources/iec_sites.md
@@ -1,0 +1,58 @@
+# huaweicloud\_iec\_sites
+
+Use this data source to get the available of HuaweiCloud IEC sites.
+
+## Example Usage
+
+### Basic IEC Sites
+
+```hcl
+data "huaweicloud_iec_sites" "iec_sites" {}
+```
+
+### IEC Sites with sites block
+```hcl
+data "huaweicloud_iec_sites" "iec_sites" {
+  sites {
+    name = "iec-site-1"
+  }
+  sites {
+    name = "iec-site-2"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+ 
+* `area` - (Optional, String) Specifies the area of the iec instance located.
+
+* `province` - (Optional, String) Specifies the province of the iec instance 
+    located.
+
+* `city` - (Optional, String) Specifies the city of the iec instance located. 
+
+* `operator` - (Optional, String) Specifies the operator supported of the iec 
+    instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `name` - The name of the iec service site.
+
+* `status` - The current status of the iec service site.
+
+* `sites` - An array of one or more iec service sites.
+    The images object structure is documented below.
+
+The `sites` block supports:
+
+* `id` - The id of the iec service site.
+* `name` - The name of the iec service site.
+* `area` - The area of the iec service site located.
+* `province` - The province of the iec service site located.
+* `city` - The city of the iec service site located.
+* `operator` - The operator information of the iec service site.
+* `status` - The current status of the iec service site.

--- a/docs/resources/iec_eip.md
+++ b/docs/resources/iec_eip.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_eip
+
+Manages a eip resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_iec_sites" "iec_sites" {}
+
+resource "huaweicloud_iec_eip" "eip_test" {
+  site_id    = data.huaweicloud_iec_sites.iec_sites.sites[0].id
+  ip_version = 4
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `site_id` - (Required, String, ForceNew) Specifies the id of iec sevice site. Changing this parameter creates a new iec eip resource.
+
+* `ip_version` - (Optional, Int) The elastic IP address object. IEC services only support IPv4 now.
+
+* `port_id` - (Optional, String) The elastic IP address object.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `status` - Specifies the [status](https://support.huaweicloud.com/intl/en-us/api-eip/eip_api_0002.html#eip_api_0002__en-us_topic_0201534285_table3035698) 
+    of iec eip.
+
+* `public_ip` - Indicates the elastic IP address object.
+
+* `private_ip` - Indicates the private IP address.
+
+* `bandwitch_name` - The name of bandwidth object.
+
+* `bandwitch_size` - The size of bandwidth object.
+
+* `bandwitch_share_type` - Whether the bandwidth is shared or exclusive. 
+
+* `site_info` - Specifies the information of iec subnet site.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 3 minute.
+
+## Import
+
+IEC EIPs can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_eip.eip_1 b5ad19d1-57d1-48fd-aab7-1378f9bee169
+```

--- a/docs/resources/iec_keypair.md
+++ b/docs/resources/iec_keypair.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_keypair
+
+Manages a keypair resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_iec_keypair" "test_keypair" {
+  name       = "iec-keypair-test"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDy+49hbB9Ni2SttHcbJU+ngQXUhiGDVsflp2g5A3tPrBXq46kmm/nZv9JQqxlRzqtFi9eTI7OBvn2A34Y+KCfiIQwtgZQ9LF5ROKYsGkS2o9ewsX8Hghx1r0u5G3wvcwZWNctgEOapXMD0JEJZdNHCDSK8yr+btR4R8Ypg0uN+Zp0SyYX1iLif7saiBjz0zmRMmw5ctAskQZmCf/W5v/VH60fYPrBU8lJq5Pu+eizhou7nFFDxXofr2ySF8k/yuA9OnJdVF9Fbf85Z59CWNZBvcTMaAH2ALXFzPCFyCncTJtc/OVMRcxjUWU1dkBhOGQ/UnhHKcflmrtQn04eO8xDr root@terra-dev"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) A unique name for the keypair. Changing this parameter creates a new keypair resource.
+
+* `public_key` - (Optional, String, ForceNew) A pregenerated OpenSSH-formatted public key. Changing this parameter creates a new keypair resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `fingerprint` - Specifies a resource ID in UUID format.
+
+## Import
+
+Keypairs can be imported using the `name`, e.g.
+
+```
+$ terraform import huaweicloud_iec_keypair.test_keypair iec-keypair-test
+
+```

--- a/docs/resources/iec_network_acl.md
+++ b/docs/resources/iec_network_acl.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_network\_acl
+
+Manages a network ACL resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_iec_sites" "iec_sites" {}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = "iec-vpc-test"
+  cidr = "192.168.0.0/16"
+  mode = "SYSTEM"
+}
+
+resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
+  name        = "iec-subnet-test"
+  cidr        = "192.168.199.0/24"
+  vpc_id      = huaweicloud_iec_vpc.vpc_test.id
+  site_id     = data.huaweicloud_iec_sites.iec_sites.sites[0].id
+}
+
+resource "huaweicloud_iec_network_acl_rule" "rule_test_1" {
+  protocol               = "tcp"
+  action                 = "deny"
+  source_ip_address      = "112.25.96.0/20"
+  source_port            = "445"
+}
+
+resource "huaweicloud_iec_network_acl_rule" "rule_test_2" {
+  protocol               = "tcp"
+  action                 = "allow"
+  source_ip_address      = "124.70.64.0/20"
+  source_port            = "8080"
+}
+
+resource "huaweicloud_iec_network_acl" "acl_test" {
+  name          = "iec-acl-test"
+  inbound_rules = [huaweicloud_iec_network_acl_rule.rule_test_1.id,
+    huaweicloud_iec_network_acl_rule.rule_test_2.id]
+  networks {
+    vpc_id    = huaweicloud_iec_vpc.vpc_test.id
+    subnet_id = huaweicloud_iec_vpc_subnet.subnet_test.id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the iec network ACL name. This 
+    parameter can contain a maximum of 64 characters, which may consist of 
+    letters, digits, underscores (_), and hyphens (-).
+
+* `description` - (Optional, String) Specifies the supplementary information 
+    about the iec network ACL. This parameter can contain a maximum of 255 
+    characters and cannot contain angle brackets (< or >).
+
+* `inbound_rules` - (Optional, List)  A list of the IDs of ingress rules 
+    associated with the iec network ACL. 
+
+* `outbound_rules` - (Optional, List) A list of the IDs of egress rules 
+    associated with the iec network ACL. 
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the network ACL.
+
+* `networks` - An Set of one or more networks. The networks object structure is 
+    documented below.
+
+* `status` - The status of the iec network ACL. 
+
+The `networks` block supports:
+
+* `vpc_id` - The id of the iec vpc.
+* `subnet_id` - The id of the iec subnet.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `update` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+
+## Import
+
+IEC network ACL can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_network_acl.acl_test 773d965e-43fb-11eb-b721-fa163e8ac569
+```

--- a/docs/resources/iec_network_acl_rule.md
+++ b/docs/resources/iec_network_acl_rule.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_network\_acl\_rule
+
+Manages a network ACL rule resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_iec_network_acl_rule" "rule_test" {
+  protocol               = "tcp"
+  action                 = "deny"
+  source_ip_address      = "112.25.96.0/20"
+  source_port            = "445"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `network_acl_id` - (Required, String) Specifies a unique id for the iec 
+    network ACL.
+
+* `direction` - (Required, String, ForceNew) Specifies the direction of the 
+    rule, valid values are *ingress* or *egress*. Changing this parameter 
+    creates a new iec network ACL rule resource.
+
+* `description` - (Optional, String) Specifies the description for the iec 
+    network ACL rule.
+
+* `protocol` - (Optional, String) Specifies the protocol supported by the iec 
+    network ACL rule. Valid values are: *tcp*, *udp*, *icmp* and *any*.
+
+* `action` - (Optional, String) Specifies the action in the iec network ACL 
+    rule. Currently, the value can be *allow* or *deny*.
+
+* `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) 
+    or 6. This parameter is available after the IPv6 function is enabled.
+
+* `source_ip_address` - (Optional, String) Specifies the source IP address that 
+    the traffic is allowed from. The default value is *0.0.0.0/0*. For example: 
+    xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+
+* `destination_ip_address` - (Optional, String) Specifies the destination IP 
+    address to which the traffic is allowed. The default value is *0.0.0.0/0*. 
+    For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+
+* `source_port` - (Optional, String) Specifies the source port number or port   
+    number range. The value ranges from 1 to 65535. For a port number range, 
+    enter two port numbers connected by a hyphen (-). For example, 1-100.
+
+* `destination_port` - (Optional, String) Specifies the destination port number 
+    or port number range. The value ranges from 1 to 65535. For a port number 
+    range, enter two port numbers connected by a hyphen (-). For example, 1-100.
+
+* `enabled` - (Optional, Bool) Enabled status for the iec network ACL rule. 
+    Defaults to true.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `poilicy_id` - Specifies the ID of the firewall policy for the iec network 
+    ACL.
+
+## Import
+
+network ACL rules can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_network_acl_rule.rule_test 89a84b28-4cc2-4859-9885-c67e802a46a3
+```

--- a/docs/resources/iec_security_group.md
+++ b/docs/resources/iec_security_group.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_security\_group
+
+Manages a security group resource within HuaweiCloud IEC.
+This is an alternative to `huaweicloud_iec_security_group_v1`
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_iec_security_group" "secgroup_test" {
+  name        = "my_secgroup_test"
+  description = "My security group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) A unique name for the security group.
+
+* `description` - (Optional, String) Description for the security group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a iec security group resource ID in UUID format.
+
+* `security_group_rules` - An Array of one or more security group rules. The security_group_rules object structure is documented below.
+
+The `security_group_rules` block supports:
+
+* `id` - The id of the iec security group rules.
+* `security_group_id` - The id of the iec security group rules.
+* `description` - The description for the iec security group rules.
+* `direction` - The direction of the iec security group rules.
+* `ethertype` - The layer 3 protocol type.
+* `port_range_max` - The higher part of the allowed port range.
+* `port_range_min` - The lower part of the allowed port range.
+* `protocol` - The layer 4 protocol type.
+* `remote_ip_prefix` - The remote CIDR of the iec security group rules.
+* `remote_group_id` - The remote group id of the iec security group rules.
+
+## Default Security Group Rules
+
+In most cases, HuaweiCloud will create some ingress and egress rules for each new iec security group. These iec security group rules will not be managed by Terraform.
+
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+
+## Import
+
+Security Groups can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_security_group.secgroup_test 2a02d1d3-437c-11eb-b721-fa163e8ac569
+```

--- a/docs/resources/iec_security_group_rule.md
+++ b/docs/resources/iec_security_group_rule.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_security\_group\_rule
+
+Manages a security group rule resource within HuaweiCloud IEC.
+This is an alternative to `huaweicloud_iec_security_group_rule_v1`
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_iec_security_group" "secgroup_test" {
+  name        = "my_secgroup_test"
+  description = "My security group"
+}
+
+resource "huaweicloud_iec_security_group_rule" "secgroup_rule_test" {
+  direction         = "ingress"
+  port_range_min    = 22
+  port_range_max    = 22
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  security_group_id = huaweicloud_iec_security_group.secgroup_test.id
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional, String, ForceNew) Specifies a description for the 
+    security group rule. Changing this parameter creates a new security group 
+    rule resource.
+
+* `direction` - (Required, String, ForceNew) The direction of the rule, valid 
+    values are __ingress__ or __egress__. Changing this parameter creates a new 
+    security group rule resource.
+
+* `port_range_min` - (Optional, Int, ForceNew) The lower part of the allowed 
+    port range, valid integer value needs to be between 1 and 65535. Changing 
+    this parameter creates a new security group rule resource.
+
+* `port_range_max` - (Optional, Int, ForceNew) The higher part of the allowed 
+    port range, valid integer value needs to be between 1 and 65535. Changing 
+    this parameter creates a new security group rule resource.
+
+* `ethertype` - (Required, String, ForceNew) The layer 3 protocol type, valid 
+    values are __IPv4__(IPv4 is default) or __IPv6__. Changing this parameter 
+    creates a new security group rule resource.
+
+* `protocol` - (Optional, String, ForceNew) The layer 4 protocol type, valid 
+    values are following. Changing this parameter creates a new security group 
+    rule resource. This is required if you want to specify a port range.
+  * __tcp__
+  * __udp__
+  * __icmp__
+  * __gre__
+
+* `security_group_id` - (Required, String, ForceNew) The security group id the 
+    rule should belong to, the value needs to be an Openstack ID of a security 
+    group. Changing this parameter creates a new security group rule resource.
+
+* `remote_ip_prefix` - (Optional, String, ForceNew) The remote CIDR, the value 
+    needs to be a valid CIDR (i.e. 192.168.0.0/16).Changing this parameter 
+    creates a new security group rule resource.
+
+* `remote_group_id` - (Optional, String, ForceNew) The remote group id, the 
+    value needs to be an Openstack ID of a security group. Changing this 
+    parameter creates a new security group rule resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 10 minute.
+
+## Import
+
+IEC Security Group Rules can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_security_group_rule.secgroup_rule_test 2a02d1d3-437c-11eb-b721-fa163e8ac569
+```

--- a/docs/resources/iec_vip.md
+++ b/docs/resources/iec_vip.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_vip
+
+Manages a VIP resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_iec_sites" "iec_sites" {}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = "iec-vpc-test"
+  cidr = "192.168.0.0/16"
+  mode = "SYSTEM"
+}
+
+resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
+  name        = "iec-subnet-test"
+  cidr        = "192.168.199.0/24"
+  vpc_id      = huaweicloud_iec_vpc.vpc_test.id
+  site_id     = data.huaweicloud_iec_sites.iec_sites.sites[0].id
+}
+
+resource "huaweicloud_iec_vip" "vip_test" {
+  subnet_id = huaweicloud_iec_vpc_subnet.subnet_test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `subnet_id` - (Required, ForceNew) Specifies the subnet in which to allocate 
+    IP address for this vip. Changing this parameter creates a new vip resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the vip.
+
+* `mac_address` - The MAC address of the vip.
+
+* `fixed_ips` - An Array of one or more network. The fixed_ips object structure is documented below.
+
+The `fixed_ips` block supports:
+
+* `subnet_id` - The id of the subnet network.
+* `ip_address` - The ip address of the subnet network.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 10 minute.

--- a/docs/resources/iec_vpc.md
+++ b/docs/resources/iec_vpc.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_vpc
+
+Manages a VPC resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+variable "iec_vpc_name" {
+  default = "iec-vpc-test"
+}
+
+variable "iec_vpc_cidr" {
+  default = "192.168.0.0/16"
+}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = var.iec_vpc_name
+  cidr = var.iec_vpc_cidr
+  mode = "SYSTEM"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) The name of the IEC VPC. The name must be unique.
+    The value is a string of no more than 64 characters and can contain digits, 
+    letters, underscores (_), and hyphens (-).
+
+* `cidr` - (Required, String) The range of available subnets in the VPC. 
+    The ranges of *SYSTEM* mode is from 10.0.0.0/8 to 10.255.0.0/16, 
+    172.16.0.0/12 to 172.31.0.0/16, or 192.168.0.0/16.
+    The ranges of *CUSTOMER* mode is from 10.0.0.0/8 to 10.255.255.0/24, 
+    172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
+
+* `mode` - (Optional, String) Specifies the mode of the iec vpc. "SYSTEM" and 
+    "CUSTOMER" are supported.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  ID of the VPC.
+
+* `subnet_num` - Specifies the number of the subnets. 
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 3 minute.
+
+## Import
+
+VPCs can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_vpc.vpc_test 5741168f-437a-11eb-b721-fa163e8ac569
+```

--- a/docs/resources/iec_vpc_subnet.md
+++ b/docs/resources/iec_vpc_subnet.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_vpc\_subnet
+
+Manages a VPC subnet resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_iec_sites" "iec_sites" {}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = "iec-vpc-test"
+  cidr = "192.168.0.0/16"
+  mode = "SYSTEM"
+}
+
+resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
+  name        = "iec-subnet-test"
+  cidr        = "192.168.199.0/24"
+  vpc_id      = huaweicloud_iec_vpc.vpc_test.id
+  site_id     = data.huaweicloud_iec_sites.iec_sites.sites[0].id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) The name of the subnet. Changing this updates the 
+    name of the existing subnet.
+
+* `cidr` - (Required, String, ForceNew) CIDR representing IP range for this 
+    subnet, based on IP version. Changing this parameter creates a new subnet 
+    resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the vpc. Changing 
+    this parameter creates a new subnet resource.
+
+* `site_id` - (Required, String, ForceNew) Specifies the ID of the iec site. 
+    Changing this parameter creates a new subnet resource.
+
+* `gateway_ip` - (Optional, String)  Default gateway used by devices in this 
+    subnet. Leaving this blank and not setting `no_gateway` will cause a default
+    gateway of `.1` to be used. Changing this updates the gateway IP of the
+    existing subnet.
+
+* `dhcp_enable` - (Optional, Bool) The administrative state of the network.
+    The value must be "true".
+
+* `dns_list` - (Optional, List) An array of DNS name server names used by hosts
+    in this subnet.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+
+* `site_info` - Specifies the information of the iec site.
+
+* `status` - Specifies the status of the subnet.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 3 minute.
+
+## Import
+
+Subnets can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iec_vpc_subnet.subnet_test 51be9f2b-5a3b-406a-9271-36f0c929fbcc
+```


### PR DESCRIPTION
Change list:
1. There are new data source and resource documents:
    iec_flavors.md (data source)
    iec_images.md (data source)
    iec_sites.md (data source)
    iec_eip.md (resource )
    iec_keypair.md (resource)
    iec_network_acl_rule.md (resource)
    iec_network_acl.md (resource)
    iec_security_group_rule.md (resource)
    iec_security_group.md (resource)
    iec_vip.md (resource)
    iec_vpc_subnet.md (resource)
    iec_vpc.md (resource)