### PR TITLE
add VPC endpoint client

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -628,12 +628,20 @@ func (c *Config) NetworkingV1Client(region string) (*golangsdk.ServiceClient, er
 	return c.NewServiceClient("vpc", region)
 }
 
+// NetworkingV2Client returns a ServiceClient for neutron APIs
+// the endpoint likes: https://vpc.{region}.myhuaweicloud.com/v2.0/
+func (c *Config) NetworkingV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("networkv2", region)
+}
+
 func (c *Config) SecurityGroupV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("security_group", region)
 }
 
-func (c *Config) NetworkingV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("networkv2", region)
+// VPCEPClient returns a ServiceClient for VPC Endpoint APIs
+// the endpoint likes: https://vpcep.{region}.myhuaweicloud.com/v1/{project_id}/
+func (c *Config) VPCEPClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("vpcep", region)
 }
 
 func (c *Config) natV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -162,6 +162,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v2.0",
 		WithOutProjectID: true,
 	},
+	"vpcep": ServiceCatalog{
+		Name:    "vpcep",
+		Version: "v1",
+	},
 	"dns": ServiceCatalog{
 		Name:             "dns",
 		Version:          "v2",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -667,6 +667,18 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 		t.Fatalf("DNS region endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
 	t.Logf("DNS region endpoint:\t %s", actualURL)
+
+	// test the endpoint of VPC endpoint
+	serviceClient, err = config.VPCEPClient(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud VPC endpoint client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://vpcep.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("VPCEP endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("VPCEP endpoint:\t %s", actualURL)
 }
 
 func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {


### PR DESCRIPTION
VPCEPClient returns a ServiceClient for VPC Endpoint APIs, the endpoint likes: https://vpcep.{region}.myhuaweicloud.com/v1/{project_id}/