### PR TITLE
add huaweicloud vpcep public services data source and docs

### DIFF
--- a/docs/data-sources/vpcep_public_services.md
+++ b/docs/data-sources/vpcep_public_services.md
@@ -1,0 +1,44 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+---
+
+# huaweicloud\_vpcep\_public\_services
+
+Use this data source to get available public VPC endpoint services.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_vpcep_public_services" "all_services" {
+}
+
+data "huaweicloud_vpcep_public_services" "dns_service" {
+  service_name = "dns"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the public VPC endpoint services.
+    If omitted, the provider-level region will be used.
+
+* `service_name` - (Optional, String) Specifies the name of the public VPC endpoint service.
+    The value is not case-sensitive and supports fuzzy match.
+
+* `service_id` - (Optional, String) Specifies the unique ID of the public VPC endpoint service.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a data source ID in UUID format.
+
+* `services` - Indicates the public VPC endpoint services information. Structure is documented below.
+
+The `services` block contains:
+
+* `id` - The unique ID of the public VPC endpoint service.
+* `service_name` - The name of the public VPC endpoint service.
+* `service_type` - The type of the VPC endpoint service.
+* `owner` - The owner of the VPC endpoint service.
+* `is_charge` - Indicates whether the associated VPC endpoint carries a charge.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201223081519-cedf29b4891c
+	github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20201222025841-5312fcc13866 h1:CN12N3XOk
 github.com/huaweicloud/golangsdk v0.0.0-20201222025841-5312fcc13866/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20201223081519-cedf29b4891c h1:Wn/clEpob9fqlwbRIvuKM1UpQJcyObse8uav4NyglIc=
 github.com/huaweicloud/golangsdk v0.0.0-20201223081519-cedf29b4891c/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c h1:Igfi5l8W6r8NGUVOZyaIt1m6JZQqo9Lx5bOXbx53qyE=
+github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/data_source_huaweicloud_vpcep_public_services.go
+++ b/huaweicloud/data_source_huaweicloud_vpcep_public_services.go
@@ -1,0 +1,100 @@
+package huaweicloud
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
+)
+
+func DataSourceVPCEPPublicServices() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVpcepPublicRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"services": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_charge": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpcepPublicRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	vpcepClient, err := config.VPCEPClient(region)
+	if err != nil {
+		return fmt.Errorf("Error creating Huaweicloud VPC endpoint client: %s", err)
+	}
+
+	listOpts := services.ListOpts{
+		ServiceName: d.Get("service_name").(string),
+		ID:          d.Get("service_id").(string),
+	}
+
+	allServices, err := services.ListPublic(vpcepClient, listOpts)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve vpc endpoint public services: %s", err)
+	}
+
+	if len(allServices) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	d.SetId(allServices[0].ID)
+	d.Set("region", region)
+	services := make([]map[string]interface{}, len(allServices))
+	for i, v := range allServices {
+		services[i] = map[string]interface{}{
+			"id":           v.ID,
+			"service_name": v.ServiceName,
+			"service_type": v.ServiceType,
+			"owner":        v.Owner,
+			"is_charge":    v.IsChange,
+		}
+	}
+	if err := d.Set("services", services); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_vpcep_public_services_test.go
+++ b/huaweicloud/data_source_huaweicloud_vpcep_public_services_test.go
@@ -1,0 +1,32 @@
+package huaweicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccVPCEPPublicServicesDataSourceBasic(t *testing.T) {
+	resourceName := "data.huaweicloud_vpcep_public_services.services"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEPPublicServicesDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "services.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "services.0.service_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "services.0.service_type"),
+				),
+			},
+		},
+	})
+}
+
+var testAccVPCEPPublicServicesDataSourceBasic = `
+data "huaweicloud_vpcep_public_services" "services" {
+  service_name = "dns"
+}
+`

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -291,6 +291,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_vpc_route_ids":               dataSourceVPCRouteIdsV2(),
 			"huaweicloud_vpc_subnet":                  DataSourceVpcSubnetV1(),
 			"huaweicloud_vpc_subnet_ids":              DataSourceVpcSubnetIdsV1(),
+			"huaweicloud_vpcep_public_services":       DataSourceVPCEPPublicServices(),
 			// Legacy
 			"huaweicloud_images_image_v2":           DataSourceImagesImageV2(),
 			"huaweicloud_networking_port_v2":        DataSourceNetworkingPortV2(),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/results.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 )
 
 // Service contains the response of the VPC endpoint service
@@ -33,7 +34,7 @@ type Service struct {
 	// whether the client IP address and port number or marker_id information is transmitted to the server
 	TCPProxy string `json:"tcp_proxy"`
 	// the resource tags
-	Tags []ResourceTags `json:"tags"`
+	Tags []tags.ResourceTag `json:"tags"`
 	// the error message when the status of the VPC endpoint service changes to failed
 	Error []ErrorInfo `json:"error"`
 	// the creation time of the VPC endpoint service
@@ -52,14 +53,25 @@ type PortMapping struct {
 	ServerPort int `json:"server_port"`
 }
 
-type ResourceTags struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
 type ErrorInfo struct {
 	Code    string `json:"error_code"`
 	Message string `json:"error_message"`
+}
+
+// PublicService contains the response of the public VPC endpoint service
+type PublicService struct {
+	// the ID of the public VPC endpoint service
+	ID string `json:"id"`
+	// the owner of the VPC endpoint service
+	Owner string `json:"owner"`
+	// the name of the VPC endpoint service
+	ServiceName string `json:"service_name"`
+	// the type of the VPC endpoint service: gateway or interface
+	ServiceType string `json:"service_type"`
+	// whether the associated VPC endpoint carries a charge: true or false
+	IsChange bool `json:"is_charge"`
+	// the creation time of the VPC endpoint service
+	Created string `json:"created_at"`
 }
 
 type commonResult struct {
@@ -69,6 +81,12 @@ type commonResult struct {
 // ListResult represents the result of a list operation. Call its ExtractServices
 // method to interpret it as Services.
 type ListResult struct {
+	commonResult
+}
+
+// ListPublicResult represents the result of a list public operation. Call its ExtractServices
+// method to interpret it as PublicServices.
+type ListPublicResult struct {
 	commonResult
 }
 
@@ -107,6 +125,19 @@ func (r commonResult) Extract() (*Service, error) {
 func (r ListResult) ExtractServices() ([]Service, error) {
 	var s struct {
 		Services []Service `json:"endpoint_services"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return s.Services, nil
+}
+
+// ExtractServices is a function that accepts a result and extracts the given PublicService
+func (r ListPublicResult) ExtractServices() ([]PublicService, error) {
+	var s struct {
+		Services []PublicService `json:"endpoint_services"`
 	}
 
 	err := r.ExtractInto(&s)

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/urls.go
@@ -13,3 +13,7 @@ func rootURL(c *golangsdk.ServiceClient) string {
 func resourceURL(c *golangsdk.ServiceClient, serviceID string) string {
 	return c.ServiceURL(rootPath, serviceID)
 }
+
+func publicResourceURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "public")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201223081519-cedf29b4891c
+# github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
Use “huaweicloud_vpcep_public_services” data source to get available public VPC endpoint services. The testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVPCEPPublicServicesDataSourceBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVPCEPPublicServicesDataSourceBasic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPPublicServicesDataSourceBasic
=== PAUSE TestAccVPCEPPublicServicesDataSourceBasic
=== CONT  TestAccVPCEPPublicServicesDataSourceBasic
--- PASS: TestAccVPCEPPublicServicesDataSourceBasic (13.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       13.843s
```