### PR TITLE
add permissions and connections attributes to vpcep service

### DIFF
--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -50,6 +50,9 @@ The following arguments are supported:
 
 * `approval` (Optional, Bool) - Specifies whether connection approval is required. The default value is false.
 
+* `permissions` (Optional, List) - Specifies the list of accounts to access the VPC endpoint service.
+    The record is in the `iam:domain::domain_id` format. *iam:domain::\** allows all users to access the VPC endpoint service.
+
 * `tags` - (Optional, Map) The key/value pairs to associate with the VPC endpoint service.
 
 The `port_mapping` block supports:
@@ -75,6 +78,12 @@ In addition to all arguments above, the following attributes are exported:
 * `service_name` - The full name of the VPC endpoint service in the format: *region.name.id*.
 
 * `service_type` - The type of the VPC endpoint service. Only **interface** can be configured.
+
+* `connections` - An array of VPC endpoints connect to the VPC endpoint service. Structure is documented below.
+    - `endpoint_id` - The unique ID of the VPC endpoint.
+    - `marker_id` - The packet ID of the VPC endpoint.
+    - `domain_id` - The user's domain ID.
+    - `status` - The connection status of the VPC endpoint.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768
+	github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c h1:Igfi5l8W6
 github.com/huaweicloud/golangsdk v0.0.0-20201224083252-010617edf28c/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768 h1:v+5rLipFpQ99TnlPneFWn28mw6koeLtXgplfDdpDWag=
 github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f h1:5gf/WhTTYklU59Ah+hcnCkQAyQzlylglysX6E8I82f8=
+github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_service_test.go
@@ -75,7 +75,7 @@ func TestAccVPCEPServicePermission(t *testing.T) {
 					testAccCheckVPCEPServiceExists(resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
-					resource.TestCheckResourceAttrSet(resourceName, "permissions.#"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
 				),
 			},
 			{
@@ -83,7 +83,7 @@ func TestAccVPCEPServicePermission(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
-					resource.TestCheckResourceAttrSet(resourceName, "permissions.#"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
 				),
 			},
 		},
@@ -239,7 +239,7 @@ resource "huaweicloud_vpcep_service" "test" {
   vpc_id      = data.huaweicloud_vpc.myvpc.id
   port_id     = huaweicloud_compute_instance.ecs.network[0].port
   approval    = false
-  permissions = ["iam:domain::1234", "iam:domain::abcd"]
+  permissions = ["iam:domain::abcd"]
 
   port_mapping {
     service_port  = 8080

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/results.go
@@ -146,3 +146,73 @@ func (r ListPublicResult) ExtractServices() ([]PublicService, error) {
 	}
 	return s.Services, nil
 }
+
+// Connection contains the response of querying Connections of a VPC Endpoint Service
+type Connection struct {
+	// the ID of the VPC endpoint
+	EndpointID string `json:"id"`
+	// the packet ID of the VPC endpoint
+	MarkerID int `json:"marker_id"`
+	// the ID of the user's domain
+	DomainID string `json:"domain_id"`
+	// the connection status of the VPC endpoint
+	Status string `json:"status"`
+	// the creation time of the VPC endpoint
+	Created string `json:"created_at"`
+	// the update time of the VPC endpoint
+	Updated string `json:"updated_at"`
+	// the error message when the status of the VPC endpoint service changes to failed
+	Error []ErrorInfo `json:"error"`
+}
+
+// ConnectionResult represents the result of a list connections.
+// Call its ExtractConnections method to interpret it as []Connection.
+type ConnectionResult struct {
+	commonResult
+}
+
+// ExtractConnections is a function that accepts a result and extracts the given []Connection
+func (r ConnectionResult) ExtractConnections() ([]Connection, error) {
+	var s struct {
+		Connections []Connection `json:"connections"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return s.Connections, nil
+}
+
+// Permission contains the response of querying Permissions of a VPC Endpoint Service
+type Permission struct {
+	// the unique ID of the permission.
+	ID string `json:"id"`
+	// the whitelist records.
+	Permission string `json:"permission"`
+	// the time of adding the whitelist record
+	Created string `json:"created_at"`
+}
+
+type PermActionResult struct {
+	commonResult
+}
+
+// ListPermResult represents the result of a list permissions. Call its ExtractPermissions
+// method to interpret it as []Permission.
+type ListPermResult struct {
+	commonResult
+}
+
+// ExtractPermissions is a function that accepts a result and extracts the given []Permission
+func (r ListPermResult) ExtractPermissions() ([]Permission, error) {
+	var s struct {
+		Permissions []Permission `json:"permissions"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return s.Permissions, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services/urls.go
@@ -17,3 +17,19 @@ func resourceURL(c *golangsdk.ServiceClient, serviceID string) string {
 func publicResourceURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL(rootPath, "public")
 }
+
+func connectionsURL(c *golangsdk.ServiceClient, serviceID string) string {
+	return c.ServiceURL(rootPath, serviceID, "connections")
+}
+
+func connectionsActionURL(c *golangsdk.ServiceClient, serviceID string) string {
+	return c.ServiceURL(rootPath, serviceID, "connections/action")
+}
+
+func permissionsURL(c *golangsdk.ServiceClient, serviceID string) string {
+	return c.ServiceURL(rootPath, serviceID, "permissions")
+}
+
+func permissionsActionURL(c *golangsdk.ServiceClient, serviceID string) string {
+	return c.ServiceURL(rootPath, serviceID, "permissions/action")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201225034918-fe22e43ed768
+# github.com/huaweicloud/golangsdk v0.0.0-20201228013212-d10065a3dc7f
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
add permissions and connections attributes to vpcep service, the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVPCEPServicePermission'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVPCEPServicePermission -timeout 360m -parallel 4
=== RUN   TestAccVPCEPServicePermission
=== PAUSE TestAccVPCEPServicePermission
=== CONT  TestAccVPCEPServicePermission
--- PASS: TestAccVPCEPServicePermission (208.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       208.575s
```