### PR TITLE
rename marker_id to packet_id in vpc endpoint resources

### DIFF
--- a/docs/resources/vpcep_approval.md
+++ b/docs/resources/vpcep_approval.md
@@ -65,7 +65,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `connections` - An array of VPC endpoints connect to the VPC endpoint service. Structure is documented below.
     - `endpoint_id` - The unique ID of the VPC endpoint.
-    - `marker_id` - The packet ID of the VPC endpoint.
+    - `packet_id` - The packet ID of the VPC endpoint.
     - `domain_id` - The user's domain ID.
     - `status` - The connection status of the VPC endpoint.
 

--- a/docs/resources/vpcep_endpoint.md
+++ b/docs/resources/vpcep_endpoint.md
@@ -98,8 +98,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `service_type` - The type of the VPC endpoint service.
 
-* `domain_name` -  The domain name for accessing the associated VPC endpoint service. This parameter is only
-    available when enable_dns is set to true.
+* `packet_id` - The packet ID of the VPC endpoint.
+
+* `private_domain_name` -  The domain name for accessing the associated VPC endpoint service.
+    This parameter is only available when enable_dns is set to true.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -8,7 +8,7 @@ Provides a resource to manage a VPC endpoint service resource.
 
 ## Example Usage
 
- ```hcl
+```hcl
 variable "vpc_id" {}
 variable "vm_port" {}
 
@@ -23,7 +23,7 @@ resource "huaweicloud_vpcep_service" "demo" {
     terminal_port = 80
   }
 }
- ```
+```
 
 ## Argument Reference
 
@@ -81,7 +81,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `connections` - An array of VPC endpoints connect to the VPC endpoint service. Structure is documented below.
     - `endpoint_id` - The unique ID of the VPC endpoint.
-    - `marker_id` - The packet ID of the VPC endpoint.
+    - `packet_id` - The packet ID of the VPC endpoint.
     - `domain_id` - The user's domain ID.
     - `status` - The connection status of the VPC endpoint.
 

--- a/huaweicloud/resource_huaweicloud_vpcep_approval.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_approval.go
@@ -60,7 +60,7 @@ func ResourceVPCEndpointApproval() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"marker_id": {
+						"packet_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},

--- a/huaweicloud/resource_huaweicloud_vpcep_endpoint.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_endpoint.go
@@ -84,7 +84,11 @@ func ResourceVPCEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"domain_name": {
+			"packet_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"private_domain_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -182,11 +186,12 @@ func resourceVPCEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("enable_dns", ep.EnableDNS)
 	d.Set("enable_whitelist", ep.EnableWhitelist)
 	d.Set("whitelist", ep.Whitelist)
+	d.Set("packet_id", ep.MarkerID)
 
 	if len(ep.DNSNames) > 0 {
-		d.Set("domain_name", ep.DNSNames[0])
+		d.Set("private_domain_name", ep.DNSNames[0])
 	} else {
-		d.Set("domain_name", nil)
+		d.Set("private_domain_name", nil)
 	}
 
 	// fetch tags from endpoints.Endpoint

--- a/huaweicloud/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_service.go
@@ -112,7 +112,7 @@ func ResourceVPCEndpointService() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"marker_id": {
+						"packet_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
@@ -382,7 +382,7 @@ func flattenVPCEndpointConnections(client *golangsdk.ServiceClient, id string) (
 	for i, v := range allConns {
 		connections[i] = map[string]interface{}{
 			"endpoint_id": v.EndpointID,
-			"marker_id":   v.MarkerID,
+			"packet_id":   v.MarkerID,
 			"domain_id":   v.DomainID,
 			"status":      v.Status,
 		}


### PR DESCRIPTION
- update `marker_id` to `packet_id`
- update `domain_name` to `private_domain_name`