### PR TITLE
support iec keypair resource and docs

### DIFF
--- a/docs/resources/iec_keypair.md
+++ b/docs/resources/iec_keypair.md
@@ -10,7 +10,7 @@ Manages a keypair resource within HuaweiCloud IEC.
 
 ```hcl
 resource "huaweicloud_iec_keypair" "test_keypair" {
-  name       = "iec-keypair-demo"
+  name = "iec-keypair-demo"
 }
 ```
 
@@ -39,5 +39,4 @@ Keypairs can be imported using the `name`, e.g.
 
 ```
 $ terraform import huaweicloud_iec_keypair.test_keypair iec-keypair-demo
-
 ```

--- a/docs/resources/iec_keypair.md
+++ b/docs/resources/iec_keypair.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud\_iec\_keypair
+
+Manages a keypair resource within HuaweiCloud IEC.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_iec_keypair" "test_keypair" {
+  name       = "iec-keypair-demo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies a unique name for the keypair. 
+    Changing this parameter creates a new keypair resource.
+
+* `public_key` - (Optional, String, ForceNew) Specifies a pregenerated OpenSSH-formatted 
+    public key. Changing this parameter creates a new keypair resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `fingerprint` - The finger of iec keypair. The value contains a encoding 
+    type(SHA256) and a string of 43 characters.
+
+## Import
+
+Keypairs can be imported using the `name`, e.g.
+
+```
+$ terraform import huaweicloud_iec_keypair.test_keypair iec-keypair-demo
+
+```

--- a/docs/resources/iec_keypair.md
+++ b/docs/resources/iec_keypair.md
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID in UUID format.
+* `id` - The keypair use the unique name as the ID.
 
 * `fingerprint` - The finger of iec keypair. The value contains a encoding 
     type(SHA256) and a string of 43 characters.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -395,6 +395,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_identity_role_assignment":        ResourceIdentityRoleAssignmentV3(),
 			"huaweicloud_identity_user":                   ResourceIdentityUserV3(),
 			"huaweicloud_iec_eip":                         resourceIecNetworkEip(),
+			"huaweicloud_iec_keypair":                     resourceIecKeypair(),
 			"huaweicloud_iec_vpc":                         ResourceIecVpc(),
 			"huaweicloud_iec_vpc_subnet":                  resourceIecSubnet(),
 			"huaweicloud_images_image":                    ResourceImsImage(),

--- a/huaweicloud/resource_huaweicloud_iec_keypair.go
+++ b/huaweicloud/resource_huaweicloud_iec_keypair.go
@@ -22,6 +22,7 @@ func resourceIecKeypair() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_iec_keypair.go
+++ b/huaweicloud/resource_huaweicloud_iec_keypair.go
@@ -1,0 +1,100 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs"
+)
+
+func resourceIecKeypair() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceIecKeypairCreate,
+		Read:   resourceIecKeypairRead,
+		Delete: resourceIecKeypairDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"public_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIecKeypairCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+	}
+
+	createOpts := keypairs.CreateOpts{
+		Name:      d.Get("name").(string),
+		PublicKey: d.Get("public_key").(string),
+	}
+
+	log.Printf("[DEBUG] Create iec keypair Options: %#v", createOpts)
+	kp, err := keypairs.Create(iecClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud iec keypair: %s", err)
+	}
+
+	d.SetId(kp.Name)
+
+	return resourceIecKeypairRead(d, meta)
+}
+
+func resourceIecKeypairRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+	}
+
+	kp, err := keypairs.Get(iecClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "keypair")
+	}
+
+	d.Set("name", kp.Name)
+	d.Set("public_key", kp.PublicKey)
+	d.Set("fingerprint", kp.Fingerprint)
+
+	return nil
+}
+
+func resourceIecKeypairDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	iecClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+	}
+
+	err = keypairs.Delete(iecClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting HuaweiCloud iec keypair: %s", err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/huaweicloud/resource_huaweicloud_iec_keypair_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_keypair_test.go
@@ -1,0 +1,101 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/common"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs"
+)
+
+func TestAccIECKeypairResource_basic(t *testing.T) {
+	var keypair common.KeyPair
+	resourceName := "huaweicloud_iec_keypair.kp_1"
+	rName := fmt.Sprintf("KeyPair-%s", acctest.RandString(4))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIECKeypairDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIECKeypair_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIECKeypairExists(resourceName, &keypair),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIECKeypairDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	iecClient, err := config.IECV1Client(HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_iec_keypair" {
+			continue
+		}
+
+		_, err := keypairs.Get(iecClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Keypair still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIECKeypairExists(n string, kp *common.KeyPair) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		iecClient, err := config.IECV1Client(HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+		}
+
+		found, err := keypairs.Get(iecClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Keypair not found")
+		}
+
+		*kp = *found
+
+		return nil
+	}
+}
+
+func testAccIECKeypair_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iec_keypair" "kp_1" {
+  name = "%s"
+}
+`, rName)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs/requests.go
@@ -1,0 +1,83 @@
+package keypairs
+
+import (
+	"net/http"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// create request.
+type CreateOptsBuilder interface {
+	ToKeyPairCreateMap() (map[string]interface{}, error)
+}
+type CreateOpts struct {
+	// Name is a friendly name to refer to this KeyPair in other services.
+	Name string `json:"name" required:"true"`
+
+	// PublicKey [optional] is a pregenerated OpenSSH-formatted public key.
+	// If provided, this key will be imported and no new key will be created.
+	PublicKey string `json:"public_key,omitempty"`
+}
+
+// ToSecurityGroupsCreateMap converts CreateOpts structures to map[string]interface{}
+func (opts CreateOpts) ToKeyPairCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Create create key pair
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToKeyPairCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	createURL := CreateURL(client)
+
+	var resp *http.Response
+	resp, r.Err = client.Post(createURL, b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK, http.StatusCreated},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+// Get get key pair detail
+func Get(client *golangsdk.ServiceClient, keyPairID string) (r GetResult) {
+	getURL := GetURL(client, keyPairID)
+
+	var resp *http.Response
+	resp, r.Err = client.Get(getURL, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+//Delete delete the key pair
+func Delete(client *golangsdk.ServiceClient, keyPairID string) (r DeleteResult) {
+	deleteURL := DeleteURL(client, keyPairID)
+
+	var resp *http.Response
+	resp, r.Err = client.Delete(deleteURL, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusNoContent},
+	})
+	if r.Err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs/results.go
@@ -1,0 +1,34 @@
+package keypairs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/common"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (*common.KeyPair, error) {
+	var entity common.KeyPair
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r GetResult) Extract() (*common.KeyPair, error) {
+	var entity common.KeyPair
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs/urls.go
@@ -1,0 +1,17 @@
+package keypairs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+func CreateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("os-keypairs")
+}
+
+func DeleteURL(c *golangsdk.ServiceClient, KeyPairName string) string {
+	return c.ServiceURL("os-keypairs", KeyPairName)
+}
+
+func GetURL(c *golangsdk.ServiceClient, KeyPairName string) string {
+	return c.ServiceURL("os-keypairs", KeyPairName)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -270,6 +270,7 @@ github.com/huaweicloud/golangsdk/openstack/identity/v3/users
 github.com/huaweicloud/golangsdk/openstack/iec/v1/common
 github.com/huaweicloud/golangsdk/openstack/iec/v1/flavors
 github.com/huaweicloud/golangsdk/openstack/iec/v1/images
+github.com/huaweicloud/golangsdk/openstack/iec/v1/keypairs
 github.com/huaweicloud/golangsdk/openstack/iec/v1/publicips
 github.com/huaweicloud/golangsdk/openstack/iec/v1/sites
 github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets


### PR DESCRIPTION
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIECKeypairResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccIECKeypairResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIECKeypairResource_basic
--- PASS: TestAccIECKeypairResource_basic (17.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       17.067s