### PR TITLE
support tags for dns zone resource

### DIFF
--- a/docs/resources/dns_recordset.md
+++ b/docs/resources/dns_recordset.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `description` - (Optional, String) A description of the record set.
 
-* `tags` - (Optional, Map) The key/value pairs to associate with the zone.
+* `tags` - (Optional, Map) The key/value pairs to associate with the record set.
 
 * `value_specs` - (Optional, Map, ForceNew) Map of additional options. Changing this creates a
   new record set.

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `description` - (Optional, String) A description of the zone.
 
+* `tags` - (Optional, Map) The key/value pairs to associate with the zone.
+
 * `value_specs` - (Optional, Map, ForceNew) Map of additional options. Changing this creates a
   new DNS zone.
 

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -139,7 +139,7 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
-		resourceType, err := getDNSRecordSetResourceType(zoneType)
+		resourceType, err := getDNSRecordSetTagType(zoneType)
 		if err != nil {
 			return fmt.Errorf("Error getting resource type of DNS record set %s: %s", n.ID, err)
 		}
@@ -186,7 +186,7 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("zone_id", zoneID)
 
 	// save tags
-	resourceType, err := getDNSRecordSetResourceType(zoneType)
+	resourceType, err := getDNSRecordSetTagType(zoneType)
 	if err != nil {
 		return fmt.Errorf("Error getting resource type of DNS record set %s: %s", recordsetID, err)
 	}
@@ -258,7 +258,7 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// update tags
-	resourceType, err := getDNSRecordSetResourceType(zoneType)
+	resourceType, err := getDNSRecordSetTagType(zoneType)
 	if err != nil {
 		return fmt.Errorf("Error getting resource type of DNS record set %s: %s", d.Id(), err)
 	}
@@ -341,16 +341,6 @@ func parseDNSV2RecordSetID(id string) (string, string, error) {
 	recordsetID := idParts[1]
 
 	return zoneID, recordsetID, nil
-}
-
-// get resource type of DNS record set by zoneType
-func getDNSRecordSetResourceType(zoneType string) (string, error) {
-	if zoneType == "public" {
-		return "DNS-public_recordset", nil
-	} else if zoneType == "private" {
-		return "DNS-private_recordset", nil
-	}
-	return "", fmt.Errorf("invalid zone type: %s", zoneType)
 }
 
 func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interface{}) (*golangsdk.ServiceClient, string, error) {

--- a/huaweicloud/resource_huaweicloud_dns_zone_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2_test.go
@@ -31,6 +31,8 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "a zone"),
 					resource.TestCheckResourceAttr(resourceName, "email", "email1@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "300"),
+					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "public"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -44,6 +46,8 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "an updated zone"),
 					resource.TestCheckResourceAttr(resourceName, "email", "email2@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "600"),
+					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "public"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
 				),
 			},
 		},
@@ -69,6 +73,8 @@ func TestAccDNSV2Zone_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "a private zone"),
 					resource.TestCheckResourceAttr(resourceName, "email", "email@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "300"),
+					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "private"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 		},
@@ -156,6 +162,11 @@ resource "huaweicloud_dns_zone" "zone_1" {
   email       = "email1@example.com"
   description = "a zone"
   ttl         = 300
+
+  tags = {
+    zone_type = "public"
+    owner     = "terraform"
+  }
 }
 	`, zoneName)
 }
@@ -167,6 +178,11 @@ resource "huaweicloud_dns_zone" "zone_1" {
   email       = "email2@example.com"
   description = "an updated zone"
   ttl         = 600
+
+  tags = {
+    zone_type = "public"
+    owner     = "tf-acc"
+  }
 }
 	`, zoneName)
 }
@@ -194,6 +210,10 @@ resource "huaweicloud_dns_zone" "zone_1" {
 
   router {
     router_id = data.huaweicloud_vpc.default.id
+  }
+  tags = {
+    zone_type = "private"
+    owner     = "terraform"
   }
 }
 	`, zoneName)

--- a/huaweicloud/tags.go
+++ b/huaweicloud/tags.go
@@ -1,6 +1,8 @@
 package huaweicloud
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/common/tags"
@@ -73,4 +75,24 @@ func expandResourceTags(tagmap map[string]interface{}) []tags.ResourceTag {
 	}
 
 	return taglist
+}
+
+// get resource tag type of DNS zone by zoneType
+func getDNSZoneTagType(zoneType string) (string, error) {
+	if zoneType == "public" {
+		return "DNS-public_zone", nil
+	} else if zoneType == "private" {
+		return "DNS-private_zone", nil
+	}
+	return "", fmt.Errorf("invalid zone type: %s", zoneType)
+}
+
+// get resource tag type of DNS record set by zoneType
+func getDNSRecordSetTagType(zoneType string) (string, error) {
+	if zoneType == "public" {
+		return "DNS-public_recordset", nil
+	} else if zoneType == "private" {
+		return "DNS-private_recordset", nil
+	}
+	return "", fmt.Errorf("invalid zone type: %s", zoneType)
 }


### PR DESCRIPTION
support tags for dns zone resource, the testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDNSV2Zone'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDNSV2Zone -timeout 360m -parallel 4
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== RUN   TestAccDNSV2Zone_readTTL
=== PAUSE TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_readTTL (26.42s)
--- PASS: TestAccDNSV2Zone_private (36.52s)
--- PASS: TestAccDNSV2Zone_basic (46.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       46.990s
```