### PR TITLE
fix test cases of DCS, Network, OBS

### DIFF
--- a/huaweicloud/data_source_huaweicloud_dcs_az_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_az_v1_test.go
@@ -18,7 +18,7 @@ func TestAccDcsAZV1DataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDcsAZV1DataSourceID("data.huaweicloud_dcs_az_v1.az1"),
 					resource.TestCheckResourceAttr(
-						"data.huaweicloud_dcs_az_v1.az1", "port", "8002"),
+						"data.huaweicloud_dcs_az_v1.az1", "port", "8403"),
 				),
 			},
 		},
@@ -41,8 +41,10 @@ func testAccCheckDcsAZV1DataSourceID(n string) resource.TestCheckFunc {
 }
 
 var testAccDcsAZV1DataSource_basic = fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
 data "huaweicloud_dcs_az_v1" "az1" {
-  code = "%s"
-  port = "8002"
+  code = data.huaweicloud_availability_zones.test.names[0]
+  port = "8403"
 }
-`, HW_AVAILABILITY_ZONE)
+`)

--- a/huaweicloud/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/data_source_huaweicloud_obs_bucket_object_test.go
@@ -103,7 +103,6 @@ func TestAccHuaweiCloudObsBucketObjectDataSource_allParams(t *testing.T) {
 					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
 					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "application/unknown"),
 					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "body", "\t{\"msg\": \"Hi there!\"}\n"),
 				),
 			},
 		},

--- a/huaweicloud/resource_huaweicloud_dcs_instance_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_dcs_instance_v1_test.go
@@ -271,7 +271,7 @@ func testAccDcsV1Instance_tiny(instanceName string) string {
 	  vpc_id            = data.huaweicloud_vpc.test.id
 	  subnet_id         = data.huaweicloud_vpc_subnet.test.id
 	  available_zones   = [data.huaweicloud_dcs_az.az_1.id]
-	  product_id        = "redis.ha.au1.tiny.128-h"
+	  product_id        = "redis.ha.xu1.tiny.r2.128-h"
 	  save_days         = 1
 	  backup_type       = "manual"
 	  begin_at          = "00:00-01:00"
@@ -306,7 +306,7 @@ func testAccDcsV1Instance_whitelists(instanceName string) string {
 	  vpc_id            = data.huaweicloud_vpc.test.id
 	  subnet_id         = data.huaweicloud_vpc_subnet.test.id
 	  available_zones   = [data.huaweicloud_dcs_az.az_1.id]
-	  product_id        = "redis.ha.au1.large.r2.2-h"
+	  product_id        = "redis.ha.xu1.large.r2.2-h"
 	  save_days         = 1
 	  backup_type       = "manual"
 	  begin_at          = "00:00-01:00"

--- a/huaweicloud/resource_huaweicloud_network_acl_rule_test.go
+++ b/huaweicloud/resource_huaweicloud_network_acl_rule_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
@@ -13,6 +14,7 @@ import (
 
 func TestAccNetworkACLRule_basic(t *testing.T) {
 	resourceKey := "huaweicloud_network_acl_rule.rule_1"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,20 +22,20 @@ func TestAccNetworkACLRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRule_basic_1,
+				Config: testAccNetworkACLRule_basic_1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceKey),
-					resource.TestCheckResourceAttr(resourceKey, "name", "rule_1"),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName),
 					resource.TestCheckResourceAttr(resourceKey, "protocol", "udp"),
 					resource.TestCheckResourceAttr(resourceKey, "action", "deny"),
 					resource.TestCheckResourceAttr(resourceKey, "enabled", "true"),
 				),
 			},
 			{
-				Config: testAccNetworkACLRule_basic_2,
+				Config: testAccNetworkACLRule_basic_2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceKey),
-					resource.TestCheckResourceAttr(resourceKey, "name", "rule_1"),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName),
 					resource.TestCheckResourceAttr(resourceKey, "protocol", "udp"),
 					resource.TestCheckResourceAttr(resourceKey, "action", "deny"),
 					resource.TestCheckResourceAttr(resourceKey, "enabled", "true"),
@@ -44,10 +46,10 @@ func TestAccNetworkACLRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNetworkACLRule_basic_3,
+				Config: testAccNetworkACLRule_basic_3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceKey),
-					resource.TestCheckResourceAttr(resourceKey, "name", "rule_1"),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName),
 					resource.TestCheckResourceAttr(resourceKey, "protocol", "tcp"),
 					resource.TestCheckResourceAttr(resourceKey, "action", "allow"),
 					resource.TestCheckResourceAttr(resourceKey, "enabled", "false"),
@@ -68,6 +70,7 @@ func TestAccNetworkACLRule_basic(t *testing.T) {
 
 func TestAccNetworkACLRule_anyProtocol(t *testing.T) {
 	resourceKey := "huaweicloud_network_acl_rule.rule_any"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,10 +78,10 @@ func TestAccNetworkACLRule_anyProtocol(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkACLRule_anyProtocol,
+				Config: testAccNetworkACLRule_anyProtocol(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists(resourceKey),
-					resource.TestCheckResourceAttr(resourceKey, "name", "rule_any"),
+					resource.TestCheckResourceAttr(resourceKey, "name", rName),
 					resource.TestCheckResourceAttr(resourceKey, "protocol", "any"),
 					resource.TestCheckResourceAttr(resourceKey, "action", "allow"),
 					resource.TestCheckResourceAttr(resourceKey, "enabled", "true"),
@@ -151,17 +154,20 @@ func testAccCheckNetworkACLRuleExists(key string) resource.TestCheckFunc {
 	}
 }
 
-const testAccNetworkACLRule_basic_1 = `
+func testAccNetworkACLRule_basic_1(rName string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_network_acl_rule" "rule_1" {
-  name = "rule_1"
+  name = "%s"
   protocol = "udp"
   action = "deny"
 }
-`
+`, rName)
+}
 
-const testAccNetworkACLRule_basic_2 = `
+func testAccNetworkACLRule_basic_2(rName string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_network_acl_rule" "rule_1" {
-  name = "rule_1"
+  name = "%s"
   description = "Terraform accept test"
   protocol = "udp"
   action = "deny"
@@ -171,11 +177,13 @@ resource "huaweicloud_network_acl_rule" "rule_1" {
   destination_port = "555"
   enabled = true
 }
-`
+`, rName)
+}
 
-const testAccNetworkACLRule_basic_3 = `
+func testAccNetworkACLRule_basic_3(rName string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_network_acl_rule" "rule_1" {
-  name = "rule_1"
+  name = "%s"
   description = "Terraform accept test updated"
   protocol = "tcp"
   action = "allow"
@@ -185,15 +193,18 @@ resource "huaweicloud_network_acl_rule" "rule_1" {
   destination_port = "777"
   enabled = false
 }
-`
+`, rName)
+}
 
-const testAccNetworkACLRule_anyProtocol = `
+func testAccNetworkACLRule_anyProtocol(rName string) string {
+	return fmt.Sprintf(`
 resource "huaweicloud_network_acl_rule" "rule_any" {
-  name = "rule_any"
+  name = "%s"
   description = "Allow any protocol"
   protocol = "any"
   action = "allow"
   source_ip_address = "192.168.199.0/24"
   enabled = true
 }
-`
+`, rName)
+}

--- a/huaweicloud/resource_huaweicloud_network_acl_test.go
+++ b/huaweicloud/resource_huaweicloud_network_acl_test.go
@@ -163,28 +163,29 @@ func testAccCheckNetworkACLExists(n string, fwGroup *FirewallGroup) resource.Tes
 	}
 }
 
-const testAccNetworkACLRules = `
-resource "huaweicloud_vpc_v1" "vpc_1" {
-  name = "acc_vpc_test"
+func testAccNetworkACLRules(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "vpc_1" {
+  name = "%s_vpc"
   cidr = "192.168.0.0/16"
 }
 
-resource "huaweicloud_vpc_subnet_v1" "subnet_1" {
-  name = "acc_subnet_1"
+resource "huaweicloud_vpc_subnet" "subnet_1" {
+  name = "%s_subnet_1"
   cidr = "192.168.0.0/24"
   gateway_ip = "192.168.0.1"
-  vpc_id = huaweicloud_vpc_v1.vpc_1.id
+  vpc_id = huaweicloud_vpc.vpc_1.id
 }
 
-resource "huaweicloud_vpc_subnet_v1" "subnet_2" {
-	name = "acc_subnet_2"
+resource "huaweicloud_vpc_subnet" "subnet_2" {
+	name = "%s_subnet_2"
 	cidr = "192.168.10.0/24"
 	gateway_ip = "192.168.10.1"
-	vpc_id = huaweicloud_vpc_v1.vpc_1.id
+	vpc_id = huaweicloud_vpc.vpc_1.id
   }
 
 resource "huaweicloud_network_acl_rule" "rule_1" {
-  name             = "my-rule-1"
+  name             = "%s-rule-1"
   description      = "drop TELNET traffic"
   action           = "deny"
   protocol         = "tcp"
@@ -192,13 +193,14 @@ resource "huaweicloud_network_acl_rule" "rule_1" {
 }
 
 resource "huaweicloud_network_acl_rule" "rule_2" {
-  name             = "my-rule-2"
+  name             = "%s-rule-2"
   description      = "drop NTP traffic"
   action           = "deny"
   protocol         = "udp"
   destination_port = "123"
 }
-`
+`, name, name, name, name, name)
+}
 
 func testAccNetworkACL_basic(name string) string {
 	return fmt.Sprintf(`
@@ -209,9 +211,9 @@ resource "huaweicloud_network_acl" "fw_1" {
   description = "created by terraform test acc"
 
   inbound_rules = [huaweicloud_network_acl_rule.rule_1.id]
-  subnets = [huaweicloud_vpc_subnet_v1.subnet_1.id]
+  subnets = [huaweicloud_vpc_subnet.subnet_1.id]
 }
-`, testAccNetworkACLRules, name)
+`, testAccNetworkACLRules(name), name)
 }
 
 func testAccNetworkACL_basic_update(name string) string {
@@ -224,10 +226,10 @@ resource "huaweicloud_network_acl" "fw_1" {
 
   inbound_rules = [huaweicloud_network_acl_rule.rule_1.id,
       huaweicloud_network_acl_rule.rule_2.id]
-  subnets = [huaweicloud_vpc_subnet_v1.subnet_1.id,
-      huaweicloud_vpc_subnet_v1.subnet_2.id]
+  subnets = [huaweicloud_vpc_subnet.subnet_1.id,
+      huaweicloud_vpc_subnet.subnet_2.id]
 }
-`, testAccNetworkACLRules, name)
+`, testAccNetworkACLRules(name), name)
 }
 
 func testAccNetworkACL_no_subnets(name string) string {


### PR DESCRIPTION
The following test cases were fixed:
TestAccDcsAZV1DataSource_basic
TestAccDcsInstancesV1_tiny
TestAccDcsInstancesV1_whitelists
TestAccHuaweiCloudObsBucketObjectDataSource_allParams
TestAccNetworkACL_basic
TestAccNetworkACLRule_anyProtocol
TestAccNetworkACLRule_basic

Test Results:
```bash
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkACL_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkACL_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkACL_basic
=== PAUSE TestAccNetworkACL_basic
=== CONT  TestAccNetworkACL_basic
--- PASS: TestAccNetworkACL_basic (79.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       79.280s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccHuaweiCloudObsBucketObjectDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccHuaweiCloudObsBucketObjectDataSource -timeout 360m -parallel 4
=== RUN   TestAccHuaweiCloudObsBucketObjectDataSource_content
=== PAUSE TestAccHuaweiCloudObsBucketObjectDataSource_content
=== RUN   TestAccHuaweiCloudObsBucketObjectDataSource_source
=== PAUSE TestAccHuaweiCloudObsBucketObjectDataSource_source
=== RUN   TestAccHuaweiCloudObsBucketObjectDataSource_allParams
=== PAUSE TestAccHuaweiCloudObsBucketObjectDataSource_allParams
=== CONT  TestAccHuaweiCloudObsBucketObjectDataSource_content
=== CONT  TestAccHuaweiCloudObsBucketObjectDataSource_allParams
=== CONT  TestAccHuaweiCloudObsBucketObjectDataSource_source
--- PASS: TestAccHuaweiCloudObsBucketObjectDataSource_content (20.39s)
--- PASS: TestAccHuaweiCloudObsBucketObjectDataSource_allParams (21.74s)
--- PASS: TestAccHuaweiCloudObsBucketObjectDataSource_source (29.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       29.188s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDcsAZV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDcsAZV1DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsAZV1DataSource_basic
=== PAUSE TestAccDcsAZV1DataSource_basic
=== CONT  TestAccDcsAZV1DataSource_basic
--- PASS: TestAccDcsAZV1DataSource_basic (11.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       11.311s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDcsInstancesV1_tiny'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDcsInstancesV1_tiny -timeout 360m -parallel 4
=== RUN   TestAccDcsInstancesV1_tiny
=== PAUSE TestAccDcsInstancesV1_tiny
=== CONT  TestAccDcsInstancesV1_tiny
--- PASS: TestAccDcsInstancesV1_tiny (81.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       81.166s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDcsInstancesV1_whitelists'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDcsInstancesV1_whitelists -timeout 360m -parallel 4
=== RUN   TestAccDcsInstancesV1_whitelists
=== PAUSE TestAccDcsInstancesV1_whitelists
=== CONT  TestAccDcsInstancesV1_whitelists
--- PASS: TestAccDcsInstancesV1_whitelists (91.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       91.070s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkACLRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkACLRule -timeout 360m -parallel 4
=== RUN   TestAccNetworkACLRule_basic
=== PAUSE TestAccNetworkACLRule_basic
=== RUN   TestAccNetworkACLRule_anyProtocol
=== PAUSE TestAccNetworkACLRule_anyProtocol
=== CONT  TestAccNetworkACLRule_basic
=== CONT  TestAccNetworkACLRule_anyProtocol
--- PASS: TestAccNetworkACLRule_anyProtocol (6.29s)
--- PASS: TestAccNetworkACLRule_basic (15.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       15.910s
```