### PR TITLE
support kms cryption and enhanced type for sfs turbo

### DIFF
--- a/docs/resources/sfs_turbo.md
+++ b/docs/resources/sfs_turbo.md
@@ -8,7 +8,7 @@ Provides an Shared File System (SFS) Turbo resource.
 
 ## Example Usage
 
- ```hcl
+```hcl
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "secgroup_id" {}
@@ -23,7 +23,7 @@ resource "huaweicloud_sfs_turbo" "sfs-turbo-1" {
   security_group_id = var.secgroup_id
   availability_zone = var.test_az
 }
- ```
+```
 
 ## Argument Reference
 The following arguments are supported:
@@ -33,7 +33,8 @@ The following arguments are supported:
 * `name` - (Required, String, ForceNew) Specifies the name of an SFS Turbo file system. The value contains 4 to 64
   characters and must start with a letter. Changing this will create a new resource.
 
-* `size` - (Required, Int) Specifies the capacity of a common file system, in GB. The value ranges from 500 to 32768.
+* `size` - (Required, Int) Specifies the capacity of a common file system, in GB. The value ranges from 500 to 32768,
+  and must be large than 10240 for an enhanced file system.
 
 * `share_proto` - (Optional, String, ForceNew) Specifies the protocol for sharing file systems. The valid value is NFS.
   Changing this will create a new resource.
@@ -42,13 +43,19 @@ The following arguments are supported:
   Changing this will create a new resource.
 
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone where the file system is located.
-  Changing this parameter will create a new resource.
+  Changing this will create a new resource.
 
-* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this parameter will create a new resource.
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this will create a new resource.
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the network ID of the subnet. Changing this parameter will create a new resource.
+* `subnet_id` - (Required, String, ForceNew) Specifies the network ID of the subnet. Changing this will create a new resource.
 
 * `security_group_id` - (Required, String, ForceNew) Specifies the security group ID. Changing this will create a new resource.
+
+* `enhanced` - (Optional, Bool, ForceNew) Specifies whether the file system is enhanced or not.
+  Changing this will create a new resource.
+
+* `crypt_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key to encrypt the file system.
+  Changing this will create a new resource.
 
 -> **NOTE:**
   SFS Turbo will create two private IP addresses and one virtual IP address under the subnet you specified.
@@ -81,6 +88,5 @@ This resource provides the following timeouts configuration options:
 SFS Turbo can be imported using the `id`, e.g.
 
 ```
-> $ terraform import huaweicloud_sfs_turbo 1e3d5306-24c9-4316-9185-70e9787d71ab
+$ terraform import huaweicloud_sfs_turbo 1e3d5306-24c9-4316-9185-70e9787d71ab
 ```
-   

--- a/huaweicloud/resource_huaweicloud_sfs_turbo.go
+++ b/huaweicloud/resource_huaweicloud_sfs_turbo.go
@@ -3,6 +3,7 @@ package huaweicloud
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -77,6 +78,17 @@ func resourceSFSTurbo() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"crypt_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"enhanced": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 
 			"status": {
 				Type:     schema.TypeString,
@@ -116,6 +128,15 @@ func resourceSFSTurboCreate(d *schema.ResourceData, meta interface{}) error {
 		AvailabilityZone: d.Get("availability_zone").(string),
 	}
 
+	metaOpts := shares.Metadata{}
+	if v, ok := d.GetOk("crypt_key_id"); ok {
+		metaOpts.CryptKeyID = v.(string)
+	}
+	if _, ok := d.GetOk("enhanced"); ok {
+		metaOpts.ExpandType = "bandwidth"
+	}
+	createOpts.Metadata = metaOpts
+
 	log.Printf("[DEBUG] create sfs turbo with option: %+v", createOpts)
 	create, err := shares.Create(sfsClient, createOpts).Extract()
 	if err != nil {
@@ -152,7 +173,6 @@ func resourceSFSTurboRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", n.Name)
-	d.Set("size", n.Size)
 	d.Set("share_proto", n.ShareProto)
 	d.Set("share_type", n.ShareType)
 	d.Set("vpc_id", n.VpcID)
@@ -163,6 +183,20 @@ func resourceSFSTurboRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", n.AvailabilityZone)
 	d.Set("available_capacity", n.AvailCapacity)
 	d.Set("export_location", n.ExportLocation)
+	d.Set("crypt_key_id", n.CryptKeyID)
+
+	// n.Size is a string of float64, should convert it to int
+	if fsize, err := strconv.ParseFloat(n.Size, 64); err == nil {
+		if err = d.Set("size", int(fsize)); err != nil {
+			return fmt.Errorf("Error reading size of SFS Turbo: %s", err)
+		}
+	}
+
+	if n.ExpandType == "bandwidth" {
+		d.Set("enhanced", true)
+	} else {
+		d.Set("enhanced", false)
+	}
 
 	var status string
 	if n.SubStatus != "" {

--- a/huaweicloud/resource_huaweicloud_sfs_turbo_test.go
+++ b/huaweicloud/resource_huaweicloud_sfs_turbo_test.go
@@ -25,24 +25,53 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 				Config: testAccSFSTurbo_basic(randSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSFSTurboExists(resourceName, &turbo),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", turboName),
-					resource.TestCheckResourceAttr(
-						resourceName, "share_proto", "NFS"),
-					resource.TestCheckResourceAttr(
-						resourceName, "share_type", "STANDARD"),
-					resource.TestCheckResourceAttr(
-						resourceName, "size", "500"),
-					resource.TestCheckResourceAttr(
-						resourceName, "status", "200"),
+					resource.TestCheckResourceAttr(resourceName, "name", turboName),
+					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(resourceName, "share_type", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced", "false"),
+					resource.TestCheckResourceAttr(resourceName, "size", "500"),
+					resource.TestCheckResourceAttr(resourceName, "status", "200"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccSFSTurbo_update(randSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSFSTurboExists(resourceName, &turbo),
-					resource.TestCheckResourceAttr(
-						resourceName, "size", "600"),
+					resource.TestCheckResourceAttr(resourceName, "size", "600"),
+					resource.TestCheckResourceAttr(resourceName, "status", "221"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSFSTurbo_crypt(t *testing.T) {
+	randSuffix := acctest.RandString(5)
+	turboName := fmt.Sprintf("sfs-turbo-acc-%s", randSuffix)
+	resourceName := "huaweicloud_sfs_turbo.sfs-turbo1"
+	var turbo shares.Turbo
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSTurboDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurbo_crypt(randSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", turboName),
+					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(resourceName, "share_type", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced", "false"),
+					resource.TestCheckResourceAttr(resourceName, "size", "500"),
+					resource.TestCheckResourceAttr(resourceName, "status", "200"),
+					resource.TestCheckResourceAttrSet(resourceName, "crypt_key_id"),
 				),
 			},
 		},
@@ -154,4 +183,27 @@ resource "huaweicloud_sfs_turbo" "sfs-turbo1" {
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
 }
 `, testAccNetworkPreConditions(suffix), suffix)
+}
+
+func testAccSFSTurbo_crypt(suffix string) string {
+	return fmt.Sprintf(`
+%s
+data "huaweicloud_availability_zones" "myaz" {}
+
+resource "huaweicloud_kms_key" "key_1" {
+  key_alias = "kms-acc-%s"
+  pending_days = "7"
+}
+
+resource "huaweicloud_sfs_turbo" "sfs-turbo1" {
+  name        = "sfs-turbo-acc-%s"
+  size        = 500
+  share_proto = "NFS"
+  vpc_id      = huaweicloud_vpc_v1.test.id
+  subnet_id   = huaweicloud_vpc_subnet_v1.test.id
+  security_group_id = huaweicloud_networking_secgroup_v2.secgroup.id
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  crypt_key_id      = huaweicloud_kms_key.key_1.id
+}
+`, testAccNetworkPreConditions(suffix), suffix, suffix)
 }


### PR DESCRIPTION
This PR can crypt an sfs turbo with kms key id, and support enhanced type. The testing result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSFSTurbo_crypy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSFSTurbo_crypt -timeout 360m -parallel 4
=== RUN   TestAccSFSTurbo_crypt
=== PAUSE TestAccSFSTurbo_crypt
=== CONT  TestAccSFSTurbo_crypt
--- PASS: TestAccSFSTurbo_crypt (430.09s)
PASS
ok    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       430.09s
```