### PR TITLE
Update enterprise_project_id description for gaussdb_mysql

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `configuration_id` - (Optional, String, ForceNew) Specifies the configuration ID.
   Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id. Required if EPS enabled.
   Changing this parameter will create a new resource.
 
 * `read_replicas` - (Optional, Int) Specifies the count of read replicas. Defaults to 1.


### PR DESCRIPTION
This updates the description of the enpterprise_prject_id parameter as it's required when EPS enabled.