### PR TITLE
fix tiny bugs of vpc endpoint

### DIFF
--- a/docs/resources/vpcep_approval.md
+++ b/docs/resources/vpcep_approval.md
@@ -52,9 +52,9 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to obtain the VPC endpoint service.
     If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `service_id` (Optional, String, ForceNew) - Specifies the ID of the VPC endpoint service. Changing this creates a new resource.
+* `service_id` (Required, String, ForceNew) - Specifies the ID of the VPC endpoint service. Changing this creates a new resource.
 
-* `endpoints` (Optional, List) - Specifies the list of VPC endpoint IDs which accepted to connect to VPC endpoint service.
+* `endpoints` (Required, List) - Specifies the list of VPC endpoint IDs which accepted to connect to VPC endpoint service.
     The VPC endpoints will be rejected when the resource was destroyed.
 
 ## Attributes Reference

--- a/huaweicloud/resource_huaweicloud_vpcep_endpoint_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_endpoint_test.go
@@ -30,7 +30,7 @@ func TestAccVPCEndpointBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_domain_name"),
 				),
 			},
 			{
@@ -69,7 +69,7 @@ func TestAccVPCEndpointPublic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
 					resource.TestCheckResourceAttr(resourceName, "whitelist.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_domain_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
 				),
 			},


### PR DESCRIPTION
- vpcep_endpoint: The bug is introduced by commit 7d486b3.
The `domain_name` has renamed to `private_domain_name`, we should update the acceptance as while.

- vpcep_approval: The parameter `service_id` and `endpoints` should be required