### PR TITLE
removed `host` attribute in sfs file system

### DIFF
--- a/docs/resources/sfs_file_system.md
+++ b/docs/resources/sfs_file_system.md
@@ -119,8 +119,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `export_location` - The address for accessing the shared file system.
 
-* `host` - The host name of the shared file system.
-
 * `share_access_id` - The UUID of the share access rule.
 
 * `access_rule_status` - The status of the share access rule.

--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
@@ -100,10 +100,6 @@ func resourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"host": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"export_location": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -246,7 +242,6 @@ func resourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) error
 	d.Set("availability_zone", n.AvailabilityZone)
 	d.Set("region", GetRegion(d, config))
 	d.Set("export_location", n.ExportLocation)
-	d.Set("host", n.Host)
 	d.Set("enterprise_project_id", n.Metadata["enterprise_project_id"])
 
 	// NOTE: only support the following metadata key


### PR DESCRIPTION
the `host` attribute is an internal attribute whch is meaningless for users.
so, drop it.