### PR TITLE
fix type error of port range setting

### DIFF
--- a/huaweicloud/resource_huaweicloud_iec_security_group_rule.go
+++ b/huaweicloud/resource_huaweicloud_iec_security_group_rule.go
@@ -3,6 +3,7 @@ package huaweicloud
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -148,11 +149,11 @@ func resourceIecSecurityGroupRuleV1Read(d *schema.ResourceData, meta interface{}
 	d.Set("remote_ip_prefix", rule.SecurityGroupRule.RemoteIPPrefix)
 	d.Set("remote_group_id", rule.SecurityGroupRule.RemoteGroupID)
 
-	if rule.SecurityGroupRule.PortRangeMin.(string) != "" {
-		d.Set("port_range_min", rule.SecurityGroupRule.PortRangeMin)
+	if ret, err := strconv.Atoi(rule.SecurityGroupRule.PortRangeMin.(string)); err == nil {
+		d.Set("port_range_min", ret)
 	}
-	if rule.SecurityGroupRule.PortRangeMax.(string) != "" {
-		d.Set("port_range_max", rule.SecurityGroupRule.PortRangeMax)
+	if ret, err := strconv.Atoi(rule.SecurityGroupRule.PortRangeMax.(string)); err == nil {
+		d.Set("port_range_max", ret)
 	}
 
 	return nil


### PR DESCRIPTION
**Type invalid**
Problem: port range need int but provider set string.
**Fix**
Use strconv.Atoi() function to transport port range.
**Validation**
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIecSecurityGroupRuleResource_Basic'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccIecSecurityGroupRuleResource_Basic -timeout 360m -parallel 4
=== RUN   TestAccIecSecurityGroupRuleResource_Basic
--- PASS: TestAccIecSecurityGroupRuleResource_Basic (37.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       37.104s