### PR TITLE
update docs for compute instance import

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -322,12 +322,24 @@ Instances can be imported by their `id`. For example,
 ```
 terraform import huaweicloud_compute_instance.my_instance b11b407c-e604-4e8d-8bc4-92398320b847
 ```
-Note that the imported state may not be identical to your resource definition, which 
-could be because of a different network interface attachment order, missing ephemeral
-disk configuration, or some other reason. It is generally recommended running 
+Note that the imported state may not be identical to your resource definition, due to some attrubutes
+missing from the API response, security or some other reason. The missing attributes include:
+`admin_pass`, `user_data`, `data_disks`, `scheduler_hints`, `stop_before_destroy`, `delete_disks_on_termination`,
+`network/access_network` and arguments for pre-paid. It is generally recommended running
 `terraform plan` after importing an instance. You can then decide if changes should
 be applied to the instance, or the resource definition should be updated to align
-with the instance. 
+with the instance. Also you can ignore changes as below.
+```
+resource "huaweicloud_compute_instance" "myinstance" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      user_data, data_disks,
+    ]
+  }
+}
+```
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -744,14 +744,14 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Retrieved root volume %s: %+v", b.ID, volumeInfo)
+			log.Printf("[DEBUG] Retrieved volume %s: %#v", b.ID, volumeInfo)
 
 			// retrieve volume `pci_address`
 			va, err := block_devices.Get(ecsClient, d.Id(), b.ID).Extract()
 			if err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Retrieved volume attachment %s: %#v", d.Id(), va)
+			log.Printf("[DEBUG] Retrieved block device %s: %#v", b.ID, va)
 
 			bds[i] = map[string]interface{}{
 				"volume_id":   b.ID,
@@ -768,6 +768,18 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 			}
 		}
 		d.Set("volume_attached", bds)
+	}
+
+	// set scheduler_hints
+	osHints := server.OsSchedulerHints
+	if len(osHints.Group) > 0 {
+		schedulerHints := make([]map[string]interface{}, len(osHints.Group))
+		for i, v := range osHints.Group {
+			schedulerHints[i] = map[string]interface{}{
+				"group": v,
+			}
+		}
+		d.Set("scheduler_hints", schedulerHints)
 	}
 
 	// Set instance tags

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -41,7 +41,6 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"stop_before_destroy",
-					"force_delete",
 				},
 			},
 		},


### PR DESCRIPTION
some attributes wil be missing by `terraform import`, we should change our resource definition or ignore them.

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (154.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       154.690s
```