### PR TITLE
Remove share parameter from vpc data source and resource

### DIFF
--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -9,8 +9,6 @@ This is an alternative to `huaweicloud_vpc_v1`
 
 ## Example Usage
 
-The following example shows how one might accept a VPC id as a variable and use this data source to obtain the data necessary to create a subnet within it.
-
 ```hcl
 variable "vpc_name" {}
 

--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -12,35 +12,29 @@ This is an alternative to `huaweicloud_vpc_v1`
 The following example shows how one might accept a VPC id as a variable and use this data source to obtain the data necessary to create a subnet within it.
 
 ```hcl
-
 variable "vpc_name" {}
 
 data "huaweicloud_vpc" "vpc" {
   name = var.vpc_name
 }
-
 ```
 
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available VPCs in the current region. The given filters must match exactly one VPC whose data will be exported as attributes.
 
-* `region` - (Optional, String) The region in which to obtain the vpc. If omitted, the provider-level region will be used.
+* `region` - (Optional, String) Specifies the region in which to obtain the vpc. If omitted, the provider-level region will be used.
 
-* `id` - (Optional, String) The id of the specific VPC to retrieve.
+* `id` - (Optional, String) Specifies the id of the VPC to retrieve.
 
-* `status` - (Optional, String) The current status of the desired VPC. Can be either CREATING, OK, DOWN, PENDING_UPDATE, PENDING_DELETE, or ERROR.
+* `status` - (Optional, String) Specifies the current status of the desired VPC. Can be either CREATING, OK, DOWN, PENDING_UPDATE, PENDING_DELETE, or ERROR.
 
-* `name` - (Optional, String) A unique name for the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-).
+* `name` - (Optional, String) Specifies an unique name for the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-).
 
-* `cidr` - (Optional, String) The cidr block of the desired VPC.
-
-
+* `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `routes` - The list of route information with destination and nexthop fields.
-
-* `shared` - Specifies whether the cross-tenant sharing is supported.

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -32,22 +32,21 @@ resource "huaweicloud_vpc" "vpc_with_tags" {
     key = "value"
   }
 }
-
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the vpc resource. If omitted, the provider-level region will be used. Changing this creates a new resource. Changing this creates a new vpc resource.
+* `cidr` - (Required, String) Specifies the range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to 10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
 
-* `cidr` - (Required, String) The range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to 10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
+* `name` - (Required, String) Specifies the name of the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-). Changing this updates the name of the existing VPC.
 
-* `name` - (Required, String) The name of the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-). Changing this updates the name of the existing VPC.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the vpc resource. If omitted, the provider-level region will be used. Changing this creates a new resource. Changing this creates a new vpc resource.
 
-* `tags` - (Optional, Map) The key/value pairs to associate with the vpc.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the vpc.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the vpc. Changing this creates a new vpc.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the vpc. Changing this creates a new vpc.
 
 ## Attributes Reference
 
@@ -57,15 +56,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The current status of the desired VPC. Can be either CREATING, OK, DOWN, PENDING_UPDATE, PENDING_DELETE, or ERROR.
 
-* `shared` - Specifies whether the cross-tenant sharing is supported.
-
-* `routes` - Specifies the route information. Structure is documented below.
+* `routes` - The route information. Structure is documented below.
 
 The `routes` block contains:
 
-* `destination` - Specifies the destination network segment of a route.
+* `destination` - The destination network segment of a route.
 
-* `nexthop` - Specifies the next hop of a route.
+* `nexthop` - The next hop of a route.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:
@@ -77,5 +74,5 @@ This resource provides the following timeouts configuration options:
 VPCs can be imported using the `id`, e.g.
 
 ```
-$ terraform import huaweicloud_vpc.vpc_v1 7117d38e-4c8f-4624-a505-bd96b97d024c
+$ terraform import huaweicloud_vpc.vpc_with_tags 7117d38e-4c8f-4624-a505-bd96b97d024c
 ```

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -38,11 +38,11 @@ resource "huaweicloud_vpc" "vpc_with_tags" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the vpc resource. If omitted, the provider-level region will be used. Changing this creates a new resource. Changing this creates a new vpc resource.
+
 * `cidr` - (Required, String) Specifies the range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to 10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
 
 * `name` - (Required, String) Specifies the name of the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-). Changing this updates the name of the existing VPC.
-
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the vpc resource. If omitted, the provider-level region will be used. Changing this creates a new resource. Changing this creates a new vpc resource.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the vpc.
 
@@ -74,5 +74,5 @@ This resource provides the following timeouts configuration options:
 VPCs can be imported using the `id`, e.g.
 
 ```
-$ terraform import huaweicloud_vpc.vpc_with_tags 7117d38e-4c8f-4624-a505-bd96b97d024c
+$ terraform import huaweicloud_vpc.vpc_v1 7117d38e-4c8f-4624-a505-bd96b97d024c
 ```

--- a/huaweicloud/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/data_source_huaweicloud_vpc.go
@@ -39,10 +39,6 @@ func DataSourceVirtualPrivateCloudVpcV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"shared": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
 			"routes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -117,7 +113,6 @@ func dataSourceVirtualPrivateCloudV1Read(d *schema.ResourceData, meta interface{
 	d.Set("enterprise_project_id", Vpc.EnterpriseProjectID)
 	d.Set("status", Vpc.Status)
 	d.Set("id", Vpc.ID)
-	d.Set("shared", Vpc.EnableSharedSnat)
 	d.Set("region", GetRegion(d, config))
 	if err := d.Set("routes", s); err != nil {
 		return err

--- a/huaweicloud/data_source_huaweicloud_vpc_test.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_test.go
@@ -26,8 +26,6 @@ func TestAccVpcV1DataSource_basic(t *testing.T) {
 					testAccDataSourceVpcV1Check("data.huaweicloud_vpc.by_cidr", rName),
 					testAccDataSourceVpcV1Check("data.huaweicloud_vpc.by_name", rName),
 					resource.TestCheckResourceAttr(
-						"data.huaweicloud_vpc.by_id", "shared", "false"),
-					resource.TestCheckResourceAttr(
 						"data.huaweicloud_vpc.by_id", "status", "OK"),
 				),
 			},

--- a/huaweicloud/resource_huaweicloud_vpc.go
+++ b/huaweicloud/resource_huaweicloud_vpc.go
@@ -29,12 +29,6 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{ //request and response parameters
-			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -51,12 +45,14 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
-			"status": {
+			"region": {
 				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 				Computed: true,
 			},
-			"shared": {
-				Type:     schema.TypeBool,
+			"status": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"routes": {
@@ -161,7 +157,6 @@ func resourceVirtualPrivateCloudV1Read(d *schema.ResourceData, meta interface{})
 	d.Set("cidr", n.CIDR)
 	d.Set("enterprise_project_id", n.EnterpriseProjectID)
 	d.Set("status", n.Status)
-	d.Set("shared", n.EnableSharedSnat)
 	d.Set("region", GetRegion(d, config))
 
 	// save route tables

--- a/huaweicloud/resource_huaweicloud_vpc.go
+++ b/huaweicloud/resource_huaweicloud_vpc.go
@@ -29,6 +29,12 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{ //request and response parameters
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -40,12 +46,6 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 				ValidateFunc: validateCIDR,
 			},
 			"enterprise_project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
-			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,

--- a/huaweicloud/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/resource_huaweicloud_vpc_test.go
@@ -30,7 +30,6 @@ func TestAccVpcV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "status", "OK"),
-					resource.TestCheckResourceAttr(resourceName, "shared", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),


### PR DESCRIPTION
Change list:
1. Remove 'shared' parameter from vpc data source and resource.
2. Update description of vpc date source and resource docs:
    a.  Sort resources by schema type.
    b. Update description of 'Argument Reference' and 'Attributes Reference'.
    c. remove 'shared' parameter from doc.

****Validation****
*Data source*
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVpcV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVpcV1DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1DataSource_basic
=== PAUSE TestAccVpcV1DataSource_basic
=== CONT  TestAccVpcV1DataSource_basic
--- PASS: TestAccVpcV1DataSource_basic (35.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       35.255s

*Resource*
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVpcV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1_basic (50.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       50.103s