### PR TITLE
add volume_attached/type to compute instance data source

### DIFF
--- a/docs/data-sources/compute_instance.md
+++ b/docs/data-sources/compute_instance.md
@@ -69,6 +69,7 @@ The `volume_attached` block supports:
 * `volume_id` - The volume id on that attachment.
 * `boot_index` - The volume boot index on that attachment.
 * `size` - The volume size on that attachment.
+* `type` - The volume type on that attachment.
 * `pci_address` - The volume pci address on that attachment.
 
 The `scheduler_hints` block supports:

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -250,6 +250,8 @@ func ResourceComputeInstanceV2() *schema.Resource {
 			"enterprise_project_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
 				ConflictsWith: []string{"block_device", "metadata"},
 			},
 			"delete_disks_on_termination": {


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (178.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       178.486s
```