### PR TITLE
support updating backup_strategy in opengauss

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -92,8 +92,7 @@ The following arguments are supported:
 * `datastore` - (Optional, List, ForceNew) Specifies the datastore information. Structure is documented below.
   Changing this parameter will create a new resource.
 
-* `backup_strategy` - (Optional, List, ForceNew) Specifies the advanced backup policy. Structure is documented below.
-  Changing this parameter will create a new resource.
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
 
 * `ha` - (Optional, List, ForceNew) Specifies the HA information. Structure is documented below.
   Changing this parameter will create a new resource.
@@ -123,13 +122,13 @@ The `ha` block supports:
 
 The `backup_strategy` block supports:
 
-* `start_time` - (Required, String, ForceNew) Specifies the backup time window. Automated backups
+* `start_time` - (Required, String) Specifies the backup time window. Automated backups
   will be triggered during the backup time window. It must be a valid value in
   the "hh:mm-HH:MM" format. The current time is in the UTC format.
   The HH value must be 1 greater than the hh value. The values of mm and MM
   must be the same and must be set to 00, 15, 30 or 45. Example value: 08:15-09:15, 23:00-00:00.
 
-* `keep_days` - (Optional, Int, ForceNew) Specifies the number of days to retain the generated
+* `keep_days` - (Optional, Int) Specifies the number of days to retain the generated
    backup files. The value ranges from 0 to 732.
    If this parameter is set to 0, the automated backup policy is not set.
    If this parameter is not transferred, the automated backup policy is enabled by default.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210116064800-601b4de34229
+	github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210116064800-601b4de34229 h1:tbgMbWp2CbIxSb6/YVXLjSnliKDzz5luUjEavpD1jZE=
-github.com/huaweicloud/golangsdk v0.0.0-20210116064800-601b4de34229/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a h1:0T/imzv2jl8yzmeqVIsZ/A/R/kTiDTVqdU+gUBMBWnE=
+github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups/requests.go
@@ -1,0 +1,45 @@
+package backups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToBackupUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a Backup.
+type UpdateOpts struct {
+	//Keep Days
+	KeepDays *int `json:"keep_days" required:"true"`
+	//Start Time
+	StartTime string `json:"start_time" required:"true"`
+	//Period
+	Period string `json:"period" required:"true"`
+	//DifferentialPeriod
+	DifferentialPeriod string `json:"differential_period" required:"true"`
+}
+
+// ToBackupUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToBackupUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "backup_policy")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a Backup.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToBackupUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders}
+	_, r.Err = c.Put(resourceURL(c, id), b, nil, reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups/results.go
@@ -1,0 +1,10 @@
+package backups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// UpdateResult represents the result of a update operation.
+type UpdateResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups/urls.go
@@ -1,0 +1,7 @@
+package backups
+
+import "github.com/huaweicloud/golangsdk"
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("instances", id, "backups/policy")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210116064800-601b4de34229
+# github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -331,6 +331,7 @@ github.com/huaweicloud/golangsdk/openstack/networking/v2/ports
 github.com/huaweicloud/golangsdk/openstack/networking/v2/routes
 github.com/huaweicloud/golangsdk/openstack/networking/v2/subnets
 github.com/huaweicloud/golangsdk/openstack/obs
+github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups
 github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances
 github.com/huaweicloud/golangsdk/openstack/rds/v1/datastores
 github.com/huaweicloud/golangsdk/openstack/rds/v1/flavors


### PR DESCRIPTION
support updating backup_strategy in opengauss
Test result:
```bash
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccOpenGaussInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccOpenGaussInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstance_basic
=== PAUSE TestAccOpenGaussInstance_basic
=== CONT  TestAccOpenGaussInstance_basic
--- PASS: TestAccOpenGaussInstance_basic (1418.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1418.068s
```