### PR TITLE
[Style] Update reading tags error return of dms instance

### DIFF
--- a/huaweicloud/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1.go
@@ -285,13 +285,13 @@ func resourceDmsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	engine := d.Get("engine").(string)
-	resourceTags, err := tags.Get(dmsV2Client, engine, d.Id()).Extract()
-	if err != nil {
-		return fmt.Errorf("Error fetching tags of dms instance: %s", err)
-	}
-	tagmap := tagsToMap(resourceTags.Tags)
-	if err := d.Set("tags", tagmap); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving tag to state for dms instance (%s): %s", d.Id(), err)
+	if resourceTags, err := tags.Get(dmsV2Client, engine, d.Id()).Extract(); err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		if err := d.Set("tags", tagmap); err != nil {
+			return fmt.Errorf("Error saving tags to state for dms instance (%s): %s", d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of dms instance (%s): %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
This revision mainly solves the following problems:

- Update reading tags logic from error return to log print.

Release note for CHANGELOG:

 `NONE`
