### PR TITLE
[Style] Update reading tags error return of dns ptrrecord

### DIFF
--- a/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_ptrrecord_v2.go
@@ -147,15 +147,15 @@ func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("address", n.Address)
 
 	// save tags
-	resourceTags, err := tags.Get(dnsClient, "DNS-ptr_record", d.Id()).Extract()
-	if err != nil {
-		return fmt.Errorf("Error fetching HuaweiCloud DNS ptr record tags: %s", err)
+	if resourceTags, err := tags.Get(dnsClient, "DNS-ptr_record", d.Id()).Extract(); err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		if err := d.Set("tags", tagmap); err != nil {
+			return fmt.Errorf("Error saving tags to state for DNS ptr record (%s): %s", d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of DNS ptr record (%s): %s", d.Id(), err)
 	}
 
-	tagmap := tagsToMap(resourceTags.Tags)
-	if err := d.Set("tags", tagmap); err != nil {
-		return fmt.Errorf("Error saving tags for HuaweiCloud DNS ptr record %s: %s", d.Id(), err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
This revision mainly solves the following problems:

- Update reading tags logic from error return to log print.

Release note for CHANGELOG:

 `NONE`
