### PR TITLE
[Style] Update reading tags error return of ecs instance

### DIFF
--- a/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
@@ -360,14 +360,13 @@ func resourceEcsInstanceV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("nics", nics)
 
 	// Set instance tags
-	resourceTags, err := tags.Get(computeClient, "cloudservers", d.Id()).Extract()
-	if err != nil {
-		return fmt.Errorf("Error fetching HuaweiCloud instance tags: %s", err)
-	}
-
-	tagmap := tagsToMap(resourceTags.Tags)
-	if err := d.Set("tags", tagmap); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving tag to state for HuaweiCloud instance (%s): %s", d.Id(), err)
+	if resourceTags, err := tags.Get(computeClient, "cloudservers", d.Id()).Extract(); err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		if err := d.Set("tags", tagmap); err != nil {
+			return fmt.Errorf("Error saving tags to state for ECS instance (%s): %s", d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of ECS instance (%s): %s", d.Id(), err)
 	}
 
 	ar, err := resourceECSAutoRecoveryV1Read(d, meta, d.Id())


### PR DESCRIPTION
This revision mainly solves the following problems:

- Update reading tags logic from error return to log print.

Release note for CHANGELOG:

 `NONE`
