### PR TITLE
[Style] Update reading tags error return of vpc and vbs

### DIFF
--- a/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -206,22 +206,25 @@ func resourceVBSBackupPolicyV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("status", n.ScheduledPolicy.Status)
 	d.Set("policy_resource_count", n.ResourceCount)
 
-	if tags, err := tags.Get(vbsClient, d.Id()).Extract(); err == nil {
-		var tagList []map[string]interface{}
-		for _, v := range tags.Tags {
-			tag := make(map[string]interface{})
-			tag["key"] = v.Key
-			tag["value"] = v.Value
+	tags, err := tags.Get(vbsClient, d.Id()).Extract()
 
-			tagList = append(tagList, tag)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return nil
 		}
-		if err := d.Set("tags", tagList); err != nil {
-			return fmt.Errorf("Error saving tags to state for backup policy (%s): %s", d.Id(), err)
-		}
-	} else {
-		log.Printf("[WARN] Error fetching tags of backup policy (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error retrieving Huaweicloud Backup Policy Tags: %s", err)
 	}
+	var tagList []map[string]interface{}
+	for _, v := range tags.Tags {
+		tag := make(map[string]interface{})
+		tag["key"] = v.Key
+		tag["value"] = v.Value
 
+		tagList = append(tagList, tag)
+	}
+	if err := d.Set("tags", tagList); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving tags to state for Huaweicloud backup policy (%s): %s", d.Id(), err)
+	}
 	return nil
 }
 

--- a/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vbs_backup_policy_v2.go
@@ -206,25 +206,22 @@ func resourceVBSBackupPolicyV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("status", n.ScheduledPolicy.Status)
 	d.Set("policy_resource_count", n.ResourceCount)
 
-	tags, err := tags.Get(vbsClient, d.Id()).Extract()
+	if tags, err := tags.Get(vbsClient, d.Id()).Extract(); err == nil {
+		var tagList []map[string]interface{}
+		for _, v := range tags.Tags {
+			tag := make(map[string]interface{})
+			tag["key"] = v.Key
+			tag["value"] = v.Value
 
-	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			return nil
+			tagList = append(tagList, tag)
 		}
-		return fmt.Errorf("Error retrieving Huaweicloud Backup Policy Tags: %s", err)
+		if err := d.Set("tags", tagList); err != nil {
+			return fmt.Errorf("Error saving tags to state for backup policy (%s): %s", d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of backup policy (%s): %s", d.Id(), err)
 	}
-	var tagList []map[string]interface{}
-	for _, v := range tags.Tags {
-		tag := make(map[string]interface{})
-		tag["key"] = v.Key
-		tag["value"] = v.Value
 
-		tagList = append(tagList, tag)
-	}
-	if err := d.Set("tags", tagList); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving tags to state for Huaweicloud backup policy (%s): %s", d.Id(), err)
-	}
 	return nil
 }
 

--- a/huaweicloud/resource_huaweicloud_vpc.go
+++ b/huaweicloud/resource_huaweicloud_vpc.go
@@ -171,17 +171,17 @@ func resourceVirtualPrivateCloudV1Read(d *schema.ResourceData, meta interface{})
 	d.Set("routes", routes)
 
 	// save VirtualPrivateCloudV2 tags
-	vpcV2Client, err := config.NetworkingV2Client(GetRegion(d, config))
-	if err != nil {
-		return fmt.Errorf("Error creating vpc client: %s", err)
-	}
-	if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
-		tagmap := tagsToMap(resourceTags.Tags)
-		if err := d.Set("tags", tagmap); err != nil {
-			return fmt.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+	if vpcV2Client, err := config.NetworkingV2Client(GetRegion(d, config)); err == nil {
+		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
+			tagmap := tagsToMap(resourceTags.Tags)
+			if err := d.Set("tags", tagmap); err != nil {
+				return fmt.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+			}
+		} else {
+			log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
 		}
 	} else {
-		log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error creating vpc client: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_vpc.go
+++ b/huaweicloud/resource_huaweicloud_vpc.go
@@ -173,20 +173,15 @@ func resourceVirtualPrivateCloudV1Read(d *schema.ResourceData, meta interface{})
 	// save VirtualPrivateCloudV2 tags
 	vpcV2Client, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating Huaweicloud vpc client: %s", err)
+		return fmt.Errorf("Error creating vpc client: %s", err)
 	}
-	resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract()
-	if err != nil {
-		if err404, ok := err.(golangsdk.ErrDefault404); ok {
-			log.Printf("[INFO] fetching VPC tags failed: %s", err404)
-		} else {
-			return fmt.Errorf("Error fetching HuaweiCloud VPC %s tags: %s", d.Id(), err)
-		}
-	} else {
+	if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
 		tagmap := tagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return fmt.Errorf("Error saving HuaweiCloud VPC %s tags: %s", d.Id(), err)
+			return fmt.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
 		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/resource_huaweicloud_vpc_subnet.go
@@ -198,17 +198,17 @@ func resourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("region", GetRegion(d, config))
 
 	// save VpcSubnet tags
-	vpcSubnetV2Client, err := config.NetworkingV2Client(GetRegion(d, config))
-	if err != nil {
-		return fmt.Errorf("Error creating VpcSubnet client: %s", err)
-	}
-	if resourceTags, err := tags.Get(vpcSubnetV2Client, "subnets", d.Id()).Extract(); err == nil {
-		tagmap := tagsToMap(resourceTags.Tags)
-		if err := d.Set("tags", tagmap); err != nil {
-			return fmt.Errorf("Error saving tags to state for Subnet (%s): %s", d.Id(), err)
+	if vpcSubnetV2Client, err := config.NetworkingV2Client(GetRegion(d, config)); err == nil {
+		if resourceTags, err := tags.Get(vpcSubnetV2Client, "subnets", d.Id()).Extract(); err == nil {
+			tagmap := tagsToMap(resourceTags.Tags)
+			if err := d.Set("tags", tagmap); err != nil {
+				return fmt.Errorf("Error saving tags to state for Subnet (%s): %s", d.Id(), err)
+			}
+		} else {
+			log.Printf("[WARN] Error fetching tags of Subnet (%s): %s", d.Id(), err)
 		}
 	} else {
-		log.Printf("[WARN] Error fetching tags of Subnet (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error creating VpcSubnet client: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/resource_huaweicloud_vpc_subnet.go
@@ -200,20 +200,15 @@ func resourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 	// save VpcSubnet tags
 	vpcSubnetV2Client, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating Huaweicloud VpcSubnet client: %s", err)
+		return fmt.Errorf("Error creating VpcSubnet client: %s", err)
 	}
-	resourceTags, err := tags.Get(vpcSubnetV2Client, "subnets", d.Id()).Extract()
-	if err != nil {
-		if err404, ok := err.(golangsdk.ErrDefault404); ok {
-			log.Printf("[INFO] fetching Subnet tags failed: %s", err404)
-		} else {
-			return fmt.Errorf("Error fetching HuaweiCloud Subnet %s tags: %s", d.Id(), err)
-		}
-	} else {
+	if resourceTags, err := tags.Get(vpcSubnetV2Client, "subnets", d.Id()).Extract(); err == nil {
 		tagmap := tagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return fmt.Errorf("Error saving HuaweiCloud Subnet %s tags: %s", d.Id(), err)
+			return fmt.Errorf("Error saving tags to state for Subnet (%s): %s", d.Id(), err)
 		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of Subnet (%s): %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
This revision mainly solves the following problems:

- In vpc, vpc subnet and vbs backup policy resource, we update reading tags logic from error return to log print.
- Remove 404 error check in vbs backup policy and vpc subnet resource.

Release note for CHANGELOG:

`NONE`