### PR TITLE
make obs support customizing service endpoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ The following arguments are supported:
   If omitted, the `HW_ENTERPRISE_PROJECT_ID` environment variable is used.
 
 * `endpoints` - (Optional) Configuration block in key/value pairs for customizing service endpoints.
-  The following endpoints support to be customized: autoscaling, ecs, ims, vpc, evs, sfs, cce, rds, dds, iam.
+  The following endpoints support to be customized: autoscaling, ecs, ims, vpc, evs, obs, sfs, cce, rds, dds, iam.
   An example provider configuration:
 
 ```hcl

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -373,6 +373,9 @@ func (l sLogger) Log(args ...interface{}) {
 }
 
 func getObsEndpoint(c *Config, region string) string {
+	if endpoint, ok := c.endpoints["obs"]; ok {
+		return endpoint
+	}
 	return fmt.Sprintf("https://obs.%s.%s/", region, c.Cloud)
 }
 


### PR DESCRIPTION
we can customizing obs service endpoint with
```
provider "huaweicloud" {
  endpoints = {
    obs = "your customizing endpoint"
  }
}
```