### PR TITLE
skip to log the catalog response

### DIFF
--- a/huaweicloud/types.go
+++ b/huaweicloud/types.go
@@ -181,6 +181,9 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 	}
 
 	// Ignore the catalog
+	if _, ok := data["catalog"]; ok {
+		return "{ **skipped** }"
+	}
 	if v, ok := data["token"].(map[string]interface{}); ok {
 		if _, ok := v["catalog"]; ok {
 			return ""


### PR DESCRIPTION
the catalog response is too huge and it's useless for us, so skip to log the response message.