### PR TITLE
[Feature Request] Support fixed_ip in RDS instance resource

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -140,6 +140,9 @@ The following arguments are supported:
 
 * `volume` - (Required, List) Specifies the volume information. Structure is documented below.
 
+* `fixed_ip` - (Optional, String, ForceNew) Specifies an intranet floating IP address of RDS DB instance. 
+    Changing this parameter will create a new resource.
+
 * `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
 
 * `ha_replication_mode` - (Optional, String, ForceNew) Specifies the replication mode for the standby DB instance. For MySQL, the value

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -234,7 +234,6 @@ func resourceRdsInstanceV3() *schema.Resource {
 
 			"private_ips": {
 				Type:     schema.TypeList,
-				Optional: true,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -1124,6 +1123,11 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	if err = d.Set("private_ips", v); err != nil {
 		return fmt.Errorf("Error setting Instance:private_ips, err: %s", err)
 	}
+	if len(v.([]interface{})) != 0 {
+		if err = d.Set("fixed_ip", v.([]interface{})[0]); err != nil {
+			return fmt.Errorf("Error setting Instance:fixed_ip, err: %s", err)
+		}
+	}
 
 	v, err = navigateValue(response, []string{"list", "public_ips"}, nil)
 	if err != nil {
@@ -1131,11 +1135,6 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	}
 	if err = d.Set("public_ips", v); err != nil {
 		return fmt.Errorf("Error setting Instance:public_ips, err: %s", err)
-	}
-	if len(v.([]interface{})) != 0 {
-		if err = d.Set("fixed_ip", v.([]interface{})[0]); err != nil {
-			return fmt.Errorf("Error setting Instance:fixed_ip, err: %s", err)
-		}
 	}
 
 	v, err = navigateValue(response, []string{"list", "security_group_id"}, nil)

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -234,6 +234,7 @@ func resourceRdsInstanceV3() *schema.Resource {
 
 			"private_ips": {
 				Type:     schema.TypeList,
+				Optional: true,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -1131,6 +1132,11 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	if err = d.Set("public_ips", v); err != nil {
 		return fmt.Errorf("Error setting Instance:public_ips, err: %s", err)
 	}
+	if len(v.([]interface{})) != 0 {
+		if err = d.Set("fixed_ip", v.([]interface{})[0]); err != nil {
+			return fmt.Errorf("Error setting Instance:fixed_ip, err: %s", err)
+		}
+	}
 
 	v, err = navigateValue(response, []string{"list", "security_group_id"}, nil)
 	if err != nil {
@@ -1179,14 +1185,6 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	}
 	if err = d.Set("time_zone", v); err != nil {
 		return fmt.Errorf("Error setting Instance:time_zone, err: %s", err)
-	}
-
-	v, err = navigateValue(response, []string{"list", "private_ips"}, nil)
-	if err != nil {
-		return fmt.Errorf("Error reading Instance:private_ips, err: %s", err)
-	}
-	if err = d.Set("fixed_ip", v.([]interface{})[0]); err != nil {
-		return fmt.Errorf("Error setting Instance:fixed_ip, err: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
@@ -43,6 +43,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+10:00"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.58"),
 				),
 			},
 			{
@@ -115,6 +116,7 @@ resource "huaweicloud_rds_instance" "instance" {
   subnet_id = huaweicloud_vpc_subnet.test.id
   vpc_id = huaweicloud_vpc.test.id
   time_zone = "UTC+10:00"
+  fixed_ip = "192.168.0.58"
 
   db {
     password = "Huangwei!120521"


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- support `fixed_ip` in rds instance resource.
- add `fixed_ip` in Rds instance basic test.

Fixed: #807

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (629.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       629.341s
```