### PR TITLE
[Feature Request] Support tags and remove realm parameter of kms key

### DIFF
--- a/docs/data-sources/kms_key.md
+++ b/docs/data-sources/kms_key.md
@@ -53,3 +53,4 @@ In addition to all arguments above, the following attributes are exported:
 * `scheduled_deletion_date` - Scheduled deletion time (time stamp) of a key.
 * `expiration_time` - Expiration time.
 * `creation_date` - Creation time (time stamp) of a key.
+* `tags` - The key/value pairs to associate with the kms key.

--- a/docs/resources/kms_key.md
+++ b/docs/resources/kms_key.md
@@ -39,6 +39,7 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the kms key. Changing this creates a new key.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the kms key.
 
 ## Attributes Reference
 

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1.go
@@ -171,7 +171,9 @@ func dataSourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	if resourceTags, err := tags.Get(kmsKeyV1Client, "kms", key.KeyID).Extract(); err == nil {
 		tagmap := tagsToMap(resourceTags.Tags)
-		d.Set("tags", tagmap)
+		if err := d.Set("tags", tagmap); err != nil {
+			return fmt.Errorf("Error saving tags to state for kms (%s): %s", key.KeyID, err)
+		}
 	} else {
 		log.Printf("[WARN] Error fetching tags of kms (%s): %s", key.KeyID, err)
 	}

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -35,7 +35,7 @@ func TestAccKmsKeyV1DataSource_basic(t *testing.T) {
 func TestAccKmsKeyV1DataSource_WithTags(t *testing.T) {
 	var datasourceName = "data.huaweicloud_kms_key.key1"
 	resource.ParallelTest(t, resource.TestCase{
-		// PreCheck:  func() { testAccPreCheckKms(t) },
+		PreCheck:  func() { testAccPreCheckKms(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -32,6 +32,25 @@ func TestAccKmsKeyV1DataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccKmsKeyV1DataSource_WithTags(t *testing.T) {
+	var datasourceName = "data.huaweicloud_kms_key.key1"
+	resource.ParallelTest(t, resource.TestCase{
+		// PreCheck:  func() { testAccPreCheckKms(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsKeyV1DataSource_withTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsKeyV1DataSourceID(datasourceName),
+					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(datasourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKmsKeyV1DataSource_WithEpsId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t); testAccPreCheckEpsID(t) },
@@ -74,6 +93,19 @@ resource "huaweicloud_kms_key_v1" "key1" {
   is_enabled      = true
 }`, keyAlias)
 
+var testAccKmsKeyV1DataSource_key_withTags = fmt.Sprintf(`
+resource "huaweicloud_kms_key" "key1" {
+  region = "af-south-1"
+  key_alias       = "%s"
+  key_description = "test description"
+  pending_days    = "7"
+  is_enabled      = true
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}`, keyAlias)
+
 var testAccKmsKeyV1DataSource_basic = fmt.Sprintf(`
 %s
 data "huaweicloud_kms_key_v1" "key1" {
@@ -83,6 +115,16 @@ data "huaweicloud_kms_key_v1" "key1" {
   key_state       = "2"
 }
 `, testAccKmsKeyV1DataSource_key)
+
+var testAccKmsKeyV1DataSource_withTags = fmt.Sprintf(`
+%s
+data "huaweicloud_kms_key" "key1" {
+  key_alias       = huaweicloud_kms_key.key1.key_alias
+  key_id          = huaweicloud_kms_key.key1.id
+  key_description = "test description"
+  key_state       = "2"
+}
+`, testAccKmsKeyV1DataSource_key_withTags)
 
 var testAccKmsKeyV1DataSource_epsId = fmt.Sprintf(`
 resource "huaweicloud_kms_key_v1" "key1" {

--- a/huaweicloud/resource_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 	"github.com/huaweicloud/golangsdk/openstack/kms/v1/keys"
 )
 
@@ -40,12 +41,6 @@ func resourceKmsKeyV1() *schema.Resource {
 			"key_description": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"realm": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
@@ -87,6 +82,11 @@ func resourceKmsKeyV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -101,7 +101,6 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 	createOpts := &keys.CreateOpts{
 		KeyAlias:            d.Get("key_alias").(string),
 		KeyDescription:      d.Get("key_description").(string),
-		Realm:               d.Get("realm").(string),
 		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
 	}
 
@@ -142,6 +141,15 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		taglist := expandResourceTags(tagRaw)
+		tagErr := tags.Create(kmsKeyV1Client, "kms", v.KeyID, taglist).ExtractErr()
+		if tagErr != nil {
+			log.Printf("Error creating tags for kms (%s): %s", v.KeyID, err)
+		}
+	}
+
 	// Store the key ID now
 	d.SetId(v.KeyID)
 	d.Set("key_id", v.KeyID)
@@ -172,7 +180,7 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_id", v.KeyID)
 	d.Set("domain_id", v.DomainID)
 	d.Set("key_alias", v.KeyAlias)
-	d.Set("realm", v.Realm)
+	d.Set("region", GetRegion(d, config))
 	d.Set("key_description", v.KeyDescription)
 	d.Set("creation_date", v.CreationDate)
 	d.Set("scheduled_deletion_date", v.ScheduledDeletionDate)
@@ -180,6 +188,16 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("default_key_flag", v.DefaultKeyFlag)
 	d.Set("expiration_time", v.ExpirationTime)
 	d.Set("enterprise_project_id", v.EnterpriseProjectID)
+
+	// Set instance tags
+	if resourceTags, err := tags.Get(kmsKeyV1Client, "kms", d.Id()).Extract(); err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		if err := d.Set("tags", tagmap); err != nil {
+			return fmt.Errorf("Error saving tags to state for kms (%s): %s", d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of kms (%s): %s", d.Id(), err)
+	}
 
 	return nil
 }
@@ -237,6 +255,13 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 			if key.KeyState != DisabledState {
 				return fmt.Errorf("Error disabling key, the key state is: %s", key.KeyState)
 			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		tagErr := UpdateResourceTags(kmsKeyV1Client, d, "kms", d.Id())
+		if tagErr != nil {
+			return fmt.Errorf("Error updating tags of kms:%s, err:%s", d.Id(), err)
 		}
 	}
 

--- a/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
@@ -52,6 +52,30 @@ func TestAccKmsKeyV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccKmsKeyV1_WithTags(t *testing.T) {
+	var key keys.Key
+	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
+	var resourceName = "huaweicloud_kms_key.key_2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckKms(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKmsV1KeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsV1Key_withTags(keyAlias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsV1KeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(resourceName, "region", "af-south-1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKmsKeyV1_WithEpsId(t *testing.T) {
 	var key keys.Key
 	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
@@ -179,6 +203,20 @@ func testAccKmsV1Key_basic(keyAlias string) string {
 		resource "huaweicloud_kms_key_v1" "key_2" {
 			key_alias = "%s"
 			pending_days = "7"
+		}
+	`, keyAlias)
+}
+
+func testAccKmsV1Key_withTags(keyAlias string) string {
+	return fmt.Sprintf(`
+		resource "huaweicloud_kms_key" "key_2" {
+			region = "af-south-1"
+			key_alias = "%s"
+			pending_days = "7"
+			tags = {
+				foo = "bar"
+				key = "value"
+			}
 		}
 	`, keyAlias)
 }


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- support `tags` in kms key resource and data source.
- remove `realm` in kms key resource and data source.
- add the above changes to the document of kms key resource and data source.
- update test example with tags.

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
- kms key data source
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyV1DataSource_WithTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyV1DataSource_WithTags -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyV1DataSource_WithTags
=== PAUSE TestAccKmsKeyV1DataSource_WithTags
=== CONT  TestAccKmsKeyV1DataSource_WithTags
--- PASS: TestAccKmsKeyV1DataSource_WithTags (49.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       50.056s
```
- kms key resource
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyV1_WithTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyV1_WithTags -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyV1_WithTags
=== PAUSE TestAccKmsKeyV1_WithTags
=== CONT  TestAccKmsKeyV1_WithTags
--- PASS: TestAccKmsKeyV1_WithTags (41.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       41.288s
```