### PR TITLE
[Feature Request] Remove kms key realm parameter

### DIFF
--- a/huaweicloud/data_source_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1.go
@@ -31,11 +31,6 @@ func dataSourceKmsKeyV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"realm": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"domain_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -71,7 +66,8 @@ func dataSourceKmsKeyV1() *schema.Resource {
 
 func dataSourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	kmsKeyV1Client, err := config.kmsKeyV1Client(GetRegion(d, config))
+	kmsRegion := GetRegion(d, config)
+	kmsKeyV1Client, err := config.kmsKeyV1Client(kmsRegion)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud kms key client: %s", err)
 	}
@@ -102,9 +98,6 @@ func dataSourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOk("key_id"); ok {
 		keyProperties["KeyID"] = v.(string)
-	}
-	if v, ok := d.GetOk("realm"); ok {
-		keyProperties["Realm"] = v.(string)
 	}
 	if v, ok := d.GetOk("key_alias"); ok {
 		keyProperties["KeyAlias"] = v.(string)
@@ -162,7 +155,7 @@ func dataSourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_id", key.KeyID)
 	d.Set("domain_id", key.DomainID)
 	d.Set("key_alias", key.KeyAlias)
-	d.Set("realm", key.Realm)
+	d.Set("region", kmsRegion)
 	d.Set("key_description", key.KeyDescription)
 	d.Set("creation_date", key.CreationDate)
 	d.Set("scheduled_deletion_date", key.ScheduledDeletionDate)

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -12,20 +12,18 @@ import (
 var keyAlias = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
 var keyAlias_epsId = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
 
-func TestAccKmsKeyV1DataSource_basic(t *testing.T) {
+func TestAccKmsKeyV1DataSourceBasic(t *testing.T) {
+	var datasourceName = "data.huaweicloud_kms_key.key_2"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyV1DataSource_key,
-			},
-			{
-				Config: testAccKmsKeyV1DataSource_basic,
+				Config: testAccKmsKeyV1DataSourceBasic(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsKeyV1DataSourceID("data.huaweicloud_kms_key_v1.key1"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_kms_key_v1.key1", "key_alias", keyAlias),
+					testAccCheckKmsKeyV1DataSourceID(datasourceName),
+					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(datasourceName, "region", HW_REGION_NAME),
 				),
 			},
 		},
@@ -66,23 +64,17 @@ func testAccCheckKmsKeyV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccKmsKeyV1DataSource_key = fmt.Sprintf(`
-resource "huaweicloud_kms_key_v1" "key1" {
-  key_alias       = "%s"
-  key_description = "test description"
-  pending_days    = "7"
-  is_enabled      = true
-}`, keyAlias)
-
-var testAccKmsKeyV1DataSource_basic = fmt.Sprintf(`
+func testAccKmsKeyV1DataSourceBasic(keyAlias string) string {
+	return fmt.Sprintf(`
 %s
-data "huaweicloud_kms_key_v1" "key1" {
-  key_alias       = "${huaweicloud_kms_key_v1.key1.key_alias}"
-  key_id          = "${huaweicloud_kms_key_v1.key1.id}"
+data "huaweicloud_kms_key" "key_2" {
+  key_alias       = huaweicloud_kms_key.key_2.key_alias
+  key_id          = huaweicloud_kms_key.key_2.id
   key_description = "test description"
   key_state       = "2"
 }
-`, testAccKmsKeyV1DataSource_key)
+`, testAccKmsV1KeyBasic(keyAlias))
+}
 
 var testAccKmsKeyV1DataSource_epsId = fmt.Sprintf(`
 resource "huaweicloud_kms_key_v1" "key1" {

--- a/huaweicloud/resource_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1.go
@@ -41,12 +41,6 @@ func resourceKmsKeyV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"realm": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -101,7 +95,6 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 	createOpts := &keys.CreateOpts{
 		KeyAlias:            d.Get("key_alias").(string),
 		KeyDescription:      d.Get("key_description").(string),
-		Realm:               d.Get("realm").(string),
 		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
 	}
 
@@ -152,7 +145,8 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	kmsKeyV1Client, err := config.kmsKeyV1Client(GetRegion(d, config))
+	kmsRegion := GetRegion(d, config)
+	kmsKeyV1Client, err := config.kmsKeyV1Client(kmsRegion)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud kms key client: %s", err)
 	}
@@ -172,7 +166,7 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_id", v.KeyID)
 	d.Set("domain_id", v.DomainID)
 	d.Set("key_alias", v.KeyAlias)
-	d.Set("realm", v.Realm)
+	d.Set("region", kmsRegion)
 	d.Set("key_description", v.KeyDescription)
 	d.Set("creation_date", v.CreationDate)
 	d.Set("scheduled_deletion_date", v.ScheduledDeletionDate)

--- a/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccKmsKeyV1_basic(t *testing.T) {
+func TestAccKmsKeyV1Basic(t *testing.T) {
 	var key keys.Key
 	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
 	var keyAliasUpdate = fmt.Sprintf("kms_updated_%s", acctest.RandString(5))
+	var resourceName = "huaweicloud_kms_key.key_2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckKms(t) },
@@ -22,15 +23,15 @@ func TestAccKmsKeyV1_basic(t *testing.T) {
 		CheckDestroy: testAccCheckKmsV1KeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsV1Key_basic(keyAlias),
+				Config: testAccKmsV1KeyBasic(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsV1KeyExists("huaweicloud_kms_key_v1.key_2", &key),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_kms_key_v1.key_2", "key_alias", keyAlias),
+					testAccCheckKmsV1KeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(resourceName, "region", HW_REGION_NAME),
 				),
 			},
 			{
-				ResourceName:      "huaweicloud_kms_key_v1.key_2",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -39,13 +40,12 @@ func TestAccKmsKeyV1_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccKmsV1Key_update(keyAliasUpdate),
+				Config: testAccKmsV1KeyUpdate(keyAliasUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsV1KeyExists("huaweicloud_kms_key_v1.key_2", &key),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_kms_key_v1.key_2", "key_alias", keyAliasUpdate),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_kms_key_v1.key_2", "key_description", "key update description"),
+					testAccCheckKmsV1KeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "key_alias", keyAliasUpdate),
+					resource.TestCheckResourceAttr(resourceName, "key_description", "key update description"),
+					resource.TestCheckResourceAttr(resourceName, "region", HW_REGION_NAME),
 				),
 			},
 		},
@@ -174,13 +174,14 @@ func testAccCheckKmsKeyIsEnabled(key *keys.Key, isEnabled bool) resource.TestChe
 	}
 }
 
-func testAccKmsV1Key_basic(keyAlias string) string {
+func testAccKmsV1KeyBasic(keyAlias string) string {
 	return fmt.Sprintf(`
-		resource "huaweicloud_kms_key_v1" "key_2" {
-			key_alias = "%s"
-			pending_days = "7"
-		}
-	`, keyAlias)
+resource "huaweicloud_kms_key" "key_2" {
+  key_alias    = "%s"
+  pending_days = "7"
+  region       = "%s"
+}
+`, keyAlias, HW_REGION_NAME)
 }
 
 func testAccKmsV1Key_epsId(keyAlias string) string {
@@ -193,14 +194,14 @@ func testAccKmsV1Key_epsId(keyAlias string) string {
 	`, keyAlias, HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccKmsV1Key_update(keyAliasUpdate string) string {
+func testAccKmsV1KeyUpdate(keyAliasUpdate string) string {
 	return fmt.Sprintf(`
-		resource "huaweicloud_kms_key_v1" "key_2" {
-           key_alias       = "%s"
-           key_description = "key update description"
-           pending_days = "7"
-		}
-	`, keyAliasUpdate)
+resource "huaweicloud_kms_key" "key_2" {
+  key_alias       = "%s"
+  key_description = "key update description"
+  pending_days    = "7"
+}
+`, keyAliasUpdate)
 }
 
 func testAccKmsKey_enabled(rName string) string {


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- remove `realm` from kms key resource and data source.
- saving 'region' to state for kms key resource and data source to instead of 'realm'.

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
- kms key data source
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyV1DataSourceBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyV1DataSourceBasic -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyV1DataSourceBasic
=== PAUSE TestAccKmsKeyV1DataSourceBasic
=== CONT  TestAccKmsKeyV1DataSourceBasic
--- PASS: TestAccKmsKeyV1DataSourceBasic (46.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       46.074s
```
- kms key resource
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyV1Basic'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyV1Basic -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyV1Basic
=== PAUSE TestAccKmsKeyV1Basic
=== CONT  TestAccKmsKeyV1Basic
--- PASS: TestAccKmsKeyV1Basic (53.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       53.654s
```