### PR TITLE
resource_huaweicloud_as_group support enable, disable and support import

### DIFF
--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -189,6 +189,9 @@ The following arguments are supported:
 * `delete_instances` - (Optional, String) Whether to delete the instances in the AS group
     when deleting the AS group. The options are `yes` and `no`.
 
+* `enable` - (Optional, Bool) Whether to enable the AS Group. The options are `true` and `false`.
+    The default value is `true`.
+
 The `networks` block supports:
 
 * `id` - (Required, String) The network UUID.


### PR DESCRIPTION
fixes #837 
Test result
```bash
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccASV1Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccASV1Group_basic -timeout 360m -parallel 4
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (135.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       135.669s
```