### PR TITLE
fix a bug in smn  Delete func which can not return err correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a
+	github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a h1:0T/imzv2jl8yzmeqVIsZ/A/R/kTiDTVqdU+gUBMBWnE=
-github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517 h1:l/Aa5CisHTWEg5ZEvNPRlrfxkCDEgYQieJRqFlthkXw=
+github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_smn_subscription_v2.go
+++ b/huaweicloud/resource_huaweicloud_smn_subscription_v2.go
@@ -107,7 +107,7 @@ func resourceSubscriptionDelete(d *schema.ResourceData, meta interface{}) error 
 	id := d.Id()
 	result := subscriptions.Delete(client, id)
 	if result.Err != nil {
-		return err
+		return result.Err
 	}
 
 	log.Printf("[DEBUG] Successfully deleted subscription %s", id)

--- a/huaweicloud/resource_huaweicloud_smn_topic_v2.go
+++ b/huaweicloud/resource_huaweicloud_smn_topic_v2.go
@@ -3,7 +3,6 @@ package huaweicloud
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
@@ -83,7 +82,6 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Create : topic.TopicUrn %s", topic.TopicUrn)
 	if topic.TopicUrn != "" {
 		d.SetId(topic.TopicUrn)
-		time.Sleep(120 * time.Second)
 		return resourceTopicRead(d, meta)
 	}
 
@@ -127,7 +125,7 @@ func resourceTopicDelete(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 	result := topics.Delete(client, id)
 	if result.Err != nil {
-		return err
+		return result.Err
 	}
 
 	for {
@@ -163,7 +161,6 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error updating topic from result: %s", err)
 	}
 
-	time.Sleep(120 * time.Second)
 	log.Printf("[DEBUG] Update : topic.TopicUrn: %s", id)
 	return resourceTopicRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_smn_topic_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_smn_topic_v2_test.go
@@ -3,7 +3,6 @@ package huaweicloud
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -54,7 +53,6 @@ func testAccCheckSMNTopicV2Destroy(s *terraform.State) error {
 		return fmt.Errorf("Error creating HuaweiCloud smn: %s", err)
 	}
 
-	time.Sleep(120 * time.Second)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "huaweicloud_smn_topic_v2" {
 			continue

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/smn/v2/subscriptions/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/smn/v2/subscriptions/requests.go
@@ -46,7 +46,10 @@ func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder, topicUrn stri
 
 //delete a subscription via subscription urn
 func Delete(client *golangsdk.ServiceClient, subscriptionUrn string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, subscriptionUrn), &RequestOpts)
+	_, r.Err = client.Delete(deleteURL(client, subscriptionUrn), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
@@ -58,12 +61,16 @@ func Delete(client *golangsdk.ServiceClient, subscriptionUrn string) (r DeleteRe
 
 //list all the subscriptions
 func List(client *golangsdk.ServiceClient) (r ListResult) {
-	_, r.Err = client.Get(listURL(client), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(listURL(client), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
 //list all the subscriptions
 func ListFromTopic(client *golangsdk.ServiceClient, subscriptionUrn string) (r ListResult) {
-	_, r.Err = client.Get(listFromTopicURL(client, subscriptionUrn), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(listFromTopicURL(client, subscriptionUrn), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/smn/v2/topics/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/smn/v2/topics/requests.go
@@ -77,18 +77,25 @@ func Update(client *golangsdk.ServiceClient, ops UpdateOpsBuilder, id string) (r
 
 //delete a topic via id
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, id), &RequestOpts)
+	_, r.Err = client.Delete(deleteURL(client, id), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
 //get a topic with detailed information by id
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, id), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(getURL(client, id), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
 //list all the topics
 func List(client *golangsdk.ServiceClient) (r ListResult) {
-	_, r.Err = client.Get(listURL(client), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(listURL(client), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210118061029-b3a40d772e0a
+# github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
Test result:
```bash
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSMNV2Topic_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSMNV2Topic_basic -timeout 360m -parallel 4
=== RUN   TestAccSMNV2Topic_basic
=== PAUSE TestAccSMNV2Topic_basic
=== CONT  TestAccSMNV2Topic_basic
--- PASS: TestAccSMNV2Topic_basic (371.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       371.249s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSMNV2Subscription_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSMNV2Subscription_basic -timeout 360m -parallel 4
=== RUN   TestAccSMNV2Subscription_basic
=== PAUSE TestAccSMNV2Subscription_basic
=== CONT  TestAccSMNV2Subscription_basic
--- PASS: TestAccSMNV2Subscription_basic (127.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       127.926s