### PR TITLE
[Feature Request] support tags of kms key resource and data source

### DIFF
--- a/docs/data-sources/kms_key.md
+++ b/docs/data-sources/kms_key.md
@@ -53,3 +53,4 @@ In addition to all arguments above, the following attributes are exported:
 * `scheduled_deletion_date` - Scheduled deletion time (time stamp) of a key.
 * `expiration_time` - Expiration time.
 * `creation_date` - Creation time (time stamp) of a key.
+* `tags` - The key/value pairs to associate with the kms key.

--- a/docs/resources/kms_key.md
+++ b/docs/resources/kms_key.md
@@ -39,6 +39,7 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the kms key. Changing this creates a new key.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the kms key.
 
 ## Attributes Reference
 

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -30,6 +30,25 @@ func TestAccKmsKeyV1DataSourceBasic(t *testing.T) {
 	})
 }
 
+func TestAccKmsKeyDataSourceWithTags(t *testing.T) {
+	var datasourceName = "data.huaweicloud_kms_key.key_2"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckKms(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsKeyDataSourceWithTags(keyAlias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsKeyV1DataSourceID(datasourceName),
+					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(datasourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKmsKeyV1DataSource_WithEpsId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t); testAccPreCheckEpsID(t) },
@@ -74,6 +93,17 @@ data "huaweicloud_kms_key" "key_2" {
   key_state       = "2"
 }
 `, testAccKmsV1KeyBasic(keyAlias))
+}
+
+func testAccKmsKeyDataSourceWithTags(keyAlias string) string {
+	return fmt.Sprintf(`
+%s
+data "huaweicloud_kms_key" "key_2" {
+  key_alias = huaweicloud_kms_key.key_2.key_alias
+  key_id    = huaweicloud_kms_key.key_2.id
+  key_state = "2"
+}
+`, testAccKmsKeyWithTags(keyAlias))
 }
 
 var testAccKmsKeyV1DataSource_epsId = fmt.Sprintf(`

--- a/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
@@ -52,6 +52,29 @@ func TestAccKmsKeyV1Basic(t *testing.T) {
 	})
 }
 
+func TestAccKmsKeyWithTags(t *testing.T) {
+	var key keys.Key
+	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
+	var resourceName = "huaweicloud_kms_key.key_2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckKms(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKmsV1KeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsKeyWithTags(keyAlias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsV1KeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKmsKeyV1_WithEpsId(t *testing.T) {
 	var key keys.Key
 	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
@@ -182,6 +205,19 @@ resource "huaweicloud_kms_key" "key_2" {
   region       = "%s"
 }
 `, keyAlias, HW_REGION_NAME)
+}
+
+func testAccKmsKeyWithTags(keyAlias string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "key_2" {
+  key_alias    = "%s"
+  pending_days = "7"
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, keyAlias)
 }
 
 func testAccKmsV1Key_epsId(keyAlias string) string {


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- support `tags` in kms key resource and data source.
- add the above changes to the document of kms key resource and data source.
- update test example with tags.

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
- kms key data source
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyDataSourceWithTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyDataSourceWithTags -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyDataSourceWithTags
=== PAUSE TestAccKmsKeyDataSourceWithTags
=== CONT  TestAccKmsKeyDataSourceWithTags
--- PASS: TestAccKmsKeyDataSourceWithTags (52.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       52.171s
```
- kms key resource
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyWithTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyWithTags -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyWithTags
=== PAUSE TestAccKmsKeyWithTags
=== CONT  TestAccKmsKeyWithTags
--- PASS: TestAccKmsKeyWithTags (44.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       44.368s
```