### PR TITLE
fix param problems in smn

### DIFF
--- a/docs/resources/smn_subscription.md
+++ b/docs/resources/smn_subscription.md
@@ -50,19 +50,17 @@ The following arguments are supported:
 * `remark` - (Optional, String, ForceNew) Remark information. The remarks must be a UTF-8-coded
      character string containing 128 bytes.
 
-* `subscription_urn` - (Optional, String, ForceNew) Resource identifier of a subscription, which
-     is unique.
-
-* `owner` - (Optional, String, ForceNew) Project ID of the topic creator.
-
-* `status` - (Optional, Int, ForceNew) Subscription status.
-     0 indicates that the subscription is not confirmed.
-     1 indicates that the subscription is confirmed.
-     3 indicates that the subscription is canceled.
-
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
+
+* `subscription_urn` - Resource identifier of a subscription, which is unique.
+
+* `owner` - Project ID of the topic creator.
+
+* `status` - Subscription status.
+     0 indicates that the subscription is not confirmed.
+     1 indicates that the subscription is confirmed.
+     3 indicates that the subscription is canceled.

--- a/docs/resources/smn_topic.md
+++ b/docs/resources/smn_topic.md
@@ -27,17 +27,17 @@ The following arguments are supported:
 * `display_name` - (Optional, String) Topic display name, which is presented as the
     name of the email sender in an email message.
 
-* `topic_urn` - (Optional, String, ForceNew) Resource identifier of a topic, which is unique.
-
-* `push_policy` - (Optional, Int, ForceNew) Message pushing policy. 0 indicates that the message
-    sending fails and the message is cached in the queue. 1 indicates that the
-    failed message is discarded.
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
+
+* `topic_urn` - Resource identifier of a topic, which is unique.
+
+* `push_policy` - Message pushing policy. 0 indicates that the message
+    sending fails and the message is cached in the queue. 1 indicates that the
+    failed message is discarded.
 
 * `create_time` - Time when the topic was created.
 

--- a/huaweicloud/resource_huaweicloud_smn_subscription_v2.go
+++ b/huaweicloud/resource_huaweicloud_smn_subscription_v2.go
@@ -47,20 +47,14 @@ func resourceSubscription() *schema.Resource {
 			},
 			"subscription_urn": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"owner": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"status": {
 				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 		},

--- a/huaweicloud/resource_huaweicloud_smn_topic_v2.go
+++ b/huaweicloud/resource_huaweicloud_smn_topic_v2.go
@@ -36,26 +36,18 @@ func resourceTopic() *schema.Resource {
 			},
 			"topic_urn": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"push_policy": {
 				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"update_time": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"create_time": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
In smn topic:
`topic_urn`, `push_policy`, `update_time`, `create_time` should be attributes, not arguments.
In smn subscription:
`subscription_urn`, `owner`, `status` should be attributes, not arguments.