### PR TITLE
[Fix] Update struct of cce node from string to map

### DIFF
--- a/huaweicloud/data_source_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_v3.go
@@ -112,8 +112,44 @@ func DataSourceCCENodeV3() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"spec_extend_param": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"extend_param_charging_mode": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ecs_performance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"order_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_pods": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"preinstall": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"postinstall": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"eip_count": {
 				Type:     schema.TypeInt,
@@ -201,7 +237,20 @@ func dataSourceCceNodesV3Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("server_id", Node.Status.ServerID)
 	d.Set("public_ip", Node.Status.PublicIP)
 	d.Set("private_ip", Node.Status.PrivateIP)
-	d.Set("spec_extend_param", Node.Spec.ExtendParam)
+
+	var paramSet []map[string]interface{}
+	specExtendParam := map[string]interface{}{
+		"extend_param_charging_mode": Node.Spec.ExtendParam.ChargingMode,
+		"ecs_performance_type":       Node.Spec.ExtendParam.EcsPerformanceType,
+		"order_id":                   Node.Spec.ExtendParam.OrderID,
+		"product_id":                 Node.Spec.ExtendParam.ProductID,
+		"public_key":                 Node.Spec.ExtendParam.PublicKey,
+		"max_pods":                   Node.Spec.ExtendParam.MaxPods,
+		"preinstall":                 Node.Spec.ExtendParam.PreInstall,
+		"postinstall":                Node.Spec.ExtendParam.PostInstall,
+	}
+	paramSet = append(paramSet, specExtendParam)
+	d.Set("spec_extend_param", paramSet)
 	d.Set("eip_count", Node.Spec.PublicIP.Count)
 	d.Set("eip_ids", PublicIDs)
 


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- fixed `R004` Strandard Acceptance Test Check of terraform lint.
  - update struct of 'spec_extend_param' parameter.
  - saving map of spec_extend_param when fetching data.

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
- kms key data source
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCCENodeV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCCENodeV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== CONT  TestAccCCENodeV3DataSource_basic
--- PASS: TestAccCCENodeV3DataSource_basic (874.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       874.074s
```