### PR TITLE
[Style] Fix AT001 of terraform lint in huaweicloud provider

### DIFF
--- a/huaweicloud/resource_huaweicloud_iec_network_acl_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_network_acl_test.go
@@ -49,8 +49,9 @@ func TestAccIecNetworkACLResource_no_subnets(t *testing.T) {
 	var fwGroup firewalls.Firewall
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIecNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIecNetworkACL_no_subnets(rName),


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- add destroy check to iec network acl test.

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIecNetworkACLResource_no_subnets'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccIecNetworkACLResource_no_subnets -timeout 360m -parallel 4
=== RUN   TestAccIecNetworkACLResource_no_subnets
=== PAUSE TestAccIecNetworkACLResource_no_subnets
=== CONT  TestAccIecNetworkACLResource_no_subnets
--- PASS: TestAccIecNetworkACLResource_no_subnets (25.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       25.583s
```