### PR TITLE
[tflint][AT003] Add underscore to test function name

### DIFF
--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -12,14 +12,14 @@ import (
 var keyAlias = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
 var keyAlias_epsId = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
 
-func TestAccKmsKeyV1DataSourceBasic(t *testing.T) {
+func TestAccKmsKeyV1DataSource_Basic(t *testing.T) {
 	var datasourceName = "data.huaweicloud_kms_key.key_2"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyV1DataSourceBasic(keyAlias),
+				Config: testAccKmsKeyV1DataSource_Basic(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKmsKeyV1DataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
@@ -30,14 +30,14 @@ func TestAccKmsKeyV1DataSourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccKmsKeyDataSourceWithTags(t *testing.T) {
+func TestAccKmsKeyDataSource_WithTags(t *testing.T) {
 	var datasourceName = "data.huaweicloud_kms_key.key_2"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyDataSourceWithTags(keyAlias),
+				Config: testAccKmsKeyDataSource_WithTags(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKmsKeyV1DataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
@@ -83,19 +83,18 @@ func testAccCheckKmsKeyV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccKmsKeyV1DataSourceBasic(keyAlias string) string {
+func testAccKmsKeyV1DataSource_Basic(keyAlias string) string {
 	return fmt.Sprintf(`
 %s
 data "huaweicloud_kms_key" "key_2" {
   key_alias       = huaweicloud_kms_key.key_2.key_alias
   key_id          = huaweicloud_kms_key.key_2.id
-  key_description = "test description"
   key_state       = "2"
 }
-`, testAccKmsV1KeyBasic(keyAlias))
+`, testAccKmsV1Key_Basic(keyAlias))
 }
 
-func testAccKmsKeyDataSourceWithTags(keyAlias string) string {
+func testAccKmsKeyDataSource_WithTags(keyAlias string) string {
 	return fmt.Sprintf(`
 %s
 data "huaweicloud_kms_key" "key_2" {
@@ -103,7 +102,7 @@ data "huaweicloud_kms_key" "key_2" {
   key_id    = huaweicloud_kms_key.key_2.id
   key_state = "2"
 }
-`, testAccKmsKeyWithTags(keyAlias))
+`, testAccKmsKey_WithTags(keyAlias))
 }
 
 var testAccKmsKeyV1DataSource_epsId = fmt.Sprintf(`

--- a/huaweicloud/data_source_huaweicloud_vpcep_public_services_test.go
+++ b/huaweicloud/data_source_huaweicloud_vpcep_public_services_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccVPCEPPublicServicesDataSourceBasic(t *testing.T) {
+func TestAccVPCEPPublicServicesDataSource_Basic(t *testing.T) {
 	resourceName := "data.huaweicloud_vpcep_public_services.services"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccKmsKeyV1Basic(t *testing.T) {
+func TestAccKmsKeyV1_Basic(t *testing.T) {
 	var key keys.Key
 	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
 	var keyAliasUpdate = fmt.Sprintf("kms_updated_%s", acctest.RandString(5))
@@ -23,7 +23,7 @@ func TestAccKmsKeyV1Basic(t *testing.T) {
 		CheckDestroy: testAccCheckKmsV1KeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsV1KeyBasic(keyAlias),
+				Config: testAccKmsV1Key_Basic(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKmsV1KeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "key_alias", keyAlias),
@@ -52,7 +52,7 @@ func TestAccKmsKeyV1Basic(t *testing.T) {
 	})
 }
 
-func TestAccKmsKeyWithTags(t *testing.T) {
+func TestAccKmsKey_WithTags(t *testing.T) {
 	var key keys.Key
 	var keyAlias = fmt.Sprintf("kms_%s", acctest.RandString(5))
 	var resourceName = "huaweicloud_kms_key.key_2"
@@ -63,7 +63,7 @@ func TestAccKmsKeyWithTags(t *testing.T) {
 		CheckDestroy: testAccCheckKmsV1KeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyWithTags(keyAlias),
+				Config: testAccKmsKey_WithTags(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKmsV1KeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "key_alias", keyAlias),
@@ -197,7 +197,7 @@ func testAccCheckKmsKeyIsEnabled(key *keys.Key, isEnabled bool) resource.TestChe
 	}
 }
 
-func testAccKmsV1KeyBasic(keyAlias string) string {
+func testAccKmsV1Key_Basic(keyAlias string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_kms_key" "key_2" {
   key_alias    = "%s"
@@ -207,7 +207,7 @@ resource "huaweicloud_kms_key" "key_2" {
 `, keyAlias, HW_REGION_NAME)
 }
 
-func testAccKmsKeyWithTags(keyAlias string) string {
+func testAccKmsKey_WithTags(keyAlias string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_kms_key" "key_2" {
   key_alias    = "%s"

--- a/huaweicloud/resource_huaweicloud_vpcep_approval_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_approval_test.go
@@ -23,7 +23,7 @@ func TestAccVPCEndpointApproval(t *testing.T) {
 		CheckDestroy: testAccCheckVPCEPServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointApprovalBasic(rName),
+				Config: testAccVPCEndpointApproval_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEPServiceExists("huaweicloud_vpcep_service.test", &service),
 					testAccCheckVPCEndpointExists("huaweicloud_vpcep_endpoint.test", &endpoint),
@@ -33,7 +33,7 @@ func TestAccVPCEndpointApproval(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCEndpointApprovalUpdate(rName),
+				Config: testAccVPCEndpointApproval_Update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPtr(resourceName, "connections.0.endpoint_id", &endpoint.ID),
 					resource.TestCheckResourceAttr(resourceName, "connections.0.status", "rejected"),
@@ -43,7 +43,7 @@ func TestAccVPCEndpointApproval(t *testing.T) {
 	})
 }
 
-func testAccVPCEndpointApprovalBasic(rName string) string {
+func testAccVPCEndpointApproval_Basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -81,10 +81,10 @@ resource "huaweicloud_vpcep_approval" "approval" {
   service_id = huaweicloud_vpcep_service.test.id
   endpoints  = [huaweicloud_vpcep_endpoint.test.id]
 }
-`, testAccVPCEndpointPrecondition(rName), rName)
+`, testAccVPCEndpoint_Precondition(rName), rName)
 }
 
-func testAccVPCEndpointApprovalUpdate(rName string) string {
+func testAccVPCEndpointApproval_Update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -122,5 +122,5 @@ resource "huaweicloud_vpcep_approval" "approval" {
   service_id = huaweicloud_vpcep_service.test.id
   endpoints  = []
 }
-`, testAccVPCEndpointPrecondition(rName), rName)
+`, testAccVPCEndpoint_Precondition(rName), rName)
 }

--- a/huaweicloud/resource_huaweicloud_vpcep_approval_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_approval_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
 )
 
-func TestAccVPCEndpointApproval(t *testing.T) {
+func TestAccVPCEndpointApproval_Basic(t *testing.T) {
 	var service services.Service
 	var endpoint endpoints.Endpoint
 

--- a/huaweicloud/resource_huaweicloud_vpcep_endpoint_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_endpoint_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints"
 )
 
-func TestAccVPCEndpointBasic(t *testing.T) {
+func TestAccVPCEndpoint_Basic(t *testing.T) {
 	var endpoint endpoints.Endpoint
 
 	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
@@ -22,7 +22,7 @@ func TestAccVPCEndpointBasic(t *testing.T) {
 		CheckDestroy: testAccCheckVPCEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointBasic(rName),
+				Config: testAccVPCEndpoint_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEndpointExists(resourceName, &endpoint),
 					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
@@ -34,7 +34,7 @@ func TestAccVPCEndpointBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCEndpointUpdate(rName),
+				Config: testAccVPCEndpoint_Update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc-update"),
@@ -50,7 +50,7 @@ func TestAccVPCEndpointBasic(t *testing.T) {
 	})
 }
 
-func TestAccVPCEndpointPublic(t *testing.T) {
+func TestAccVPCEndpoint_Public(t *testing.T) {
 	var endpoint endpoints.Endpoint
 	resourceName := "huaweicloud_vpcep_endpoint.myendpoint"
 
@@ -130,7 +130,7 @@ func testAccCheckVPCEndpointExists(n string, endpoint *endpoints.Endpoint) resou
 	}
 }
 
-func testAccVPCEndpointPrecondition(rName string) string {
+func testAccVPCEndpoint_Precondition(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -152,7 +152,7 @@ resource "huaweicloud_compute_instance" "ecs" {
 `, testAccCompute_data, rName)
 }
 
-func testAccVPCEndpointBasic(rName string) string {
+func testAccVPCEndpoint_Basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -182,10 +182,10 @@ resource "huaweicloud_vpcep_endpoint" "test" {
     owner = "tf-acc"
   }
 }
-`, testAccVPCEndpointPrecondition(rName), rName)
+`, testAccVPCEndpoint_Precondition(rName), rName)
 }
 
-func testAccVPCEndpointUpdate(rName string) string {
+func testAccVPCEndpoint_Update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -216,7 +216,7 @@ resource "huaweicloud_vpcep_endpoint" "test" {
     foo   = "bar"
   }
 }
-`, testAccVPCEndpointPrecondition(rName), rName)
+`, testAccVPCEndpoint_Precondition(rName), rName)
 }
 
 var testAccVPCEndpointPublic string = `

--- a/huaweicloud/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
 )
 
-func TestAccVPCEPServiceBasic(t *testing.T) {
+func TestAccVPCEPService_Basic(t *testing.T) {
 	var service services.Service
 
 	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
@@ -23,7 +23,7 @@ func TestAccVPCEPServiceBasic(t *testing.T) {
 		CheckDestroy: testAccCheckVPCEPServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEPServiceBasic(rName),
+				Config: testAccVPCEPService_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEPServiceExists(resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -38,7 +38,7 @@ func TestAccVPCEPServiceBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCEPServiceUpdate(rName),
+				Config: testAccVPCEPService_Update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "tf-"+rName),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
@@ -58,7 +58,7 @@ func TestAccVPCEPServiceBasic(t *testing.T) {
 	})
 }
 
-func TestAccVPCEPServicePermission(t *testing.T) {
+func TestAccVPCEPService_Permission(t *testing.T) {
 	var service services.Service
 
 	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
@@ -70,7 +70,7 @@ func TestAccVPCEPServicePermission(t *testing.T) {
 		CheckDestroy: testAccCheckVPCEPServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEPServicePermission(rName),
+				Config: testAccVPCEPService_Permission(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCEPServiceExists(resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -79,7 +79,7 @@ func TestAccVPCEPServicePermission(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVPCEPServicePermissionUpdate(rName),
+				Config: testAccVPCEPService_PermissionUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
@@ -143,7 +143,7 @@ func testAccCheckVPCEPServiceExists(n string, service *services.Service) resourc
 	}
 }
 
-func testAccVPCEPServicePrecondition(rName string) string {
+func testAccVPCEPService_Precondition(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -165,7 +165,7 @@ resource "huaweicloud_compute_instance" "ecs" {
 `, testAccCompute_data, rName)
 }
 
-func testAccVPCEPServiceBasic(rName string) string {
+func testAccVPCEPService_Basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -184,10 +184,10 @@ resource "huaweicloud_vpcep_service" "test" {
     owner = "tf-acc"
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName)
+`, testAccVPCEPService_Precondition(rName), rName)
 }
 
-func testAccVPCEPServiceUpdate(rName string) string {
+func testAccVPCEPService_Update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -206,10 +206,10 @@ resource "huaweicloud_vpcep_service" "test" {
     owner = "tf-acc-update"
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName)
+`, testAccVPCEPService_Precondition(rName), rName)
 }
 
-func testAccVPCEPServicePermission(rName string) string {
+func testAccVPCEPService_Permission(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -226,10 +226,10 @@ resource "huaweicloud_vpcep_service" "test" {
     terminal_port = 80
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName)
+`, testAccVPCEPService_Precondition(rName), rName)
 }
 
-func testAccVPCEPServicePermissionUpdate(rName string) string {
+func testAccVPCEPService_PermissionUpdate(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -246,5 +246,5 @@ resource "huaweicloud_vpcep_service" "test" {
     terminal_port = 80
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName)
+`, testAccVPCEPService_Precondition(rName), rName)
 }


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- add underscore to kms key test.
- add underscore to vpcep approval test.
- add underscore to vpcep endpoint test.
- add underscore to vpcep service test.

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
- (datasource) kms key basic test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyV1DataSource_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyV1DataSource_Basic -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyV1DataSource_Basic
=== PAUSE TestAccKmsKeyV1DataSource_Basic
=== CONT  TestAccKmsKeyV1DataSource_Basic
--- PASS: TestAccKmsKeyV1DataSource_Basic (26.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       26.136s
```
- (datasource) kms key tags test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKeyDataSource_WithTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKeyDataSource_WithTags -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyDataSource_WithTags
=== PAUSE TestAccKmsKeyDataSource_WithTags
=== CONT  TestAccKmsKeyDataSource_WithTags
--- PASS: TestAccKmsKeyDataSource_WithTags (27.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       27.236s
```
- (datasource) vpcep public services basic test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEPPublicServicesDataSource_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEPPublicServicesDataSource_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPPublicServicesDataSource_Basic
=== PAUSE TestAccVPCEPPublicServicesDataSource_Basic
=== CONT  TestAccVPCEPPublicServicesDataSource_Basic
--- PASS: TestAccVPCEPPublicServicesDataSource_Basic (13.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       13.143s
```
- (resource) vpc approval test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEndpointApproval'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEndpointApproval -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpointApproval
=== PAUSE TestAccVPCEndpointApproval
=== CONT  TestAccVPCEndpointApproval
--- PASS: TestAccVPCEndpointApproval (229.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       229.600s
```
- (resource) vpc endpoint basic test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEndpoint_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEndpoint_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Basic
=== PAUSE TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Basic
--- PASS: TestAccVPCEndpoint_Basic (209.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       209.061s
```
- (resource) vpc endpoint public test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEndpoint_Public'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEndpoint_Public -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Public
=== PAUSE TestAccVPCEndpoint_Public
=== CONT  TestAccVPCEndpoint_Public
--- PASS: TestAccVPCEndpoint_Public (31.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       31.519s
```
- (resource) vpcep service basic test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEPService_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEPService_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (210.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       210.568s
```
- (resource) vpcep service permission test:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEPService_Permission'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEPService_Permission -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Permission
=== PAUSE TestAccVPCEPService_Permission
=== CONT  TestAccVPCEPService_Permission
--- PASS: TestAccVPCEPService_Permission (198.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       198.823s
```
