### PR TITLE
[tflint][R001] Ignore R001 check which these code were auto created

### DIFF
--- a/huaweicloud/build_param_util.go
+++ b/huaweicloud/build_param_util.go
@@ -188,13 +188,13 @@ func (e *exchangeParam) BuildResourceData(resp interface{}, d *schema.ResourceDa
 
 		switch v.Kind() {
 		default:
-			err := d.Set(optn, optv)
+			err := d.Set(optn, optv) //lintignore:R001
 			if err != nil {
 				return err
 			}
 		case reflect.Struct:
 			//The corresponding schema of Struct is TypeList in Terrafrom
-			err := d.Set(optn, []interface{}{optv})
+			err := d.Set(optn, []interface{}{optv}) //lintignore:R001
 			if err != nil {
 				return err
 			}

--- a/huaweicloud/resource_huaweicloud_cs_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_cluster_v1.go
@@ -604,6 +604,7 @@ func flattenCsClusterV1UsedSpuNum(d interface{}, arrayIndex map[string]int) (int
 
 func setCsClusterV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
+		//lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("Error setting CsClusterV1:%s, err: %s", k, err)
 		}

--- a/huaweicloud/resource_huaweicloud_cs_peering_connect_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_peering_connect_v1.go
@@ -424,6 +424,7 @@ func flattenCsPeeringConnectV1TargetVpcInfo(d interface{}, arrayIndex map[string
 
 func setCsPeeringConnectV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
+		//lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("Error setting CsPeeringConnectV1:%s, err: %s", k, err)
 		}

--- a/huaweicloud/resource_huaweicloud_cs_route_v1.go
+++ b/huaweicloud/resource_huaweicloud_cs_route_v1.go
@@ -248,6 +248,7 @@ func flattenCsRouteV1Options(response map[string]interface{}) (map[string]interf
 
 func setCsRouteV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
+		//lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("Error setting CsRouteV1:%s, err: %s", k, err)
 		}

--- a/huaweicloud/resource_huaweicloud_dli_queue_v1.go
+++ b/huaweicloud/resource_huaweicloud_dli_queue_v1.go
@@ -367,6 +367,7 @@ func flattenDliQueueV1CreateTime(d interface{}, arrayIndex map[string]int) (inte
 
 func setDliQueueV1States(d *schema.ResourceData, opts map[string]interface{}) error {
 	for k, v := range opts {
+		//lintignore:R001
 		if err := d.Set(k, v); err != nil {
 			return fmt.Errorf("Error setting DliQueueV1:%s, err: %s", k, err)
 		}

--- a/huaweicloud/resource_huaweicloud_network_acl.go
+++ b/huaweicloud/resource_huaweicloud_network_acl.go
@@ -483,6 +483,7 @@ func updateNetworkACLPolicyRules(d *schema.ResourceData, client *golangsdk.Servi
 			return fmt.Errorf("Error creating firewall policy: %s", err)
 		}
 
+		//lintignore:R001
 		d.Set(policyKey, policy.ID)
 	}
 


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- fix R001 of terraform lint in 'build_param_util.go'.
- fix R001 of terraform lint in 'cs_cluster.go'.
- fix R001 of terraform lint in 'cs_peering_connect.go'.
- fix R001 of terraform lint in 'cs_route.go'.
- fix R001 of terraform lint in 'dli_queue.go'.
- fix R001 of terraform lint in 'network_acl.go'.