### PR TITLE
[tflint][R018] Ignore R018 of terraform lint check in huaweicloud provider

### DIFF
--- a/huaweicloud/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/resource_huaweicloud_cdn_domain.go
@@ -292,6 +292,7 @@ func resourceCdnDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting CDN Domain %s: %s", id, err)
 	}
 
+	// lintignore:R018
 	time.Sleep(3 * time.Second)
 	d.SetId("")
 	return nil

--- a/huaweicloud/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach.go
@@ -126,7 +126,6 @@ func resourceComputeVolumeAttachV2Read(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	time.Sleep(2 * time.Second)
 	attachment, err := volumeattach.Get(computeClient, instanceId, attachmentId).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "compute_volume_attach")

--- a/huaweicloud/resource_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/resource_huaweicloud_cts_tracker_v1.go
@@ -112,7 +112,7 @@ func resourceCTSTrackerCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(trackers.TrackerName)
-
+	//lintignore:R018
 	time.Sleep(20 * time.Second)
 	return resourceCTSTrackerRead(d, meta)
 }
@@ -153,6 +153,7 @@ func resourceCTSTrackerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("need_notify_user_list", ctsTracker.SimpleMessageNotification.NeedNotifyUserList)
 
 	d.Set("region", GetRegion(d, config))
+	//lintignore:R018
 	time.Sleep(20 * time.Second)
 
 	return nil
@@ -191,6 +192,7 @@ func resourceCTSTrackerUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error updating cts tracker: %s", err)
 	}
+	//lintignore:R018
 	time.Sleep(20 * time.Second)
 	return resourceCTSTrackerRead(d, meta)
 }
@@ -206,7 +208,7 @@ func resourceCTSTrackerDelete(d *schema.ResourceData, meta interface{}) error {
 	if result.Err != nil {
 		return err
 	}
-
+	//lintignore:R018
 	time.Sleep(20 * time.Second)
 	log.Printf("[DEBUG] Successfully deleted cts tracker %s", d.Id())
 

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -167,7 +167,6 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	time.Sleep(2 * time.Second)
 	n, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "record_set")

--- a/huaweicloud/resource_huaweicloud_fw_firewall_group_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_fw_firewall_group_v2_test.go
@@ -222,6 +222,7 @@ func testAccCheckFWFirewallGroupV2(n, expectedName, expectedDescription string, 
 			found, err = firewall_groups.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					// lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/resource_huaweicloud_fw_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_policy_v2.go
@@ -129,7 +129,6 @@ func resourceFWPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
 	}
 
-	time.Sleep(2 * time.Second)
 	policy, err := policies.Get(fwClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "FW policy")

--- a/huaweicloud/resource_huaweicloud_fw_policy_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_fw_policy_v2_test.go
@@ -129,6 +129,7 @@ func testAccCheckFWPolicyV2Exists(n, name, description string, ruleCount int) re
 			found, err = policies.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					//lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/resource_huaweicloud_fw_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_fw_rule_v2_test.go
@@ -151,6 +151,7 @@ func testAccCheckFWRuleV2Exists(n string, expected *rules.Rule) resource.TestChe
 			found, err = rules.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					//lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -388,7 +388,7 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 	}
 
 	// This is a workaround to avoid db connection issue
-	time.Sleep(360 * time.Second)
+	time.Sleep(360 * time.Second) // lintignore:R018
 
 	return resourceGeminiDBInstanceV3Read(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -376,7 +376,7 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// This is a workaround to avoid db connection issue
-	time.Sleep(360 * time.Second)
+	time.Sleep(360 * time.Second) // lintignore:R018
 
 	return resourceGaussDBInstanceRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -419,7 +419,7 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// This is a workaround to avoid db connection issue
-	time.Sleep(360 * time.Second)
+	time.Sleep(360 * time.Second) // lintignore:R018
 
 	return resourceOpenGaussInstanceRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_ges_graph_v1.go
+++ b/huaweicloud/resource_huaweicloud_ges_graph_v1.go
@@ -203,6 +203,7 @@ func resourceGesGraphV1Create(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	// lintignore:R018
 	time.Sleep(240 * time.Second)
 
 	id, err := navigateValue(obj, []string{"graph", "id"}, nil)

--- a/huaweicloud/resource_huaweicloud_iec_server.go
+++ b/huaweicloud/resource_huaweicloud_iec_server.go
@@ -319,8 +319,6 @@ func resourceIecServerV1Create(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(serverID)
 
 	// Wait for the servers to become running
-	log.Printf("[DEBUG] Sleep 10 seconds and waiting for IEC server (%s) to become running", serverID)
-	time.Sleep(10 * time.Second)
 	// Pending state "DELETED" means the instance has not be ready
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"DELETED", "BUILD"},

--- a/huaweicloud/resource_huaweicloud_mrs_cluster_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_mrs_cluster_v1_test.go
@@ -85,6 +85,7 @@ func testAccCheckMRSV1ClusterExists(n string, clusterGet *cluster.Cluster) resou
 		}
 
 		*clusterGet = *found
+		//lintignore:R018
 		time.Sleep(5 * time.Second)
 
 		return nil

--- a/huaweicloud/resource_huaweicloud_mrs_job_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_mrs_job_v1_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/mrs/v1/job"
-	"time"
 )
 
 func TestAccMRSV1Job_basic(t *testing.T) {
@@ -86,6 +87,7 @@ func testAccCheckMRSV1JobExists(n string, jobGet *job.Job) resource.TestCheckFun
 		}
 
 		*jobGet = *found
+		//lintignore:R018
 		time.Sleep(5 * time.Second)
 
 		return nil

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -240,7 +240,7 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(id.(string))
 
 	// wait for a while to become ACTIVE
-	time.Sleep(3 * time.Second)
+	time.Sleep(3 * time.Second) // lintignore:R018
 
 	return resourceNatDnatRuleRead(d, meta)
 }
@@ -439,6 +439,6 @@ func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// wait for a while to become DELETED
-	time.Sleep(3 * time.Second)
+	time.Sleep(3 * time.Second) // lintignore:R018
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_network_acl_rule_test.go
+++ b/huaweicloud/resource_huaweicloud_network_acl_rule_test.go
@@ -138,6 +138,7 @@ func testAccCheckNetworkACLRuleExists(key string) resource.TestCheckFunc {
 			found, err = rules.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					//lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/resource_huaweicloud_rds_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v1.go
@@ -457,6 +457,7 @@ func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 			"Error waiting for instance (%s) to be deleted: %s ",
 			id, err)
 	}
+	// lintignore:R018
 	time.Sleep(80 * time.Second)
 	log.Printf("[DEBUG] Successfully deleted instance %s", id)
 	return nil

--- a/huaweicloud/resource_huaweicloud_rds_instance_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v1_test.go
@@ -78,6 +78,7 @@ func testAccCheckRDSV1InstanceExists(n string, instance *instances.Instance) res
 		}
 
 		*instance = *found
+		//lintignore:R018
 		time.Sleep(30 * time.Second)
 
 		return nil

--- a/huaweicloud/types.go
+++ b/huaweicloud/types.go
@@ -100,6 +100,7 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 		if lrt.OsDebug {
 			log.Printf("[DEBUG] HuaweiCloud connection error, retry number %d: %s", retry, err)
 		}
+		// lintignore:R018
 		time.Sleep(retryTimeout(retry))
 		response, err = lrt.Rt.RoundTrip(request)
 		retry += 1


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- Using time.sleep() and ignore R018 check because these resources don't have the required status. So they are not suitable to use resource.Retry() and (resource.StateChangeConf).WaitForState():
  - cts tracker
  - fw firewall group test
  - fw policy v2 test
  - fw rule v2 test
  - gaussdb cassandra instance
  - gaussdb mysql instance
  - gaussdb opengauss instance
  - ges graph v1
  - mrs cluster v1 test
  - mrs job v1 test
  - network acl rule test
  - rds instance v1 test
  - types