### PR TITLE
add data_source_huaweicloud_gaussdb_mysql_instances

### DIFF
--- a/docs/data-sources/gaussdb_mysql_instances.md
+++ b/docs/data-sources/gaussdb_mysql_instances.md
@@ -1,0 +1,98 @@
+---
+subcategory: "GaussDB"
+---
+
+# huaweicloud\_gaussdb\_mysql\_instances
+
+Use this data source to list all available HuaweiCloud gaussdb mysql instances.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_gaussdb_mysql_instances" "this" {
+  name = "gaussdb-instance"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the instances. If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the instance.
+
+* `vpc_id` -  (Optional, String) Specifies the VPC ID.
+
+* `subnet_id` - (Optional, String) Specifies the network ID of a subnet.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a data source ID in UUID format.
+
+* `instances` - An array of available instances.
+
+The `instances` block supports:
+
+* `region` - The region of the instance.
+
+* `name` - Indicates the name of the instance.
+
+* `vpc_id` - Indicates the VPC ID.
+
+* `subnet_id` - Indicates the network ID of a subnet.
+
+* `id` - Indicates the ID of the instance.
+
+* `flavor` - Indicates the instance specifications.
+
+* `security_group_id` - Indicates the security group ID.
+
+* `configuration_id` - Indicates the configuration ID.
+
+* `enterprise_project_id` - Indicates the enterprise project id.
+
+* `read_replicas` - Indicates the count of read replicas.
+
+* `time_zone` - Indicates the time zone.
+
+* `availability_zone_mode` - Indicates the availability zone mode: "single" or "multi".
+
+* `master_availability_zone` - Indicates the availability zone where the master node resides.
+
+* `datastore` - Indicates the database information. Structure is documented below.
+
+* `backup_strategy` - Indicates the advanced backup policy. Structure is documented below.
+
+* `status` - Indicates the DB instance status.
+
+* `port` - Indicates the database port.
+
+* `mode` - Indicates the instance mode.
+
+* `db_user_name` - Indicates the default username.
+
+* `private_write_ip` - Indicates the private IP address of the DB instance.
+
+* `nodes` - Indicates the instance nodes information. Structure is documented below.
+
+
+The `datastore` block supports:
+
+* `engine` - Indicates the database engine.
+* `version` - Indicates the database version.
+
+The `backup_strategy` block supports:
+
+* `start_time` - Indicates the backup time window.
+* `keep_days` - Indicates the number of days to retain the generated
+
+The `nodes` block contains:
+
+- `id` - Indicates the node ID.
+- `name` - Indicates the node name.
+- `type` - Indicates the node type: master or slave.
+- `status` - Indicates the node status.
+- `private_read_ip` - Indicates the private IP address of a node.
+- `availability_zone` - Indicates the availability zone where the node resides.

--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_instances.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_instances.go
@@ -1,0 +1,316 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances"
+)
+
+func dataSourceGaussDBMysqlInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGaussDBMysqlInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"configuration_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"db_user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"time_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"master_availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"private_write_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"datastore": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"engine": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"backup_strategy": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"start_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"keep_days": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"read_replicas": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"flavor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nodes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"private_read_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"availability_zone": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGaussDBMysqlInstancesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	client, err := config.gaussdbV3Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
+	}
+
+	listOpts := instances.ListTaurusDBInstanceOpts{
+		Name:     d.Get("name").(string),
+		VpcId:    d.Get("vpc_id").(string),
+		SubnetId: d.Get("subnet_id").(string),
+	}
+
+	pages, err := instances.List(client, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allInstances, err := instances.ExtractTaurusDBInstances(pages)
+
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve instances: %s", err)
+	}
+
+	if allInstances.TotalCount < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	var instancesToSet []map[string]interface{}
+	var instancesIds []string
+
+	for _, instanceInAll := range allInstances.Instances {
+		instanceToSet := map[string]interface{}{
+			"id":                    instanceInAll.Id,
+			"region":                region,
+			"name":                  instanceInAll.Name,
+			"status":                instanceInAll.Status,
+			"mode":                  instanceInAll.Type,
+			"vpc_id":                instanceInAll.VpcId,
+			"subnet_id":             instanceInAll.SubnetId,
+			"security_group_id":     instanceInAll.SecurityGroupId,
+			"enterprise_project_id": instanceInAll.EnterpriseProjectId,
+			"db_user_name":          instanceInAll.DbUserName,
+			"time_zone":             instanceInAll.TimeZone,
+		}
+
+		if dbPort, err := strconv.Atoi(instanceInAll.Port); err == nil {
+			instanceToSet["port"] = dbPort
+		}
+
+		// set data store
+		dbList := make([]map[string]interface{}, 1)
+		db := map[string]interface{}{
+			"version": instanceInAll.DataStore.Version,
+		}
+		// normalize engine
+		engine := instanceInAll.DataStore.Type
+		if engine == "GaussDB(for MySQL)" {
+			engine = "gaussdb-mysql"
+		}
+		db["engine"] = engine
+		dbList[0] = db
+		instanceToSet["datastore"] = dbList
+
+		// set backup_strategy
+		backupStrategyList := make([]map[string]interface{}, 1)
+		backupStrategy := map[string]interface{}{
+			"start_time": instanceInAll.BackupStrategy.StartTime,
+		}
+		if days, err := strconv.Atoi(instanceInAll.BackupStrategy.KeepDays); err == nil {
+			backupStrategy["keep_days"] = days
+		}
+		backupStrategyList[0] = backupStrategy
+		instanceToSet["backup_strategy"] = backupStrategyList
+
+		// set nodes, configuration_id, availability_zone_mode, master_availability_zone, private_write_ip
+		instanceID := instanceInAll.Id
+		instancesIds = append(instancesIds, instanceID)
+
+		instance, err := instances.Get(client, instanceID).Extract()
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Retrieved Instance %s: %+v", instance.Id, instance)
+
+		instanceToSet["configuration_id"] = instance.ConfigurationId
+		instanceToSet["availability_zone_mode"] = instance.AZMode
+		instanceToSet["master_availability_zone"] = instance.MasterAZ
+
+		if len(instance.PrivateIps) > 0 {
+			instanceToSet["private_write_ip"] = instance.PrivateIps[0]
+		}
+
+		flavor := ""
+		slave_count := 0
+		nodesList := make([]map[string]interface{}, 0, 1)
+		for _, raw := range instance.Nodes {
+			node := map[string]interface{}{
+				"id":                raw.Id,
+				"name":              raw.Name,
+				"status":            raw.Status,
+				"type":              raw.Type,
+				"availability_zone": raw.AvailabilityZone,
+			}
+			if len(raw.PrivateIps) > 0 {
+				node["private_read_ip"] = raw.PrivateIps[0]
+			}
+			nodesList = append(nodesList, node)
+			if raw.Type == "slave" && raw.Status == "ACTIVE" {
+				slave_count += 1
+			}
+			if flavor == "" {
+				flavor = raw.Flavor
+			}
+		}
+
+		instanceToSet["nodes"] = nodesList
+		instanceToSet["read_replicas"] = slave_count
+		if flavor != "" {
+			log.Printf("[DEBUG] Node Flavor: %s", flavor)
+			instanceToSet["flavor"] = flavor
+		}
+
+		instancesToSet = append(instancesToSet, instanceToSet)
+	}
+
+	d.SetId(hashcode.Strings(instancesIds))
+	d.Set("instances", instancesToSet)
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_instances_test.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_instances_test.go
@@ -1,0 +1,69 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccGaussdbMysqlInstancesDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussdbMysqlInstancesDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGaussdbMysqlInstancesDataSourceID("data.huaweicloud_gaussdb_mysql_instances.test"),
+					resource.TestCheckResourceAttr("data.huaweicloud_gaussdb_mysql_instances.test", "instances.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGaussdbMysqlInstancesDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find GaussDB mysql instance data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("GaussDB mysql instances data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccGaussdbMysqlInstancesDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
+resource "huaweicloud_gaussdb_mysql_instance" "test" {
+  name                  = "%s"
+  password              = "Test@123"
+  flavor                = "gaussdb.mysql.2xlarge.x86.4"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = data.huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+}
+
+data "huaweicloud_gaussdb_mysql_instances" "test" {
+  name = huaweicloud_gaussdb_mysql_instance.test.name
+}
+`, testAccVpcConfig_Base(rName), rName)
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -269,6 +269,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_gaussdb_mysql_configuration": dataSourceGaussdbMysqlConfigurations(),
 			"huaweicloud_gaussdb_mysql_flavors":       dataSourceGaussdbMysqlFlavors(),
 			"huaweicloud_gaussdb_mysql_instance":      dataSourceGaussDBMysqlInstance(),
+			"huaweicloud_gaussdb_mysql_instances":     dataSourceGaussDBMysqlInstances(),
 			"huaweicloud_iam_role":                    dataSourceIAMRoleV3(),
 			"huaweicloud_identity_role":               DataSourceIdentityRoleV3(),
 			"huaweicloud_identity_custom_role":        DataSourceIdentityCustomRole(),


### PR DESCRIPTION
fixes #853 
Test result:
```bash
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccGaussdbMysqlInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccGaussdbMysqlInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussdbMysqlInstancesDataSource_basic
=== PAUSE TestAccGaussdbMysqlInstancesDataSource_basic
=== CONT  TestAccGaussdbMysqlInstancesDataSource_basic
--- PASS: TestAccGaussdbMysqlInstancesDataSource_basic (730.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       731.020s
```