### PR TITLE
[tflint][R018] Remove time sleep to fix terraform lint R018 check

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach.go
@@ -126,7 +126,6 @@ func resourceComputeVolumeAttachV2Read(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	time.Sleep(2 * time.Second)
 	attachment, err := volumeattach.Get(computeClient, instanceId, attachmentId).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "compute_volume_attach")

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -167,7 +167,6 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	time.Sleep(2 * time.Second)
 	n, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "record_set")

--- a/huaweicloud/resource_huaweicloud_fw_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_policy_v2.go
@@ -129,7 +129,6 @@ func resourceFWPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
 	}
 
-	time.Sleep(2 * time.Second)
 	policy, err := policies.Get(fwClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "FW policy")

--- a/huaweicloud/resource_huaweicloud_iec_server.go
+++ b/huaweicloud/resource_huaweicloud_iec_server.go
@@ -319,8 +319,6 @@ func resourceIecServerV1Create(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(serverID)
 
 	// Wait for the servers to become running
-	log.Printf("[DEBUG] Sleep 10 seconds and waiting for IEC server (%s) to become running", serverID)
-	time.Sleep(10 * time.Second)
 	// Pending state "DELETED" means the instance has not be ready
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"DELETED", "BUILD"},


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
-Remove time.sleep() because resource status is right when reading data from server, we don't need to wait time:
  - compute volume attach
  - dns recordset
  - fw policy
  - iec server