### PR TITLE
[tflint][R018] Fix R018 of terraform lint check in nat dnat

### DIFF
--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -485,7 +485,6 @@ func resourceDnatStateRefreshFunc(client *golangsdk.ServiceClient, url string, r
 			return nil, "", fmt.Errorf("Error getting dnat resource params")
 		}
 		res := map[string]interface{}{"read": v}
-		log.Printf("[Lance Log] read params map: %s", res)
 		statusProp, err := navigateNatDnatValue(res, []string{"read", "dnat_rules", "status"}, nil)
 		if err != nil {
 			return nil, "", fmt.Errorf("Error reading Dnat:status, err: %s", err)


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- Using '(resource.StateChangeConf).WaitForState()' to replace' time.sleep()' at Creating dnat check and Deleting dnat check:
- Function navigateValue has been overrided because of responses of creating and deleting were different.