### PR TITLE
change type of fixed_ips to list in iec vip resource

### DIFF
--- a/docs/resources/iec_vip.md
+++ b/docs/resources/iec_vip.md
@@ -21,8 +21,8 @@ resource "huaweicloud_iec_vip" "vip_test" {
 The following arguments are supported:
 
 * `subnet_id` - (Required, String, ForceNew) Specifies the subnet network id 
-    of vip binding in which to allocate IP address for this vip. Changing this 
-    parameter creates a new vip resource.
+    of vip binding in which to allocate IP address for this vip.
+    Changing this parameter creates a new vip resource.
 
 ## Attributes Reference
 
@@ -32,13 +32,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `mac_address` - The MAC address of the vip.
 
-* `fixed_ips` - An subnet Array of the vip binding. The fixed_ips object 
-    structure is documented below.
-
-The `fixed_ips` block supports:
-
-* `subnet_id` - The subnet id of the vip binding.
-* `ip_address` - The ip address of the subnet network.
+* `fixed_ips` - An array of IP addresses binding to the vip.
 
 ## Timeouts
 

--- a/huaweicloud/resource_huaweicloud_iec_vip.go
+++ b/huaweicloud/resource_huaweicloud_iec_vip.go
@@ -39,20 +39,9 @@ func resourceIecVipV1() *schema.Resource {
 				Computed: true,
 			},
 			"fixed_ips": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"subnet_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ip_address": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -107,14 +96,11 @@ func resourceIecVIPV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("subnet_id", n.NetworkID)
 	d.Set("mac_address", n.MacAddress)
 
-	ipsSet := make([]map[string]interface{}, len(n.FixedIPs))
-	for index, ipObj := range n.FixedIPs {
-		ipsSet[index] = map[string]interface{}{
-			"subnet_id":  ipObj.SubnetId,
-			"ip_address": ipObj.IpAddress,
-		}
+	allIPs := make([]string, len(n.FixedIPs))
+	for i, ipObj := range n.FixedIPs {
+		allIPs[i] = ipObj.IpAddress
 	}
-	d.Set("fixed_ips", ipsSet)
+	d.Set("fixed_ips", allIPs)
 
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_iec_vip_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_vip_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
@@ -14,6 +15,7 @@ import (
 
 func TestAccIecVipResource_basic(t *testing.T) {
 	var iecPort iec_common.Port
+	rName := fmt.Sprintf("iec-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_iec_vip.vip_test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,7 +24,7 @@ func TestAccIecVipResource_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIecVipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIecVip_basic(),
+				Config: testAccIecVip_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIecVipExists(resourceName, &iecPort),
 					resource.TestMatchResourceAttr(resourceName, "mac_address", regexp.MustCompile("^[0-9A-Fa-f]{2}\\:[0-9A-Fa-f]{2}\\:[0-9A-Fa-f]{2}\\:[0-9A-Fa-f]{2}\\:[0-9A-Fa-f]{2}\\:[0-9A-Fa-f]{2}$")),
@@ -91,18 +93,18 @@ func testAccCheckIecVipExists(n string, resource *iec_common.Port) resource.Test
 	}
 }
 
-func testAccIecVip_basic() string {
+func testAccIecVip_basic(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_iec_sites" "sites_test" {}
 
 resource "huaweicloud_iec_vpc" "vpc_test" {
-  name = "iec-vpc-demo"
+  name = "vpc-%s"
   cidr = "192.168.0.0/16"
   mode = "CUSTOMER"
 }
 
 resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
-  name = "iec-subnet-demo"
+  name = "subnet-%s"
   cidr = "192.168.0.0/16"
   gateway_ip = "192.168.0.1"
   vpc_id = huaweicloud_iec_vpc.vpc_test.id
@@ -112,5 +114,5 @@ resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
 resource "huaweicloud_iec_vip" "vip_test" {
   subnet_id = huaweicloud_iec_vpc_subnet.subnet_test.id
 }
-`)
+`, rName, rName)
 }


### PR DESCRIPTION
fixes #858 

the type of `fixed_ips` is Set which has no index to reference them, so we change the type to List.
Also, the **list(object)** is not necessary, so we update it to **list(string)**.
The testing result as follows:

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecVipResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecVipResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecVipResource_basic
=== PAUSE TestAccIecVipResource_basic
=== CONT  TestAccIecVipResource_basic
--- PASS: TestAccIecVipResource_basic (56.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       56.172s
```