### PR TITLE
continues executing after operateOnPort in iec eip

### DIFF
--- a/huaweicloud/resource_huaweicloud_iec_eip_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_eip_test.go
@@ -99,8 +99,6 @@ func testAccIecEIP_basic() string {
 	return fmt.Sprintf(`
 data "huaweicloud_iec_sites" "sites_test" {
   region = "%s"
-  area   = "east"
-  city   = "hangzhou"
 }
 
 resource "huaweicloud_iec_eip" "eip_test" {


### PR DESCRIPTION
fixes #857 

the testing result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecEIPResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecEIPResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecEIPResource_basic
=== PAUSE TestAccIecEIPResource_basic
=== CONT  TestAccIecEIPResource_basic
--- PASS: TestAccIecEIPResource_basic (33.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       33.227s
```