### PR TITLE
update sdk for iec flavors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517
+	github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517 h1:l/Aa5CisHTWEg5ZEvNPRlrfxkCDEgYQieJRqFlthkXw=
 github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7 h1:7CkjSplJmYll80TgMsjhYy7PMLNPjBMtnuEPhDf/NvU=
+github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/data_source_huaweicloud_iec_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_iec_flavors.go
@@ -87,6 +87,8 @@ func dataSourceIecFlavorsV1Read(d *schema.ResourceData, meta interface{}) error 
 		City:     d.Get("city").(string),
 		Operator: d.Get("operator").(string),
 	}
+
+	log.Printf("[DEBUG] fetching IEC flavors by filter: %#v", listOpts)
 	allFlavors, err := flavors.List(iecClient, listOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Unable to extract iec flavors: %s", err)

--- a/huaweicloud/data_source_huaweicloud_iec_flavors_test.go
+++ b/huaweicloud/data_source_huaweicloud_iec_flavors_test.go
@@ -28,6 +28,25 @@ func TestAccIECFlavorsDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccIECFlavorsDataSource_FilterName(t *testing.T) {
+	resourceName := "data.huaweicloud_iec_flavors.flavors_test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIECFlavorsWithName(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIECFlavorsDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "flavors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "region", HW_REGION_NAME),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIECFlavorsDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -46,6 +65,15 @@ func testAccIECFlavorsConfig() string {
 	return fmt.Sprintf(`
 data "huaweicloud_iec_flavors" "flavors_test" {
   region = "%s"
+}
+	`, HW_REGION_NAME)
+}
+
+func testAccIECFlavorsWithName() string {
+	return fmt.Sprintf(`
+data "huaweicloud_iec_flavors" "flavors_test" {
+  region = "%s"
+  name   = "c6.large.2"
 }
 	`, HW_REGION_NAME)
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/flavors/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/flavors/requests.go
@@ -14,10 +14,10 @@ type ListOptsBuilder interface {
 // ListOpts to list site
 type ListOpts struct {
 	//SiteIDS query by site ids
-	SiteIDS string `json:"site_ids"`
+	SiteIDS string `q:"site_ids"`
 
 	//Name query by name
-	Name string `json:"name"`
+	Name string `q:"name"`
 
 	//Limit query limit
 	Limit string `q:"limit"`
@@ -52,7 +52,8 @@ func List(client *golangsdk.ServiceClient, listOpts ListOptsBuilder) (r GetResul
 	if listOpts != nil {
 		query, err := listOpts.ToListQuery()
 		if err != nil {
-			//return pagination.Pager{Err: err}
+			r.Err = err
+			return
 		}
 		url += query
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517
+# github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
fixes #859 

the issue was caused by golangsdk, should update sdk. the testting result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIECFlavorsDataSource_FilterName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIECFlavorsDataSource_FilterName -timeout 360m -parallel 4
=== RUN   TestAccIECFlavorsDataSource_FilterName
=== PAUSE TestAccIECFlavorsDataSource_FilterName
=== CONT  TestAccIECFlavorsDataSource_FilterName
--- PASS: TestAccIECFlavorsDataSource_FilterName (12.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       12.906s
```