### PR TITLE
[tflint] Fix AT009 of terraform lint check

### DIFF
--- a/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1_test.go
@@ -151,7 +151,7 @@ func testAccCheckKmsV1KeyExists(n string, key *keys.Key) resource.TestCheckFunc 
 
 func TestAccKmsKey_isEnabled(t *testing.T) {
 	var key1, key2, key3 keys.Key
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := fmt.Sprintf("kms_%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckKms(t) },


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- Using RandString() to replace RandStringFromCharSet().

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccKmsKey_isEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccKmsKey_isEnabled -timeout 360m -parallel 4
=== RUN   TestAccKmsKey_isEnabled
=== PAUSE TestAccKmsKey_isEnabled
=== CONT  TestAccKmsKey_isEnabled
--- PASS: TestAccKmsKey_isEnabled (44.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       44.480s
```