### PR TITLE
cleanup after de46e4c6

### DIFF
--- a/huaweicloud/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/resource_huaweicloud_cdn_domain.go
@@ -292,7 +292,8 @@ func resourceCdnDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting CDN Domain %s: %s", id, err)
 	}
 
-	// lintignore:R018
+	// an API issue will be raised in ForceNew scene, so wait for a while
+	//lintignore:R018
 	time.Sleep(3 * time.Second)
 	d.SetId("")
 	return nil

--- a/huaweicloud/resource_huaweicloud_cts_tracker_v1.go
+++ b/huaweicloud/resource_huaweicloud_cts_tracker_v1.go
@@ -153,8 +153,6 @@ func resourceCTSTrackerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("need_notify_user_list", ctsTracker.SimpleMessageNotification.NeedNotifyUserList)
 
 	d.Set("region", GetRegion(d, config))
-	//lintignore:R018
-	time.Sleep(20 * time.Second)
 
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_fw_firewall_group_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_fw_firewall_group_v2_test.go
@@ -222,7 +222,7 @@ func testAccCheckFWFirewallGroupV2(n, expectedName, expectedDescription string, 
 			found, err = firewall_groups.Get(fwClient, rs.Primary.ID).Extract()
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					// lintignore:R018
+					//lintignore:R018
 					time.Sleep(time.Second)
 					continue
 				}

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -388,7 +388,8 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 	}
 
 	// This is a workaround to avoid db connection issue
-	time.Sleep(360 * time.Second) // lintignore:R018
+	//lintignore:R018
+	time.Sleep(360 * time.Second)
 
 	return resourceGeminiDBInstanceV3Read(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -376,7 +376,8 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// This is a workaround to avoid db connection issue
-	time.Sleep(360 * time.Second) // lintignore:R018
+	//lintignore:R018
+	time.Sleep(360 * time.Second)
 
 	return resourceGaussDBInstanceRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -419,7 +419,8 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// This is a workaround to avoid db connection issue
-	time.Sleep(360 * time.Second) // lintignore:R018
+	//lintignore:R018
+	time.Sleep(360 * time.Second)
 
 	return resourceOpenGaussInstanceRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_ges_graph_v1.go
+++ b/huaweicloud/resource_huaweicloud_ges_graph_v1.go
@@ -203,8 +203,6 @@ func resourceGesGraphV1Create(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	// lintignore:R018
-	time.Sleep(240 * time.Second)
 
 	id, err := navigateValue(obj, []string{"graph", "id"}, nil)
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_iec_server.go
+++ b/huaweicloud/resource_huaweicloud_iec_server.go
@@ -319,6 +319,8 @@ func resourceIecServerV1Create(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(serverID)
 
 	// Wait for the servers to become running
+	log.Printf("[DEBUG] waiting for IEC server (%s) to become running", serverID)
+
 	// Pending state "DELETED" means the instance has not be ready
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"DELETED", "BUILD"},

--- a/huaweicloud/resource_huaweicloud_mrs_cluster_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_mrs_cluster_v1_test.go
@@ -3,7 +3,6 @@ package huaweicloud
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -85,8 +84,6 @@ func testAccCheckMRSV1ClusterExists(n string, clusterGet *cluster.Cluster) resou
 		}
 
 		*clusterGet = *found
-		//lintignore:R018
-		time.Sleep(5 * time.Second)
 
 		return nil
 	}

--- a/huaweicloud/resource_huaweicloud_mrs_job_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_mrs_job_v1_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk"
@@ -87,8 +85,6 @@ func testAccCheckMRSV1JobExists(n string, jobGet *job.Job) resource.TestCheckFun
 		}
 
 		*jobGet = *found
-		//lintignore:R018
-		time.Sleep(5 * time.Second)
 
 		return nil
 	}

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -240,7 +240,8 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(id.(string))
 
 	// wait for a while to become ACTIVE
-	time.Sleep(3 * time.Second) // lintignore:R018
+	//lintignore:R018
+	time.Sleep(3 * time.Second)
 
 	return resourceNatDnatRuleRead(d, meta)
 }
@@ -439,6 +440,7 @@ func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// wait for a while to become DELETED
-	time.Sleep(3 * time.Second) // lintignore:R018
+	//lintignore:R018
+	time.Sleep(3 * time.Second)
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_network_acl_rule_test.go
+++ b/huaweicloud/resource_huaweicloud_network_acl_rule_test.go
@@ -3,7 +3,6 @@ package huaweicloud
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -131,24 +130,13 @@ func testAccCheckNetworkACLRuleExists(key string) resource.TestCheckFunc {
 			return fmt.Errorf("Error creating HuaweiCloud fw client: %s", err)
 		}
 
-		var found *rules.Rule
-		for i := 0; i < 5; i++ {
-			// Network ACL rule creation is asynchronous. Retry some times
-			// if we get a 404 error. Fail on any other error.
-			found, err = rules.Get(fwClient, rs.Primary.ID).Extract()
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					//lintignore:R018
-					time.Sleep(time.Second)
-					continue
-				}
-				return err
-			}
-			break
+		found, err := rules.Get(fwClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
 		}
 
-		if found == nil {
-			return fmt.Errorf("Network ACL rule (%s) is not found", rs.Primary.ID)
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Network ACL rule not found")
 		}
 
 		return nil

--- a/huaweicloud/resource_huaweicloud_rds_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v1.go
@@ -457,8 +457,7 @@ func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 			"Error waiting for instance (%s) to be deleted: %s ",
 			id, err)
 	}
-	// lintignore:R018
-	time.Sleep(80 * time.Second)
+
 	log.Printf("[DEBUG] Successfully deleted instance %s", id)
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_rds_instance_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v1_test.go
@@ -3,7 +3,6 @@ package huaweicloud
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -78,8 +77,6 @@ func testAccCheckRDSV1InstanceExists(n string, instance *instances.Instance) res
 		}
 
 		*instance = *found
-		//lintignore:R018
-		time.Sleep(30 * time.Second)
 
 		return nil
 	}

--- a/huaweicloud/types.go
+++ b/huaweicloud/types.go
@@ -100,7 +100,7 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 		if lrt.OsDebug {
 			log.Printf("[DEBUG] HuaweiCloud connection error, retry number %d: %s", retry, err)
 		}
-		// lintignore:R018
+		//lintignore:R018
 		time.Sleep(retryTimeout(retry))
 		response, err = lrt.Rt.RoundTrip(request)
 		retry += 1


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkACLRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkACLRule_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkACLRule_basic
=== PAUSE TestAccNetworkACLRule_basic
=== CONT  TestAccNetworkACLRule_basic
--- PASS: TestAccNetworkACLRule_basic (31.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       31.368s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccGesGraphV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccGesGraphV1_basic -timeout 360m -parallel 4
=== RUN   TestAccGesGraphV1_basic
=== PAUSE TestAccGesGraphV1_basic
=== CONT  TestAccGesGraphV1_basic
--- PASS: TestAccGesGraphV1_basic (997.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       997.678s
```