### PR TITLE
Update state setting of iec network acl

### DIFF
--- a/huaweicloud/resource_huaweicloud_iec_network_acl.go
+++ b/huaweicloud/resource_huaweicloud_iec_network_acl.go
@@ -135,6 +135,16 @@ func resourceIecNetworkACLRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", fwGroup.Description)
 	d.Set("inbound_rules", getFirewallRuleIDs(fwGroup.IngressFWPolicy))
 	d.Set("outbound_rules", getFirewallRuleIDs(fwGroup.EgressFWPolicy))
+	var networkSet []map[string]interface{}
+	for _, val := range fwGroup.Subnets {
+		subnet := make(map[string]interface{})
+		subnet["vpc_id"] = val.VpcID
+		subnet["subnet_id"] = val.ID
+		networkSet = append(networkSet, subnet)
+	}
+	if err = d.Set("networks", networkSet); err != nil {
+		return fmt.Errorf("Saving iec networks failed: %s", err)
+	}
 
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_iec_network_acl_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_network_acl_test.go
@@ -31,6 +31,11 @@ func TestAccIecNetworkACLResource_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceKey,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccIecNetworkACL_basic_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIecNetworkACLExists(resourceKey, &fwGroup),


### PR DESCRIPTION
### Community Node
This revison mainly solves the following problems:
- add networks satate setting when reading resource data from server.
- update test with import check

fixes #871

Release note for [CHANGELOG](https://github.com/huaweicloud/terraform-provider-huaweicloud/blob/master/CHANGELOG.md):
```
NONE
```

Output from acceptance testing:
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIecNetworkACLResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccIecNetworkACLResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecNetworkACLResource_basic
=== PAUSE TestAccIecNetworkACLResource_basic
=== CONT  TestAccIecNetworkACLResource_basic
--- PASS: TestAccIecNetworkACLResource_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```