### PR TITLE
support associate ports with iec vip resource

### DIFF
--- a/docs/resources/iec_vip.md
+++ b/docs/resources/iec_vip.md
@@ -20,9 +20,10 @@ resource "huaweicloud_iec_vip" "vip_test" {
 
 The following arguments are supported:
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the subnet network id 
-    of vip binding in which to allocate IP address for this vip.
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the network to which the vip belongs.
     Changing this parameter creates a new vip resource.
+
+* `port_ids` - (Required, List) Specifies an array of IDs of the ports to attach the vip to.
 
 ## Attributes Reference
 
@@ -33,6 +34,8 @@ In addition to all arguments above, the following attributes are exported:
 * `mac_address` - The MAC address of the vip.
 
 * `fixed_ips` - An array of IP addresses binding to the vip.
+
+* `allowed_addresses` - An array of IP addresses of the ports to attach the vip to.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7
+	github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517 h1:l/Aa5CisH
 github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7 h1:7CkjSplJmYll80TgMsjhYy7PMLNPjBMtnuEPhDf/NvU=
 github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd h1:jHD4wEEoUCkbsf4Vlm5TeFKHdyxnjoYoTGe0E6tJgHo=
+github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/ports/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/ports/requests.go
@@ -59,16 +59,16 @@ type UpdateOpts struct {
 	// characters. This parameter is left blank by default.
 	Name string `json:"name,omitempty"`
 
-	// Specifies the UUID of the security group. This attribute is
-	// extended.
-	SecurityGroups []string `json:"security_groups,omitempty"`
+	// Specifies the UUID of the security group.
+	// This attribute is extended.
+	SecurityGroups *[]string `json:"security_groups,omitempty"`
 
 	// 1. Specifies a set of zero or more allowed address pairs. An
 	// address pair consists of an IP address and MAC address. This attribute is extended.
 	// For details, see parameter?allow_address_pair. 2. The IP address cannot be?0.0.0.0.
 	// 3. Configure an independent security group for the port if a large CIDR block (subnet
 	// mask less than 24) is configured for parameter?allowed_address_pairs.
-	AllowedAddressPairs []common.AllowedAddressPair `json:"allowed_address_pairs,omitempty"`
+	AllowedAddressPairs *[]common.AllowedAddressPair `json:"allowed_address_pairs,omitempty"`
 
 	// Specifies a set of zero or more extra DHCP option pairs. An
 	// option pair consists of an option value and name. This attribute is extended.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7
+# github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:


## PR Checklist

* [√] Tests added/passed.
* [√] Documentation updated.
* [√] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecVipResource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecVipResource -timeout 360m -parallel 4
=== RUN   TestAccIecVipResource_basic
=== PAUSE TestAccIecVipResource_basic
=== RUN   TestAccIecVipResource_associate
=== PAUSE TestAccIecVipResource_associate
=== CONT  TestAccIecVipResource_basic
=== CONT  TestAccIecVipResource_associate
--- PASS: TestAccIecVipResource_basic (57.31s)
--- PASS: TestAccIecVipResource_associate (147.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       147.097s
```
