### PR TITLE
Update rds instance provider

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -125,11 +125,11 @@ The following arguments are supported:
 
 * `flavor` - (Required, String) Specifies the specification code.
 
-* `name` - (Required, String, ForceNew) Specifies the DB instance name. The DB instance name of the same type
+* `name` - (Required, String) Specifies the DB instance name. The DB instance name of the same type
   must be unique for the same tenant. The value must be 4 to 64
   characters in length and start with a letter. It is case-sensitive
   and can contain only letters, digits, hyphens (-), and underscores
-  (_).  Changing this parameter will create a new resource.
+  (_).
 
 * `security_group_id` - (Required, String, ForceNew) Specifies the security group which the RDS DB instance belongs to.
   Changing this parameter will create a new resource.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd
+	github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517 h1:l/Aa5CisH
 github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7 h1:7CkjSplJmYll80TgMsjhYy7PMLNPjBMtnuEPhDf/NvU=
 github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd h1:jHD4wEEoUCkbsf4Vlm5TeFKHdyxnjoYoTGe0E6tJgHo=
-github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd h1:tgbXiqSIM86dGQD7tLgeV/LEX7CysuuoHfUKLKoIIRs=
+github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestAccRdsInstanceV3_basic(t *testing.T) {
-	name := acctest.RandString(10)
+	basicName := fmt.Sprintf("terraform_test_rds_instance_%s", acctest.RandString(5))
+	updateName := fmt.Sprintf("terraform_test_rds_instance_update_%s", acctest.RandString(5))
 	resourceName := "huaweicloud_rds_instance.instance"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,16 +35,17 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_basic(name),
+				Config: testAccRdsInstanceV3_basic(basicName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_rds_instance%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "name", basicName),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "1"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+10:00"),
 					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.58"),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.large"),
 				),
 			},
 			{
@@ -55,14 +57,15 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccRdsInstanceV3_update(name),
+				Config: testAccRdsInstanceV3_update(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_rds_instance%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "2"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_updated"),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.xlarge"),
 				),
 			},
 		},
@@ -109,7 +112,7 @@ resource "huaweicloud_networking_secgroup" "secgroup_1" {
 }
 
 resource "huaweicloud_rds_instance" "instance" {
-  name = "terraform_test_rds_instance%s"
+  name = "%s"
   flavor = "rds.pg.c2.large"
   availability_zone = ["%s"]
   security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
@@ -163,8 +166,8 @@ resource "huaweicloud_networking_secgroup" "secgroup_1" {
 }
 
 resource "huaweicloud_rds_instance" "instance" {
-  name = "terraform_test_rds_instance%s"
-  flavor = "rds.pg.c2.large"
+  name = "%s"
+  flavor = "rds.pg.c2.xlarge"
   availability_zone = ["%s"]
   security_group_id = huaweicloud_networking_secgroup.secgroup_1.id
   subnet_id = huaweicloud_vpc_subnet.test.id

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/requests.go
@@ -1,0 +1,18 @@
+package datastores
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+func List(client *golangsdk.ServiceClient, databasesname string) pagination.Pager {
+	url := listURL(client, databasesname)
+
+	pageRdsList := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DataStoresPage{pagination.SinglePageBase(r)}
+	})
+
+	rdsheader := map[string]string{"Content-Type": "application/json"}
+	pageRdsList.Headers = rdsheader
+	return pageRdsList
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/results.go
@@ -1,0 +1,35 @@
+package datastores
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type DataStoresResult struct {
+	golangsdk.Result
+}
+type DataStores struct {
+	DataStores []dataStores `json:"dataStores" `
+}
+type dataStores struct {
+	Id   string `json:"id" `
+	Name string `json:"name"`
+}
+
+type DataStoresPage struct {
+	pagination.SinglePageBase
+}
+
+func (r DataStoresPage) IsEmpty() (bool, error) {
+	data, err := ExtractDataStores(r)
+	if err != nil {
+		return false, err
+	}
+	return len(data.DataStores) == 0, err
+}
+
+func ExtractDataStores(r pagination.Page) (DataStores, error) {
+	var s DataStores
+	err := (r.(DataStoresPage)).ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/urls.go
@@ -1,0 +1,7 @@
+package datastores
+
+import "github.com/huaweicloud/golangsdk"
+
+func listURL(sc *golangsdk.ServiceClient, databasename string) string {
+	return sc.ServiceURL("datastores", databasename)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/requests.go
@@ -1,0 +1,42 @@
+package flavors
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type DbFlavorsOpts struct {
+	Versionname string `q:"version_name"`
+}
+
+type DbFlavorsBuilder interface {
+	ToDbFlavorsListQuery() (string, error)
+}
+
+func (opts DbFlavorsOpts) ToDbFlavorsListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+func List(client *golangsdk.ServiceClient, opts DbFlavorsBuilder, databasename string) pagination.Pager {
+	url := listURL(client, databasename)
+	if opts != nil {
+		query, err := opts.ToDbFlavorsListQuery()
+
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	pageRdsList := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DbFlavorsPage{pagination.SinglePageBase(r)}
+	})
+
+	rdsheader := map[string]string{"Content-Type": "application/json"}
+	pageRdsList.Headers = rdsheader
+	return pageRdsList
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/results.go
@@ -1,0 +1,34 @@
+package flavors
+
+import (
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type DbFlavorsResp struct {
+	Flavorslist []Flavors `json:"flavors"`
+}
+type Flavors struct {
+	Vcpus        string            `json:"vcpus" `
+	Ram          int               `json:"ram" `
+	Speccode     string            `json:"spec_code"  `
+	Instancemode string            `json:"instance_mode" `
+	Azstatus     map[string]string `json:"az_status" `
+}
+
+type DbFlavorsPage struct {
+	pagination.SinglePageBase
+}
+
+func (r DbFlavorsPage) IsEmpty() (bool, error) {
+	data, err := ExtractDbFlavors(r)
+	if err != nil {
+		return false, err
+	}
+	return len(data.Flavorslist) == 0, err
+}
+
+func ExtractDbFlavors(r pagination.Page) (DbFlavorsResp, error) {
+	var s DbFlavorsResp
+	err := (r.(DbFlavorsPage)).ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/urls.go
@@ -1,0 +1,7 @@
+package flavors
+
+import "github.com/huaweicloud/golangsdk"
+
+func listURL(sc *golangsdk.ServiceClient, databasename string) string {
+	return sc.ServiceURL("flavors", databasename)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/requests.go
@@ -166,8 +166,36 @@ func Restart(client *golangsdk.ServiceClient, opts RestartRdsInstanceBuilder, in
 		return
 	}
 	fmt.Println("restart Rds instance body = ", b)
-	_, r.Err = client.Post(restartURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
+	})
+	return
+}
+
+type RenameRdsInstanceOpts struct {
+	Name string `json:"name" required:"true"`
+}
+
+type RenameRdsInstanceBuilder interface {
+	ToRenameRdsInstanceMap() (map[string]interface{}, error)
+}
+
+func (opts RenameRdsInstanceOpts) ToRenameRdsInstanceMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Rename(client *golangsdk.ServiceClient, opts RenameRdsInstanceBuilder, instanceId string) (r golangsdk.Result) {
+	b, err := opts.ToRenameRdsInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, instanceId, "name"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
 	})
 	return
 }
@@ -242,7 +270,7 @@ func SingleToHa(client *golangsdk.ServiceClient, opts SingleToRdsHaBuilder, inst
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(singletohaURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -275,7 +303,7 @@ func Resize(client *golangsdk.ServiceClient, opts ResizeFlavorBuilder, instanceI
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(resizeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -308,7 +336,7 @@ func EnlargeVolume(client *golangsdk.ServiceClient, opts EnlargeVolumeBuilder, i
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(enlargeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -336,7 +364,7 @@ func (opts DbErrorlogOpts) DbErrorlogQuery() (string, error) {
 }
 
 func ListErrorLog(client *golangsdk.ServiceClient, opts DbErrorlogBuilder, instanceID string) pagination.Pager {
-	url := listerrorlogURL(client, instanceID)
+	url := updateURL(client, instanceID, "errorlog")
 	if opts != nil {
 		query, err := opts.DbErrorlogQuery()
 
@@ -376,7 +404,7 @@ func (opts DbSlowLogOpts) ToDbSlowLogListQuery() (string, error) {
 }
 
 func ListSlowLog(client *golangsdk.ServiceClient, opts DbSlowLogBuilder, instanceID string) pagination.Pager {
-	url := listslowlogURL(client, instanceID)
+	url := updateURL(client, instanceID, "slowlog")
 	if opts != nil {
 		query, err := opts.ToDbSlowLogListQuery()
 

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/urls.go
@@ -14,26 +14,6 @@ func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func restartURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func singletohaURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func resizeURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func enlargeURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func listerrorlogURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "errorlog")
-}
-
-func listslowlogURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "slowlog")
+func updateURL(c *golangsdk.ServiceClient, instancesId string, updata string) string {
+	return c.ServiceURL("instances", instancesId, updata)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd
+# github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -338,6 +338,8 @@ github.com/huaweicloud/golangsdk/openstack/rds/v1/flavors
 github.com/huaweicloud/golangsdk/openstack/rds/v1/instances
 github.com/huaweicloud/golangsdk/openstack/rds/v3/backups
 github.com/huaweicloud/golangsdk/openstack/rds/v3/configurations
+github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores
+github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors
 github.com/huaweicloud/golangsdk/openstack/rds/v3/instances
 github.com/huaweicloud/golangsdk/openstack/rts/v1/softwareconfig
 github.com/huaweicloud/golangsdk/openstack/rts/v1/stackresources


### PR DESCRIPTION
**What this PR does / why we need it**:
Rds instance support v3 client but we using v1 client in rds instance provider, so we need to update these code blocks:
  - *flavors* (v1 to v3)
  - *volume* (v1 to v3)

After rds instance created, instance will be backing up for a few minute. After rds instance backup is completed, the creation is really completed. So, in creation, we need to check instance status from 'BACKING UP' to 'ACTIVE'. 

The name is support update API and updating is not forceNew now.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
```release-note
1. Update code blocks of *Flavors* and *Volume* in update function.
  a. update client version from v1 to v3.
  b. add instance status refresh check(Flavors : 'MODIFYING' -> 'ACTIVE', Volume : 'MODIFYING' -> 'MODIFIED'). 
2. Fix DBS.200019 by adding instance status refresh check after backup is started.  (DBS.200019 : Another operation is being performed on the DB instance or the DB instance is faulty.)
3. Support updation of rds instance name.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (959.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       959.105s
```