### PR TITLE
fix service port error when protocol is any

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,36 @@
+<!-- Thanks for sending a pull request! -->
+
+**What this PR does / why we need it**:
+
+**Which issue this PR fixes**:
+*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
+fixes #xxx
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Steps to write your release note:
+1. Use the release-note-* labels to set the release note state (if you have access)
+2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
+-->
+
+```release-note
+
+```
+
+## PR Checklist
+
+* [ ] Tests added/passed.
+* [ ] Documentation updated.
+* [ ] Schema updated.
+
+## Acceptance Steps Performed
+
+```
+make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
+...
+=== RUN   TestAccSomethingV0_basic
+--- PASS: TestAccSomethingV0_basic (70.75s)
+PASS
+ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
+```

--- a/docs/resources/iec_security_group.md
+++ b/docs/resources/iec_security_group.md
@@ -20,10 +20,10 @@ resource "huaweicloud_iec_security_group" "secgroup_test" {
 
 The following arguments are supported:
 
-* `name` - (Required, String) Specifies the name for the security group.
+* `name` - (Required, String, ForceNew) Specifies the name for the security group.
     The iec security group allowed to have the same name.
 
-* `description` - (Optional, String) Specifies the description of the iec
+* `description` - (Optional, String, ForceNew) Specifies the description of the iec
     security group.
 
 ## Attributes Reference

--- a/docs/resources/iec_vip.md
+++ b/docs/resources/iec_vip.md
@@ -20,9 +20,10 @@ resource "huaweicloud_iec_vip" "vip_test" {
 
 The following arguments are supported:
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the subnet network id 
-    of vip binding in which to allocate IP address for this vip.
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the network to which the vip belongs.
     Changing this parameter creates a new vip resource.
+
+* `port_ids` - (Required, List) Specifies an array of IDs of the ports to attach the vip to.
 
 ## Attributes Reference
 
@@ -33,6 +34,8 @@ In addition to all arguments above, the following attributes are exported:
 * `mac_address` - The MAC address of the vip.
 
 * `fixed_ips` - An array of IP addresses binding to the vip.
+
+* `allowed_addresses` - An array of IP addresses of the ports to attach the vip to.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7
+	github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517 h1:l/Aa5CisH
 github.com/huaweicloud/golangsdk v0.0.0-20210121015204-d66fe0197517/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7 h1:7CkjSplJmYll80TgMsjhYy7PMLNPjBMtnuEPhDf/NvU=
 github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd h1:jHD4wEEoUCkbsf4Vlm5TeFKHdyxnjoYoTGe0E6tJgHo=
+github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/data_source_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_v3.go
@@ -1,6 +1,7 @@
 package huaweicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 
@@ -201,7 +202,13 @@ func dataSourceCceNodesV3Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("server_id", Node.Status.ServerID)
 	d.Set("public_ip", Node.Status.PublicIP)
 	d.Set("private_ip", Node.Status.PrivateIP)
-	d.Set("spec_extend_param", Node.Spec.ExtendParam)
+	if byte, err := json.Marshal(Node.Spec.ExtendParam); err == nil {
+		if err = d.Set("spec_extend_param", string(byte)); err != nil {
+			return fmt.Errorf("Saving spec extend param ERROR: %s", err)
+		}
+	} else {
+		return fmt.Errorf("Spec extend param translate ERROR: %s", err)
+	}
 	d.Set("eip_count", Node.Spec.PublicIP.Count)
 	d.Set("eip_ids", PublicIDs)
 

--- a/huaweicloud/data_source_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_subnet_v2.go
@@ -246,9 +246,16 @@ func dataSourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) 
 		log.Printf("[DEBUG] Unable to set dns_nameservers: %s", err)
 	}
 
-	err = d.Set("host_routes", subnet.HostRoutes)
-	if err != nil {
-		log.Printf("[DEBUG] Unable to set host_routes: %s", err)
+	// Set the host_routes
+	var hostRoutes []map[string]interface{} = make([]map[string]interface{}, len(subnet.HostRoutes))
+	for i, v := range subnet.HostRoutes {
+		routes := make(map[string]interface{})
+		routes["destination_cidr"] = v.DestinationCIDR
+		routes["next_hop"] = v.NextHop
+		hostRoutes[i] = routes
+	}
+	if err = d.Set("host_routes", hostRoutes); err != nil {
+		return fmt.Errorf("Saving host_routes failed: %s", err)
 	}
 
 	// Set the allocation_pools

--- a/huaweicloud/import_huaweicloud_s3_bucket.go
+++ b/huaweicloud/import_huaweicloud_s3_bucket.go
@@ -38,7 +38,7 @@ func resourceS3BucketImportState(
 	pData.SetId(d.Id())
 	pData.SetType("huaweicloud_s3_bucket_policy")
 	pData.Set("bucket", d.Id())
-	pData.Set("policy", pol)
+	pData.Set("policy", pol.Policy)
 	results = append(results, pData)
 
 	return results, nil

--- a/huaweicloud/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/resource_huaweicloud_cdn_domain.go
@@ -293,8 +293,8 @@ func resourceCdnDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// an API issue will be raised in ForceNew scene, so wait for a while
-	//lintignore:R018
-	time.Sleep(3 * time.Second)
+	time.Sleep(3 * time.Second) //lintignore:R018
+
 	d.SetId("")
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -388,8 +388,7 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 	}
 
 	// This is a workaround to avoid db connection issue
-	//lintignore:R018
-	time.Sleep(360 * time.Second)
+	time.Sleep(360 * time.Second) //lintignore:R018
 
 	return resourceGeminiDBInstanceV3Read(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -376,8 +376,7 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// This is a workaround to avoid db connection issue
-	//lintignore:R018
-	time.Sleep(360 * time.Second)
+	time.Sleep(360 * time.Second) //lintignore:R018
 
 	return resourceGaussDBInstanceRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -419,8 +419,7 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// This is a workaround to avoid db connection issue
-	//lintignore:R018
-	time.Sleep(360 * time.Second)
+	time.Sleep(360 * time.Second) //lintignore:R018
 
 	return resourceOpenGaussInstanceRead(d, meta)
 }

--- a/huaweicloud/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool.go
@@ -245,8 +245,16 @@ func resourcePoolV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("tenant_id", pool.TenantID)
 	d.Set("admin_state_up", pool.AdminStateUp)
 	d.Set("name", pool.Name)
-	d.Set("persistence", pool.Persistence)
 	d.Set("region", GetRegion(d, config))
+
+	var persistence []map[string]interface{} = make([]map[string]interface{}, 1)
+	params := make(map[string]interface{})
+	params["cookie_name"] = pool.Persistence.CookieName
+	params["type"] = pool.Persistence.Type
+	persistence[0] = params
+	if err = d.Set("persistence", persistence); err != nil {
+		return fmt.Errorf("Load balance persistence set error: %s", err)
+	}
 
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -147,25 +147,13 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	e, err = isEmptyValue(reflect.ValueOf(internalServicePortProp))
-	if err != nil {
-		return err
-	}
-	if !e {
-		params["internal_service_port"] = internalServicePortProp
-	}
+	params["internal_service_port"] = internalServicePortProp
 
 	externalServicePortProp, err := navigateValue(opts, []string{"external_service_port"}, nil)
 	if err != nil {
 		return err
 	}
-	e, err = isEmptyValue(reflect.ValueOf(externalServicePortProp))
-	if err != nil {
-		return err
-	}
-	if !e {
-		params["external_service_port"] = externalServicePortProp
-	}
+	params["external_service_port"] = externalServicePortProp
 
 	natGatewayIDProp, err := navigateValue(opts, []string{"nat_gateway_id"}, nil)
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -240,8 +240,7 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(id.(string))
 
 	// wait for a while to become ACTIVE
-	//lintignore:R018
-	time.Sleep(3 * time.Second)
+	time.Sleep(3 * time.Second) //lintignore:R018
 
 	return resourceNatDnatRuleRead(d, meta)
 }
@@ -440,7 +439,6 @@ func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// wait for a while to become DELETED
-	//lintignore:R018
-	time.Sleep(3 * time.Second)
+	time.Sleep(3 * time.Second) //lintignore:R018
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_subnet_v2.go
@@ -226,11 +226,22 @@ func resourceNetworkingSubnetV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("name", s.Name)
 	d.Set("tenant_id", s.TenantID)
 	d.Set("dns_nameservers", s.DNSNameservers)
-	d.Set("host_routes", s.HostRoutes)
 	d.Set("enable_dhcp", s.EnableDHCP)
 	d.Set("network_id", s.NetworkID)
 	d.Set("ipv6_address_mode", s.IPv6AddressMode)
 	d.Set("ipv6_ra_mode", s.IPv6RAMode)
+
+	// Set the host_routes
+	var hostRoutes []map[string]interface{} = make([]map[string]interface{}, len(s.HostRoutes))
+	for i, v := range s.HostRoutes {
+		routes := make(map[string]interface{})
+		routes["destination_cidr"] = v.DestinationCIDR
+		routes["next_hop"] = v.NextHop
+		hostRoutes[i] = routes
+	}
+	if err = d.Set("host_routes", hostRoutes); err != nil {
+		return fmt.Errorf("Saving host_routes failed: %s", err)
+	}
 
 	// Set the allocation_pools
 	var allocationPools []map[string]interface{}

--- a/huaweicloud/resource_huaweicloud_s3_bucket.go
+++ b/huaweicloud/resource_huaweicloud_s3_bucket.go
@@ -1234,6 +1234,7 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 			Bucket: aws.String(bucket),
 		}
 
+		//lintignore:R006
 		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 			if _, err := s3conn.DeleteBucketLifecycle(i); err != nil {
 				return resource.NonRetryableError(err)
@@ -1321,6 +1322,7 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 	}
 	//fmt.Printf("PutBucketLifecycleConfigurationInput=%+v.\n", i)
 
+	//lintignore:R006
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		if _, err := s3conn.PutBucketLifecycleConfiguration(i); err != nil {
 			return resource.NonRetryableError(err)

--- a/huaweicloud/validators.go
+++ b/huaweicloud/validators.go
@@ -126,6 +126,7 @@ func validateName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+//lintignore:V001
 func validateString64WithChinese(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 64 {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/ports/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/ports/requests.go
@@ -59,16 +59,16 @@ type UpdateOpts struct {
 	// characters. This parameter is left blank by default.
 	Name string `json:"name,omitempty"`
 
-	// Specifies the UUID of the security group. This attribute is
-	// extended.
-	SecurityGroups []string `json:"security_groups,omitempty"`
+	// Specifies the UUID of the security group.
+	// This attribute is extended.
+	SecurityGroups *[]string `json:"security_groups,omitempty"`
 
 	// 1. Specifies a set of zero or more allowed address pairs. An
 	// address pair consists of an IP address and MAC address. This attribute is extended.
 	// For details, see parameter?allow_address_pair. 2. The IP address cannot be?0.0.0.0.
 	// 3. Configure an independent security group for the port if a large CIDR block (subnet
 	// mask less than 24) is configured for parameter?allowed_address_pairs.
-	AllowedAddressPairs []common.AllowedAddressPair `json:"allowed_address_pairs,omitempty"`
+	AllowedAddressPairs *[]common.AllowedAddressPair `json:"allowed_address_pairs,omitempty"`
 
 	// Specifies a set of zero or more extra DHCP option pairs. An
 	// option pair consists of an option value and name. This attribute is extended.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210126090908-31d3a6a5cee7
+# github.com/huaweicloud/golangsdk v0.0.0-20210128073103-0683919fcabd
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Nat dnat rule cannot create which request set with zero service port.
This issue because of isEmptyValue function return false when service port is zero(int) and program will abandom setting data.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #880

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove isEmptyValue function check because service port can be set with zero.
```

## PR Checklist

- [x] Tests added/passed.
- [ ] Documentation updated.
- [ ] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatDnat_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatDnat_basic -timeout 360m -parallel 4
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== CONT  TestAccNatDnat_basic
--- PASS: TestAccNatDnat_basic (177.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       177.841s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatDnat_protocol'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatDnat_protocol -timeout 360m -parallel 4
=== RUN   TestAccNatDnat_protocol
=== PAUSE TestAccNatDnat_protocol
=== CONT  TestAccNatDnat_protocol
--- PASS: TestAccNatDnat_protocol (165.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       165.575s
```