### PR TITLE
Fix the problem that any type of DNAT rule cannot open all ports

### DIFF
--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -147,25 +147,13 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	e, err = isEmptyValue(reflect.ValueOf(internalServicePortProp))
-	if err != nil {
-		return err
-	}
-	if !e {
-		params["internal_service_port"] = internalServicePortProp
-	}
+	params["internal_service_port"] = internalServicePortProp
 
 	externalServicePortProp, err := navigateValue(opts, []string{"external_service_port"}, nil)
 	if err != nil {
 		return err
 	}
-	e, err = isEmptyValue(reflect.ValueOf(externalServicePortProp))
-	if err != nil {
-		return err
-	}
-	if !e {
-		params["external_service_port"] = externalServicePortProp
-	}
+	params["external_service_port"] = externalServicePortProp
 
 	natGatewayIDProp, err := navigateValue(opts, []string{"nat_gateway_id"}, nil)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Nat dnat rule cannot create which request set with zero service port.
This issue because of isEmptyValue function return false when service port is zero(int) and program will abandom setting data.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #880

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove isEmptyValue function check because service port can be set with zero.
```

## PR Checklist

- [x] Tests added/passed.
- [ ] Documentation updated.
- [ ] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatDnat_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatDnat_basic -timeout 360m -parallel 4
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== CONT  TestAccNatDnat_basic
--- PASS: TestAccNatDnat_basic (167.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       167.984s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatDnat_protocol'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatDnat_protocol -timeout 360m -parallel 4
=== RUN   TestAccNatDnat_protocol
=== PAUSE TestAccNatDnat_protocol
=== CONT  TestAccNatDnat_protocol
--- PASS: TestAccNatDnat_protocol (163.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       163.349s
```