### PR TITLE
[Refactor] Update the client version of RDS from V1 to V3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210130015616-a15f013de8ca
+	github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210130015616-a15f013de8ca h1:ucLVgXpwEIbvBZn6OeEz9/gtIxBWDYRHgef44HkYp5o=
 github.com/huaweicloud/golangsdk v0.0.0-20210130015616-a15f013de8ca/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd h1:tgbXiqSIM86dGQD7tLgeV/LEX7CysuuoHfUKLKoIIRs=
+github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -25,10 +25,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/common/tags"
-	"github.com/huaweicloud/golangsdk/openstack/rds/v1/datastores"
-	"github.com/huaweicloud/golangsdk/openstack/rds/v1/flavors"
-	"github.com/huaweicloud/golangsdk/openstack/rds/v1/instances"
 	"github.com/huaweicloud/golangsdk/openstack/rds/v3/backups"
+	"github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores"
+	"github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors"
+	"github.com/huaweicloud/golangsdk/openstack/rds/v3/instances"
 )
 
 func resourceRdsInstanceV3() *schema.Resource {
@@ -357,6 +357,19 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("Error updating HuaweiCloud RDS Instance: %s", err)
 		}
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"BACKING UP"},
+			Target:     []string{"ACTIVE"},
+			Refresh:    InstanceV3StateUpdateRefreshFunc(rdsClient, d),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      15 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf("Error waiting for instance (%s) back up to be done: %s ", d.Id(), err)
+		}
 	}
 
 	// Fetching node id
@@ -395,54 +408,61 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("flavor") {
 		nflavor := d.Get("flavor")
-		client, err := config.RdsV1Client(GetRegion(d, config))
-		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud rds v1 client: %s ", err)
-		}
-
 		// Fetch flavor id
 		db := d.Get("db").([]interface{})
 		datastore_name := db[0].(map[string]interface{})["type"].(string)
 		datastore_version := db[0].(map[string]interface{})["version"].(string)
-		datastoresList, err := datastores.List(client, datastore_name).Extract()
+		datastoreAllPages, err := datastores.List(rdsClient, datastore_name).AllPages()
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve datastores: %s ", err)
+			return fmt.Errorf("Unable to retrieve datastores pages: %s ", err)
 		}
-		if len(datastoresList) < 1 {
+		dataStores, err := datastores.ExtractDataStores(datastoreAllPages)
+		if err != nil {
+			return fmt.Errorf("Unable to analyse datastores: %s ", err)
+		}
+		if len(dataStores.DataStores) < 1 {
 			return fmt.Errorf("Returned no datastore result. ")
 		}
-		var datastoreId string
-		for _, datastore := range datastoresList {
-			if strings.HasPrefix(datastore.Name, datastore_version) {
-				datastoreId = datastore.ID
+		var datastoreVersion string
+		for _, datastore := range dataStores.DataStores {
+			if datastore.Name == datastore_version {
+				datastoreVersion = datastore.Name
 				break
 			}
 		}
-		if datastoreId == "" {
-			return fmt.Errorf("Returned no datastore ID. ")
+		if datastoreVersion == "" {
+			return fmt.Errorf("Returned no datastore Name. ")
 		}
-		log.Printf("[DEBUG] Received datastore Id: %s", datastoreId)
-		flavorsList, err := flavors.List(client, datastoreId, GetRegion(d, config)).Extract()
+		log.Printf("[DEBUG] Received datastore Version: %s", datastoreVersion)
+
+		var dbFlavorsOpts flavors.DbFlavorsOpts
+		dbFlavorsOpts.Versionname = datastore_version
+
+		flavorAllPages, err := flavors.List(rdsClient, dbFlavorsOpts, datastore_name).AllPages()
 		if err != nil {
-			return fmt.Errorf("Unable to retrieve flavors: %s", err)
+			return fmt.Errorf("Unable to retrieve flavors pages: %s", err)
 		}
-		if len(flavorsList) < 1 {
-			return fmt.Errorf("Returned no flavor result. ")
+		dbFlavorsResp, err := flavors.ExtractDbFlavors(flavorAllPages)
+		if err != nil {
+			return fmt.Errorf("Unable to analyse flavors Resp: %s", err)
 		}
-		var rdsFlavor flavors.Flavor
-		for _, flavor := range flavorsList {
-			if flavor.SpecCode == nflavor.(string) {
+		if len(dbFlavorsResp.Flavorslist) < 1 {
+			return fmt.Errorf("Returned no datastore result. ")
+		}
+		var rdsFlavor flavors.Flavors
+		for _, flavor := range dbFlavorsResp.Flavorslist {
+			if flavor.Speccode == nflavor.(string) {
 				rdsFlavor = flavor
 				break
 			}
 		}
 
-		var updateFlavorOpts instances.UpdateFlavorOps
+		var resizeFlavorOpts instances.ResizeFlavorOpts
+		var resizeFlavor instances.SpecCode
+		resizeFlavor.Speccode = rdsFlavor.Speccode
+		resizeFlavorOpts.ResizeFlavor = &resizeFlavor
 
-		log.Printf("[DEBUG] Update flavor: %s", nflavor.(string))
-
-		updateFlavorOpts.FlavorRef = rdsFlavor.ID
-		_, err = instances.UpdateFlavorRef(client, updateFlavorOpts, node_id).Extract()
+		_, err = instances.Resize(rdsClient, resizeFlavorOpts, d.Id()).Extract()
 		if err != nil {
 			return fmt.Errorf("Error updating instance Flavor from result: %s ", err)
 		}
@@ -450,8 +470,8 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"MODIFYING"},
 			Target:     []string{"ACTIVE"},
-			Refresh:    InstanceStateFlavorUpdateRefreshFunc(client, node_id, d.Get("flavor").(string)),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Refresh:    InstanceV3StateUpdateRefreshFunc(rdsClient, d),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			Delay:      15 * time.Second,
 			MinTimeout: 3 * time.Second,
 		}
@@ -460,39 +480,35 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf(
 				"Error waiting for instance (%s) flavor to be Updated: %s ",
-				node_id, err)
+				d.Id(), err)
 		}
-		log.Printf("[DEBUG] Successfully updated instance %s flavor: %s", node_id, d.Get("flavor").(string))
+		log.Printf("[DEBUG] Successfully updated instance %s flavor: %s", d.Id(), d.Get("flavor").(string))
 	}
 
 	// Update volume
 	if d.HasChange("volume") {
-		client, err := config.RdsV1Client(GetRegion(d, config))
-		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud rds v1 client: %s ", err)
-		}
 		nvolume := d.Get("volume")
-		var updateOpts instances.UpdateOps
-		volume := make(map[string]interface{})
+
+		var enlargeVolumeRdsOpts instances.EnlargeVolumeRdsOpts
+
 		volumeRaw := nvolume.([]interface{})
-		log.Printf("[DEBUG] volumeRaw: %+v", volumeRaw)
+		log.Printf("[DEBUG] Enlarge Volume : %+v", volumeRaw)
 		if len(volumeRaw) == 1 {
 			if m, ok := volumeRaw[0].(map[string]interface{}); ok {
-				volume["size"] = m["size"].(int)
+				var enlargeVolumeSize instances.EnlargeVolumeSize
+				enlargeVolumeSize.Size = m["size"].(int)
+				enlargeVolumeRdsOpts.EnlargeVolume = &enlargeVolumeSize
 			}
 		}
-		log.Printf("[DEBUG] volume: %+v", volume)
-		updateOpts.Volume = volume
-		_, err = instances.UpdateVolumeSize(client, updateOpts, node_id).Extract()
+		_, err = instances.EnlargeVolume(rdsClient, enlargeVolumeRdsOpts, d.Id()).Extract()
 		if err != nil {
 			return fmt.Errorf("Error updating instance volume from result: %s ", err)
 		}
-
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"MODIFYING"},
-			Target:     []string{"UPDATED"},
-			Refresh:    InstanceStateUpdateRefreshFunc(client, node_id, updateOpts.Volume["size"].(int)),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Target:     []string{"MODIFIED"},
+			Refresh:    InstanceV3StateVolumeUpdateRefreshFunc(rdsClient, d, enlargeVolumeRdsOpts.EnlargeVolume.Size),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			Delay:      15 * time.Second,
 			MinTimeout: 3 * time.Second,
 		}
@@ -501,9 +517,9 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf(
 				"Error waiting for instance (%s) volume to be Updated: %s ",
-				node_id, err)
+				d.Id(), err)
 		}
-		log.Printf("[DEBUG] Successfully updated instance %s volume: %+v", node_id, volume)
+		log.Printf("[DEBUG] Successfully updated instance %s volume", d.Id())
 	}
 
 	if d.HasChange("tags") {
@@ -1393,4 +1409,42 @@ func flattenRdsInstanceTags(d interface{}) (map[string]interface{}, error) {
 
 	log.Printf("[DEBUG] reading RDS Instance tags: %#v", result)
 	return result, nil
+}
+
+func InstanceV3StateVolumeUpdateRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData, size int) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		v, err := fetchRdsInstanceV3ByList(d, client)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil, "DELETED", nil
+			}
+			return nil, "", err
+		}
+		log.Printf("[Lance] Fetching Rds Instance : (%T) %#v", v, v)
+		var rdsInstances map[string]interface{} = v.(map[string]interface{})
+		var volume map[string]interface{} = rdsInstances["volume"].(map[string]interface{})
+		log.Printf("[RDS Status] instance status : (%T) %v", rdsInstances["status"].(string), rdsInstances["status"].(string))
+
+		if int(volume["size"].(float64)) == size {
+			return v, "MODIFIED", nil
+		}
+		return v, rdsInstances["status"].(string), nil
+	}
+}
+
+func InstanceV3StateUpdateRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		v, err := fetchRdsInstanceV3ByList(d, client)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil, "DELETED", nil
+			}
+			return nil, "", err
+		}
+		log.Printf("[Lance] Fetching Rds Instance : (%T) %#v", v, v)
+		var rdsInstances map[string]interface{} = v.(map[string]interface{})
+		log.Printf("[RDS Status] instance status : (%T) %v", rdsInstances["status"].(string), rdsInstances["status"].(string))
+
+		return v, rdsInstances["status"].(string), nil
+	}
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/requests.go
@@ -1,0 +1,18 @@
+package datastores
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+func List(client *golangsdk.ServiceClient, databasesname string) pagination.Pager {
+	url := listURL(client, databasesname)
+
+	pageRdsList := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DataStoresPage{pagination.SinglePageBase(r)}
+	})
+
+	rdsheader := map[string]string{"Content-Type": "application/json"}
+	pageRdsList.Headers = rdsheader
+	return pageRdsList
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/results.go
@@ -1,0 +1,35 @@
+package datastores
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type DataStoresResult struct {
+	golangsdk.Result
+}
+type DataStores struct {
+	DataStores []dataStores `json:"dataStores" `
+}
+type dataStores struct {
+	Id   string `json:"id" `
+	Name string `json:"name"`
+}
+
+type DataStoresPage struct {
+	pagination.SinglePageBase
+}
+
+func (r DataStoresPage) IsEmpty() (bool, error) {
+	data, err := ExtractDataStores(r)
+	if err != nil {
+		return false, err
+	}
+	return len(data.DataStores) == 0, err
+}
+
+func ExtractDataStores(r pagination.Page) (DataStores, error) {
+	var s DataStores
+	err := (r.(DataStoresPage)).ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores/urls.go
@@ -1,0 +1,7 @@
+package datastores
+
+import "github.com/huaweicloud/golangsdk"
+
+func listURL(sc *golangsdk.ServiceClient, databasename string) string {
+	return sc.ServiceURL("datastores", databasename)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/requests.go
@@ -1,0 +1,42 @@
+package flavors
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type DbFlavorsOpts struct {
+	Versionname string `q:"version_name"`
+}
+
+type DbFlavorsBuilder interface {
+	ToDbFlavorsListQuery() (string, error)
+}
+
+func (opts DbFlavorsOpts) ToDbFlavorsListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+func List(client *golangsdk.ServiceClient, opts DbFlavorsBuilder, databasename string) pagination.Pager {
+	url := listURL(client, databasename)
+	if opts != nil {
+		query, err := opts.ToDbFlavorsListQuery()
+
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	pageRdsList := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DbFlavorsPage{pagination.SinglePageBase(r)}
+	})
+
+	rdsheader := map[string]string{"Content-Type": "application/json"}
+	pageRdsList.Headers = rdsheader
+	return pageRdsList
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/results.go
@@ -1,0 +1,34 @@
+package flavors
+
+import (
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type DbFlavorsResp struct {
+	Flavorslist []Flavors `json:"flavors"`
+}
+type Flavors struct {
+	Vcpus        string            `json:"vcpus" `
+	Ram          int               `json:"ram" `
+	Speccode     string            `json:"spec_code"  `
+	Instancemode string            `json:"instance_mode" `
+	Azstatus     map[string]string `json:"az_status" `
+}
+
+type DbFlavorsPage struct {
+	pagination.SinglePageBase
+}
+
+func (r DbFlavorsPage) IsEmpty() (bool, error) {
+	data, err := ExtractDbFlavors(r)
+	if err != nil {
+		return false, err
+	}
+	return len(data.Flavorslist) == 0, err
+}
+
+func ExtractDbFlavors(r pagination.Page) (DbFlavorsResp, error) {
+	var s DbFlavorsResp
+	err := (r.(DbFlavorsPage)).ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors/urls.go
@@ -1,0 +1,7 @@
+package flavors
+
+import "github.com/huaweicloud/golangsdk"
+
+func listURL(sc *golangsdk.ServiceClient, databasename string) string {
+	return sc.ServiceURL("flavors", databasename)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/requests.go
@@ -166,8 +166,36 @@ func Restart(client *golangsdk.ServiceClient, opts RestartRdsInstanceBuilder, in
 		return
 	}
 	fmt.Println("restart Rds instance body = ", b)
-	_, r.Err = client.Post(restartURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
+	})
+	return
+}
+
+type RenameRdsInstanceOpts struct {
+	Name string `json:"name" required:"true"`
+}
+
+type RenameRdsInstanceBuilder interface {
+	ToRenameRdsInstanceMap() (map[string]interface{}, error)
+}
+
+func (opts RenameRdsInstanceOpts) ToRenameRdsInstanceMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Rename(client *golangsdk.ServiceClient, opts RenameRdsInstanceBuilder, instanceId string) (r golangsdk.Result) {
+	b, err := opts.ToRenameRdsInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, instanceId, "name"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
 	})
 	return
 }
@@ -242,7 +270,7 @@ func SingleToHa(client *golangsdk.ServiceClient, opts SingleToRdsHaBuilder, inst
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(singletohaURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -275,7 +303,7 @@ func Resize(client *golangsdk.ServiceClient, opts ResizeFlavorBuilder, instanceI
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(resizeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -308,7 +336,7 @@ func EnlargeVolume(client *golangsdk.ServiceClient, opts EnlargeVolumeBuilder, i
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(enlargeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -336,7 +364,7 @@ func (opts DbErrorlogOpts) DbErrorlogQuery() (string, error) {
 }
 
 func ListErrorLog(client *golangsdk.ServiceClient, opts DbErrorlogBuilder, instanceID string) pagination.Pager {
-	url := listerrorlogURL(client, instanceID)
+	url := updateURL(client, instanceID, "errorlog")
 	if opts != nil {
 		query, err := opts.DbErrorlogQuery()
 
@@ -376,7 +404,7 @@ func (opts DbSlowLogOpts) ToDbSlowLogListQuery() (string, error) {
 }
 
 func ListSlowLog(client *golangsdk.ServiceClient, opts DbSlowLogBuilder, instanceID string) pagination.Pager {
-	url := listslowlogURL(client, instanceID)
+	url := updateURL(client, instanceID, "slowlog")
 	if opts != nil {
 		query, err := opts.ToDbSlowLogListQuery()
 

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/urls.go
@@ -14,26 +14,6 @@ func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func restartURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func singletohaURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func resizeURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func enlargeURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func listerrorlogURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "errorlog")
-}
-
-func listslowlogURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "slowlog")
+func updateURL(c *golangsdk.ServiceClient, instancesId string, updata string) string {
+	return c.ServiceURL("instances", instancesId, updata)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210130015616-a15f013de8ca
+# github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -338,6 +338,8 @@ github.com/huaweicloud/golangsdk/openstack/rds/v1/flavors
 github.com/huaweicloud/golangsdk/openstack/rds/v1/instances
 github.com/huaweicloud/golangsdk/openstack/rds/v3/backups
 github.com/huaweicloud/golangsdk/openstack/rds/v3/configurations
+github.com/huaweicloud/golangsdk/openstack/rds/v3/datastores
+github.com/huaweicloud/golangsdk/openstack/rds/v3/flavors
 github.com/huaweicloud/golangsdk/openstack/rds/v3/instances
 github.com/huaweicloud/golangsdk/openstack/rts/v1/softwareconfig
 github.com/huaweicloud/golangsdk/openstack/rts/v1/stackresources


### PR DESCRIPTION
**What this PR does / why we need it**:
Rds instance support v3 client but we using v1 client in rds instance provider, so we need to update these code blocks:
  - *flavors* (v1 to v3)
  - *volume* (v1 to v3)

After rds instance created, instance will be backing up for a few minute. After rds instance backup is completed, the creation is really completed. So, in creation, we need to check instance status from 'BACKING UP' to 'ACTIVE'. 

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
```release-note
1. Update code blocks of *Flavors* and *Volume* in update function.
  a. update client version from v1 to v3.
  b. add status refresh-check(Flavor update: 'MODIFYING' -> 'ACTIVE', Volume update: 'MODIFYING' -> 'MODIFIED', Create: 'BACKING UP' -> 'ACTIVE') to rds resource updation. 
2. Fix DBS.200019 by adding instance status refresh check after backup is started.  (DBS.200019 : Another operation is being performed on the DB instance or the DB instance is faulty.)
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (935.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       935.207s
```