### PR TITLE
[Feature Request] Rds instance supports renaming

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -125,11 +125,11 @@ The following arguments are supported:
 
 * `flavor` - (Required, String) Specifies the specification code.
 
-* `name` - (Required, String, ForceNew) Specifies the DB instance name. The DB instance name of the same type
+* `name` - (Required, String) Specifies the DB instance name. The DB instance name of the same type
   must be unique for the same tenant. The value must be 4 to 64
   characters in length and start with a letter. It is case-sensitive
   and can contain only letters, digits, hyphens (-), and underscores
-  (_).  Changing this parameter will create a new resource.
+  (_).
 
 * `security_group_id` - (Required, String, ForceNew) Specifies the security group which the RDS DB instance belongs to.
   Changing this parameter will create a new resource.

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -107,7 +107,6 @@ func resourceRdsInstanceV3() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"security_group_id": {
@@ -341,6 +340,18 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud RDS Client: %s", err)
 	}
+
+	if d.HasChange("name") {
+		var renameRdsInstanceOpts instances.RenameRdsInstanceOpts
+		renameRdsInstanceOpts.Name = d.Get("name").(string)
+		r := golangsdk.ErrResult{}
+		log.Printf("[DEBUG] Renaming Instance %s", d.Id())
+		r.Result = instances.Rename(rdsClient, renameRdsInstanceOpts, d.Id())
+		if r.ExtractErr() != nil {
+			return fmt.Errorf("HuaweiCloud Rds instance (%s) renamed Error: %s", d.Id(), r.Err)
+		}
+	}
+
 	var updateOpts backups.UpdateOpts
 
 	if d.HasChange("backup_strategy") {

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
@@ -59,7 +59,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 				Config: testAccRdsInstanceV3_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_rds_instance%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_rds_instance_update%s", name)),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "2"),
 					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.xlarge"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
@@ -149,13 +149,13 @@ resource "huaweicloud_rds_instance" "instance" {
 	`, testAccRdsInstanceV3_base(val), val, HW_AVAILABILITY_ZONE)
 }
 
-// volume.size, backup_strategy, flavor and tags will be updated
+// name, volume.size, backup_strategy, flavor and tags will be updated
 func testAccRdsInstanceV3_update(val string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "huaweicloud_rds_instance" "instance" {
-  name = "terraform_test_rds_instance%s"
+  name = "terraform_test_rds_instance_update%s"
   flavor = "rds.pg.c2.xlarge"
   availability_zone = ["%s"]
   security_group_id = huaweicloud_networking_secgroup.secgroup_1.id


### PR DESCRIPTION
**What this PR does / why we need it**:
RDS instance API supports renaming function. SDK has updated and provided renaming related methods and structures. Now it needs to provide this function in provider.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
```release-note
1. update Rds resource:
  a. remove the forcenew property of the *name* parameter.
  b. add the corresponding rename method to the resource update function.
2. update Rds resource document:
  a. remove forcenew property.
  b. remove forcenew description. 
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (936.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       936.576s
```