### PR TITLE
[Style][Docs] Organize nat gateway document format and update test acc

### DIFF
--- a/docs/data-sources/nat_gateway.md
+++ b/docs/data-sources/nat_gateway.md
@@ -17,33 +17,29 @@ data "huaweicloud_nat_gateway" "natgateway" {
 
 ## Argument Reference
 
-* `region` - (Optional, String) The region in which to obtain the gateways. If omitted, the provider-level region will be used.
+* `region` - (Optional, String) Specifies the region in which to create the Nat
+    gateway resource. If omitted, the provider-level region will be used.
 
-* `id` - (Optional, String) The ID of the NAT gateway.
+* `id` - (Optional, String) Specifies the ID of the NAT gateway.
 
-* `name` - (Optional, String) The name of the NAT gateway.
+* `name` - (Optional, String) Specifies the nat gateway name. The name can
+    contain only digits, letters, underscores (_), and hyphens(-).
 
-* `description` - (Optional, String) The information about the NAT gateway..
+* `internal_network_id` - (Optional, String) Specifies the network ID of the
+    downstream interface (the next hop of the DVR) of the NAT gateway.
+
+* `router_id` - (Optional, String) Specifies the ID of the router this nat
+    gateway belongs to.
 
 * `spec` - (Optional, String) The NAT gateway type.
-              The value can be:
-              1: small type, which supports up to 10,000 SNAT connections.
-              2: medium type, which supports up to 50,000 SNAT connections.
-              3: large type, which supports up to 200,000 SNAT connections.
-              4: extra-large type, which supports up to 1,000,000 SNAT connections.
+    The value can be:
+    * `1`: small type, which supports up to 10,000 SNAT connections.
+    * `2`: medium type, which supports up to 50,000 SNAT connections.
+    * `3`: large type, which supports up to 200,000 SNAT connections.
+    * `4`: extra-large type, which supports up to 1,000,000 SNAT connections.
 
-* `router_id` - (Optional, String) The router ID.
+* `description` - (Optional, String) Specifies the description of the nat
+   gateway. The value contains 0 to 255 characters, and angle brackets (<)
+   and (>) are not allowed.
 
-* `internal_network_id` - (Optional, String) The network ID of the downstream interface (the next hop of the DVR) of the NAT gateway.
-
-* `status` - (Optional, String) The status of the NAT gateway.
-
-
-## Attributes Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `admin_state_up` - The unfrozen or frozen state.
-                        The value can be:
-                          true: indicates the unfrozen state.
-                          false: indicates the frozen state.
+* `status` - (Optional, String) Specifies the status of the NAT gateway.

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -23,32 +23,44 @@ resource "huaweicloud_nat_gateway" "nat_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the Nat gateway resource. If omitted, the provider-level region will be used. Changing this creates a new Nat gateway resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to
+    create the Nat gateway resource. If omitted, the provider-level region will
+    be used. Changing this creates a new nat gateway.
 
-* `name` - (Required, String) The name of the nat gateway.
+* `name` - (Required, String) Specifies the nat gateway name. The name can
+    contain only digits, letters, underscores (_), and hyphens(-).
 
-* `description` - (Optional, String) The description of the nat gateway.
-
-* `spec` - (Required, String) The specification of the nat gateway, valid values are "1",
-    "2", "3", "4".
-
-* `tenant_id` - (Optional, String, ForceNew) The target tenant ID in which to allocate the nat
-    gateway. Changing this creates a new nat gateway.
-
-* `router_id` - (Required, String, ForceNew) ID of the router this nat gateway belongs to. Changing
-    this creates a new nat gateway.
-
-* `internal_network_id` - (Required, String, ForceNew) ID of the network this nat gateway connects to.
+* `internal_network_id` - (Required, String, ForceNew) Specifies the network ID
+    of the downstream interface (the next hop of the DVR) of the NAT gateway.
     Changing this creates a new nat gateway.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the nat gateway. 
+* `router_id` - (Required, String, ForceNew) Specifies the ID of the router
+    this nat gateway belongs to. Changing this creates a new nat gateway.
+
+* `spec` - (Required, String) Specifies the nat gateway type.
+    The value can be:
+    * `1`: small type, which supports up to 10,000 SNAT connections.
+    * `2`: medium type, which supports up to 50,000 SNAT connections.
+    * `3`: large type, which supports up to 200,000 SNAT connections.
+    * `4`: extra-large type, which supports up to 1,000,000 SNAT connections.
+
+* `description` - (Optional, String) Specifies the description of the nat
+   gateway. The value contains 0 to 255 characters, and angle brackets (<)
+   and (>) are not allowed.
+
+* `tenant_id` - (Optional, String, ForceNew) Specifies the target tenant ID in
+    which to allocate the nat gateway. Changing this creates a new nat gateway.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the
+    enterprise project id of the nat gateway. The value can contains maximum of
+    36 characters which it is string "0" or in UUID format with hyphens (-).
     Changing this creates a new nat gateway.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - The resource ID in UUID format.
 
 * `status` - The status of the nat gateway.
 

--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2_test.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2_test.go
@@ -25,10 +25,6 @@ func TestAccNatGatewayDataSource_basic(t *testing.T) {
 						"data.huaweicloud_nat_gateway.nat_by_name", "name", natgateway),
 					resource.TestCheckResourceAttr(
 						"data.huaweicloud_nat_gateway.nat_by_id", "name", natgateway),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_nat_gateway.nat_by_name", "admin_state_up", "true"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_nat_gateway.nat_by_id", "admin_state_up", "true"),
 				),
 			},
 		},

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -39,20 +39,9 @@ func resourceNatGatewayV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": {
+			"internal_network_id": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"spec": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: resourceNatGatewayV2ValidateSpec,
-			},
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"router_id": {
@@ -60,9 +49,20 @@ func resourceNatGatewayV2() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"internal_network_id": {
+			"spec": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: resourceNatGatewayV2ValidateSpec,
+			},
+			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"enterprise_project_id": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Document format confusion:
1. Parameters are not arranged by type.
2. The description of *spec* is not detailed enough
3. Parameter *admin_state_up* always true and never used, should be deprecated.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the prefix description of gateway parameters
2. add description to spec item(for each type: 1, 2, 3, 4)
3. reorder all parameters(Required > Optional > Computed)
4. remove admin_state_up parameter from data source and test acc
```

## PR Checklist

- [x] Tests added/passed.
- [x] Documentation updated.
- [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatGatewayDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatGatewayDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGatewayDataSource_basic
--- PASS: TestAccNatGatewayDataSource_basic (83.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       83.197s
```
