### PR TITLE
[Feature][Docs] Nat gateway support querying by enterprise_project_id

### DIFF
--- a/docs/data-sources/nat_gateway.md
+++ b/docs/data-sources/nat_gateway.md
@@ -38,6 +38,8 @@ data "huaweicloud_nat_gateway" "natgateway" {
 
 * `status` - (Optional, String) The status of the NAT gateway.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project
+    ID of the NAT gateway.
 
 ## Attributes Reference
 

--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
@@ -50,25 +50,30 @@ func dataSourceNatGatewayV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
 
 func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	natClient, err := config.natV2Client(GetRegion(d, config))
+	natClient, err := config.natGatewayV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}
 
 	listOpts := natgateways.ListOpts{
-		ID:                d.Get("id").(string),
-		Name:              d.Get("name").(string),
-		Description:       d.Get("description").(string),
-		Spec:              d.Get("spec").(string),
-		RouterID:          d.Get("router_id").(string),
-		InternalNetworkID: d.Get("internal_network_id").(string),
-		Status:            d.Get("status").(string),
+		ID:                  d.Get("id").(string),
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		Spec:                d.Get("spec").(string),
+		RouterID:            d.Get("router_id").(string),
+		InternalNetworkID:   d.Get("internal_network_id").(string),
+		Status:              d.Get("status").(string),
+		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
 	}
 
 	pages, err := natgateways.List(natClient, listOpts).AllPages()
@@ -104,6 +109,7 @@ func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("spec", natgateway.Spec)
 	d.Set("status", natgateway.Status)
 	d.Set("admin_state_up", natgateway.AdminStateUp)
+	d.Set("enterprise_project_id", natgateway.EnterpriseProjectID)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Enterprise project id is supported with Nat gateway support,  but it can not be used to querying gateway list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add enterprise project id to Nat gateway datasource.
2. fixed client exception call (natV2Client).
3. update acc test with enterprise project id.
```

## PR Checklist

- [x] Tests added/passed.
- [x] Documentation updated.
- [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatGatewayDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatGatewayDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGatewayDataSource_basic
--- PASS: TestAccNatGatewayDataSource_basic (85.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       85.928s
```
