### PR TITLE
fix a bug in cce cluster

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -259,24 +259,28 @@ func resourceClusterExtendParamV3(d *schema.ResourceData, config *Config) map[st
 }
 
 func resourceClusterMastersV3(d *schema.ResourceData) ([]clusters.MasterSpec, error) {
-	flavorId := d.Get("flavor_id").(string)
-	mastersRaw := d.Get("masters").([]interface{})
-	if strings.Contains(flavorId, "s1") && len(mastersRaw) != 1 {
-		return nil, fmt.Errorf("Error creating HuaweiCloud Cluster: "+
-			"single-master cluster need 1 az for master node, but got %d", len(mastersRaw))
-	}
-	if strings.Contains(flavorId, "s2") && len(mastersRaw) != 3 {
-		return nil, fmt.Errorf("Error creating HuaweiCloud Cluster: "+
-			"high-availability cluster need 3 az for master nodes, but got %d", len(mastersRaw))
-	}
-	masters := make([]clusters.MasterSpec, len(mastersRaw))
-	for i, raw := range mastersRaw {
-		rawMap := raw.(map[string]interface{})
-		masters[i] = clusters.MasterSpec{
-			MasterAZ: rawMap["availability_zone"].(string),
+	if v, ok := d.GetOk("masters"); ok {
+		flavorId := d.Get("flavor_id").(string)
+		mastersRaw := v.([]interface{})
+		if strings.Contains(flavorId, "s1") && len(mastersRaw) != 1 {
+			return nil, fmt.Errorf("Error creating HuaweiCloud Cluster: "+
+				"single-master cluster need 1 az for master node, but got %d", len(mastersRaw))
 		}
+		if strings.Contains(flavorId, "s2") && len(mastersRaw) != 3 {
+			return nil, fmt.Errorf("Error creating HuaweiCloud Cluster: "+
+				"high-availability cluster need 3 az for master nodes, but got %d", len(mastersRaw))
+		}
+		masters := make([]clusters.MasterSpec, len(mastersRaw))
+		for i, raw := range mastersRaw {
+			rawMap := raw.(map[string]interface{})
+			masters[i] = clusters.MasterSpec{
+				MasterAZ: rawMap["availability_zone"].(string),
+			}
+		}
+		return masters, nil
 	}
-	return masters, nil
+
+	return nil, nil
 }
 
 func resourceCCEClusterV3Create(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix a bug in cce cluster, which cause err when param `masters` is empty.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (487.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       487.248s
```
