### PR TITLE
[docs] Remove vpc route tenant_id parameter

### DIFF
--- a/docs/resources/vpc_route.md
+++ b/docs/resources/vpc_route.md
@@ -32,8 +32,6 @@ The following arguments are supported:
 
 * `vpc_id` (Required, String, ForceNew) - Specifies the VPC for which a route is to be added. Changing this creates a new Route.
 
-* `tenant_id` (Optional, String, ForceNew) - Specifies the tenant ID. Only the administrator can specify the tenant ID of other tenant. Changing this creates a new Route.
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/resource_huaweicloud_vpc_route.go
+++ b/huaweicloud/resource_huaweicloud_vpc_route.go
@@ -49,12 +49,6 @@ func ResourceVPCRouteV2() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateCIDR,
 			},
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -76,7 +70,6 @@ func resourceVpcRouteV2Create(d *schema.ResourceData, meta interface{}) error {
 		Type:        d.Get("type").(string),
 		NextHop:     d.Get("nexthop").(string),
 		Destination: d.Get("destination").(string),
-		Tenant_Id:   d.Get("tenant_id").(string),
 		VPC_ID:      d.Get("vpc_id").(string),
 	}
 
@@ -115,7 +108,6 @@ func resourceVpcRouteV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("type", n.Type)
 	d.Set("nexthop", n.NextHop)
 	d.Set("destination", n.Destination)
-	d.Set("tenant_id", n.Tenant_Id)
 	d.Set("vpc_id", n.VPC_ID)
 	d.Set("region", GetRegion(d, config))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Vpc route API is not support tenant_id parameter for Request Body now.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove tenant_id from document and data source
```

## PR Checklist

- [ ] Tests added/passed.
- [x] Documentation updated.
- [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
