### PR TITLE
nat_gateway replace client v2.0 with client v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd
+	github.com/huaweicloud/golangsdk v0.0.0-20210203063806-fb00aaa2f808
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,10 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210130015616-a15f013de8ca h1:ucLVgXpwEIbvBZn6OeEz9/gtIxBWDYRHgef44HkYp5o=
-github.com/huaweicloud/golangsdk v0.0.0-20210130015616-a15f013de8ca/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd h1:tgbXiqSIM86dGQD7tLgeV/LEX7CysuuoHfUKLKoIIRs=
-github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210203063806-fb00aaa2f808 h1:VutIOJU3qNKI8kuXqksk2SB2LfIOwv7Awo7+hWAv6f4=
+github.com/huaweicloud/golangsdk v0.0.0-20210203063806-fb00aaa2f808/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -122,7 +122,7 @@ func resourceNatDnatUserInputParams(d *schema.ResourceData) map[string]interface
 
 func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.natV2Client(GetRegion(d, config))
+	client, err := config.natGatewayV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
@@ -235,7 +235,7 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceNatDnatRuleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.natV2Client(GetRegion(d, config))
+	client, err := config.natGatewayV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
@@ -404,7 +404,7 @@ func resourceNatDnatRuleRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.natV2Client(GetRegion(d, config))
+	client, err := config.natGatewayV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
@@ -413,7 +413,8 @@ func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	url = client.ServiceURL(url)
+	natGatewayID := d.Get("nat_gateway_id").(string)
+	url = client.ServiceURL("nat_gateways", natGatewayID, url)
 
 	log.Printf("[DEBUG] Deleting Dnat %q", d.Id())
 	r := golangsdk.Result{}

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
@@ -39,7 +39,7 @@ func TestAccNatSnatRule_basic(t *testing.T) {
 
 func testAccCheckNatV2SnatRuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	natClient, err := config.natV2Client(HW_REGION_NAME)
+	natClient, err := config.natGatewayV2Client(HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}
@@ -70,7 +70,7 @@ func testAccCheckNatV2SnatRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		natClient, err := config.natV2Client(HW_REGION_NAME)
+		natClient, err := config.natGatewayV2Client(HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 		}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/hw_snatrules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/hw_snatrules/requests.go
@@ -47,7 +47,7 @@ func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
 }
 
 // Delete is a method by which can be able to delete a snat rule
-func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
-	_, r.Err = c.Delete(resourceURL(c, id), nil)
+func Delete(c *golangsdk.ServiceClient, id, natGatewayID string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURLDelete(c, id, natGatewayID), nil)
 	return
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/hw_snatrules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/hw_snatrules/urls.go
@@ -11,3 +11,7 @@ func rootURL(c *golangsdk.ServiceClient) string {
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
+
+func resourceURLDelete(c *golangsdk.ServiceClient, id, natGatewayID string) string {
+	return c.ServiceURL("nat_gateways", natGatewayID, resourcePath, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210130071727-0e4040f46efd
+# github.com/huaweicloud/golangsdk v0.0.0-20210203063806-fb00aaa2f808
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

nat_gateway replace client v2.0 with client v2
Affected resources:
data_source_huaweicloud_nat_gateway
resource_huaweicloud_nat_dnat_rule
resource_huaweicloud_nat_snat_rule


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNat'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNat -timeout 360m -parallel 4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== RUN   TestAccNatDnat_protocol
=== PAUSE TestAccNatDnat_protocol
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== RUN   TestAccNatGateway_withEpsId
=== PAUSE TestAccNatGateway_withEpsId
=== RUN   TestAccNatSnatRule_basic
=== PAUSE TestAccNatSnatRule_basic
=== CONT  TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGateway_withEpsId
=== CONT  TestAccNatSnatRule_basic
=== CONT  TestAccNatDnat_protocol
=== CONT  TestAccNatGateway_withEpsId
    provider_test.go:149: This environment does not support EPS_ID tests
--- SKIP: TestAccNatGateway_withEpsId (0.01s)
=== CONT  TestAccNatDnat_basic
--- PASS: TestAccNatGatewayDataSource_basic (81.98s)
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatSnatRule_basic (100.66s)
--- PASS: TestAccNatGateway_basic (87.69s)
--- PASS: TestAccNatDnat_protocol (216.01s)
--- PASS: TestAccNatDnat_basic (216.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       216.610s
```
