### PR TITLE
unify the nat gateway client to customize nat service endpoint by nat key

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ The following arguments are supported:
   If omitted, the `HW_ENTERPRISE_PROJECT_ID` environment variable is used.
 
 * `endpoints` - (Optional) Configuration block in key/value pairs for customizing service endpoints.
-  The following endpoints support to be customized: autoscaling, ecs, ims, vpc, evs, obs, sfs, cce, rds, dds, iam.
+  The following endpoints support to be customized: autoscaling, ecs, ims, vpc, nat, evs, obs, sfs, cce, rds, dds, iam.
   An example provider configuration:
 
 ```hcl

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -647,12 +647,8 @@ func (c *Config) VPCEPClient(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("vpcep", region)
 }
 
-func (c *Config) natV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("natv2", region)
-}
-
-func (c *Config) natGatewayV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("nat_gatewayv2", region)
+func (c *Config) NatGatewayClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("nat", region)
 }
 
 func (c *Config) elasticLBClient(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
@@ -60,7 +60,7 @@ func dataSourceNatGatewayV2() *schema.Resource {
 
 func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	natClient, err := config.natGatewayV2Client(GetRegion(d, config))
+	natClient, err := config.NatGatewayClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -138,12 +138,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "vpc",
 		Version: "v1",
 	},
-	"natv2": ServiceCatalog{
-		Name:             "nat",
-		Version:          "v2.0",
-		WithOutProjectID: true,
-	},
-	"nat_gatewayv2": ServiceCatalog{
+	"nat": ServiceCatalog{
 		Name:    "nat",
 		Version: "v2",
 	},

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -550,7 +550,6 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 }
 
 // TestAccServiceEndpoints_Network test for the endpoints of the clients used in network
-// include networkingV1Client, networkingV2Client, natV2Client, loadElasticLoadBalancerClient and FwV2Client
 func TestAccServiceEndpoints_Network(t *testing.T) {
 
 	testAccPreCheckServiceEndpoints(t)
@@ -585,21 +584,11 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "networking", "v2.0", t)
 
-	// test endpoint of nat v2
+	// test endpoint of nat gateway
 	serviceClient, err = nil, nil
-	serviceClient, err = config.natV2Client(HW_REGION_NAME)
+	serviceClient, err = config.NatGatewayClient(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud nat v2 client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://nat.%s.%s/v2.0/", HW_REGION_NAME, config.Cloud)
-	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "nat", "v2.0", t)
-
-	// test endpoint of nat_gateway v2
-	serviceClient, err = nil, nil
-	serviceClient, err = config.natGatewayV2Client(HW_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud nat_gateway v2 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud nat gateway client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://nat.%s.%s/v2/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -122,7 +122,7 @@ func resourceNatDnatUserInputParams(d *schema.ResourceData) map[string]interface
 
 func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.natGatewayV2Client(GetRegion(d, config))
+	client, err := config.NatGatewayClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
@@ -235,7 +235,7 @@ func resourceNatDnatRuleCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceNatDnatRuleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.natGatewayV2Client(GetRegion(d, config))
+	client, err := config.NatGatewayClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
@@ -404,7 +404,7 @@ func resourceNatDnatRuleRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceNatDnatRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.natGatewayV2Client(GetRegion(d, config))
+	client, err := config.NatGatewayClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2_test.go
@@ -79,7 +79,7 @@ func TestAccNatDnat_protocol(t *testing.T) {
 
 func testAccCheckNatDnatDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.natGatewayV2Client(HW_REGION_NAME)
+	client, err := config.NatGatewayClient(HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
@@ -109,7 +109,7 @@ func testAccCheckNatDnatDestroy(s *terraform.State) error {
 func testAccCheckNatDnatExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.natGatewayV2Client(HW_REGION_NAME)
+		client, err := config.NatGatewayClient(HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating sdk client, err=%s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
@@ -69,7 +69,7 @@ func TestAccNatGateway_withEpsId(t *testing.T) {
 
 func testAccCheckNatV2GatewayDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	natClient, err := config.natGatewayV2Client(HW_REGION_NAME)
+	natClient, err := config.NatGatewayClient(HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}
@@ -100,7 +100,7 @@ func testAccCheckNatV2GatewayExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		natClient, err := config.natGatewayV2Client(HW_REGION_NAME)
+		natClient, err := config.NatGatewayClient(HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
@@ -39,7 +39,7 @@ func TestAccNatSnatRule_basic(t *testing.T) {
 
 func testAccCheckNatV2SnatRuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	natClient, err := config.natGatewayV2Client(HW_REGION_NAME)
+	natClient, err := config.NatGatewayClient(HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}
@@ -70,7 +70,7 @@ func testAccCheckNatV2SnatRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		natClient, err := config.natGatewayV2Client(HW_REGION_NAME)
+		natClient, err := config.NatGatewayClient(HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
unify the nat gateway client to NatGatewayClient, so we can customize nat service endpoint by `nat` key.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatSnatRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccNatSnatRule_basic
=== PAUSE TestAccNatSnatRule_basic
=== CONT  TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (108.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       108.380s
```
