### PR TITLE
[Fix] Fix the error of access type setting

### DIFF
--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
@@ -72,10 +72,12 @@ func resourceSFSFileSystemV2() *schema.Resource {
 			"access_level": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"access_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"access_to": {
 				Type:     schema.TypeString,
@@ -336,9 +338,8 @@ func resourceSFSFileSystemV2Update(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChanges("access_to", "access_level", "access_type") {
-		ruleID := d.Get("share_access_id").(string)
-		if ruleID != "" {
-			deleteAccessOpts := shares.DeleteAccessOpts{AccessID: ruleID}
+		if ruleID, ok := d.GetOk("share_access_id"); ok {
+			deleteAccessOpts := shares.DeleteAccessOpts{AccessID: ruleID.(string)}
 			deny := shares.DeleteAccess(sfsClient, d.Id(), deleteAccessOpts)
 			if deny.Err != nil {
 				return fmt.Errorf("Error changing access rules for share file : %s", deny.Err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Access type and access level hasn't default value, program will throw a Error when SFS doing upodation.
In huaweicloud SFS API, access level has a default value 'rw' and access type is 'cert'. When program doing updation,
Terraform will doing read and use it to compare with state config. Then, program find a difference because of access type
set null in updation and state config is not empty. The API doesn't accept null values, so, the Error happiend.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. set access_level and access_type to computed.
2. use d.GetOk() instead of d.Get() and empty check because of d.GetOk() contains d.Get() and empty check.
```

## PR Checklist

- [x] Tests added/passed.
- [ ] Documentation updated.
- [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccSFSFileSystemV2_basic -timeout 360m -parallel 4
=== RUN   TestAccSFSFileSystemV2_basic
=== PAUSE TestAccSFSFileSystemV2_basic
=== CONT  TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (103.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       103.818s
```
