### PR TITLE
change the type of volume extend_param to map

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -162,13 +162,13 @@ The following arguments are supported:
 
   * `size` - (Required, Int) Disk size in GB.
   * `volumetype` - (Required, String) Disk type.
-  * `extend_param` - (Optional, String) Disk expansion parameters.
+  * `extend_param` - (Optional, Map) Disk expansion parameters.
 
 * `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
 
   * `size` - (Required, Int) Disk size in GB.
   * `volumetype` - (Required, String) Disk type.
-  * `extend_param` - (Optional, String) Disk expansion parameters.
+  * `extend_param` - (Optional, Map) Disk expansion parameters.
 
 * `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210204094539-de5c86db6e57
+	github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210204094539-de5c86db6e57 h1:4E3GRv08sl+5YAhp9bl0GfD/8QrxVoPlFojaT8qAj4c=
-github.com/huaweicloud/golangsdk v0.0.0-20210204094539-de5c86db6e57/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52 h1:+fuguE3AQsM8HRuT1dvcr1uO3eK0jXi3OXiUsb/kAF4=
+github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -102,8 +102,9 @@ func ResourceCCENodeV3() *schema.Resource {
 							Required: true,
 						},
 						"extend_param": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					}},
 			},
@@ -122,8 +123,9 @@ func ResourceCCENodeV3() *schema.Resource {
 							Required: true,
 						},
 						"extend_param": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					}},
 			},
@@ -318,7 +320,7 @@ func resourceCCEDataVolume(d *schema.ResourceData) []nodes.VolumeSpec {
 		volumes[i] = nodes.VolumeSpec{
 			Size:        rawMap["size"].(int),
 			VolumeType:  rawMap["volumetype"].(string),
-			ExtendParam: rawMap["extend_param"].(string),
+			ExtendParam: rawMap["extend_param"].(map[string]interface{}),
 		}
 	}
 	return volumes
@@ -344,7 +346,7 @@ func resourceCCERootVolume(d *schema.ResourceData) nodes.VolumeSpec {
 	if len(nicsRaw) == 1 {
 		nics.Size = nicsRaw[0].(map[string]interface{})["size"].(int)
 		nics.VolumeType = nicsRaw[0].(map[string]interface{})["volumetype"].(string)
-		nics.ExtendParam = nicsRaw[0].(map[string]interface{})["extend_param"].(string)
+		nics.ExtendParam = nicsRaw[0].(map[string]interface{})["extend_param"].(map[string]interface{})
 	}
 	return nics
 }

--- a/huaweicloud/resource_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3_test.go
@@ -56,6 +56,14 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
 				),
 			},
+			{
+				Config: testAccCCENodeV3_volume_extendParam(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.extend_param.test_key", "test_val"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.0.extend_param.test_key", "test_val"),
+				),
+			},
 		},
 	})
 }
@@ -265,6 +273,39 @@ resource "huaweicloud_cce_node_v3" "test" {
 
   // Assign existing EIP
   eip_id = huaweicloud_vpc_eip_v1.test.id
+}
+`, testAccCCENodeV3_Base(rName), rName)
+}
+
+func testAccCCENodeV3_volume_extendParam(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_node_v3" "test" {
+  cluster_id        = huaweicloud_cce_cluster_v3.test.id
+  name              = "%s"
+  flavor_id         = "s6.small.1"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  key_pair          = huaweicloud_compute_keypair_v2.test.name
+
+  root_volume {
+    size         = 40
+	volumetype   = "SSD"
+	extend_param = {
+	  test_key = "test_val"
+	}
+  }
+  data_volumes {
+    size         = 100
+	volumetype   = "SSD"
+	extend_param = {
+	  test_key = "test_val"
+	}
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, testAccCCENodeV3_Base(rName), rName)
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes/results.go
@@ -135,7 +135,7 @@ type VolumeSpec struct {
 	// Disk type
 	VolumeType string `json:"volumetype" required:"true"`
 	// Disk extension parameter
-	ExtendParam string `json:"extendParam,omitempty"`
+	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
 }
 
 type ExtendParam struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210204094539-de5c86db6e57
+# github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

change the type of volume extend_param to map
In the API docs the type of root_volume and data_volumes in cce node is `Map`, but it was `String` in our code, this problem need to be fixed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1698.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1698.739s
```
