### PR TITLE
[refactor] Add empty check for access type and level in updation

### DIFF
--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
@@ -347,11 +347,21 @@ func resourceSFSFileSystemV2Update(d *schema.ResourceData, meta interface{}) err
 			d.Set("share_access_id", "")
 		}
 
-		if _, ok := d.GetOk("access_to"); ok {
+		if v, ok := d.GetOk("access_to"); ok {
 			grantAccessOpts := shares.GrantAccessOpts{
-				AccessLevel: d.Get("access_level").(string),
-				AccessType:  d.Get("access_type").(string),
-				AccessTo:    d.Get("access_to").(string),
+				AccessTo: v.(string),
+			}
+
+			if v, ok := d.GetOk("access_level"); ok {
+				grantAccessOpts.AccessLevel = v.(string)
+			} else {
+				grantAccessOpts.AccessLevel = "rw"
+			}
+
+			if v, ok := d.GetOk("access_type"); ok {
+				grantAccessOpts.AccessType = v.(string)
+			} else {
+				grantAccessOpts.AccessType = "cert"
 			}
 
 			log.Printf("[DEBUG] Grant Access Rules: %#v", grantAccessOpts)

--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2_test.go
@@ -171,7 +171,6 @@ resource "huaweicloud_sfs_file_system" "sfs_1" {
   name         = "%s"
   description  = "sfs_c2c_test-file"
   access_to    = huaweicloud_vpc.test.id
-  access_type  = "cert"
   access_level = "rw"
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
 
@@ -216,13 +215,12 @@ resource "huaweicloud_vpc" "test" {
 data "huaweicloud_availability_zones" "myaz" {}
 
 resource "huaweicloud_sfs_file_system" "sfs_1" {
-  share_proto  = "NFS"
-  size         = 20
-  name         = "%s"
-  description  = "sfs_c2c_test-file"
-  access_to    = huaweicloud_vpc.test.id
-  access_type  = "cert"
-  access_level = "rw"
+  share_proto = "NFS"
+  size        = 20
+  name        = "%s"
+  description = "sfs_c2c_test-file"
+  access_to   = huaweicloud_vpc.test.id
+  access_type = "cert"
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
 
   tags = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For access_to, access_level and access_type, separate null values are determined.
When access_level or access_type is null, corresponding default values need to be set.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add empty check for each access parameter and setting default value for access type and level.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccSFSFileSystemV2_basic -timeout 360m -parallel 4
=== RUN   TestAccSFSFileSystemV2_basic
=== PAUSE TestAccSFSFileSystemV2_basic
=== CONT  TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (109.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       109.499s
```
