### PR TITLE
[Fix] Get epsID form config when resource parameter get empty

### DIFF
--- a/docs/resources/cdm_cluster.md
+++ b/docs/resources/cdm_cluster.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `email` - (Optional, List, ForceNew) Notification email addresses. The max number is 5.  Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, List, ForceNew) The enterprise project id.  Changing this parameter will create a new resource.
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id.  Changing this parameter will create a new resource.
 
 * `is_auto_off` - (Optional, Bool, ForceNew) Whether to automatically shut down.  Changing this parameter will create a new resource.
 

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -486,8 +486,9 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 			extendParam.IsAutoPay = "true"
 			extendParam.IsAutoRenew = d.Get("auto_renew").(string)
 		}
-		if hasFilledOpt(d, "enterprise_project_id") {
-			extendParam.EnterpriseProjectId = d.Get("enterprise_project_id").(string)
+		epsID := GetEnterpriseProjectID(d, config)
+		if epsID != "" {
+			extendParam.EnterpriseProjectId = epsID
 		}
 		if extendParam != (cloudservers.ServerExtendParam{}) {
 			createOpts.ExtendParam = &extendParam

--- a/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
@@ -249,8 +249,9 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 		extendParam.IsAutoPay = "true"
 		extendParam.IsAutoRenew = d.Get("auto_renew").(string)
 	}
-	if hasFilledOpt(d, "enterprise_project_id") {
-		extendParam.EnterpriseProjectId = d.Get("enterprise_project_id").(string)
+	epsID := GetEnterpriseProjectID(d, config)
+	if epsID != "" {
+		extendParam.EnterpriseProjectId = epsID
 	}
 	if extendParam != (cloudservers.ServerExtendParam{}) {
 		createOpts.ExtendParam = &extendParam

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -331,7 +331,7 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 		SubnetId:            d.Get("subnet_id").(string),
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		ConfigurationId:     d.Get("configuration_id").(string),
-		EnterpriseProjectId: d.Get("enterprise_project_id").(string),
+		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
 		Password:            d.Get("password").(string),
 		Mode:                "Cluster",
 		Flavor:              resourceGeminiDBFlavor(d),

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -303,7 +303,7 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		SubnetId:            d.Get("subnet_id").(string),
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		ConfigurationId:     d.Get("configuration_id").(string),
-		EnterpriseProjectId: d.Get("enterprise_project_id").(string),
+		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
 		TimeZone:            d.Get("time_zone").(string),
 		SlaveCount:          d.Get("read_replicas").(int),
 		Mode:                "Cluster",

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -356,7 +356,7 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 		SubnetId:            d.Get("subnet_id").(string),
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		Port:                d.Get("port").(string),
-		EnterpriseProjectId: d.Get("enterprise_project_id").(string),
+		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
 		TimeZone:            d.Get("time_zone").(string),
 		AvailabilityZone:    d.Get("availability_zone").(string),
 		ConfigurationId:     d.Get("configuration_id").(string),

--- a/huaweicloud/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/resource_huaweicloud_rds_read_replica_instance.go
@@ -185,7 +185,7 @@ func resourceRdsReadReplicaInstanceCreate(d *schema.ResourceData, meta interface
 		AvailabilityZone:    d.Get("availability_zone").(string),
 		Volume:              resourceReplicaInstanceVolume(d),
 		DiskEncryptionId:    resourceDiskEncryptionID(d),
-		EnterpriseProjectId: d.Get("enterprise_project_id").(string),
+		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
 	}
 	log.Printf("[DEBUG] Create replica instance Options: %#v", createOpts)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In general, resources will search provider config when terraform config is empty.
But some resources  just only use default value to create resource. It makes user's configuration in the provider useless.
So, we should update this logic referring to subnet or other resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. searching EnterpriseProjectID from provider config and environment variable when terraform config is empty.
2. update enterprise_project_id schema type from 'List' to 'String'
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
