### PR TITLE
[Refactor] Update secgroup rule resource and document

### DIFF
--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -30,65 +30,60 @@ resource "huaweicloud_networking_secgroup_rule" "secgroup_rule" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the security group rule resource. If omitted, the provider-level region will be used. Changing this creates a new security group rule resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to
+    create the security group rule resource. If omitted, the provider-level
+    region will be used.
+    Changing this creates a new security group rule.
 
-* `direction` - (Required, String, ForceNew) The direction of the rule, valid values are __ingress__
-    or __egress__. Changing this creates a new security group rule.
+* `direction` - (Required, String, ForceNew) Specifies the direction of the
+    rule, valid values are __ingress__ or __egress__.
+    Changing this creates a new security group rule.
 
-* `ethertype` - (Required, String, ForceNew) The layer 3 protocol type, valid values are __IPv4__
-    or __IPv6__. Changing this creates a new security group rule.
+* `ethertype` - (Required, String, ForceNew) Specifies the layer 3 protocol
+    type, valid values are __IPv4__ or __IPv6__.
+    Changing this creates a new security group rule.
 
-* `protocol` - (Optional, String, ForceNew) The layer 4 protocol type, valid values are following. Changing this creates a new security group rule. This is required if you want to specify a port range.
-  * __tcp__
-  * __udp__
-  * __icmp__
-  * __ah__
-  * __dccp__
-  * __egp__
-  * __esp__
-  * __gre__
-  * __igmp__
-  * __ipv6-encap__
-  * __ipv6-frag__
-  * __ipv6-icmp__
-  * __ipv6-nonxt__
-  * __ipv6-opts__
-  * __ipv6-route__
-  * __ospf__
-  * __pgm__
-  * __rsvp__
-  * __sctp__
-  * __udplite__
-  * __vrrp__
+* `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol
+    type, valid values are following. This is required if you want to specify
+    a port range.
+    * __tcp__
+    * __udp__
+    * __icmp__
+    Changing this creates a new security group rule.
 
-* `port_range_min` - (Optional, String, ForceNew) The lower part of the allowed port range, valid
-    integer value needs to be between 1 and 65535. Changing this creates a new
-    security group rule.
+* `port_range_min` - (Optional, String, ForceNew) Specifies the lower part of
+    the allowed port range, valid integer value needs to be between 1 and
+    65535.
+    Changing this creates a new security group rule.
 
-* `port_range_max` - (Optional, Int, ForceNew) The higher part of the allowed port range, valid
-    integer value needs to be between 1 and 65535. Changing this creates a new
-    security group rule.
+* `port_range_max` - (Optional, Int, ForceNew) Specifies the higher part of the
+    allowed port range, valid integer value needs to be between 1 and 65535.
+    Changing this creates a new security group rule.
 
-* `remote_ip_prefix` - (Optional, String, ForceNew) The remote CIDR, the value needs to be a valid
-    CIDR (i.e. 192.168.0.0/16). Changing this creates a new security group rule.
+* `remote_ip_prefix` - (Optional, String, ForceNew) Specifies the remote CIDR,
+    the value needs to be a valid CIDR (i.e. 192.168.0.0/16).
+    Changing this creates a new security group rule.
 
-* `remote_group_id` - (Optional, String, ForceNew) The remote group id, the value needs to be an
-    Openstack ID of a security group in the same tenant. Changing this creates
-    a new security group rule.
+* `remote_group_id` - (Optional, String, ForceNew) Specifies the remote group
+    id, the value needs to be an Openstack ID of a security group in the same
+    tenant.
+    Changing this creates a new security group rule.
 
-* `security_group_id` - (Required, String, ForceNew) The security group id the rule should belong
-    to, the value needs to be an Openstack ID of a security group in the same
-    tenant. Changing this creates a new security group rule.
+* `security_group_id` - (Required, String, ForceNew) Specifies the security
+    group id the rule should belong to, the value needs to be an Openstack ID
+    of a security group in the same tenant.
+    Changing this creates a new security group rule.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the security group. Required if admin
-    wants to create a port for another tenant. Changing this creates a new
-    security group rule.
+* `tenant_id` - (Optional, String, ForceNew) Specifies the owner of the
+    security group. Required if admin wants to create a port for another
+    tenant.
+    Changing this creates a new security group rule.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - The resource ID in UUID format.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Secgroup rule test does not conform to the writing specification:
  a. The verification of security group should be written in the test of security group.
  b. To avoid duplicate security group names, names containing random strings should be used.
  c. Incomplete verification samples.
  d. The example format of terraform script is not aligned.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update parameter prefix description.
2. refactor acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
Security group rule Basic Test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2SecGroupRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2SecGroupRule_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (38.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       38.567s
```
Security group rule remoteGroup Test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2SecGroupRule_remoteGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2SecGroupRule_remoteGroup -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingV2SecGroupRule_remoteGroup
=== CONT  TestAccNetworkingV2SecGroupRule_remoteGroup
--- PASS: TestAccNetworkingV2SecGroupRule_remoteGroup (37.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       37.333s
```
Security group rule lowcase CIDR Test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2SecGroupRule_lowerCaseCIDR'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2SecGroupRule_lowerCaseCIDR -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroupRule_lowerCaseCIDR
=== PAUSE TestAccNetworkingV2SecGroupRule_lowerCaseCIDR
=== CONT  TestAccNetworkingV2SecGroupRule_lowerCaseCIDR
--- PASS: TestAccNetworkingV2SecGroupRule_lowerCaseCIDR (36.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       36.334s
```
Security group rule numeric Protocol Test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2SecGroupRule_numericProtocol'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2SecGroupRule_numericProtocol -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (44.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       44.147s
```