### PR TITLE
[Fix][Refactor] Fix field values missing of volume import operation

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -45,10 +45,12 @@ resource "huaweicloud_evs_volume" "volume" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the EVS volume resource. If omitted, the provider-level region will be used. Changing this creates a new EVS resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the EVS volume resource.
+    If omitted, the provider-level region will be used.
+    Changing this creates a new EVS volume resource.
 
-* `availability_zone` - (Required, String, ForceNew) The availability zone for the volume.
-    Changing this creates a new volume.
+* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone for the volume.
+    Changing this creates a new EVS volume resource.
 
 * `volume_type` - (Required, String, ForceNew) Specifies the disk type.
     Currently, the value can be SSD, SAS, or SATA.
@@ -56,6 +58,7 @@ The following arguments are supported:
     - SAS: specifies the high I/O disk type.
     - SATA: specifies the common I/O disk type.
     If the specified disk type is not available in the AZ, the disk will fail to create.
+    Changing this creates a new EVS volume resource.
 
 * `name` - (Optional, String) Specifies the disk name.
     If you create disks one by one, the name value is the disk name. The value can contain a maximum of 255 bytes.
@@ -66,27 +69,31 @@ The following arguments are supported:
 * `size` - (Optional, Int) Specifies the disk size, in GB. Its value can be as follows:
     - System disk: 1 GB to 1024 GB
     - Data disk: 10 GB to 32768 GB
-    This parameter is mandatory when you create an empty disk. You can specify the parameter value as required within the value range.
-    This parameter is mandatory when you create the disk from a snapshot. Ensure that the disk size is greater than or equal to the snapshot size.
-    This parameter is mandatory when you create the disk from an image. Ensure that the disk size is greater than or equal to 
-    the minimum disk capacity required by min_disk in the image attributes.
-    This parameter is optional when you create the disk from a backup. If this parameter is not specified, the disk size is equal to the backup size.
-    Changing this parameter will update the disk. You can extend the disk by setting this parameter to a new value, which must be between current size
-    and the max size(System disk: 1024 GB; Data disk: 32768 GB). Shrinking the disk is not supported.
+    This parameter is mandatory when you create an empty disk. You can specify the parameter value as required within
+    the value range.
+    This parameter is mandatory when you create the disk from a snapshot. Ensure that the disk size is greater than or
+    equal to the snapshot size.
+    This parameter is mandatory when you create the disk from an image. Ensure that the disk size is greater than or
+    equal to the minimum disk capacity required by min_disk in the image attributes.
+    This parameter is optional when you create the disk from a backup. If this parameter is not specified, the disk
+    size is equal to the backup size.
+    You can extend the disk by setting this parameter to a new value, which must be between current size
+    and the max size (System disk: 1024 GB; Data disk: 32768 GB). Shrinking the disk is not supported.
 
 * `description` - (Optional, String) Specifies the disk description. The value can contain a maximum of 255 bytes.
 
-* `image_id` - (Optional, String, ForceNew) The image ID from which to create the volume.
-    Changing this creates a new volume.
+* `image_id` - (Optional, String, ForceNew) Specifies the image ID from which to create the volume.
+    Changing this creates a new EVS volume resource.
 
-* `backup_id` - (Optional, String, ForceNew) The backup ID from which to create the volume.
-    Changing this creates a new volume.
+* `backup_id` - (Optional, String, ForceNew) Specifies the backup ID from which to create the volume.
+    Changing this creates a new EVS volume resource.
 
-* `snapshot_id` - (Optional, String, ForceNew) The snapshot ID from which to create the volume.
-    Changing this creates a new volume.
+* `snapshot_id` - (Optional, String, ForceNew) Specifies the snapshot ID from which to create the volume.
+    Changing this creates a new EVS volume resource.
 
-* `tags` - (Optional, Map, String) A maximum of 10 tags can be created for a disk.
-    Tag keys of a tag must be unique. Deduplication will be performed for duplicate keys. 
+* `tags` - (Optional, Map, String) Specifies the key/value pairs to associate with the instance.
+    A maximum of 10 tags can be created for a disk. Tag keys of a tag must be unique.
+    Deduplication will be performed for duplicate keys. 
     Therefore, only one tag key in the duplicate keys is valid.
 
     - Tag key: A tag key is a string of no more than 36 characters.
@@ -95,25 +102,25 @@ The following arguments are supported:
     - Tag value: A tag value is a string of no more than 43 characters and can be an empty string.
     It consists of letters, digits, underscores (_), periods (.), hyphens (-), and Unicode characters (\u4E00-\u9FFF).
 	
-* `multiattach` - (Optional, String, ForceNew) Default:false. Specifies the shared EVS disk information.
-    Changing this creates a new volume.
+* `multiattach` - (Optional, String, ForceNew) Specifies the shared EVS disk information. Defaults to false. 
+    Changing this creates a new EVS volume resource.
 
-* `kms_id` - (Optional, String, ForceNew) The Encryption KMS ID to create the volume.
-    Changing this creates a new volume.
+* `kms_id` - (Optional, String, ForceNew) Specifies the Encryption KMS ID to create the volume.
+    Changing this creates a new EVS volume resource.
 
-* `device_type` - (Optional, String, ForceNew) The device type of volume to create. Valid options are VBD and SCSI.
-	Defaults to VBD. Changing this creates a new volume.
+* `device_type` - (Optional, String, ForceNew) Specifies the device type of volume to create.
+    Valid options are VBD and SCSI. Defaults to VBD.
+    Changing this creates a new EVS volume resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - A resource ID in UUID format.
 
-* `attachment` - If a volume is attached to an instance, this attribute will
-    display the Attachment ID, Instance ID, and the Device as the Instance
-    sees it.
-* `wwn` - Specifies the unique identifier used for mounting the EVS disk.
+* `attachment` - If a volume is attached to an instance, this attribute will display the Attachment ID, Instance ID,
+    and the Device as the Instance sees it.
+* `wwn` - The unique identifier used for mounting the EVS disk.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/resource_huaweicloud_evs_volume_test.go
@@ -31,6 +31,11 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccEvsStorageV3Volume_basic(rNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
@@ -56,6 +61,11 @@ func TestAccEvsStorageV3Volume_tags(t *testing.T) {
 					testAccCheckEvsStorageV3VolumeTags(resourceName, "foo", "bar"),
 					testAccCheckEvsStorageV3VolumeTags(resourceName, "key", "value"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccEvsStorageV3Volume_tags_update(rName),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/requests.go
@@ -69,3 +69,11 @@ func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
+
+// Delete will permanently delete a particular service stage based on its unique ID.
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/results.go
@@ -123,3 +123,7 @@ func (r commonResult) ExtractInto(v interface{}) error {
 type GetResult struct {
 	commonResult
 }
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/urls.go
@@ -6,6 +6,10 @@ func createURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("cloudvolumes")
 }
 
+func deleteURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("cloudvolumes", id)
+}
+
 func getURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL("os-vendor-volumes", id)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Some fields were not support import operation, like multiattach and device_type. 
2. cascade parameter was deprecated in API, we need to remove it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #916

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. saving device_type and multiattach to terraform state at resource reading. 
2. remove cascade parameter from schema.
3. add import test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

Basic test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccEvsStorageV3Volume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccEvsStorageV3Volume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsStorageV3Volume_basic
=== PAUSE TestAccEvsStorageV3Volume_basic
=== CONT  TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (60.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       60.890s
```
Tags test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccEvsStorageV3Volume_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccEvsStorageV3Volume_tags -timeout 360m -parallel 4
=== RUN   TestAccEvsStorageV3Volume_tags
=== PAUSE TestAccEvsStorageV3Volume_tags
=== CONT  TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (61.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       61.135s
```