### PR TITLE
[Fix][Refactor] Fix field values missing of volume import operation

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -12,7 +12,7 @@ Manages a volume resource within HuaweiCloud.
 resource "huaweicloud_evs_volume" "volume" {
   name              = "volume"
   description       = "my volume"
-  volume_type       = "SATA"
+  volume_type       = "SAS"
   size              = 20
   availability_zone = "cn-north-4a"
 
@@ -29,7 +29,7 @@ resource "huaweicloud_evs_volume" "volume" {
 resource "huaweicloud_evs_volume" "volume" {
   name              = "volume"
   description       = "my volume"
-  volume_type       = "SATA"
+  volume_type       = "SAS"
   size              = 20
   kms_id            = var.kms_id
   availability_zone = "cn-north-4a"
@@ -45,81 +45,72 @@ resource "huaweicloud_evs_volume" "volume" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the EVS volume resource. If omitted, the provider-level region will be used. Changing this creates a new EVS resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the disk.
+    If omitted, the provider-level region will be used.
+    Changing this creates a new disk.
 
-* `availability_zone` - (Required, String, ForceNew) The availability zone for the volume.
-    Changing this creates a new volume.
+* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone for the disk.
+    Changing this creates a new disk.
 
 * `volume_type` - (Required, String, ForceNew) Specifies the disk type.
-    Currently, the value can be SSD, SAS, or SATA.
+    Currently, the value can be SSD, GPSSD or SAS.
     - SSD: specifies the ultra-high I/O disk type.
+    - GPSSD: specifies the general purpose SSD disk type.
     - SAS: specifies the high I/O disk type.
-    - SATA: specifies the common I/O disk type.
-    If the specified disk type is not available in the AZ, the disk will fail to create.
 
-* `name` - (Optional, String) Specifies the disk name.
-    If you create disks one by one, the name value is the disk name. The value can contain a maximum of 255 bytes.
-    If you create multiple disks (the count value is greater than 1), the system automatically adds a hyphen followed 
-    by a four-digit incremental number, such as -0000, to the end of each disk name. For example, 
-    the disk names can be volume-0001 and volume-0002. The value can contain a maximum of 250 bytes.
+    If the specified disk type is not available in the AZ, the disk will fail to create.
+    Changing this creates a new disk.
+
+* `name` - (Optional, String) Specifies the disk name. The value can contain a maximum of 255 bytes.
 
 * `size` - (Optional, Int) Specifies the disk size, in GB. Its value can be as follows:
     - System disk: 1 GB to 1024 GB
     - Data disk: 10 GB to 32768 GB
-    This parameter is mandatory when you create an empty disk. You can specify the parameter value as required within the value range.
-    This parameter is mandatory when you create the disk from a snapshot. Ensure that the disk size is greater than or equal to the snapshot size.
-    This parameter is mandatory when you create the disk from an image. Ensure that the disk size is greater than or equal to 
-    the minimum disk capacity required by min_disk in the image attributes.
-    This parameter is optional when you create the disk from a backup. If this parameter is not specified, the disk size is equal to the backup size.
-    Changing this parameter will update the disk. You can extend the disk by setting this parameter to a new value, which must be between current size
-    and the max size(System disk: 1024 GB; Data disk: 32768 GB). Shrinking the disk is not supported.
+
+    This parameter is mandatory when you create an empty disk. You can specify the parameter value as required within
+    the value range.
+    <br>This parameter is mandatory when you create the disk from a snapshot. Ensure that the disk size is greater
+    than or equal to the snapshot size.
+    <br>This parameter is mandatory when you create the disk from an image. Ensure that the disk size is greater than
+    or equal to the minimum disk capacity required by min_disk in the image attributes.
+    <br>This parameter is optional when you create the disk from a backup. If this parameter is not specified, the
+    disk size is equal to the backup size.
+    <br>Shrinking the disk is not supported.
 
 * `description` - (Optional, String) Specifies the disk description. The value can contain a maximum of 255 bytes.
 
-* `image_id` - (Optional, String, ForceNew) The image ID from which to create the volume.
-    Changing this creates a new volume.
+* `image_id` - (Optional, String, ForceNew) Specifies the image ID from which to create the disk.
+    Changing this creates a new disk.
 
-* `backup_id` - (Optional, String, ForceNew) The backup ID from which to create the volume.
-    Changing this creates a new volume.
+* `backup_id` - (Optional, String, ForceNew) Specifies the backup ID from which to create the disk.
+    Changing this creates a new disk.
 
-* `snapshot_id` - (Optional, String, ForceNew) The snapshot ID from which to create the volume.
-    Changing this creates a new volume.
+* `snapshot_id` - (Optional, String, ForceNew) Specifies the snapshot ID from which to create the disk.
+    Changing this creates a new disk.
 
-* `tags` - (Optional, Map, String) A maximum of 10 tags can be created for a disk.
-    Tag keys of a tag must be unique. Deduplication will be performed for duplicate keys. 
-    Therefore, only one tag key in the duplicate keys is valid.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the disk.
 
-    - Tag key: A tag key is a string of no more than 36 characters.
-    It consists of letters, digits, underscores (_), hyphens (-), and Unicode characters (\u4E00-\u9FFF).
+* `multiattach` - (Optional, Bool, ForceNew) Specifies whether the disk is shareable. The default value is false.
+    Changing this creates a new disk.
 
-    - Tag value: A tag value is a string of no more than 43 characters and can be an empty string.
-    It consists of letters, digits, underscores (_), periods (.), hyphens (-), and Unicode characters (\u4E00-\u9FFF).
-	
-* `multiattach` - (Optional, String, ForceNew) Default:false. Specifies the shared EVS disk information.
-    Changing this creates a new volume.
+* `kms_id` - (Optional, String, ForceNew) Specifies the Encryption KMS ID to create the disk.
+    Changing this creates a new disk.
 
-* `kms_id` - (Optional, String, ForceNew) The Encryption KMS ID to create the volume.
-    Changing this creates a new volume.
+* `device_type` - (Optional, String, ForceNew) Specifies the device type of disk to create.
+    Valid options are VBD and SCSI. Defaults to VBD.
+    Changing this creates a new disk.
 
-* `device_type` - (Optional, String, ForceNew) The device type of volume to create. Valid options are VBD and SCSI.
-	Defaults to VBD. Changing this creates a new volume.
+* `cascade` - (Optional, Bool) Specifies the delete mode of snapshot. The default value is false.
+    All snapshot associated with the disk will also be deleted when the parameter is set to true.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
-
-* `attachment` - If a volume is attached to an instance, this attribute will
-    display the Attachment ID, Instance ID, and the Device as the Instance
-    sees it.
-* `wwn` - Specifies the unique identifier used for mounting the EVS disk.
-
-## Timeouts
-This resource provides the following timeouts configuration options:
-- `create` - Default is 10 minute.
-- `update` - Default is 3 minute.
-- `delete` - Default is 3 minute.
+* `id` - A resource ID in UUID format.
+* `attachment` - If a disk is attached to an instance, this attribute will display the Attachment ID, Instance ID,
+    and the Device as the Instance sees it.
+* `wwn` - The unique identifier used for mounting the EVS disk.
 
 ## Import
 
@@ -128,3 +119,25 @@ Volumes can be imported using the `id`, e.g.
 ```
 $ terraform import huaweicloud_evs_volume.volume_1 14a80bc7-c12c-4fe0-a38a-cb77eeac9bd6
 ```
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include: cascade.
+<br>It is generally recommended running terraform plan after importing an disk.
+<br>You can then decide if changes should be applied to the disk, or the resource definition should be updated to
+align with the disk. Also you can ignore changes as below.
+```
+resource "huaweicloud_evs_volume" "volume_1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      cascade,
+    ]
+  }
+}
+```
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `update` - Default is 3 minute.
+- `delete` - Default is 3 minute.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52
+	github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52 h1:+fuguE3AQsM8HRuT1dvcr1uO3eK0jXi3OXiUsb/kAF4=
 github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0 h1:n92GyvoN8wTBHZ16vvvEytIPJbQJ6yCkyYYWEVij2Os=
+github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/resource_huaweicloud_evs_volume_test.go
@@ -28,13 +28,23 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "size", "12"),
 				),
 			},
 			{
-				Config: testAccEvsStorageV3Volume_basic(rNameUpdate),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+				},
+			},
+			{
+				Config: testAccEvsStorageV3Volume_update(rNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "size", "20"),
 				),
 			},
 		},
@@ -197,6 +207,20 @@ resource "huaweicloud_evs_volume" "test" {
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   volume_type       = "SAS"
   size              = 12
+}
+`, rName)
+}
+
+func testAccEvsStorageV3Volume_update(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%s"
+  description       = "test volume"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  volume_type       = "SAS"
+  size              = 20
 }
 `, rName)
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes/results.go
@@ -56,6 +56,8 @@ type Volume struct {
 	Description string `json:"description"`
 	// The type of volume to create, either SATA or SSD.
 	VolumeType string `json:"volume_type"`
+	// The image ID of volume to create.
+	VolumeImageMetadata map[string]string `json:"volume_image_metadata"`
 	// The ID of the snapshot from which the volume was created
 	SnapshotID string `json:"snapshot_id"`
 	// The ID of another block storage volume from which the current volume was created

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52
+# github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some fields were not support import operation, like multiattach, image_id and device_type. 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #916

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. saving device_type and multiattach to terraform state at resource reading. 
2. reorder schema.
3. update acc test:
    a. add import test.
    b. add volume size test and check.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

Basic test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccEvsStorageV3Volume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccEvsStorageV3Volume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsStorageV3Volume_basic
=== PAUSE TestAccEvsStorageV3Volume_basic
=== CONT  TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (67.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       67.988s
```
Tags test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccEvsStorageV3Volume_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccEvsStorageV3Volume_tags -timeout 360m -parallel 4
=== RUN   TestAccEvsStorageV3Volume_tags
=== PAUSE TestAccEvsStorageV3Volume_tags
=== CONT  TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (61.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       61.135s
```
Image ID test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccEvsStorageV3Volume_image'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccEvsStorageV3Volume_image -timeout 360m -parallel 4
=== RUN   TestAccEvsStorageV3Volume_image
=== PAUSE TestAccEvsStorageV3Volume_image
=== CONT  TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (42.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       43.019s
```