### PR TITLE
[Feature][Docs][Test] Networking vip supports import operation

### DIFF
--- a/docs/resources/networking_vip.md
+++ b/docs/resources/networking_vip.md
@@ -45,3 +45,11 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The status of vip.
 * `tenant_id` - The tenant ID of the vip.
 * `device_owner` - The device owner of the vip.
+
+## Import
+
+Networking VIP can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_networking_vip.myvip ce595799-da26-4015-8db5-7733c6db292e
+```

--- a/huaweicloud/resource_huaweicloud_networking_vip_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_v2.go
@@ -18,6 +18,9 @@ func resourceNetworkingVIPV2() *schema.Resource {
 		Read:   resourceNetworkingVIPV2Read,
 		Update: resourceNetworkingVIPV2Update,
 		Delete: resourceNetworkingVIPV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {

--- a/huaweicloud/resource_huaweicloud_networking_vip_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_v2_test.go
@@ -29,6 +29,11 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccNetworkingV2VIPConfig_update(rand),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "acc-test-vip-updated"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refer Issue #915, import operation should be supported for networking vip.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #915

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports import operation.
2. add import test to TestAccNetworkingV2VIP_basic function.
3. add import example to vip document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2VIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2VIP_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIP_basic
=== PAUSE TestAccNetworkingV2VIP_basic
=== CONT  TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (94.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       94.907s
```
