### PR TITLE
[Feature][Test][Docs] Security group rule supports description parameter

### DIFF
--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -43,6 +43,12 @@ The following arguments are supported:
     type, valid values are __IPv4__ or __IPv6__.
     Changing this creates a new security group rule.
 
+* `description` - (Optional, String, ForceNew) Specifies the supplementary
+    information about the networking security group rule. 
+    This parameter can contain a maximum of 255 characters and cannot contain
+    angle brackets (< or >).
+    Changing this creates a new security group rule.
+
 * `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol
     type, valid values are following. This is required if you want to specify
     a port range.

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_rule_v2.go
@@ -51,6 +51,11 @@ func ResourceNetworkingSecGroupRuleV2() *schema.Resource {
 					"IPv4", "IPv6",
 				}, true),
 			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"port_range_min": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -84,9 +89,9 @@ func ResourceNetworkingSecGroupRuleV2() *schema.Resource {
 					return strings.ToLower(v.(string))
 				},
 			},
-			"security_group_id": {
+			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"tenant_id": {
@@ -118,6 +123,7 @@ func resourceNetworkingSecGroupRuleV2Create(d *schema.ResourceData, meta interfa
 	}
 
 	opts := rules.CreateOpts{
+		Description:    d.Get("description").(string),
 		SecGroupID:     d.Get("security_group_id").(string),
 		PortRangeMin:   d.Get("port_range_min").(int),
 		PortRangeMax:   d.Get("port_range_max").(int),
@@ -171,6 +177,7 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 	}
 
 	d.Set("direction", security_group_rule.Direction)
+	d.Set("description", security_group_rule.Description)
 	d.Set("ethertype", security_group_rule.EtherType)
 	d.Set("protocol", security_group_rule.Protocol)
 	d.Set("port_range_min", security_group_rule.PortRangeMin)

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_rule_v2_test.go
@@ -26,6 +26,7 @@ func TestAccNetworkingV2SecGroupRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupRuleExists(resourceRuleName, &secgroupRule),
 					resource.TestCheckResourceAttr(resourceRuleName, "direction", "ingress"),
+					resource.TestCheckResourceAttr(resourceRuleName, "description", "This is a basic acc test"),
 					resource.TestCheckResourceAttr(resourceRuleName, "port_range_min", "80"),
 					resource.TestCheckResourceAttr(resourceRuleName, "port_range_max", "80"),
 					resource.TestCheckResourceAttr(resourceRuleName, "ethertype", "IPv4"),
@@ -192,6 +193,7 @@ func testAccNetworkingV2SecGroupRule_basic(rName string) string {
 
 resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_test" {
   direction         = "ingress"
+  description       = "This is a basic acc test"
   ethertype         = "IPv4"
   port_range_max    = 80
   port_range_min    = 80


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Networking Security Group API supports description set and update operation, these actions can be supported by huaweicloud porvider.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #905 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add description parameter to provider schema, document and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2SecGroupRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2SecGroupRule_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (48.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       48.476s
```
