### PR TITLE
export param endpoints in config

### DIFF
--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	DomainClient *golangsdk.ProviderClient
 
 	// the custom endpoints used to override the default endpoint URL
-	endpoints map[string]string
+	Endpoints map[string]string
 
 	// RegionProjectIDMap is a map which stores the region-projectId pairs,
 	// and region name will be the key and projectID will be the value in this map.
@@ -373,7 +373,7 @@ func (l sLogger) Log(args ...interface{}) {
 }
 
 func getObsEndpoint(c *Config, region string) string {
-	if endpoint, ok := c.endpoints["obs"]; ok {
+	if endpoint, ok := c.Endpoints["obs"]; ok {
 		return endpoint
 	}
 	return fmt.Sprintf("https://obs.%s.%s/", region, c.Cloud)
@@ -437,7 +437,7 @@ func (c *Config) NewServiceClient(srv, region string) (*golangsdk.ServiceClient,
 		client = c.DomainClient
 	}
 
-	if endpoint, ok := c.endpoints[srv]; ok {
+	if endpoint, ok := c.Endpoints[srv]; ok {
 		return c.newServiceClientByEndpoint(client, srv, endpoint)
 	}
 	return c.newServiceClientByName(client, serviceCatalog, region)

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -709,7 +709,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 	if err != nil {
 		return nil, err
 	}
-	config.endpoints = endpoints
+	config.Endpoints = endpoints
 
 	return &config, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

export param endpoints in config
Replace `endpoints` with `Endpoints`, so this param can be used in G42cloud

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
