### PR TITLE
[Fix] Fix null exception of EpsID

### DIFF
--- a/huaweicloud/resource_huaweicloud_cdm_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_cdm_cluster_v1.go
@@ -556,12 +556,17 @@ func expandCdmClusterV1CreateClusterSysTags(d interface{}, arrayIndex map[string
 	if err != nil {
 		return nil, err
 	}
-	sysTags := make([]interface{}, 1, 1)
-	sysTags[0] = map[string]string{
-		"key":   "_sys_enterprise_project_id",
-		"value": v.(string),
+	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
+		return nil, fmt.Errorf("Error sys_tags enterprise_project_id, err = %s", err)
+	} else if !e {
+		sysTags := make([]interface{}, 1, 1)
+		sysTags[0] = map[string]string{
+			"key":   "_sys_enterprise_project_id",
+			"value": v.(string),
+		}
+		return sysTags, nil
 	}
-	return sysTags, nil
+	return nil, nil
 }
 
 func expandCdmClusterV1CreateEmail(d interface{}, arrayIndex map[string]int) (interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Sys_tags array missing empty check, when enterprise project id in getting response is null, terraform apply will throw ERROR.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #910

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. return empty sys_tags array when enterprise project id in getting response is null.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCdmClusterV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCdmClusterV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCdmClusterV1_basic
=== PAUSE TestAccCdmClusterV1_basic
=== CONT  TestAccCdmClusterV1_basic
--- PASS: TestAccCdmClusterV1_basic (765.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       765.510s
```
