### PR TITLE
add acc-test job in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,23 +65,24 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      #  run acceptance test
+      # run acceptance test
       - name: Run acceptance basic test
         # run the step only when HW_ACCESS_KEY is setted
         if: ${{ env.HW_ACCESS_KEY }}
         run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
-          all_files=$(git diff origin/master HEAD --stat huaweicloud | grep huaweicloud | grep -v "test.go" | awk -F '.' '{print $1}' | awk -F '/' '{print $2}')
+          all_files=$(git diff origin/master HEAD --name-only huaweicloud | grep -v "_test.go")
           echo "the following files have changed: $all_files"
 
           for f in $all_files; do
-            if [ -f "./huaweicloud/${f}_test.go" ]; then
-              all_cases=$(grep "^func TestAcc" ./huaweicloud/${f}_test.go | awk '{print $2}' | awk -F '(' '{print $1}' | grep basic)
-              echo "run acceptance tests: $all_cases"
-              for acc in $all_cases; do
-                make testacc TEST="./huaweicloud" TESTARGS="-run ${acc}"
-              done
+            test_file=${f/%.go/_test.go}
+            if [ -f "./${test_file}" ]; then
+              basic_cases=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk '{print $2}' | awk -F '(' '{print $1}')
+              if [ "X$basic_cases" != "X" ]; then
+                echo "run acceptance basic tests: $basic_cases"
+                make testacc TEST="./huaweicloud" TESTARGS="-run ${basic_cases}"
+              fi
             else
-              echo "[skipped] --- ./huaweicloud/${f}_test.go does not exist"
+              echo "[skipped] --- ./${test_file} does not exist"
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,41 @@ on:
     tags:
       - 'v*'
 jobs:
+  acc-test:
+    env:
+      HW_ACCESS_KEY: ${{ secrets.HW_ACCESS_KEY }}
+      HW_SECRET_KEY: ${{ secrets.HW_SECRET_KEY }}
+      HW_REGION_NAME: cn-north-4
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # run acceptance test
+      - name: Run acceptance basic test
+        # run the step only when HW_ACCESS_KEY is setted
+        if: ${{ env.HW_ACCESS_KEY }}
+        run: |
+          last_tag=$(git tag --sort=-creatordate | sed -n 2p)
+          all_files=$(git diff $last_tag --name-only huaweicloud | grep -v "_test.go")
+          echo "the following files have changed since $last_tag: $all_files"
+
+          for f in $all_files; do
+            test_file=${f/%.go/_test.go}
+            if [ -f "./${test_file}" ]; then
+              basic_cases=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk '{print $2}' | awk -F '(' '{print $1}')
+              if [ "X$basic_cases" != "X" ]; then
+                echo "run acceptance basic tests: $basic_cases"
+                make testacc TEST="./huaweicloud" TESTARGS="-run ${basic_cases}"
+              fi
+            else
+              echo "[skipped] --- ./${test_file} does not exist"
+            fi
+          done
+
   goreleaser:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add `acc-test` job in release action, it will run acceptance basic testing when add a new tag.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
