### PR TITLE
support eni network in cce cluster

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -127,8 +127,16 @@ versions are available, choose Dashboard > Buy Cluster on the CCE console. Chang
 	* `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS)
 	* `underlay_ipvlan` - An underlay_ipvlan network built for bare metal servers by using ipvlan.
 	* `vpc-router` - An vpc-router network built for containers by using ipvlan and custom VPC routes.
+	* `eni` - A Yangtse network built for cce turbo cluster. The container network deeply integrates the native ENI capability of VPC, 
+	uses the VPC CIDR block to allocate container addresses, and supports direct connections between ELB and containers to provide high performance.
 
 * `container_network_cidr` - (Optional, String, ForceNew) Container network segment. Changing this parameter will create a new cluster resource.
+
+* `eni_subnet_id` - (Optional, String, ForceNew) Eni subnet id. Specified when creating a CCE Turbo cluster.
+  Changing this parameter will create a new cluster resource.
+
+* `eni_subnet_cidr` - (Optional, String, ForceNew) Eni network segment. Specified when creating a CCE Turbo cluster.
+  Changing this parameter will create a new cluster resource.
 
 * `authentication_mode` - (Optional, String, ForceNew) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to *rbac*.
     Changing this parameter will create a new cluster resource.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0
+	github.com/huaweicloud/golangsdk v0.0.0-20210223120144-b19dc64fca83
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,10 +129,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52 h1:+fuguE3AQsM8HRuT1dvcr1uO3eK0jXi3OXiUsb/kAF4=
-github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0 h1:n92GyvoN8wTBHZ16vvvEytIPJbQJ6yCkyYYWEVij2Os=
-github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210223120144-b19dc64fca83 h1:x/OVCFJrUjaekdDtuAJPX6NPhvCKzfxnuAu9/xuW6Vc=
+github.com/huaweicloud/golangsdk v0.0.0-20210223120144-b19dc64fca83/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/results.go
@@ -56,6 +56,8 @@ type Spec struct {
 	HostNetwork HostNetworkSpec `json:"hostNetwork" required:"true"`
 	//Container network parameters
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
+	//ENI network parameters
+	EniNetwork *EniNetworkSpec `json:"eniNetwork,omitempty"`
 	//Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)
@@ -87,6 +89,13 @@ type ContainerNetworkSpec struct {
 	Mode string `json:"mode" required:"true"`
 	//Container network segment: 172.16.0.0/16 ~ 172.31.0.0/16. If there is a network segment conflict, it will be automatically reselected.
 	Cidr string `json:"cidr,omitempty"`
+}
+
+type EniNetworkSpec struct {
+	//Eni network subnet id
+	SubnetId string `json:"eniSubnetId" required:"true"`
+	//Eni network cidr
+	Cidr string `json:"eniSubnetCIDR" required:"true"`
 }
 
 //Authentication parameters

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0
+# github.com/huaweicloud/golangsdk v0.0.0-20210223120144-b19dc64fca83
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support eni network in cce cluster, which need to be specified when creating a cce turbo cluster

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3_turbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3_turbo -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_turbo
=== PAUSE TestAccCCEClusterV3_turbo
=== CONT  TestAccCCEClusterV3_turbo
--- PASS: TestAccCCEClusterV3_turbo (507.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       507.352s
```
