### PR TITLE
[Feature] Server group supports members updation

### DIFF
--- a/docs/resources/compute_servergroup.md
+++ b/docs/resources/compute_servergroup.md
@@ -33,13 +33,13 @@ The following arguments are supported:
 
 * `value_specs` - (Optional, Map, ForceNew) Map of additional options.
 
+* `members` - (Optional, Set) Specifies the IDs of the an server group.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
-
-* `members` - The instances that are part of this server group.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0
+	github.com/huaweicloud/golangsdk v0.0.0-20210223120349-95b96c64969c
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52 h1:+fuguE3AQ
 github.com/huaweicloud/golangsdk v0.0.0-20210205071117-066cac2eec52/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0 h1:n92GyvoN8wTBHZ16vvvEytIPJbQJ6yCkyYYWEVij2Os=
 github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210223120349-95b96c64969c h1:OLgbcIr+6i9Qhex7ISLhDcssUPOXARq52Pye8LhBAPA=
+github.com/huaweicloud/golangsdk v0.0.0-20210223120349-95b96c64969c/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -201,11 +201,13 @@ func ResourceComputeInstanceV2() *schema.Resource {
 			"scheduler_hints": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"group": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 						"fault_domain": {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups/requests.go
@@ -57,3 +57,30 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
+
+type MemberOptsBuilder interface {
+	ToServerGroupUpdateMemberMap(string) (map[string]interface{}, error)
+}
+
+type MemberOpts struct {
+	InstanceUUid string `json:"instance_uuid" required:"true"`
+}
+
+func (opts MemberOpts) ToServerGroupUpdateMemberMap(optsType string) (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, optsType)
+}
+
+// UpdateMembers is used to add and delete members from Server Group.
+// (params)optsType: The opts type is title of block in request body.
+//                   Add options is add_memebr and remove options is remove_member.
+func UpdateMember(client *golangsdk.ServiceClient, opts MemberOptsBuilder, optsType, id string) (r MemberResult) {
+	b, err := opts.ToServerGroupUpdateMemberMap(optsType)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups/results.go
@@ -93,3 +93,9 @@ type GetResult struct {
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
+
+// MemberResult is the response from a Member update operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type MemberResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups/urls.go
@@ -20,6 +20,10 @@ func getURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
+func actionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("cloudservers", resourcePath, id, "action")
+}
+
 func deleteURL(c *golangsdk.ServiceClient, id string) string {
 	return getURL(c, id)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210218092317-09c77d0b0be0
+# github.com/huaweicloud/golangsdk v0.0.0-20210223120349-95b96c64969c
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
    For now, only instance and servergroup create can make members attaching to servergroup. Referring to the latest APIs, servergroup member should support update operation.
    Instance schedule_hints updating will make resource be replaced by new one, so group parameter should be set to computed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #913 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update function support members add and remove operations.
2. update members schema type from list to set.
3. update mmebers description of server group document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

Server group basic test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2ServerGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2ServerGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2ServerGroup_basic
=== PAUSE TestAccComputeV2ServerGroup_basic
=== CONT  TestAccComputeV2ServerGroup_basic
--- PASS: TestAccComputeV2ServerGroup_basic (55.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       55.392s
```
Server group members test with anti-affinity instance attach
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2ServerGroup_members'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2ServerGroup_members -timeout 360m -parallel 4
=== RUN   TestAccComputeV2ServerGroup_members
=== PAUSE TestAccComputeV2ServerGroup_members
=== CONT  TestAccComputeV2ServerGroup_members
--- PASS: TestAccComputeV2ServerGroup_members (225.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       225.619s
```
