### PR TITLE
change the type of volume extend param to map in cce node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -99,7 +99,7 @@ The `root_volume` block supports:
     
 * `volumetype` - (Required, String) Disk type.
     
-* `extend_param` - (Optional, String) Disk expansion parameters. 
+* `extend_param` - (Optional, Map) Disk expansion parameters. 
 
 The `data_volumes` block supports:
     
@@ -107,7 +107,7 @@ The `data_volumes` block supports:
     
 * `volumetype` - (Required, String) Disk type.
     
-* `extend_param` - (Optional, String) Disk expansion parameters. 
+* `extend_param` - (Optional, Map) Disk expansion parameters. 
 
 The `taints` block supports:
     

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -77,8 +77,9 @@ func ResourceCCENodePool() *schema.Resource {
 							Required: true,
 						},
 						"extend_param": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					}},
 			},
@@ -97,8 +98,9 @@ func ResourceCCENodePool() *schema.Resource {
 							Required: true,
 						},
 						"extend_param": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					}},
 			},

--- a/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
@@ -44,6 +44,16 @@ func TestAccCCENodePool_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
 				),
 			},
+			{
+				Config: testAccCCENodePool_volume_extendParam(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "root_volume.0.extend_param.test_key", "test_val"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.0.extend_param.test_key1", "test_val1"),
+					resource.TestCheckResourceAttr(resourceName, "data_volumes.1.extend_param.test_key2", "test_val2"),
+				),
+			},
 		},
 	})
 }
@@ -201,4 +211,50 @@ resource "huaweicloud_cce_node_pool" "test" {
   }
 }
 `, testAccCCENodePool_Base(rName), updateName)
+}
+
+func testAccCCENodePool_volume_extendParam(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_node_pool" "test" {
+  cluster_id         = huaweicloud_cce_cluster.test.id
+  name               = "%s"
+  os                 = "EulerOS 2.5"
+  flavor_id          = "s6.large.2"
+  initial_node_count = 1
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  key_pair           = huaweicloud_compute_keypair.test.name
+  scall_enable      = false
+  min_node_count    = 0
+  max_node_count    = 0
+  scale_down_cooldown_time = 0
+  priority          = 0
+  type 				= "vm"
+
+  root_volume {
+    size       = 40
+	volumetype = "SSD"
+	extend_param = {
+	  test_key = "test_val"
+	}
+  }
+
+  data_volumes {
+    size       = 100
+	volumetype = "SSD"
+	extend_param = {
+	  test_key1 = "test_val1"
+	}
+  }
+
+  data_volumes {
+    size       = 100
+	volumetype = "SSD"
+	extend_param = {
+	  test_key2 = "test_val2"
+	}
+  }
+}
+`, testAccCCENodePool_Base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

change the type of volume extend param to map in cce node pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1417.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1417.274s
```
