### PR TITLE
drop domain_id in iam group and role resources

### DIFF
--- a/docs/data-sources/identity_role.md
+++ b/docs/data-sources/identity_role.md
@@ -67,8 +67,6 @@ data "huaweicloud_identity_role" "auth_admin" {
 
 * `name` - (Required, String) The name of the role.
 
-* `domain_id` - (Optional, String) The domain the role belongs to.
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/identity_group.md
+++ b/docs/resources/identity_group.md
@@ -33,8 +33,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - A resource ID in UUID format.
 
-* `domain_id` - Indicates the domain which group belongs to.
-
 ## Import
 
 Groups can be imported using the `id`, e.g.

--- a/docs/resources/identity_role.md
+++ b/docs/resources/identity_role.md
@@ -13,10 +13,10 @@ this resource.
 
 ```hcl
 resource "huaweicloud_identity_role" role1 {
-  name = "test"
+  name        = "test"
   description = "created by terraform"
-  type = "AX"
-  policy = <<EOF
+  type        = "AX"
+  policy      = <<EOF
 {
   "Version": "1.1",
   "Statement": [
@@ -59,8 +59,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The role id.
-
-* `domain_id` - The account id.
 
 * `references` - The number of references.
 

--- a/huaweicloud/data_source_huaweicloud_identity_role.go
+++ b/huaweicloud/data_source_huaweicloud_identity_role.go
@@ -17,11 +17,6 @@ func DataSourceIdentityRoleV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"domain_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -35,8 +30,7 @@ func dataSourceIdentityRoleV3Read(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	listOpts := roles.ListOpts{
-		DomainID: d.Get("domain_id").(string),
-		Name:     d.Get("name").(string),
+		Name: d.Get("name").(string),
 	}
 
 	log.Printf("[DEBUG] List Options: %#v", listOpts)
@@ -74,7 +68,6 @@ func dataSourceIdentityRoleV3Attributes(d *schema.ResourceData, config *Config, 
 
 	d.SetId(role.ID)
 	d.Set("name", role.Name)
-	d.Set("domain_id", role.DomainID)
 
 	return nil
 }

--- a/huaweicloud/resource_huaweicloud_identity_group.go
+++ b/huaweicloud/resource_huaweicloud_identity_group.go
@@ -28,12 +28,6 @@ func ResourceIdentityGroupV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			"domain_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -48,7 +42,6 @@ func resourceIdentityGroupV3Create(d *schema.ResourceData, meta interface{}) err
 	createOpts := groups.CreateOpts{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		DomainID:    d.Get("domain_id").(string),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -77,9 +70,8 @@ func resourceIdentityGroupV3Read(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Retrieved HuaweiCloud Group: %#v", group)
 
-	d.Set("domain_id", group.DomainID)
-	d.Set("description", group.Description)
 	d.Set("name", group.Name)
+	d.Set("description", group.Description)
 
 	return nil
 }
@@ -97,11 +89,6 @@ func resourceIdentityGroupV3Update(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("description") {
 		hasChange = true
 		updateOpts.Description = d.Get("description").(string)
-	}
-
-	if d.HasChange("domain_id") {
-		hasChange = true
-		updateOpts.DomainID = d.Get("domain_id").(string)
 	}
 
 	if d.HasChange("name") {

--- a/huaweicloud/resource_huaweicloud_identity_group_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_group_test.go
@@ -30,8 +30,12 @@ func TestAccIdentityV3Group_basic(t *testing.T) {
 					testAccCheckIdentityV3GroupExists(resourceName, &group),
 					resource.TestCheckResourceAttrPtr(resourceName, "name", &group.Name),
 					resource.TestCheckResourceAttrPtr(resourceName, "description", &group.Description),
-					resource.TestCheckResourceAttrPtr(resourceName, "domain_id", &group.DomainID),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIdentityV3Group_update(groupName),
@@ -39,7 +43,6 @@ func TestAccIdentityV3Group_basic(t *testing.T) {
 					testAccCheckIdentityV3GroupExists(resourceName, &group),
 					resource.TestCheckResourceAttrPtr(resourceName, "name", &group.Name),
 					resource.TestCheckResourceAttrPtr(resourceName, "description", &group.Description),
-					resource.TestCheckResourceAttrPtr(resourceName, "domain_id", &group.DomainID),
 				),
 			},
 		},
@@ -102,7 +105,7 @@ func testAccCheckIdentityV3GroupExists(n string, group *groups.Group) resource.T
 func testAccIdentityV3Group_basic(groupName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_group" "group_1" {
-  name = "%s"
+  name        = "%s"
   description = "A ACC test group"
 }
 `, groupName)
@@ -111,7 +114,7 @@ resource "huaweicloud_identity_group" "group_1" {
 func testAccIdentityV3Group_update(groupName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_group" "group_1" {
-  name = "%s"
+  name        = "%s"
   description = "Some Group"
 }
 `, groupName)

--- a/huaweicloud/resource_huaweicloud_identity_role.go
+++ b/huaweicloud/resource_huaweicloud_identity_role.go
@@ -46,10 +46,6 @@ func resourceIdentityRole() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"domain_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -104,7 +100,6 @@ func resourceIdentityRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", role.Description)
 	d.Set("type", role.Type)
 	d.Set("references", role.References)
-	d.Set("domain_id", role.DomainId)
 
 	policy, err := json.Marshal(role.Policy)
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_identity_role_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_role_test.go
@@ -29,20 +29,23 @@ func TestAccIdentityRole_basic(t *testing.T) {
 				Config: testAccIdentityRole_basic(roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityRoleExists(resourceName, &role),
-					resource.TestCheckResourceAttrPtr(
-						resourceName, "name", &role.Name),
-					resource.TestCheckResourceAttrPtr(
-						resourceName, "description", &role.Description),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &role.Name),
+					resource.TestCheckResourceAttrPtr(resourceName, "description", &role.Description),
+					resource.TestCheckResourceAttr(resourceName, "type", "AX"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIdentityRole_update(roleNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityRoleExists(resourceName, &role),
-					resource.TestCheckResourceAttrPtr(
-						resourceName, "name", &role.Name),
-					resource.TestCheckResourceAttrPtr(
-						resourceName, "description", &role.Description),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &role.Name),
+					resource.TestCheckResourceAttrPtr(resourceName, "description", &role.Description),
+					resource.TestCheckResourceAttr(resourceName, "type", "AX"),
 				),
 			},
 		},
@@ -105,10 +108,10 @@ func testAccCheckIdentityRoleExists(n string, role *policies.Role) resource.Test
 func testAccIdentityRole_basic(roleName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_role" test {
-  name = "%s"
+  name        = "%s"
   description = "created by terraform"
-  type = "AX"
-    policy = <<EOF
+  type        = "AX"
+  policy      = <<EOF
 {
   "Version": "1.1",
   "Statement": [
@@ -131,10 +134,10 @@ EOF
 func testAccIdentityRole_update(roleName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_role" test {
-  name = "%s"
+  name        = "%s"
   description = "created by terraform"
-  type = "AX"
-    policy = <<EOF
+  type        = "AX"
+  policy      = <<EOF
 {
   "Version": "1.1",
   "Statement": [


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the `domain_id` is unique during the lifecycle, so we can drop it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [√] Tests added/passed.
* [√] Documentation updated.
* [√] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityV3Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityV3Group_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityV3Group_basic
=== PAUSE TestAccIdentityV3Group_basic
=== CONT  TestAccIdentityV3Group_basic
--- PASS: TestAccIdentityV3Group_basic (67.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       67.260s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityRole_basic' ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityRole_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityRole_basic
=== PAUSE TestAccIdentityRole_basic
=== CONT  TestAccIdentityRole_basic
--- PASS: TestAccIdentityRole_basic (61.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       61.073s
```
