### PR TITLE
Refactor server group resource and document

### DIFF
--- a/docs/resources/compute_servergroup.md
+++ b/docs/resources/compute_servergroup.md
@@ -10,9 +10,16 @@ This is an alternative to `huaweicloud_compute_servergroup_v2`
 ## Example Usage
 
 ```hcl
+data "huaweicloud_compute_instance" "instance_demo" {
+  name = "ecs-servergroup-demo"
+}
+
 resource "huaweicloud_compute_servergroup" "test-sg" {
   name     = "my-sg"
   policies = ["anti-affinity"]
+  members  = [
+      data.huaweicloud_compute_instance.instance_demo.id,
+  ]
 }
 ```
 
@@ -20,26 +27,28 @@ resource "huaweicloud_compute_servergroup" "test-sg" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the server group resource. If omitted, the provider-level region will be used. Changing this creates a new server group resource.
-
-* `name` - (Required, String, ForceNew) A unique name for the server group. Changing this creates
-    a new server group.
-
-* `policies` - (Required, List, ForceNew) The set of policies for the server group. Only two
-    policies are available right now, and both are mutually exclusive. Possible values are "affinity" and "anti-affinity". 
-    "affinity": All instances/servers launched in this group will be hosted on the same compute node.
-    "anti-affinity": All instances/servers launched in this group will be hosted on different compute nodes.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the server group resource.
+    If omitted, the provider-level region will be used.
     Changing this creates a new server group.
 
-* `value_specs` - (Optional, Map, ForceNew) Map of additional options.
+* `name` - (Required, String, ForceNew) Specifies a unique name for the server group.
+    This parameter can contain a maximum of 255 characters, which may consist of
+    letters, digits, underscores (_), and hyphens (-).
+    Changing this creates a new server group.
 
-* `members` - (Optional, Set) Specifies the IDs of the an server group.
+* `policies` - (Required, List, ForceNew) Specifies the set of policies for the server group.
+    Only *anti-affinity* policies are supported.
+
+    * `anti-affinity`: All ECS in this group must be deployed on different hosts.
+    Changing this creates a new server group.
+
+* `members` - (Optional, Set) Specifies an array of one or more instance ID to attach server group.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - A resource ID in UUID format.
 
 ## Import
 

--- a/huaweicloud/types.go
+++ b/huaweicloud/types.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups"
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets"
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/zones"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/eips"
@@ -326,18 +325,6 @@ func (opts RuleCreateOpts) ToRuleCreateMap() (map[string]interface{}, error) {
 	}
 
 	return b, nil
-}
-
-// ServerGroupCreateOpts represents the attributes used when creating a new router.
-type ServerGroupCreateOpts struct {
-	servergroups.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
-}
-
-// ToServerGroupCreateMap casts a CreateOpts struct to a map.
-// It overrides routers.ToServerGroupCreateMap to add the ValueSpecs field.
-func (opts ServerGroupCreateOpts) ToServerGroupCreateMap() (map[string]interface{}, error) {
-	return BuildRequest(opts, "server_group")
 }
 
 // SubnetCreateOpts represents the attributes used when creating a new subnet.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Document
  - According to the go programming specifications, the maximum length of each line of code should not exceed 120.
The sentence pattern with less than 120 characters is divided into lines, which is easy to read.
  - The parameter prefix description cannot uses Specifies as Attributes Reference.
  - Delete meaningless text descriptions.
  - Update the document sample based on new features.
- Resource
  - Remove meaningless parameter.
  - The programming specification suggests that the method acceptance name should be as brief as possible. Usually use one or two letters to indicate (such as c, cl for controller).
  - Reduce the use of append in slices. Initialize the length when the slice length is determined to avoid waste of memory.
  - Delete unused code instead of comments.
  - Delete meaningless comments.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. delete value_specs because it never assignment and used.
2. delete meaningless comments.
3. delete unused code instead.
4. adjust duc txt that a maximum of 120 characters are allowed in one line.
5. udpate example usage based on new features of resource.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
