### PR TITLE
fix a document error in vpcep service

### DIFF
--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -57,8 +57,8 @@ The following arguments are supported:
 
 The `port_mapping` block supports:
 
-* `type` - (Optional, String) Specifies the protocol used in port mappings.
-    The value can be TCP or UDP. The default value is TCP.
+* `protocol` - (Optional, String) Specifies the protocol used in port mappings.
+    The value can be _TCP_ or _UDP_. The default value is _TCP_.
 
 * `service_port` - (Optional, Int) Specifies the port for accessing the VPC endpoint service.
     This port is provided by the backend service to provide services. The value ranges from 1 to 65535.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The documentation for VPC Endpoint Service is wrong. UDP or TCP in port_mapping should be specified with the key `protocol` not `type`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
```
