### PR TITLE
New data source of identity user

### DIFF
--- a/docs/data-sources/identity_user.md
+++ b/docs/data-sources/identity_user.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud\_identity\_user
+
+Use this data source to get an available HuaweiCloud IAM user.
+
+```hcl
+variable "identity_user_name" {}
+
+data "huaweicloud_identity_user" "user" {
+  name = var.identity_user_name
+}
+```
+
+## Argument Reference
+
+* `name` - (Required, String) Specifies the name of the IAM user.
+
+* `enabled` - (Optional, Bool) Specifies whether the IAM user is enabled or disabled.
+    Valid values are `true` and `false`, defaults to `true`.
+
+* `domain_id` - (Optional, String) Specifies the domain which IAM user belongs to.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A data source ID in UUID format.
+
+* `description` - A description of the IAM user.

--- a/huaweicloud/data_source_huaweicloud_identity_user.go
+++ b/huaweicloud/data_source_huaweicloud_identity_user.go
@@ -1,0 +1,88 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/identity/v3/users"
+)
+
+func dataSourceIdentityUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceIdentityUserRead performs the iam user lookup.
+func dataSourceIdentityUserRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud identity client: %s", err)
+	}
+
+	enabled := d.Get("enabled").(bool)
+	listOpts := users.ListOpts{
+		Name:     d.Get("name").(string),
+		DomainID: d.Get("domain_id").(string),
+		Enabled:  &enabled,
+	}
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	allPages, err := users.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query users: %s", err)
+	}
+
+	allUsers, err := users.ExtractUsers(allPages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve users: %s", err)
+	}
+
+	if len(allUsers) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allUsers) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allUsers)
+		return fmt.Errorf("Your query returned more than one result. Please try a more " +
+			"specific search criteria, or set `most_recent` attribute to true.")
+	}
+	var user users.User
+	user = allUsers[0]
+
+	d.SetId(user.ID)
+	d.Set("name", user.Name)
+	d.Set("domain_id", user.DomainID)
+	d.Set("enable", user.Enabled)
+	d.Set("description", user.Description)
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_identity_user_test.go
+++ b/huaweicloud/data_source_huaweicloud_identity_user_test.go
@@ -1,0 +1,57 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccIdentityUserDataSource_basic(t *testing.T) {
+	datasourceName := "data.huaweicloud_identity_user.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityUserDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityUserDataSourceID(datasourceName),
+					resource.TestCheckResourceAttr(datasourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityUserDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find identity user data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Identity user dIata source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccIdentityUserDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_identity_user" "test" {
+  name = huaweicloud_identity_user.user_1.name
+}
+`, testAccIdentityV3User_basic(rName))
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -271,6 +271,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_gaussdb_mysql_instance":      dataSourceGaussDBMysqlInstance(),
 			"huaweicloud_gaussdb_mysql_instances":     dataSourceGaussDBMysqlInstances(),
 			"huaweicloud_identity_role":               DataSourceIdentityRoleV3(),
+			"huaweicloud_identity_user":               dataSourceIdentityUser(),
 			"huaweicloud_identity_custom_role":        DataSourceIdentityCustomRole(),
 			"huaweicloud_iec_flavors":                 dataSourceIecFlavors(),
 			"huaweicloud_iec_images":                  dataSourceIecImages(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Users can obtain IAM user information through this resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new document of identity user.
2. new data source of identity user.
3. new acc test of identity user.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIdentityUserDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccIdentityUserDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityUserDataSource_basic
=== PAUSE TestAccIdentityUserDataSource_basic
=== CONT  TestAccIdentityUserDataSource_basic
--- PASS: TestAccIdentityUserDataSource_basic (35.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       35.967s
```
