### PR TITLE
Deprecate tenant_id of networking resources

### DIFF
--- a/docs/data-sources/networking_network_v2.md
+++ b/docs/data-sources/networking_network_v2.md
@@ -30,9 +30,6 @@ data "huaweicloud_networking_network_v2" "network" {
 
 * `matching_subnet_cidr` - (Optional, String) The CIDR of a subnet within the network.
 
-* `tenant_id` - (Optional, String) The owner of the network.
-
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/networking_secgroup.md
+++ b/docs/data-sources/networking_secgroup.md
@@ -25,8 +25,6 @@ data "huaweicloud_networking_secgroup" "secgroup" {
 
 * `name` - (Optional, String) The name of the security group.
 
-* `tenant_id` - (Optional, String) The owner of the security group.
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/networking_subnet_v2.md
+++ b/docs/data-sources/networking_subnet_v2.md
@@ -38,8 +38,6 @@ data "huaweicloud_networking_subnet_v2" "subnet_1" {
 
 * `network_id` - (Optional, String) The ID of the network the subnet belongs to.
 
-* `tenant_id` - (Optional, String) The owner of the subnet.
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/networking_floatingip_v2.md
+++ b/docs/resources/networking_floatingip_v2.md
@@ -31,11 +31,6 @@ The following arguments are supported:
 * `port_id` - (Optional, String) ID of an existing port with at least one IP address to
     associate with this floating IP.
 
-* `tenant_id` - (Optional, String, ForceNew) The target tenant ID in which to allocate the floating
-    IP, if you specify this together with a port_id, make sure the target port
-    belongs to the same tenant. Changing this creates a new floating IP (which
-    may or may not have a different address)
-
 * `fixed_ip` - (Optional, String) Fixed IP of the port to associate with this floating IP. Required if
 the port has multiple fixed IPs.
 

--- a/docs/resources/networking_network_v2.md
+++ b/docs/resources/networking_network_v2.md
@@ -76,9 +76,6 @@ The following arguments are supported:
     by any tenant or not. Changing this updates the sharing capabalities of the
     existing network.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the network. Required if admin wants to
-    create a network for another tenant. Changing this creates a new network.
-
 * `admin_state_up` - (Optional, String) The administrative state of the network.
     Acceptable values are "true" and "false". Changing this value updates the
     state of the existing network.

--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -40,9 +40,6 @@ The following arguments are supported:
 * `mac_address` - (Optional, String, ForceNew) Specify a specific MAC address for the port. Changing
     this creates a new port.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the Port. Required if admin wants
-    to create a port for another tenant. Changing this creates a new port.
-
 * `device_owner` - (Optional, String, ForceNew) The device owner of the Port. Changing this creates
     a new port.
 

--- a/docs/resources/networking_router_v2.md
+++ b/docs/resources/networking_router_v2.md
@@ -52,9 +52,6 @@ The following arguments are supported:
     has to be set in order to set this property. Changing this updates the
     external fixed IPs of the router.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the floating IP. Required if admin wants
-    to create a router for another tenant. Changing this creates a new router.
-
 * `value_specs` - (Optional, Map, ForceNew) Map of additional driver-specific options.
 
 The `external_fixed_ip` block supports:

--- a/docs/resources/networking_secgroup.md
+++ b/docs/resources/networking_secgroup.md
@@ -26,10 +26,6 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Description for the security group.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the security group. Required if admin
-    wants to create a port for another tenant. Changing this creates a new
-    security group.
-
 * `delete_default_rules` - (Optional, Bool, ForceNew) Whether or not to delete the default
     egress security rules. This is `false` by default. See the below note
     for more information.

--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -80,11 +80,6 @@ The following arguments are supported:
     of a security group in the same tenant.
     Changing this creates a new security group rule.
 
-* `tenant_id` - (Optional, String, ForceNew) Specifies the owner of the
-    security group. Required if admin wants to create a port for another
-    tenant.
-    Changing this creates a new security group rule.
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -43,9 +43,6 @@ The following arguments are supported:
 * `name` - (Optional, String) The name of the subnet. Changing this updates the name of
     the existing subnet.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the subnet. Required if admin wants to
-    create a subnet for another tenant. Changing this creates a new subnet.
-
 * `allocation_pools` - (Optional, List) An array of sub-ranges of CIDR available for
     dynamic allocation to ports. The allocation_pool object structure is
     documented below. Changing this creates a new subnet.

--- a/huaweicloud/resource_huaweicloud_networking_floatingip_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_floatingip_v2.go
@@ -60,10 +60,11 @@ func resourceNetworkingFloatingIPV2() *schema.Resource {
 				Computed: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"fixed_ip": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_networking_network_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_network_v2.go
@@ -52,10 +52,11 @@ func resourceNetworkingNetworkV2() *schema.Resource {
 				Computed: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"segments": {
 				Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_port_v2.go
@@ -58,10 +58,11 @@ func ResourceNetworkingPortV2() *schema.Resource {
 				Computed: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"device_owner": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_networking_router_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_router_v2.go
@@ -78,10 +78,11 @@ func resourceNetworkingRouterV2() *schema.Resource {
 				},
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"value_specs": {
 				Type:     schema.TypeMap,

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_rule_v2.go
@@ -95,10 +95,11 @@ func ResourceNetworkingSecGroupRuleV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_v2.go
@@ -51,10 +51,11 @@ func ResourceNetworkingSecGroupV2() *schema.Resource {
 				Computed: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"delete_default_rules": {
 				Type:     schema.TypeBool,

--- a/huaweicloud/resource_huaweicloud_networking_subnet_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_subnet_v2.go
@@ -50,10 +50,11 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Optional: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"allocation_pools": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:c
Tenant_id is not used, deprecate it and will remove in future.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deprecate parameter tenant_id.
  Notes: For multiple resources with tenant_id setting, warning message will collapse duplicates and show 'n more similar warnings elsewhere'.
2. remove tenant_id from document.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
