### PR TITLE
[WIP][Feature] DDS instance supports import

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -192,8 +192,30 @@ The `nodes` block contains:
      and single node instances.
   - `status` - Indicates the node status.
 
+## Import
+
+Instances can be imported by their `id`. For example,
+```
+terraform import huaweicloud_dds_instance.instance 4d512930164a47ac84752394a0613e7fin02
+```
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include: `availability_zone`, `password` and
+`flavor`. It is generally recommended running `terraform plan` after importing an instance. You can then decide if
+changes should be applied to the instance, or the resource definition should be updated to align with the instance.
+Also you can ignore changes as below.
+```
+resource "huaweicloud_dds_instance" "instance" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      availability_zone, flavor,
+    ]
+  }
+}
+```
+
 ## Timeouts
 This resource provides the following timeouts configuration options:
 - `create` - Default is 30 minute.
 - `delete` - Default is 30 minute.
-

--- a/huaweicloud/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_dds_instance_v3.go
@@ -20,6 +20,9 @@ func resourceDdsInstanceV3() *schema.Resource {
 		Update: resourceDdsInstanceV3Update,
 		Delete: resourceDdsInstanceV3Delete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),

--- a/huaweicloud/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_dds_instance_v3_test.go
@@ -28,6 +28,16 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"availability_zone",
+					"password",
+					"flavor",
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Currently the DDS instance doesn’t supports resource import. Users cannot import existing resources into the state file of the terraform.
- According to the Style Conventions of Terraform Syntax, test example need to adjust the code style:
  - When multiple arguments with single-line values appear on consecutive lines at the same nesting level, align their equals signs.
  - For blocks that contain both arguments and "meta-arguments" (as defined by the Terraform language semantics), list meta-arguments first and separate them from other arguments with one blank line. Place meta-argument blocks last and separate them from other blocks with one blank line.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. dds instance supports import.
2. new import test.
3. add import description to document.
  a. some attribute values cannot be queried in the response of the API, these attributes are described in the resource import section of the document.
4. adjust test code style according to terraform style conventives.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccDDSV3Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccDDSV3Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (1076.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1076.935s
```
