### PR TITLE
Deprecate tenant_id of the left resources

### DIFF
--- a/docs/resources/fw_firewall_group_v2.md
+++ b/docs/resources/fw_firewall_group_v2.md
@@ -68,10 +68,6 @@ The following arguments are supported:
     (must be "true" or "false" if provided - defaults to "true").
     Changing this updates the `admin_state_up` of an existing firewall group.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the floating IP. Required if admin wants
-    to create a firewall group for another tenant. Changing this creates a new
-    firewall group.
-
 * `ports` - (Optional, String) Port(s) to associate this firewall group instance
     with. Must be a list of strings. Changing this updates the associated routers
     of an existing firewall group.

--- a/docs/resources/fw_policy_v2.md
+++ b/docs/resources/fw_policy_v2.md
@@ -69,10 +69,6 @@ The following arguments are supported:
     `shared` status of an existing firewall policy. Only administrative users
     can specify if the policy should be shared.
 
-* `tenant_id` - (Optional, String, ForceNew) The owner of the firewall policy. Required if admin wants
-    to create a firewall policy for another tenant. Changing this creates a new
-    firewall policy.
-
 * `value_specs` - (Optional, Map, ForceNew) Map of additional options.
 
 ## Attributes Reference

--- a/docs/resources/lb_l7policy.md
+++ b/docs/resources/lb_l7policy.md
@@ -47,10 +47,6 @@ The following arguments are supported:
     If omitted, the provider-level region will be used.
     Changing this creates a new L7 Policy.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the L7 Policy.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new L7 Policy.
-
 * `name` - (Optional, String) Human-readable name for the L7 Policy. Does not have
     to be unique.
 

--- a/docs/resources/lb_l7rule.md
+++ b/docs/resources/lb_l7rule.md
@@ -54,10 +54,6 @@ The following arguments are supported:
     If omitted, the provider-level region will be used.
     Changing this creates a new L7 Rule.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the L7 Rule.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new L7 Rule.
-
 * `description` - (Optional, String) Human-readable description for the L7 Rule.
 
 * `type` - (Required, String, ForceNew) The L7 Rule type - can either be HOST\_NAME or PATH. Changing this creates a new L7 Rule.

--- a/docs/resources/lb_listener.md
+++ b/docs/resources/lb_listener.md
@@ -35,10 +35,6 @@ The following arguments are supported:
 * `protocol_port` - (Required, Int, ForceNew) The port on which to listen for client traffic.
     Changing this creates a new listener.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the listener.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new listener.
-
 * `loadbalancer_id` - (Required, String, ForceNew) The load balancer on which to provision this
     listener. Changing this creates a new listener.
 

--- a/docs/resources/lb_member.md
+++ b/docs/resources/lb_member.md
@@ -33,10 +33,6 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Human-readable name for the member.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the member.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new member.
-
 * `address` - (Required, String, ForceNew) The IP address of the member to receive traffic from
     the load balancer. Changing this creates a new member.
 

--- a/docs/resources/lb_monitor.md
+++ b/docs/resources/lb_monitor.md
@@ -31,10 +31,6 @@ The following arguments are supported:
 
 * `name` - (Optional, String) The Name of the Monitor.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the monitor.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new monitor.
-
 * `type` - (Required, String, ForceNew) The type of probe, which is PING, TCP, HTTP, or HTTPS,
     that is sent by the load balancer to verify the member state. Changing this
     creates a new monitor.

--- a/docs/resources/lb_pool.md
+++ b/docs/resources/lb_pool.md
@@ -30,10 +30,6 @@ The following arguments are supported:
     If omitted, the the provider-level region will be used.
     Changing this creates a new pool.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the pool.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new pool.
-
 * `name` - (Optional, String) Human-readable name for the pool.
 
 * `description` - (Optional, String) Human-readable description for the pool.

--- a/docs/resources/lb_whitelist.md
+++ b/docs/resources/lb_whitelist.md
@@ -32,10 +32,6 @@ The following arguments are supported:
     If omitted, the provider-level region will be used.
     Changing this creates a new whitelist.
 
-* `tenant_id` - (Optional, String, ForceNew) Required for admins. The UUID of the tenant who owns
-    the whitelist. Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new whitelist.
-
 * `listener_id` - (Required, String, ForceNew) The Listener ID that the whitelist will be associated with. Changing this creates a new whitelist.
 
 * `enable_whitelist` - (Optional, Bool) Specify whether to enable access control.

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -48,9 +48,6 @@ The following arguments are supported:
    gateway. The value contains 0 to 255 characters, and angle brackets (<)
    and (>) are not allowed.
 
-* `tenant_id` - (Optional, String, ForceNew) Specifies the target tenant ID in
-    which to allocate the nat gateway. Changing this creates a new nat gateway.
-
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the
     enterprise project id of the nat gateway. The value can contains maximum of
     36 characters which it is string "0" or in UUID format with hyphens (-).

--- a/docs/resources/vpnaas_endpoint_group_v2.md
+++ b/docs/resources/vpnaas_endpoint_group_v2.md
@@ -29,9 +29,6 @@ The following arguments are supported:
 * `name` - (Optional) The name of the group. Changing this updates the name of
     the existing group.
 
-* `tenant_id` - (Optional) The owner of the group. Required if admin wants to
-    create an endpoint group for another project. Changing this creates a new group.
-
 * `description` - (Optional) The human-readable description for the group.
     Changing this updates the description of the existing group.
 

--- a/docs/resources/vpnaas_ike_policy_v2.md
+++ b/docs/resources/vpnaas_ike_policy_v2.md
@@ -26,9 +26,6 @@ The following arguments are supported:
 * `name` - (Optional) The name of the policy. Changing this updates the name of
     the existing policy.
 
-* `tenant_id` - (Optional) The owner of the policy. Required if admin wants to
-    create a service for another policy. Changing this creates a new policy.
-
 * `description` - (Optional) The human-readable description for the policy.
     Changing this updates the description of the existing policy.
 

--- a/docs/resources/vpnaas_ipsec_policy_v2.md
+++ b/docs/resources/vpnaas_ipsec_policy_v2.md
@@ -26,9 +26,6 @@ The following arguments are supported:
 * `name` - (Optional) The name of the policy. Changing this updates the name of
     the existing policy.
 
-* `tenant_id` - (Optional) The owner of the policy. Required if admin wants to
-    create a policy for another project. Changing this creates a new policy.
-
 * `description` - (Optional) The human-readable description for the policy.
     Changing this updates the description of the existing policy.
 

--- a/docs/resources/vpnaas_service_v2.md
+++ b/docs/resources/vpnaas_service_v2.md
@@ -28,9 +28,6 @@ The following arguments are supported:
 * `name` - (Optional) The name of the service. Changing this updates the name of
     the existing service.
 
-* `tenant_id` - (Optional) The owner of the service. Required if admin wants to
-    create a service for another project. Changing this creates a new service.
-
 * `description` - (Optional) The human-readable description for the service.
     Changing this updates the description of the existing service.
 

--- a/docs/resources/vpnaas_site_connection_v2.md
+++ b/docs/resources/vpnaas_site_connection_v2.md
@@ -33,9 +33,6 @@ The following arguments are supported:
 * `name` - (Optional) The name of the connection. Changing this updates the name of
     the existing connection.
 
-* `tenant_id` - (Optional) The owner of the connection. Required if admin wants to
-    create a connection for another project. Changing this creates a new connection.
-
 * `description` - (Optional) The human-readable description for the connection.
     Changing this updates the description of the existing connection.
 

--- a/huaweicloud/resource_huaweicloud_fw_firewall_group_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_firewall_group_v2.go
@@ -58,10 +58,11 @@ func resourceFWFirewallGroupV2() *schema.Resource {
 				Default:  true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"ports": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/resource_huaweicloud_fw_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_fw_policy_v2.go
@@ -51,10 +51,11 @@ func resourceFWPolicyV2() *schema.Resource {
 				Optional: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"rules": {
 				Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_lb_l7policy.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7policy.go
@@ -39,10 +39,11 @@ func ResourceL7PolicyV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"name": {

--- a/huaweicloud/resource_huaweicloud_lb_l7rule.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7rule.go
@@ -39,10 +39,11 @@ func ResourceL7RuleV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"type": {

--- a/huaweicloud/resource_huaweicloud_lb_listener.go
+++ b/huaweicloud/resource_huaweicloud_lb_listener.go
@@ -50,10 +50,11 @@ func ResourceListenerV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"loadbalancer_id": {

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
@@ -52,10 +52,11 @@ func ResourceLoadBalancerV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"vip_address": {

--- a/huaweicloud/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/resource_huaweicloud_lb_member.go
@@ -38,10 +38,11 @@ func ResourceMemberV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"address": {

--- a/huaweicloud/resource_huaweicloud_lb_monitor.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor.go
@@ -44,10 +44,11 @@ func ResourceMonitorV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"type": {

--- a/huaweicloud/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool.go
@@ -34,10 +34,11 @@ func ResourcePoolV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"name": {

--- a/huaweicloud/resource_huaweicloud_lb_whitelist.go
+++ b/huaweicloud/resource_huaweicloud_lb_whitelist.go
@@ -30,10 +30,11 @@ func ResourceWhitelistV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 
 			"listener_id": {

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -60,10 +60,11 @@ func resourceNatGatewayV2() *schema.Resource {
 				Computed: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_vpnaas_endpoint_group_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_endpoint_group_v2.go
@@ -43,10 +43,11 @@ func resourceVpnEndpointGroupV2() *schema.Resource {
 				Optional: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_vpnaas_ike_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_ike_policy_v2.go
@@ -85,10 +85,11 @@ func resourceVpnIKEPolicyV2() *schema.Resource {
 				},
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"value_specs": {
 				Type:     schema.TypeMap,

--- a/huaweicloud/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_ipsec_policy_v2.go
@@ -67,10 +67,11 @@ func resourceVpnIPSecPolicyV2() *schema.Resource {
 			},
 
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"lifetime": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/resource_huaweicloud_vpnaas_service_v2.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_service_v2.go
@@ -48,10 +48,11 @@ func resourceVpnServiceV2() *schema.Resource {
 				Default:  true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_vpnaas_site_connection.go
+++ b/huaweicloud/resource_huaweicloud_vpnaas_site_connection.go
@@ -98,10 +98,11 @@ func resourceVpnSiteConnectionV2() *schema.Resource {
 				Computed: true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"peer_cidrs": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Tenant_id is not used, deprecate it and will remove in future.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deprecate parameter tenant_id.
  Notes: For multiple resources with tenant_id setting, warning message will collapse duplicates and show 'n more similar warnings elsewhere'.
2. remove tenant_id from document.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
