### PR TITLE
[Fix] Bucket_domain_name can be generated correctly by provider configuration

### DIFF
--- a/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -417,7 +417,7 @@ func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("region", region)
-	d.Set("bucket_domain_name", bucketDomainName(d.Get("bucket").(string), region))
+	d.Set("bucket_domain_name", bucketDomainNameWithCloud(d.Get("bucket").(string), region, config.Cloud))
 
 	// Read storage class
 	if err := setObsBucketStorageClass(obsClient, d); err != nil {
@@ -1324,6 +1324,10 @@ func normalizeWebsiteRoutingRules(w []obs.RoutingRule) (string, error) {
 	}
 
 	return string(withoutNulls), nil
+}
+
+func bucketDomainNameWithCloud(bucket, region, cloud string) string {
+	return fmt.Sprintf("%s.obs.%s.%s", bucket, region, cloud)
 }
 
 type Condition struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Bucket_domain_name cannot be generated correctly by cloud and endpoint setting.
  - Bucket_domain_name is composed of bucket_name, region and cloud but the current cloud configuration cannot be applied to the cloud part.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #957

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. use cloud parameter to build bucket_domain_name when cloud is setting in provider config.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

provider configuration
```
provider "huaweicloud" {
  auth_url     = "https://iam.ru-moscow-1.hc.sbercloud.ru"
  cloud        = "hc.sbercloud.ru"
  domain_name  = "***"
  region       = "***"
  project_name = "***"
  access_key   = "***"
  secret_key   = "***"
  endpoints = {
    iam = "iam.ru-moscow-1.hc.sbercloud.ru"
    ecs = "ecs.ru-moscow-1.hc.sbercloud.ru"
    obs = "obs.ru-moscow-1.hc.sbercloud.ru"
  }
}
```
terraform apply 
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # huaweicloud_obs_bucket.bucket will be created
  + resource "huaweicloud_obs_bucket" "bucket" {
      + acl                   = "private"
      + bucket                = "tf-test-bucket-demo-0302"
      + bucket_domain_name    = (known after apply)
      + enterprise_project_id = (known after apply)
      + force_destroy         = false
      + id                    = (known after apply)
      + policy                = (known after apply)
      + policy_format         = "obs"
      + quota                 = 0
      + region                = "ru-moscow-1"
      + storage_class         = "STANDARD"
      + versioning            = false
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

huaweicloud_obs_bucket.bucket: Creating...
huaweicloud_obs_bucket.bucket: Creation complete after 7s [id=tf-test-bucket-demo-0302]
```
terraform show
```
# huaweicloud_obs_bucket.bucket:
resource "huaweicloud_obs_bucket" "bucket" {
    acl                = "private"
    bucket             = "tf-test-bucket-demo-0302"
    bucket_domain_name = "tf-test-bucket-demo-0302.obs.ru-moscow-1.hc.sbercloud.ru"
    force_destroy      = false
    id                 = "tf-test-bucket-demo-0302"
    policy_format      = "obs"
    quota              = 0
    region             = "ru-moscow-1"
    storage_class      = "STANDARD"
    versioning         = false
}
```