### PR TITLE
Remove tenant_id from lb and nat resources

### DIFF
--- a/huaweicloud/resource_huaweicloud_lb_l7policy.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7policy.go
@@ -38,14 +38,6 @@ func ResourceL7PolicyV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/resource_huaweicloud_lb_l7rule.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7rule.go
@@ -38,14 +38,6 @@ func ResourceL7RuleV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_lb_listener.go
+++ b/huaweicloud/resource_huaweicloud_lb_listener.go
@@ -49,14 +49,6 @@ func ResourceListenerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"loadbalancer_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
@@ -51,14 +51,6 @@ func ResourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"vip_address": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/resource_huaweicloud_lb_member.go
@@ -37,14 +37,6 @@ func ResourceMemberV2() *schema.Resource {
 				Optional: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"address": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_lb_monitor.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor.go
@@ -43,14 +43,6 @@ func ResourceMonitorV2() *schema.Resource {
 				Optional: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/huaweicloud/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool.go
@@ -33,14 +33,6 @@ func ResourcePoolV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -99,11 +99,6 @@ func resourceNatDnatRuleV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -59,13 +59,6 @@ func resourceNatGatewayV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Tenant_id should be removing from lb and nat resources which is never used and deprecated.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference #954

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove tenant_id form lb and nat resources.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
