### PR TITLE
[CCE node and node pool] recover extend_param in root_volume and data_volume

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -80,6 +80,11 @@ func ResourceCCENodePool() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"extend_param": {
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "use extend_params instead",
+						},
 						"extend_params": {
 							Type:     schema.TypeMap,
 							Optional: true,
@@ -104,6 +109,11 @@ func ResourceCCENodePool() *schema.Resource {
 						"hw_passthrough": {
 							Type:     schema.TypeBool,
 							Optional: true,
+						},
+						"extend_param": {
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "use extend_params instead",
 						},
 						"extend_params": {
 							Type:     schema.TypeMap,
@@ -371,6 +381,7 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 		volume["volumetype"] = pairObject.VolumeType
 		volume["hw_passthrough"] = pairObject.HwPassthrough
 		volume["extend_params"] = pairObject.ExtendParam
+		volume["extend_param"] = ""
 		volumes = append(volumes, volume)
 	}
 	if err := d.Set("data_volumes", volumes); err != nil {
@@ -383,6 +394,7 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 			"volumetype":     s.Spec.NodeTemplate.RootVolume.VolumeType,
 			"hw_passthrough": s.Spec.NodeTemplate.RootVolume.HwPassthrough,
 			"extend_params":  s.Spec.NodeTemplate.RootVolume.ExtendParam,
+			"extend_param":   "",
 		},
 	}
 	if err := d.Set("root_volume", rootVolume); err != nil {

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -106,6 +106,11 @@ func ResourceCCENodeV3() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"extend_param": {
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "use extend_params instead",
+						},
 						"extend_params": {
 							Type:     schema.TypeMap,
 							Optional: true,
@@ -130,6 +135,11 @@ func ResourceCCENodeV3() *schema.Resource {
 						"hw_passthrough": {
 							Type:     schema.TypeBool,
 							Optional: true,
+						},
+						"extend_param": {
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "use extend_params instead",
 						},
 						"extend_params": {
 							Type:     schema.TypeMap,
@@ -601,6 +611,7 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 		volume["volumetype"] = pairObject.VolumeType
 		volume["hw_passthrough"] = pairObject.HwPassthrough
 		volume["extend_params"] = pairObject.ExtendParam
+		volume["extend_param"] = ""
 		volumes = append(volumes, volume)
 	}
 	if err := d.Set("data_volumes", volumes); err != nil {
@@ -613,6 +624,7 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 			"volumetype":     s.Spec.RootVolume.VolumeType,
 			"hw_passthrough": s.Spec.RootVolume.HwPassthrough,
 			"extend_params":  s.Spec.RootVolume.ExtendParam,
+			"extend_param":   "",
 		},
 	}
 	if err := d.Set("root_volume", rootVolume); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

recover extend_param in root_volume and data_volume to avoid error for users of previous provider version. 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
