### PR TITLE
Revoke VPC shared parameter

### DIFF
--- a/huaweicloud/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/data_source_huaweicloud_vpc.go
@@ -39,6 +39,10 @@ func DataSourceVirtualPrivateCloudVpcV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"shared": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"routes": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/huaweicloud/resource_huaweicloud_vpc.go
+++ b/huaweicloud/resource_huaweicloud_vpc.go
@@ -55,6 +55,10 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"shared": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"routes": {
 				Type:     schema.TypeList,
 				Computed: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- When using state file in terraform version 0.14+ which create in terraform version 0.13-, terraform will throws error.
The errors is: Instance huaweicloud_vpc.test data could not be decoded from the state: unsupported attribute "shared". 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference #813

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. revoke shared parameter.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
