### PR TITLE
replace testAccPreCheckNat() with testAccPreCheck() in nat_gateway test cases

### DIFF
--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -121,12 +121,6 @@ func testAccPreCheckDms(t *testing.T) {
 	}
 }
 
-func testAccPreCheckNat(t *testing.T) {
-	if HW_NAT_ENVIRONMENT == "" {
-		t.Skip("This environment does not support NAT tests")
-	}
-}
-
 func testAccPreCheckKms(t *testing.T) {
 	if HW_KMS_ENVIRONMENT == "" {
 		t.Skip("This environment does not support KMS tests")

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
@@ -16,7 +16,7 @@ func TestAccNatGateway_basic(t *testing.T) {
 	resourceName := "huaweicloud_nat_gateway.nat_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckNat(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNatV2GatewayDestroy,
 		Steps: []resource.TestStep{
@@ -52,7 +52,7 @@ func TestAccNatGateway_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_nat_gateway.nat_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckNat(t); testAccPreCheckEpsID(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEpsID(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNatV2GatewayDestroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
@@ -16,7 +16,7 @@ func TestAccNatSnatRule_basic(t *testing.T) {
 	resourceName := "huaweicloud_nat_snat_rule.snat_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckNat(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNatV2SnatRuleDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

replace testAccPreCheckNat() with testAccPreCheck() in nat_gateway test cases

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNat'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNat -timeout 360m -parallel 4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== RUN   TestAccNatDnat_protocol
=== PAUSE TestAccNatDnat_protocol
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== RUN   TestAccNatGateway_withEpsId
=== PAUSE TestAccNatGateway_withEpsId
=== RUN   TestAccNatSnatRule_basic
=== PAUSE TestAccNatSnatRule_basic
=== CONT  TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGateway_withEpsId
=== CONT  TestAccNatSnatRule_basic
=== CONT  TestAccNatDnat_protocol
=== CONT  TestAccNatGateway_withEpsId
    provider_test.go:144: This environment does not support EPS_ID tests
--- SKIP: TestAccNatGateway_withEpsId (0.01s)
=== CONT  TestAccNatDnat_basic
--- PASS: TestAccNatGatewayDataSource_basic (84.77s)
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatSnatRule_basic (104.36s)
--- PASS: TestAccNatGateway_basic (96.08s)
--- PASS: TestAccNatDnat_protocol (211.39s)
--- PASS: TestAccNatDnat_basic (218.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       218.822s
```
