### PR TITLE
update UnsubscribePrePaidResource

### DIFF
--- a/huaweicloud/common.go
+++ b/huaweicloud/common.go
@@ -64,15 +64,14 @@ func hasFilledOpt(d *schema.ResourceData, param string) bool {
 }
 
 // UnsubscribePrePaidResource impl the action of unsubscribe resource
-func UnsubscribePrePaidResource(d *schema.ResourceData, config *Config) error {
+func UnsubscribePrePaidResource(d *schema.ResourceData, config *Config, resourceIDs []string) error {
 	bssV2Client, err := config.BssV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud bss V2 client: %s", err)
 	}
 
-	resourceIds := []string{d.Id()}
 	unsubscribeOpts := orders.UnsubscribeOpts{
-		ResourceIds:     resourceIds,
+		ResourceIds:     resourceIDs,
 		UnsubscribeType: 1,
 	}
 	_, err = orders.Unsubscribe(bssV2Client, unsubscribeOpts).Extract()

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -1011,7 +1011,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.Get("charging_mode") == "prePaid" {
-		if err := UnsubscribePrePaidResource(d, config); err != nil {
+		if err := UnsubscribePrePaidResource(d, config, []string{d.Id()}); err != nil {
 			return fmt.Errorf("Error unsubscribe HuaweiCloud server: %s", err)
 		}
 	} else {

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -500,7 +500,7 @@ func resourceGeminiDBInstanceV3Delete(d *schema.ResourceData, meta interface{}) 
 
 	instanceId := d.Id()
 	if d.Get("charging_mode") == "prePaid" {
-		if err := UnsubscribePrePaidResource(d, config); err != nil {
+		if err := UnsubscribePrePaidResource(d, config, []string{instanceId}); err != nil {
 			return fmt.Errorf("Error unsubscribe HuaweiCloud GaussDB instance: %s", err)
 		}
 	} else {

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -622,7 +622,7 @@ func resourceGaussDBInstanceDelete(d *schema.ResourceData, meta interface{}) err
 
 	instanceId := d.Id()
 	if d.Get("charging_mode") == "prePaid" {
-		if err := UnsubscribePrePaidResource(d, config); err != nil {
+		if err := UnsubscribePrePaidResource(d, config, []string{instanceId}); err != nil {
 			return fmt.Errorf("Error unsubscribe HuaweiCloud GaussDB instance: %s", err)
 		}
 	} else {


### PR DESCRIPTION
for cce node, we should unsubscribe server id rather than resource ID,
so we should add a []string variable named resourceIDs.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== CONT  TestAccComputeV2Instance_prePaid
--- PASS: TestAccComputeV2Instance_prePaid (225.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       225.940s
```
