### PR TITLE
fix tfproviderlint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       # Runs tfproviderlint-github-action
       - uses: bflad/tfproviderlint-github-action@master
         with:
-          args: ./...
+          args: -V011=false -V012=false -V013=false -V014=false ./...
 
   # This workflow contains a job called "acc-test"
   acc-test:

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -12,16 +12,16 @@ import (
 var keyAlias = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
 var keyAlias_epsId = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
 
-func TestAccKmsKeyV1DataSource_Basic(t *testing.T) {
-	var datasourceName = "data.huaweicloud_kms_key.key_2"
+func TestAccKmsKeyDataSource_Basic(t *testing.T) {
+	var datasourceName = "data.huaweicloud_kms_key.key_1"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyV1DataSource_Basic(keyAlias),
+				Config: testAccKmsKeyDataSource_Basic(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsKeyV1DataSourceID(datasourceName),
+					testAccCheckKmsKeyDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
 					resource.TestCheckResourceAttr(datasourceName, "region", HW_REGION_NAME),
 				),
@@ -31,7 +31,7 @@ func TestAccKmsKeyV1DataSource_Basic(t *testing.T) {
 }
 
 func TestAccKmsKeyDataSource_WithTags(t *testing.T) {
-	var datasourceName = "data.huaweicloud_kms_key.key_2"
+	var datasourceName = "data.huaweicloud_kms_key.key_1"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t) },
 		Providers: testAccProviders,
@@ -39,7 +39,7 @@ func TestAccKmsKeyDataSource_WithTags(t *testing.T) {
 			{
 				Config: testAccKmsKeyDataSource_WithTags(keyAlias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsKeyV1DataSourceID(datasourceName),
+					testAccCheckKmsKeyDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
 					resource.TestCheckResourceAttr(datasourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(datasourceName, "tags.key", "value"),
@@ -49,26 +49,25 @@ func TestAccKmsKeyDataSource_WithTags(t *testing.T) {
 	})
 }
 
-func TestAccKmsKeyV1DataSource_WithEpsId(t *testing.T) {
+func TestAccKmsKeyDataSource_WithEpsId(t *testing.T) {
+	var datasourceName = "data.huaweicloud_kms_key.key_1"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckKms(t); testAccPreCheckEpsID(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyV1DataSource_epsId,
+				Config: testAccKmsKeyDataSource_epsId,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsKeyV1DataSourceID("data.huaweicloud_kms_key_v1.key1"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_kms_key_v1.key1", "key_alias", keyAlias_epsId),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_kms_key_v1.key1", "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					testAccCheckKmsKeyDataSourceID(datasourceName),
+					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias_epsId),
+					resource.TestCheckResourceAttr(datasourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckKmsKeyV1DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckKmsKeyDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -83,42 +82,44 @@ func testAccCheckKmsKeyV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccKmsKeyV1DataSource_Basic(keyAlias string) string {
+func testAccKmsKeyDataSource_Basic(keyAlias string) string {
 	return fmt.Sprintf(`
 %s
-data "huaweicloud_kms_key" "key_2" {
-  key_alias       = huaweicloud_kms_key.key_2.key_alias
-  key_id          = huaweicloud_kms_key.key_2.id
-  key_state       = "2"
+
+data "huaweicloud_kms_key" "key_1" {
+  key_alias = huaweicloud_kms_key.key_1.key_alias
+  key_id    = huaweicloud_kms_key.key_1.id
+  key_state = "2"
 }
-`, testAccKmsV1Key_Basic(keyAlias))
+`, testAccKmsKey_Basic(keyAlias))
 }
 
 func testAccKmsKeyDataSource_WithTags(keyAlias string) string {
 	return fmt.Sprintf(`
 %s
-data "huaweicloud_kms_key" "key_2" {
-  key_alias = huaweicloud_kms_key.key_2.key_alias
-  key_id    = huaweicloud_kms_key.key_2.id
+
+data "huaweicloud_kms_key" "key_1" {
+  key_alias = huaweicloud_kms_key.key_1.key_alias
+  key_id    = huaweicloud_kms_key.key_1.id
   key_state = "2"
 }
 `, testAccKmsKey_WithTags(keyAlias))
 }
 
-var testAccKmsKeyV1DataSource_epsId = fmt.Sprintf(`
-resource "huaweicloud_kms_key_v1" "key1" {
-	key_alias       = "%s"
-	key_description = "test description"
-	pending_days    = "7"
-	is_enabled      = true
-	enterprise_project_id = "%s"
-  }
+var testAccKmsKeyDataSource_epsId = fmt.Sprintf(`
+resource "huaweicloud_kms_key_v1" "key_1" {
+  key_alias       = "%s"
+  key_description = "test description"
+  pending_days    = "7"
+  is_enabled      = true
+  enterprise_project_id = "%s"
+}
 
-data "huaweicloud_kms_key_v1" "key1" {
-  key_alias       = "${huaweicloud_kms_key_v1.key1.key_alias}"
-  key_id          = "${huaweicloud_kms_key_v1.key1.id}"
+data "huaweicloud_kms_key_v1" "key_1" {
+  key_alias       = huaweicloud_kms_key_v1.key_1.key_alias
+  key_id          = huaweicloud_kms_key_v1.key_1.id
   key_description = "test description"
   key_state       = "2"
-  enterprise_project_id = huaweicloud_kms_key_v1.key1.enterprise_project_id
+  enterprise_project_id = huaweicloud_kms_key_v1.key_1.enterprise_project_id
 }
 `, keyAlias_epsId, HW_ENTERPRISE_PROJECT_ID_TEST)

--- a/huaweicloud/resource_huaweicloud_evs_snapshot_test.go
+++ b/huaweicloud/resource_huaweicloud_evs_snapshot_test.go
@@ -97,5 +97,5 @@ resource "huaweicloud_evs_snapshot" "test" {
   name        = "%s"
   description = "Daily backup"
 }
-`, testAccEvsStorageV3Volume_basic(rName), rName)
+`, testAccEvsVolume_basic(rName), rName)
 }

--- a/huaweicloud/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/resource_huaweicloud_evs_volume_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes"
 )
 
-func TestAccEvsStorageV3Volume_basic(t *testing.T) {
+func TestAccEvsVolume_basic(t *testing.T) {
 	var volume volumes.Volume
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -21,12 +21,12 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy: testAccCheckEvsVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEvsStorageV3Volume_basic(rName),
+				Config: testAccEvsVolume_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
+					testAccCheckEvsVolumeExists(resourceName, &volume),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "size", "12"),
 				),
@@ -40,9 +40,9 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccEvsStorageV3Volume_update(rNameUpdate),
+				Config: testAccEvsVolume_update(rNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
+					testAccCheckEvsVolumeExists(resourceName, &volume),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
 					resource.TestCheckResourceAttr(resourceName, "size", "20"),
 				),
@@ -51,34 +51,34 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 	})
 }
 
-func TestAccEvsStorageV3Volume_tags(t *testing.T) {
+func TestAccEvsVolume_tags(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_evs_volume.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy: testAccCheckEvsVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEvsStorageV3Volume_tags(rName),
+				Config: testAccEvsVolume_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeTags(resourceName, "foo", "bar"),
-					testAccCheckEvsStorageV3VolumeTags(resourceName, "key", "value"),
+					testAccCheckEvsVolumeTags(resourceName, "foo", "bar"),
+					testAccCheckEvsVolumeTags(resourceName, "key", "value"),
 				),
 			},
 			{
-				Config: testAccEvsStorageV3Volume_tags_update(rName),
+				Config: testAccEvsVolume_tags_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeTags(resourceName, "foo2", "bar2"),
-					testAccCheckEvsStorageV3VolumeTags(resourceName, "key2", "value2"),
+					testAccCheckEvsVolumeTags(resourceName, "foo2", "bar2"),
+					testAccCheckEvsVolumeTags(resourceName, "key2", "value2"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccEvsStorageV3Volume_image(t *testing.T) {
+func TestAccEvsVolume_image(t *testing.T) {
 	var volume volumes.Volume
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -87,12 +87,12 @@ func TestAccEvsStorageV3Volume_image(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy: testAccCheckEvsVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEvsStorageV3Volume_image(rName),
+				Config: testAccEvsVolume_image(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
+					testAccCheckEvsVolumeExists(resourceName, &volume),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
@@ -109,12 +109,12 @@ func TestAccEvsVolume_withEpsId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEpsID(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy: testAccCheckEvsVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEvsVolume_epsID(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
+					testAccCheckEvsVolumeExists(resourceName, &volume),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -123,7 +123,7 @@ func TestAccEvsVolume_withEpsId(t *testing.T) {
 	})
 }
 
-func testAccCheckEvsStorageV3VolumeDestroy(s *terraform.State) error {
+func testAccCheckEvsVolumeDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	blockStorageClient, err := config.BlockStorageV3Client(HW_REGION_NAME)
 	if err != nil {
@@ -144,7 +144,7 @@ func testAccCheckEvsStorageV3VolumeDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckEvsStorageV3VolumeExists(n string, volume *volumes.Volume) resource.TestCheckFunc {
+func testAccCheckEvsVolumeExists(n string, volume *volumes.Volume) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -176,7 +176,7 @@ func testAccCheckEvsStorageV3VolumeExists(n string, volume *volumes.Volume) reso
 	}
 }
 
-func testAccCheckEvsStorageV3VolumeTags(n string, k string, v string) resource.TestCheckFunc {
+func testAccCheckEvsVolumeTags(n string, k string, v string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -220,7 +220,7 @@ func testAccCheckEvsStorageV3VolumeTags(n string, k string, v string) resource.T
 	}
 }
 
-func testAccEvsStorageV3Volume_basic(rName string) string {
+func testAccEvsVolume_basic(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -234,7 +234,7 @@ resource "huaweicloud_evs_volume" "test" {
 `, rName)
 }
 
-func testAccEvsStorageV3Volume_update(rName string) string {
+func testAccEvsVolume_update(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -248,7 +248,7 @@ resource "huaweicloud_evs_volume" "test" {
 `, rName)
 }
 
-func testAccEvsStorageV3Volume_tags(rName string) string {
+func testAccEvsVolume_tags(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -267,7 +267,7 @@ resource "huaweicloud_evs_volume" "test" {
 `, rName)
 }
 
-func testAccEvsStorageV3Volume_tags_update(rName string) string {
+func testAccEvsVolume_tags_update(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -286,7 +286,7 @@ resource "huaweicloud_evs_volume" "test" {
 `, rName)
 }
 
-func testAccEvsStorageV3Volume_image(rName string) string {
+func testAccEvsVolume_image(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the latest version of tfproviderlint is v0.24.0, and new checks were imported: AT012, V011-V014.
now we fix AT012 and disable V011-V014 to make ci action be happy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccEvsVolume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccEvsVolume -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== RUN   TestAccEvsVolume_tags
=== PAUSE TestAccEvsVolume_tags
=== RUN   TestAccEvsVolume_image
=== PAUSE TestAccEvsVolume_image
=== RUN   TestAccEvsVolume_withEpsId
=== PAUSE TestAccEvsVolume_withEpsId
=== CONT  TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_withEpsId
=== CONT  TestAccEvsVolume_image
=== CONT  TestAccEvsVolume_tags
=== CONT  TestAccEvsVolume_withEpsId
    provider_test.go:144: This environment does not support EPS_ID tests
--- SKIP: TestAccEvsVolume_withEpsId (0.03s)
--- PASS: TestAccEvsVolume_image (66.69s)
--- PASS: TestAccEvsVolume_basic (99.60s)
--- PASS: TestAccEvsVolume_tags (114.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       114.396s
```
