### PR TITLE
CCE cluster supports deleting associated resources

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -163,6 +163,27 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the cce cluster.
   Changing this creates a new cluster.
 
+* `delete_efs` - (Optional, String) Specified whether to delete the associated EFS resources when deleting CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_eni` - (Optional, String) Specified whether to delete the associated ENI resources when deleting CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_evs` - (Optional, String) Specified whether to delete the associated EVS resources when deleting CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_net` - (Optional, String) Specified whether to delete the associated NET resources when deleting CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_obs` - (Optional, String) Specified whether to delete the associated OBS resources when deleting CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_sfs` - (Optional, String) Specified whether to delete the associated SFS resources when deleting CCE cluster.
+  valid values are "true", "try" and "false". Default is false.
+
+* `delete_all` - (Optional, Bool) Specified whether to delete all associated resources when deleting CCE cluster.
+  Default is false.
+
 The `masters` block supports:
 
 * `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone of the master node. Changing this creates a new cluster.
@@ -201,4 +222,21 @@ This resource provides the following timeouts configuration options:
  Cluster can be imported using the cluster id, e.g.
  ```
  $ terraform import huaweicloud_cce_cluster.cluster_1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d  
+```
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include:
+`delete_efs`, `delete_eni`, `delete_evs`, `delete_net`, `delete_obs`, `delete_sfs` and `delete_all`.
+It is generally recommended running `terraform plan` after importing an cce cluster. You can then decide if changes
+should be applied to the cluster, or the resource definition should be updated to align with the cluster. Also you can
+ignore changes as below.
+```
+resource "huaweicloud_cce_cluster" "cluster_1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      delete_efs, delete_obs,
+    ]
+  }
+}
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244
+	github.com/huaweicloud/golangsdk v0.0.0-20210323075108-95a9f6c7bc44
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244 h1:Jzq3828aWxaRquRxPqv8aG1A6B+LatrIHiD3SMlHpFM=
 github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210323075108-95a9f6c7bc44 h1:8M/ok74wZvWL2RKjR9HUJ3JgBR6AmIC0NkNOWBEGlKU=
+github.com/huaweicloud/golangsdk v0.0.0-20210323075108-95a9f6c7bc44/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -191,6 +191,44 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 	return
 }
 
+type DeleteOpts struct {
+	ErrorStatus string `q:"errorStatus"`
+	DeleteEfs   string `q:"delete_efs"`
+	DeleteENI   string `q:"delete_eni"`
+	DeleteEvs   string `q:"delete_evs"`
+	DeleteNet   string `q:"delete_net"`
+	DeleteObs   string `q:"delete_obs"`
+	DeleteSfs   string `q:"delete_sfs"`
+}
+
+type DeleteOptsBuilder interface {
+	ToDeleteQuery() (string, error)
+}
+
+func (opts DeleteOpts) ToDeleteQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// DeleteWithOpts will permanently delete a particular cluster based on its unique ID,
+// and can delete associated resources based on DeleteOpts.
+func DeleteWithOpts(c *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := resourceURL(c, id)
+	if opts != nil {
+		var query string
+		query, r.Err = opts.ToDeleteQuery()
+		if r.Err != nil {
+			return
+		}
+		url += query
+	}
+	_, r.Err = c.Delete(url, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}
+
 // Delete will permanently delete a particular cluster based on its unique ID.
 func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), &golangsdk.RequestOpts{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,7 +257,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210323020602-6d5ee0030244
+# github.com/huaweicloud/golangsdk v0.0.0-20210323075108-95a9f6c7bc44
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- CCE API supports deleting the associated resources when deleting an cluster now.
  the associated resources contains:
  - EFS
  - ENI
  - EVS
  - NET
  - OBS
  - SFS

  In addition to the separate resource deletion option, it also supports the deletion of all the associated items of the above resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add associated resources delete parameters, like efs, eni, evs, net, obs and sfs.
2. support the deletion of all associated resources.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
