### PR TITLE
set charging_mode as a computed attribute

### DIFF
--- a/huaweicloud/resource_schema.go
+++ b/huaweicloud/resource_schema.go
@@ -12,6 +12,7 @@ func schemeChargingMode(conflicts []string) *schema.Schema {
 		Type:     schema.TypeString,
 		Optional: true,
 		ForceNew: true,
+		Computed: true,
 		ValidateFunc: validation.StringInSlice([]string{
 			"prePaid", "postPaid",
 		}, false),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the `charging_mode` of compute_instance is set to "postPaid" if not specified, so we should add the `computed` attribute.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (172.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       172.260s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== CONT  TestAccComputeV2Instance_prePaid

--- PASS: TestAccComputeV2Instance_prePaid (196.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       196.594s
```
