### PR TITLE
fix a bug in cce node

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -431,10 +431,20 @@ func resourceCCEExtendParam(d *schema.ResourceData) map[string]interface{} {
 	}
 
 	// assemble the charge info
-	if d.Get("charging_mode").(string) == "prePaid" || d.Get("billing_mode").(int) == 2 {
+	var isPrePaid bool
+	var billingMode int
+
+	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
+		isPrePaid = true
+	}
+	if v, ok := d.GetOk("billing_mode"); ok {
+		billingMode = v.(int)
+	}
+	if isPrePaid || billingMode == 2 {
 		extendParam["chargingMode"] = 2
 		extendParam["isAutoPay"] = "true"
 	}
+
 	if v, ok := d.GetOk("period_unit"); ok {
 		extendParam["periodType"] = v.(string)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

func resourceCCEExtendParam is used in both cce node and cce node pool
but the Schema of cce node pool does not contain parameter `charging_mode` or `billing_mode`
so using func d.Get() may cause crush while creating a cce node pool resource
for that reason, use func d.GetOk to repalce func d.Get()

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1698.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1698.139s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1204.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1204.596s
```
