### PR TITLE
Fix the problem that code param are not mandatory in DCS data sources

### DIFF
--- a/huaweicloud/data_source_huaweicloud_dcs_az_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_az_v1.go
@@ -67,6 +67,11 @@ func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 			if port != "" && newAZ.Port != port {
 				continue
 			}
+
+			code := d.Get("code").(string)
+			if code != "" && newAZ.Code != code {
+				continue
+			}
 			filteredAZs = append(filteredAZs, newAZ)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The results of `huaweicloud_dcs_az` data source are always the same.
- After reading dcs available zones from server, `huaweicloud_dcs_az` doesn‘t use the code parameter for verification.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #990 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add the 'code' to the verification step.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
