### PR TITLE
Gateway api supports cors setting and reading methods

### DIFF
--- a/huaweicloud/resource_huaweicloud_api_gateway_api.go
+++ b/huaweicloud/resource_huaweicloud_api_gateway_api.go
@@ -314,6 +314,7 @@ func resourceAPIGatewayAPIRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("backend_type", v.BackendType)
 	d.Set("example_success_response", v.ResultNormalSample)
 	d.Set("example_failure_response", v.ResultFailureSample)
+	d.Set("cors", v.Cors)
 
 	var requestParameters []map[string]interface{}
 	for _, val := range v.ReqParams {
@@ -442,6 +443,7 @@ func buildApiParameter(d *schema.ResourceData) (*apis.CreateOpts, error) {
 		Tags:                apiTags,
 		ResultNormalSample:  d.Get("example_success_response").(string),
 		ResultFailureSample: d.Get("example_failure_response").(string),
+		Cors:                d.Get("cors").(bool),
 	}
 
 	switch backendType {

--- a/huaweicloud/resource_huaweicloud_api_gateway_api_test.go
+++ b/huaweicloud/resource_huaweicloud_api_gateway_api_test.go
@@ -25,6 +25,7 @@ func TestAccApiGatewayAPI_basic(t *testing.T) {
 					testAccCheckApiGatewayApiExists(resName),
 					resource.TestCheckResourceAttr(resName, "name", rName),
 					resource.TestCheckResourceAttr(resName, "group_name", rName),
+					resource.TestCheckResourceAttr(resName, "cors", "false"),
 					resource.TestCheckResourceAttr(resName, "auth_type", "NONE"),
 					resource.TestCheckResourceAttr(resName, "backend_type", "HTTP"),
 					resource.TestCheckResourceAttr(resName, "request_protocol", "HTTPS"),
@@ -42,6 +43,7 @@ func TestAccApiGatewayAPI_basic(t *testing.T) {
 					testAccCheckApiGatewayApiExists(resName),
 					resource.TestCheckResourceAttr(resName, "description", "updated by acc test"),
 					resource.TestCheckResourceAttr(resName, "auth_type", "IAM"),
+					resource.TestCheckResourceAttr(resName, "cors", "true"),
 					resource.TestCheckResourceAttr(resName, "request_protocol", "BOTH"),
 					resource.TestCheckResourceAttr(resName, "request_uri", "/test/path2"),
 				),
@@ -142,6 +144,7 @@ resource "huaweicloud_api_gateway_group" "acc_apigw_group" {
 resource "huaweicloud_api_gateway_api" "acc_apigw_api" {
   group_id = huaweicloud_api_gateway_group.acc_apigw_group.id
   name   = "%s"
+  cors   = true
   description  = "updated by acc test"
   tags = ["tag1","tag2"]
   visibility = 2


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `cors` parameter is not used, so the default value of __false__ is used when creating the gateway api.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1015 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add the cors setting and reading methods.
2. test the cors updation in the acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccApiGatewayAPI_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccApiGatewayAPI_basic -timeout 360m -parallel 4
=== RUN   TestAccApiGatewayAPI_basic
=== PAUSE TestAccApiGatewayAPI_basic
=== CONT  TestAccApiGatewayAPI_basic
--- PASS: TestAccApiGatewayAPI_basic (42.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       42.986s
```
