### PR TITLE
[data/image]: use validation package to replace custom functions

### DIFF
--- a/huaweicloud/data_source_huaweicloud_images_image.go
+++ b/huaweicloud/data_source_huaweicloud_images_image.go
@@ -6,10 +6,17 @@ import (
 	"sort"
 	"time"
 
-	"github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images"
 )
+
+var iamgeValidSortKeys = []string{
+	"name", "container_format", "disk_format", "status", "id", "size",
+}
+var imageValidVisibilities = []string{
+	"public", "private", "community", "shared",
+}
 
 func DataSourceImagesImageV2() *schema.Resource {
 	return &schema.Resource{
@@ -30,7 +37,7 @@ func DataSourceImagesImageV2() *schema.Resource {
 			"visibility": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: dataSourceImagesImageV2Visibility,
+				ValidateFunc: validation.StringInSlice(imageValidVisibilities, false),
 			},
 
 			"owner": {
@@ -52,14 +59,16 @@ func DataSourceImagesImageV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "name",
-				ValidateFunc: dataSourceImagesImageV2SortKey,
+				ValidateFunc: validation.StringInSlice(iamgeValidSortKeys, false),
 			},
 
 			"sort_direction": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "asc",
-				ValidateFunc: dataSourceImagesImageV2SortDirection,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "asc",
+				ValidateFunc: validation.StringInSlice([]string{
+					"asc", "desc",
+				}, false),
 			},
 
 			"tag": {
@@ -233,43 +242,4 @@ func mostRecentImage(images []images.Image) images.Image {
 	sortedImages := images
 	sort.Sort(imageSort(sortedImages))
 	return sortedImages[len(sortedImages)-1]
-}
-
-var sortkeys = [6]string{"name", "container_format", "disk_format", "status", "id", "size"}
-
-func dataSourceImagesImageV2SortKey(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	for _, key := range sortkeys {
-		if value == key {
-			return
-		}
-	}
-
-	err := fmt.Errorf("%s must be one of %s", k, sortkeys)
-	errors = append(errors, err)
-	return
-}
-
-func dataSourceImagesImageV2SortDirection(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "asc" && value != "desc" {
-		err := fmt.Errorf("%s must be either asc or desc", k)
-		errors = append(errors, err)
-	}
-	return
-}
-
-var visibilities = [4]string{"public", "private", "community", "shared"}
-
-func dataSourceImagesImageV2Visibility(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	for _, key := range visibilities {
-		if value == key {
-			return
-		}
-	}
-
-	err := fmt.Errorf("%s must be one of %s", k, visibilities)
-	errors = append(errors, err)
-	return
 }

--- a/huaweicloud/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/data_source_huaweicloud_images_image_test.go
@@ -9,62 +9,58 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccHuaweiCloudImagesV2ImageDataSource_basic(t *testing.T) {
+func TestAccImsImageDataSource_basic(t *testing.T) {
 	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.huaweicloud_images_image.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName),
+				Config: testAccImsImageDataSource_ubuntu(rName),
 			},
 			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_basic(rName),
+				Config: testAccImsImageDataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.huaweicloud_images_image.test"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_images_image.test", "name", rName),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_images_image.test", "protected", "false"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_images_image.test", "visibility", "private"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "private"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccHuaweiCloudImagesV2ImageDataSource_testQueries(t *testing.T) {
+func TestAccImsImageDataSource_testQueries(t *testing.T) {
 	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.huaweicloud_images_image.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName),
+				Config: testAccImsImageDataSource_ubuntu(rName),
 			},
 			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_queryTag(rName),
+				Config: testAccImsImageDataSource_queryTag(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.huaweicloud_images_image.test"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
 			},
 			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_querySizeMin(rName),
+				Config: testAccImsImageDataSource_querySizeMin(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.huaweicloud_images_image.test"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
 			},
 			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_querySizeMax(rName),
+				Config: testAccImsImageDataSource_querySizeMax(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.huaweicloud_images_image.test"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
-			},
-			{
-				Config: testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName),
 			},
 		},
 	})
@@ -85,7 +81,7 @@ func testAccCheckImagesV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName string) string {
+func testAccImsImageDataSource_ubuntu(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -126,49 +122,49 @@ resource "huaweicloud_images_image" "test" {
 `, rName, rName)
 }
 
-func testAccHuaweiCloudImagesV2ImageDataSource_basic(rName string) string {
+func testAccImsImageDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_images_image" "test" {
-	most_recent = true
-	name = huaweicloud_images_image.test.name
+  most_recent = true
+  name        = huaweicloud_images_image.test.name
 }
-`, testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName))
+`, testAccImsImageDataSource_ubuntu(rName))
 }
 
-func testAccHuaweiCloudImagesV2ImageDataSource_queryTag(rName string) string {
+func testAccImsImageDataSource_queryTag(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_images_image" "test" {
-	most_recent = true
-	visibility = "private"
-	tag = "foo=bar"
+  most_recent = true
+  visibility  = "private"
+  tag         = "foo=bar"
 }
-`, testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName))
+`, testAccImsImageDataSource_ubuntu(rName))
 }
 
-func testAccHuaweiCloudImagesV2ImageDataSource_querySizeMin(rName string) string {
+func testAccImsImageDataSource_querySizeMin(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_images_image" "test" {
-	most_recent = true
-	visibility = "private"
-	size_min = "13000000"
+  most_recent = true
+  visibility  = "private"
+  size_min    = "13000000"
 }
-`, testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName))
+`, testAccImsImageDataSource_ubuntu(rName))
 }
 
-func testAccHuaweiCloudImagesV2ImageDataSource_querySizeMax(rName string) string {
+func testAccImsImageDataSource_querySizeMax(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_images_image" "test" {
-	most_recent = true
-	visibility = "private"
-	size_max = "23000000"
+  most_recent = true
+  visibility  = "private"
+  size_max    = "23000000"
 }
-`, testAccHuaweiCloudImagesV2ImageDataSource_ubuntu(rName))
+`, testAccImsImageDataSource_ubuntu(rName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
use validation package to replace custom functions
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccImsImageDataSource_testQueries'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccImsImageDataSource_testQueries -timeout 360m -parallel 4
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_testQueries (495.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       495.363s
```
