### PR TITLE
support enterprise_project_id in elb loadbalancer

### DIFF
--- a/docs/data-sources/enterprise_project.md
+++ b/docs/data-sources/enterprise_project.md
@@ -20,6 +20,7 @@ Service Name | Resource Name | Sub Resource Name
 AS  | huaweicloud_as_group |
 VPC | huaweicloud_vpc<br>huaweicloud_networking_secgroup | huaweicloud_vpc_subnet<br>huaweicloud_vpc_route<br>huaweicloud_networking_secgroup_rule
 EIP | huaweicloud_vpc_eip<br>huaweicloud_vpc_bandwidth |
+ELB | huaweicloud_lb_loadbalancer |
 ECS | huaweicloud_compute_instance |
 EVS | huaweicloud_evs_volume |
 CCE | huaweicloud_cce_cluster | huaweicloud_cce_node<br>huaweicloud_cce_node_pool<br>huaweicloud_cce_addon

--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -60,6 +60,9 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the loadbalancer.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the loadbalancer.
+  Changing this creates a new loadbalancer.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/config.go
+++ b/huaweicloud/config.go
@@ -614,8 +614,14 @@ func (c *Config) elasticLBClient(region string) (*golangsdk.ServiceClient, error
 	return c.NewServiceClient("elb", region)
 }
 
+// client for v2.0 api
 func (c *Config) ElbV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("elbv2", region)
+}
+
+// client for v2 api
+func (c *Config) LoadBalancerClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("loadbalancer", region)
 }
 
 func (c *Config) FwV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/endpoints.go
+++ b/huaweicloud/endpoints.go
@@ -156,6 +156,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v2.0",
 		WithOutProjectID: true,
 	},
+	"loadbalancer": {
+		Name:    "elb",
+		Version: "v2",
+	},
 	"fwv2": {
 		Name:             "vpc",
 		Version:          "v2.0",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -624,6 +624,16 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "elb", "v2.0", t)
 
+	// test endpoint of loadbalancer(elb v2)
+	serviceClient, err = nil, nil
+	serviceClient, err = config.LoadBalancerClient(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud ELB v2 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	compareURL(expectedURL, actualURL, "elb", "v2", t)
+
 	// test the endpoint of fw v2 service
 	serviceClient, err = config.FwV2Client(HW_REGION_NAME)
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/common/tags"
-	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
+	"github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
 )
 
@@ -98,15 +98,27 @@ func ResourceLoadBalancerV2() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	elbClient, err := config.ElbV2Client(GetRegion(d, config))
+	elbClient, err := config.LoadBalancerClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
+	}
+
+	// client for setting tags
+	elbV2Client, err := config.ElbV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud elb v2.0 client: %s", err)
 	}
 
 	var lbProvider string
@@ -116,14 +128,15 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 	adminStateUp := d.Get("admin_state_up").(bool)
 	createOpts := loadbalancers.CreateOpts{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		VipSubnetID:  d.Get("vip_subnet_id").(string),
-		TenantID:     d.Get("tenant_id").(string),
-		VipAddress:   d.Get("vip_address").(string),
-		AdminStateUp: &adminStateUp,
-		Flavor:       d.Get("flavor").(string),
-		Provider:     lbProvider,
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		VipSubnetID:         d.Get("vip_subnet_id").(string),
+		TenantID:            d.Get("tenant_id").(string),
+		VipAddress:          d.Get("vip_address").(string),
+		AdminStateUp:        &adminStateUp,
+		Flavor:              d.Get("flavor").(string),
+		Provider:            lbProvider,
+		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -134,7 +147,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 	// Wait for LoadBalancer to become active before continuing
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2LoadBalancer(elbClient, lb.ID, "ACTIVE", nil, timeout)
+	err = waitForLBV2LoadBalancer_v2(elbClient, lb.ID, "ACTIVE", nil, timeout)
 	if err != nil {
 		return err
 	}
@@ -159,7 +172,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
 		taglist := expandResourceTags(tagRaw)
-		if tagErr := tags.Create(elbClient, "loadbalancers", lb.ID, taglist).ExtractErr(); tagErr != nil {
+		if tagErr := tags.Create(elbV2Client, "loadbalancers", lb.ID, taglist).ExtractErr(); tagErr != nil {
 			return fmt.Errorf("Error setting tags of load balancer %s: %s", lb.ID, tagErr)
 		}
 	}
@@ -169,9 +182,15 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	elbClient, err := config.ElbV2Client(GetRegion(d, config))
+	elbClient, err := config.LoadBalancerClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
+	}
+
+	// client for fetching tags
+	elbV2Client, err := config.ElbV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud elb 2.0 client: %s", err)
 	}
 
 	lb, err := loadbalancers.Get(elbClient, d.Id()).Extract()
@@ -191,6 +210,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("flavor", lb.Flavor)
 	d.Set("loadbalancer_provider", lb.Provider)
 	d.Set("region", GetRegion(d, config))
+	d.Set("enterprise_project_id", lb.EnterpriseProjectID)
 
 	// Get any security groups on the VIP Port
 	if lb.VipPortID != "" {
@@ -208,7 +228,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// fetch tags
-	if resourceTags, err := tags.Get(elbClient, "loadbalancers", d.Id()).Extract(); err == nil {
+	if resourceTags, err := tags.Get(elbV2Client, "loadbalancers", d.Id()).Extract(); err == nil {
 		tagmap := tagsToMap(resourceTags.Tags)
 		d.Set("tags", tagmap)
 	} else {
@@ -220,7 +240,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 
 func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	elbClient, err := config.ElbV2Client(GetRegion(d, config))
+	elbClient, err := config.LoadBalancerClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
@@ -240,7 +260,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 
 		// Wait for LoadBalancer to become active before continuing
 		timeout := d.Timeout(schema.TimeoutUpdate)
-		err = waitForLBV2LoadBalancer(elbClient, d.Id(), "ACTIVE", nil, timeout)
+		err = waitForLBV2LoadBalancer_v2(elbClient, d.Id(), "ACTIVE", nil, timeout)
 		if err != nil {
 			return err
 		}
@@ -256,7 +276,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 		})
 
 		// Wait for LoadBalancer to become active before continuing
-		err = waitForLBV2LoadBalancer(elbClient, d.Id(), "ACTIVE", nil, timeout)
+		err = waitForLBV2LoadBalancer_v2(elbClient, d.Id(), "ACTIVE", nil, timeout)
 		if err != nil {
 			return err
 		}
@@ -279,7 +299,11 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 
 	// update tags
 	if d.HasChange("tags") {
-		tagErr := UpdateResourceTags(elbClient, d, "loadbalancers", d.Id())
+		elbV2Client, err := config.ElbV2Client(GetRegion(d, config))
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud elb 2.0 client: %s", err)
+		}
+		tagErr := UpdateResourceTags(elbV2Client, d, "loadbalancers", d.Id())
 		if tagErr != nil {
 			return fmt.Errorf("Error updating tags of load balancer:%s, err:%s", d.Id(), tagErr)
 		}
@@ -290,7 +314,7 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	elbClient, err := config.ElbV2Client(GetRegion(d, config))
+	elbClient, err := config.LoadBalancerClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
@@ -308,7 +332,7 @@ func resourceLoadBalancerV2Delete(d *schema.ResourceData, meta interface{}) erro
 
 	// Wait for LoadBalancer to become delete
 	pending := []string{"PENDING_UPDATE", "PENDING_DELETE", "ACTIVE"}
-	err = waitForLBV2LoadBalancer(elbClient, d.Id(), "DELETED", pending, timeout)
+	err = waitForLBV2LoadBalancer_v2(elbClient, d.Id(), "DELETED", pending, timeout)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/doc.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/doc.go
@@ -1,0 +1,71 @@
+/*
+Package loadbalancers provides information and interaction with Load Balancers
+of the ELB v2 extension for the OpenStack Networking service.
+
+Example to List Load Balancers
+
+	listOpts := loadbalancers.ListOpts{
+		Provider: "haproxy",
+	}
+
+	allPages, err := loadbalancers.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadbalancers, err := loadbalancers.ExtractLoadBalancers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, lb := range allLoadbalancers {
+		fmt.Printf("%+v\n", lb)
+	}
+
+Example to Create a Load Balancer
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:         "db_lb",
+		AdminStateUp: golangsdk.Enabled,
+		VipSubnetID:  "9cedb85d-0759-4898-8a4b-fa5a5ea10086",
+		VipAddress:   "10.30.176.48",
+		Flavor:       "medium",
+		Provider:     "haproxy",
+	}
+
+	lb, err := loadbalancers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+
+	i1001 := 1001
+	updateOpts := loadbalancers.UpdateOpts{
+		Name: "new-name",
+	}
+
+	lb, err := loadbalancers.Update(networkClient, lbID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Load Balancers
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	err := loadbalancers.Delete(networkClient, lbID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get the Status of a Load Balancer
+
+	lbID := "d67d56a6-4a86-4688-a282-f46444705c64"
+	status, err := loadbalancers.GetStatuses(networkClient, LBID).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package loadbalancers

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/requests.go
@@ -1,0 +1,202 @@
+package loadbalancers
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToLoadBalancerListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Loadbalancer attributes you want to see returned. SortKey allows you to
+// sort by a particular attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Description         string `q:"description"`
+	AdminStateUp        *bool  `q:"admin_state_up"`
+	TenantID            string `q:"tenant_id"`
+	ProjectID           string `q:"project_id"`
+	ProvisioningStatus  string `q:"provisioning_status"`
+	VipAddress          string `q:"vip_address"`
+	VipPortID           string `q:"vip_port_id"`
+	VipSubnetID         string `q:"vip_subnet_id"`
+	ID                  string `q:"id"`
+	OperatingStatus     string `q:"operating_status"`
+	Name                string `q:"name"`
+	Flavor              string `q:"flavor"`
+	Provider            string `q:"provider"`
+	Limit               int    `q:"limit"`
+	Marker              string `q:"marker"`
+	SortKey             string `q:"sort_key"`
+	SortDir             string `q:"sort_dir"`
+	EnterpriseProjectID string `q:"enterprise_project_id"`
+}
+
+// ToLoadBalancerListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToLoadBalancerListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// load balancers. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+//
+// Default policy settings return only those load balancers that are owned by
+// the tenant who submits the request, unless an admin user submits the request.
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToLoadBalancerListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return LoadBalancerPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToLoadBalancerCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// Human-readable name for the Loadbalancer. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Human-readable description for the Loadbalancer.
+	Description string `json:"description,omitempty"`
+
+	// The network on which to allocate the Loadbalancer's address. A tenant can
+	// only create Loadbalancers on networks authorized by policy (e.g. networks
+	// that belong to them or networks that are shared).
+	VipSubnetID string `json:"vip_subnet_id" required:"true"`
+
+	// TenantID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Loadbalancer.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The IP address of the Loadbalancer.
+	VipAddress string `json:"vip_address,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The UUID of a flavor.
+	Flavor string `json:"flavor,omitempty"`
+
+	// The name of the provider.
+	Provider string `json:"provider,omitempty"`
+
+	// Enterprise project ID
+	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+}
+
+// ToLoadBalancerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToLoadBalancerCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "loadbalancer")
+}
+
+// Create is an operation which provisions a new loadbalancer based on the
+// configuration defined in the CreateOpts struct. Once the request is
+// validated and progress has started on the provisioning process, a
+// CreateResult will be returned.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToLoadBalancerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Loadbalancer based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToLoadBalancerUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// Human-readable name for the Loadbalancer. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Human-readable description for the Loadbalancer.
+	Description string `json:"description,omitempty"`
+
+	// The administrative state of the Loadbalancer. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+// ToLoadBalancerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToLoadBalancerUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "loadbalancer")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// LoadBalancer.
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToLoadBalancerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete will permanently delete a particular LoadBalancer based on its
+// unique ID.
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+
+// CascadingDelete is like `Delete`, but will also delete any of the load balancer's
+// children (listener, monitor, etc).
+// NOTE: This function will only work with Octavia load balancers; Neutron does not
+// support this.
+func CascadingDelete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	if c.Type != "load-balancer" {
+		r.Err = fmt.Errorf("error prior to running cascade delete: only Octavia LBs supported")
+		return
+	}
+	u := fmt.Sprintf("%s?cascade=true", resourceURL(c, id))
+	_, r.Err = c.Delete(u, nil)
+	return
+}
+
+// GetStatuses will return the status of a particular LoadBalancer.
+func GetStatuses(c *golangsdk.ServiceClient, id string) (r GetStatusesResult) {
+	_, r.Err = c.Get(statusRootURL(c, id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/results.go
@@ -1,0 +1,156 @@
+package loadbalancers
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// LoadBalancer is the primary load balancing configuration object that
+// specifies the virtual IP address on which client traffic is received, as well
+// as other details such as the load balancing method to be use, protocol, etc.
+type LoadBalancer struct {
+	// Human-readable description for the Loadbalancer.
+	Description string `json:"description"`
+
+	// The administrative state of the Loadbalancer.
+	// A valid value is true (UP) or false (DOWN).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Owner of the LoadBalancer.
+	TenantID string `json:"tenant_id"`
+
+	// The provisioning status of the LoadBalancer.
+	// This value is ACTIVE, PENDING_CREATE or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+
+	// The IP address of the Loadbalancer.
+	VipAddress string `json:"vip_address"`
+
+	// The UUID of the port associated with the IP address.
+	VipPortID string `json:"vip_port_id"`
+
+	// The UUID of the subnet on which to allocate the virtual IP for the
+	// Loadbalancer address.
+	VipSubnetID string `json:"vip_subnet_id"`
+
+	// The unique ID for the LoadBalancer.
+	ID string `json:"id"`
+
+	// The operating status of the LoadBalancer. This value is ONLINE or OFFLINE.
+	OperatingStatus string `json:"operating_status"`
+
+	// Human-readable name for the LoadBalancer. Does not have to be unique.
+	Name string `json:"name"`
+
+	// The UUID of a flavor if set.
+	Flavor string `json:"flavor"`
+
+	// The name of the provider.
+	Provider string `json:"provider"`
+
+	// Listeners are the listeners related to this Loadbalancer.
+	Listeners []listeners.Listener `json:"listeners"`
+
+	// Pools are the pools related to this Loadbalancer.
+	Pools []pools.Pool `json:"pools"`
+
+	// Enterprise project ID
+	EnterpriseProjectID string `json:"enterprise_project_id"`
+}
+
+// StatusTree represents the status of a loadbalancer.
+type StatusTree struct {
+	Loadbalancer *LoadBalancer `json:"loadbalancer"`
+}
+
+// LoadBalancerPage is the page returned by a pager when traversing over a
+// collection of load balancers.
+type LoadBalancerPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of load balancers has
+// reached the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r LoadBalancerPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"loadbalancers_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a LoadBalancerPage struct is empty.
+func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancers(r)
+	return len(is) == 0, err
+}
+
+// ExtractLoadBalancers accepts a Page struct, specifically a LoadbalancerPage
+// struct, and extracts the elements into a slice of LoadBalancer structs. In
+// other words, a generic collection is mapped into a relevant slice.
+func ExtractLoadBalancers(r pagination.Page) ([]LoadBalancer, error) {
+	var s struct {
+		LoadBalancers []LoadBalancer `json:"loadbalancers"`
+	}
+	err := (r.(LoadBalancerPage)).ExtractInto(&s)
+	return s.LoadBalancers, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a loadbalancer.
+func (r commonResult) Extract() (*LoadBalancer, error) {
+	var s struct {
+		LoadBalancer *LoadBalancer `json:"loadbalancer"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoadBalancer, err
+}
+
+// GetStatusesResult represents the result of a GetStatuses operation.
+// Call its Extract method to interpret it as a StatusTree.
+type GetStatusesResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts the status of
+// a Loadbalancer.
+func (r GetStatusesResult) Extract() (*StatusTree, error) {
+	var s struct {
+		Statuses *StatusTree `json:"statuses"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Statuses, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a LoadBalancer.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a LoadBalancer.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a LoadBalancer.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers/urls.go
@@ -1,0 +1,21 @@
+package loadbalancers
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	rootPath     = "elb"
+	resourcePath = "loadbalancers"
+	statusPath   = "statuses"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}
+
+func statusRootURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id, statusPath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -320,6 +320,7 @@ github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/flavors
+github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers
 github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects
 github.com/huaweicloud/golangsdk/openstack/evs/v2/snapshots
 github.com/huaweicloud/golangsdk/openstack/evs/v2/tags


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support enterprise_project_id in elb loadbalancer
in order to support enterprise_project_id, the sdk and client of loadbalancer were updated to v2
All test cases were run to check whether it affects other related resources

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
related #1019 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2 -timeout 360m -parallel 4
=== RUN   TestAccLBV2Certificate_basic
=== PAUSE TestAccLBV2Certificate_basic
=== RUN   TestAccLBV2Certificate_client
=== PAUSE TestAccLBV2Certificate_client
=== RUN   TestAccLBV2L7Policy_basic
=== PAUSE TestAccLBV2L7Policy_basic
=== RUN   TestAccLBV2L7Rule_basic
=== PAUSE TestAccLBV2L7Rule_basic
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== RUN   TestAccLBV2LoadBalancer_secGroup
=== PAUSE TestAccLBV2LoadBalancer_secGroup
=== RUN   TestAccLBV2LoadBalancer_withEpsId
=== PAUSE TestAccLBV2LoadBalancer_withEpsId
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== RUN   TestAccLBV2Whitelist_basic
=== PAUSE TestAccLBV2Whitelist_basic
=== CONT  TestAccLBV2Certificate_basic
=== CONT  TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Certificate_basic (31.19s)
=== CONT  TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_withEpsId (44.07s)
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2Pool_basic (127.78s)
=== CONT  TestAccLBV2Listener_basic
--- PASS: TestAccLBV2LoadBalancer_basic (83.79s)
=== CONT  TestAccLBV2L7Rule_basic
--- PASS: TestAccLBV2LoadBalancer_secGroup (108.10s)
=== CONT  TestAccLBV2L7Policy_basic
--- PASS: TestAccLBV2Monitor_basic (152.58s)
=== CONT  TestAccLBV2Certificate_client
--- PASS: TestAccLBV2Certificate_client (34.61s)
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2L7Policy_basic (98.32s)
=== CONT  TestAccLBV2Whitelist_basic
--- PASS: TestAccLBV2Listener_basic (111.44s)
--- PASS: TestAccLBV2L7Rule_basic (136.62s)
--- PASS: TestAccLBV2Whitelist_basic (90.59s)
--- PASS: TestAccLBV2Member_basic (147.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       335.218s
```
