### PR TITLE
improve on acceptance test of cce resources

### DIFF
--- a/huaweicloud/data_source_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/data_source_huaweicloud_cce_cluster_v3_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "data.huaweicloud_cce_cluster_v3.test"
+	resourceName := "data.huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -49,8 +49,8 @@ func testAccCCEClusterV3DataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_cce_cluster_v3" "test" {
-  name = huaweicloud_cce_cluster_v3.test.name
+data "huaweicloud_cce_cluster" "test" {
+  name = huaweicloud_cce_cluster.test.name
 }
 `, testAccCCEClusterV3_basic(rName))
 }

--- a/huaweicloud/data_source_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_v3_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccCCENodeV3DataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "data.huaweicloud_cce_node_v3.test"
+	resourceName := "data.huaweicloud_cce_node.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -47,9 +47,9 @@ func testAccCCENodeV3DataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_cce_node_v3" "test" {
-  cluster_id = huaweicloud_cce_cluster_v3.test.id
-  name       = huaweicloud_cce_node_v3.test.name
+data "huaweicloud_cce_node" "test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+  name       = huaweicloud_cce_node.test.name
 }
 `, testAccCCENodeV3_basic(rName))
 }

--- a/huaweicloud/resource_huaweicloud_cce_addon_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_addon_v3_test.go
@@ -16,7 +16,7 @@ func TestAccCCEAddonV3_basic(t *testing.T) {
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_cce_addon.test"
-	clusterName := "huaweicloud_cce_cluster_v3.test"
+	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,7 +44,7 @@ func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
 	var clusterId string
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type == "huaweicloud_cce_cluster_v3" {
+		if rs.Type == "huaweicloud_cce_cluster" {
 			clusterId = rs.Primary.ID
 		}
 
@@ -105,21 +105,21 @@ func testAccCCEAddonV3_Base(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_node_v3" "test" {
-	cluster_id        = huaweicloud_cce_cluster_v3.test.id
-	name              = "%s"
-	flavor_id         = "s6.large.2"
-	availability_zone = data.huaweicloud_availability_zones.test.names[0]
-	key_pair          = huaweicloud_compute_keypair_v2.test.name
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
+  name              = "%s"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  key_pair          = huaweicloud_compute_keypair.test.name
 
-	root_volume {
-	size       = 40
-	volumetype = "SSD"
-	}
-	data_volumes {
-	size       = 100
-	volumetype = "SSD"
-	}
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
 }
 `, testAccCCENodeV3_Base(rName), rName)
 }
@@ -129,10 +129,10 @@ func testAccCCEAddonV3_basic(rName string) string {
 %s
 
 resource "huaweicloud_cce_addon" "test" {
-    cluster_id = huaweicloud_cce_cluster_v3.test.id
-    version = "1.1.0"
-	template_name = "metrics-server"
-	depends_on = [huaweicloud_cce_node_v3.test]
+  cluster_id    = huaweicloud_cce_cluster.test.id
+  version       = "1.1.0"
+  template_name = "metrics-server"
+  depends_on    = [huaweicloud_cce_node.test]
 }
 `, testAccCCEAddonV3_Base(rName))
 }

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
@@ -15,7 +15,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 	var cluster clusters.Clusters
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "huaweicloud_cce_cluster_v3.test"
+	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,7 +54,7 @@ func TestAccCCEClusterV3_withEip(t *testing.T) {
 	var cluster clusters.Clusters
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "huaweicloud_cce_cluster_v3.test"
+	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -132,7 +132,7 @@ func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_cce_cluster_v3" {
+		if rs.Type != "huaweicloud_cce_cluster" {
 			continue
 		}
 
@@ -179,12 +179,12 @@ func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resour
 
 func testAccCCEClusterV3_Base(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc_v1" "test" {
+resource "huaweicloud_vpc" "test" {
   name = "%s"
   cidr = "192.168.0.0/16"
 }
 
-resource "huaweicloud_vpc_subnet_v1" "test" {
+resource "huaweicloud_vpc_subnet" "test" {
   name          = "%s"
   cidr          = "192.168.0.0/16"
   gateway_ip    = "192.168.0.1"
@@ -192,7 +192,7 @@ resource "huaweicloud_vpc_subnet_v1" "test" {
   //dns is required for cce node installing
   primary_dns   = "100.125.1.250"
   secondary_dns = "100.125.21.250"
-  vpc_id        = huaweicloud_vpc_v1.test.id
+  vpc_id        = huaweicloud_vpc.test.id
 }
 `, rName, rName)
 }
@@ -201,11 +201,11 @@ func testAccCCEClusterV3_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_cluster_v3" "test" {
+resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
   service_network_cidr = "10.248.0.0/16"
 }
@@ -216,11 +216,11 @@ func testAccCCEClusterV3_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_cluster_v3" "test" {
+resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
   service_network_cidr = "10.248.0.0/16"
   description            = "new description"
@@ -232,7 +232,7 @@ func testAccCCEClusterV3_withEip(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_vpc_eip_v1" "test" {
+resource "huaweicloud_vpc_eip" "test" {
   publicip {
     type = "5_bgp"
   }
@@ -244,15 +244,15 @@ resource "huaweicloud_vpc_eip_v1" "test" {
   }
 }
 
-resource "huaweicloud_cce_cluster_v3" "test" {
+resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
-  eip                    = huaweicloud_vpc_eip_v1.test.address
+  eip                    = huaweicloud_vpc_eip.test.address
 }
 `, testAccCCEClusterV3_Base(rName), rName)
 }
@@ -264,8 +264,8 @@ func testAccCCEClusterV3_withEpsId(rName string) string {
 resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
   enterprise_project_id  = "%s"
 }
@@ -275,39 +275,25 @@ resource "huaweicloud_cce_cluster" "test" {
 
 func testAccCCEClusterV3_turbo(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc_v1" "test" {
-  name = "%s"
-  cidr = "192.168.0.0/16"
-}
+%s
 
-resource "huaweicloud_vpc_subnet_v1" "test" {
-  name          = "%s"
-  cidr          = "192.168.1.0/24"
-  gateway_ip    = "192.168.1.1"
-
-  //dns is required for cce node installing
-  primary_dns   = "100.125.1.250"
-  secondary_dns = "100.125.21.250"
-  vpc_id        = huaweicloud_vpc_v1.test.id
-}
-
-resource "huaweicloud_vpc_subnet_v1" "eni_test" {
+resource "huaweicloud_vpc_subnet" "eni_test" {
   name          = "%s-eni"
   cidr          = "192.168.2.0/24"
   gateway_ip    = "192.168.2.1"
-  vpc_id        = huaweicloud_vpc_v1.test.id
+  vpc_id        = huaweicloud_vpc.test.id
 }
 
 resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "eni"
-  eni_subnet_id          = huaweicloud_vpc_subnet_v1.eni_test.id
-  eni_subnet_cidr        = huaweicloud_vpc_subnet_v1.eni_test.cidr
+  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.id
+  eni_subnet_cidr        = huaweicloud_vpc_subnet.eni_test.cidr
 
 }
 
-`, rName, rName, rName, rName)
+`, testAccCCEClusterV3_Base(rName), rName, rName)
 }

--- a/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
@@ -179,8 +179,8 @@ resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
 }
 `, testAccCCEClusterV3_Base(rName), rName, rName)

--- a/huaweicloud/resource_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3_test.go
@@ -17,9 +17,9 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	updateName := rName + "update"
-	resourceName := "huaweicloud_cce_node_v3.test"
+	resourceName := "huaweicloud_cce_node.test"
 	//clusterName here is used to provide the cluster id to fetch cce node.
-	clusterName := "huaweicloud_cce_cluster_v3.test"
+	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,14 +46,16 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 				Config: testAccCCENodeV3_auto_assign_eip(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
+					resource.TestMatchResourceAttr(resourceName, "public_ip",
+						regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
 				),
 			},
 			{
 				Config: testAccCCENodeV3_existing_eip(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
+					resource.TestMatchResourceAttr(resourceName, "public_ip",
+						regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
 				),
 			},
 			{
@@ -78,11 +80,11 @@ func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
 	var clusterId string
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type == "huaweicloud_cce_cluster_v3" {
+		if rs.Type == "huaweicloud_cce_cluster" {
 			clusterId = rs.Primary.ID
 		}
 
-		if rs.Type != "huaweicloud_cce_node_v3" {
+		if rs.Type != "huaweicloud_cce_node" {
 			continue
 		}
 
@@ -140,17 +142,17 @@ func testAccCCENodeV3_Base(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-resource "huaweicloud_compute_keypair_v2" "test" {
+resource "huaweicloud_compute_keypair" "test" {
   name = "%s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
 
-resource "huaweicloud_cce_cluster_v3" "test" {
+resource "huaweicloud_cce_cluster" "test" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc_v1.test.id
-  subnet_id              = huaweicloud_vpc_subnet_v1.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
 }
 `, testAccCCEClusterV3_Base(rName), rName, rName)
@@ -160,12 +162,12 @@ func testAccCCENodeV3_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_node_v3" "test" {
-  cluster_id        = huaweicloud_cce_cluster_v3.test.id
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
   flavor_id         = "s6.small.1"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair_v2.test.name
+  key_pair          = huaweicloud_compute_keypair.test.name
 
   root_volume {
     size       = 40
@@ -187,12 +189,12 @@ func testAccCCENodeV3_update(rName, updateName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_node_v3" "test" {
-  cluster_id        = huaweicloud_cce_cluster_v3.test.id
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
   flavor_id         = "s6.small.1"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair_v2.test.name
+  key_pair          = huaweicloud_compute_keypair.test.name
 
   root_volume {
     size       = 40
@@ -214,12 +216,12 @@ func testAccCCENodeV3_auto_assign_eip(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_node_v3" "test" {
-  cluster_id        = huaweicloud_cce_cluster_v3.test.id
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
   flavor_id         = "s6.small.1"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair_v2.test.name
+  key_pair          = huaweicloud_compute_keypair.test.name
 
   root_volume {
     size       = 40
@@ -243,7 +245,7 @@ func testAccCCENodeV3_existing_eip(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_vpc_eip_v1" "test" {
+resource "huaweicloud_vpc_eip" "test" {
   publicip {
     type = "5_bgp"
   }
@@ -255,12 +257,12 @@ resource "huaweicloud_vpc_eip_v1" "test" {
   }
 }
 
-resource "huaweicloud_cce_node_v3" "test" {
-  cluster_id        = huaweicloud_cce_cluster_v3.test.id
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
   flavor_id         = "s6.small.1"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair_v2.test.name
+  key_pair          = huaweicloud_compute_keypair.test.name
 
   root_volume {
     size       = 40
@@ -272,7 +274,7 @@ resource "huaweicloud_cce_node_v3" "test" {
   }
 
   // Assign existing EIP
-  eip_id = huaweicloud_vpc_eip_v1.test.id
+  eip_id = huaweicloud_vpc_eip.test.id
 }
 `, testAccCCENodeV3_Base(rName), rName)
 }
@@ -281,12 +283,12 @@ func testAccCCENodeV3_volume_extendParams(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_cce_node_v3" "test" {
-  cluster_id        = huaweicloud_cce_cluster_v3.test.id
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
   flavor_id         = "s6.small.1"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair_v2.test.name
+  key_pair          = huaweicloud_compute_keypair.test.name
 
   root_volume {
     size         = 40


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
use the resource/data source key without version in acceptance testing

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== CONT  TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (412.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       412.134s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1956.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1956.423s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (466.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       466.733s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEAddonV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEAddonV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEAddonV3_basic
=== PAUSE TestAccCCEAddonV3_basic
=== CONT  TestAccCCEAddonV3_basic
--- PASS: TestAccCCEAddonV3_basic (889.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       889.614s
```