### PR TITLE
update docs of cce cluster delete options

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -179,25 +179,19 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the cce cluster.
   Changing this creates a new cluster.
 
-* `delete_efs` - (Optional, String) Specified whether to delete the associated EFS resources when deleting CCE cluster.
+* `delete_evs` - (Optional, String) Specified whether to delete associated EVS disks when deleting the CCE cluster.
   valid values are "true", "try" and "false". Default is false.
 
-* `delete_eni` - (Optional, String) Specified whether to delete the associated ENI resources when deleting CCE cluster.
+* `delete_obs` - (Optional, String) Specified whether to delete associated OBS buckets when deleting the CCE cluster.
   valid values are "true", "try" and "false". Default is false.
 
-* `delete_evs` - (Optional, String) Specified whether to delete the associated EVS resources when deleting CCE cluster.
+* `delete_sfs` - (Optional, String) Specified whether to delete associated SFS file systems when deleting the CCE cluster.
   valid values are "true", "try" and "false". Default is false.
 
-* `delete_net` - (Optional, String) Specified whether to delete the associated NET resources when deleting CCE cluster.
+* `delete_efs` - (Optional, String) Specified whether to unbind associated SFS Turbo file systems when deleting the CCE cluster.
   valid values are "true", "try" and "false". Default is false.
 
-* `delete_obs` - (Optional, String) Specified whether to delete the associated OBS resources when deleting CCE cluster.
-  valid values are "true", "try" and "false". Default is false.
-
-* `delete_sfs` - (Optional, String) Specified whether to delete the associated SFS resources when deleting CCE cluster.
-  valid values are "true", "try" and "false". Default is false.
-
-* `delete_all` - (Optional, String) Specified whether to delete all associated resources when deleting CCE cluster.
+* `delete_all` - (Optional, String) Specified whether to delete all associated storage resources when deleting the CCE cluster.
   valid values are "true", "try" and "false". Default is false.
 
 The `masters` block supports:

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -607,9 +607,7 @@ func resourceCCEClusterV3Delete(d *schema.ResourceData, meta interface{}) error 
 		if v, ok := d.GetOk("delete_all"); ok && v.(string) != "false" {
 			deleteOpt := d.Get("delete_all").(string)
 			deleteOpts.DeleteEfs = deleteOpt
-			deleteOpts.DeleteENI = deleteOpt
 			deleteOpts.DeleteEvs = deleteOpt
-			deleteOpts.DeleteNet = deleteOpt
 			deleteOpts.DeleteObs = deleteOpt
 			deleteOpts.DeleteSfs = deleteOpt
 		} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`delete_eni` and `delete_net` will unsupported in the API side, so we should ignore those two options.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (398.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       398.636s
```
