### PR TITLE
[Fix] Fixed an issue where terraform crashes during rds creation

### DIFF
--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -514,6 +514,7 @@ func resourceRdsInstanceBackupStrategy(d *schema.ResourceData) *instances.Backup
 func resourceRdsInstanceHaReplicationMode(d *schema.ResourceData) *instances.Ha {
 	var ha *instances.Ha
 	if hasFilledOpt(d, "ha_replication_mode") {
+		ha = new(instances.Ha)
 		ha.Mode = "ha"
 		ha.ReplicationMode = d.Get("ha_replication_mode").(string)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Terraform will crash when creating ha mode rds instance, the reason is:
- Forget open up pointer storage space before ha parameter setting.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1054 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fixed an issue where terraform crashes during ha mode rds instance creation.
2. new ha mode instance test.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=Te
stAccRdsInstanceV3_ha'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_ha -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_ha
=== PAUSE TestAccRdsInstanceV3_ha
=== CONT  TestAccRdsInstanceV3_ha
--- PASS: TestAccRdsInstanceV3_ha (578.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud    578.568s
```
