### PR TITLE
Add port option to lb_monitor

### DIFF
--- a/docs/resources/lb_monitor.md
+++ b/docs/resources/lb_monitor.md
@@ -45,6 +45,8 @@ The following arguments are supported:
     changing the member's status to INACTIVE. Must be a number between 1
     and 10.
 
+* `port` - (Optional, Int) Specifies the health check port. The value ranges from 1 to 65535.
+
 * `url_path` - (Optional, String) Required for HTTP(S) types. URI path that will be
     accessed if monitor type is HTTP or HTTPS.
 

--- a/huaweicloud/resource_huaweicloud_lb_monitor.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor.go
@@ -33,23 +33,15 @@ func ResourceMonitorV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"pool_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
+			"pool_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"type": {
@@ -71,6 +63,11 @@ func ResourceMonitorV2() *schema.Resource {
 			"max_retries": {
 				Type:     schema.TypeInt,
 				Required: true,
+			},
+
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
 			},
 
 			"url_path": {
@@ -96,6 +93,14 @@ func ResourceMonitorV2() *schema.Resource {
 				Default:  true,
 				Optional: true,
 			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
+			},
 		},
 	}
 }
@@ -119,6 +124,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 		HTTPMethod:    d.Get("http_method").(string),
 		ExpectedCodes: d.Get("expected_codes").(string),
 		Name:          d.Get("name").(string),
+		MonitorPort:   d.Get("port").(int),
 		AdminStateUp:  &adminStateUp,
 	}
 
@@ -180,6 +186,9 @@ func resourceMonitorV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("admin_state_up", monitor.AdminStateUp)
 	d.Set("name", monitor.Name)
 	d.Set("region", GetRegion(d, config))
+	if monitor.MonitorPort != 0 {
+		d.Set("port", monitor.MonitorPort)
+	}
 
 	return nil
 }
@@ -213,6 +222,9 @@ func resourceMonitorV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("name") {
 		updateOpts.Name = d.Get("name").(string)
+	}
+	if d.HasChange("port") {
+		updateOpts.MonitorPort = d.Get("port").(int)
 	}
 	if d.HasChange("http_method") {
 		updateOpts.HTTPMethod = d.Get("http_method").(string)

--- a/huaweicloud/resource_huaweicloud_lb_monitor_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor_test.go
@@ -29,6 +29,7 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "delay", "20"),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
+					resource.TestCheckResourceAttr(resourceName, "max_retries", "5"),
 				),
 			},
 			{
@@ -37,6 +38,8 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
 					resource.TestCheckResourceAttr(resourceName, "delay", "30"),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "15"),
+					resource.TestCheckResourceAttr(resourceName, "max_retries", "10"),
+					resource.TestCheckResourceAttr(resourceName, "port", "8888"),
 				),
 			},
 		},
@@ -128,12 +131,6 @@ resource "huaweicloud_lb_monitor" "monitor_1" {
   timeout     = 10
   max_retries = 5
   pool_id     = huaweicloud_lb_pool.pool_1.id
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, rName, rName, rName, rName)
 }
@@ -169,14 +166,9 @@ resource "huaweicloud_lb_monitor" "monitor_1" {
   delay          = 30
   timeout        = 15
   max_retries    = 10
+  port           = 8888
   admin_state_up = "true"
   pool_id        = huaweicloud_lb_pool.pool_1.id
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, rName, rName, rName, rNameUpdate)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add port option to lb_monitor
The port value ranges from 1 to 65535.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Monitor_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Monitor_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== CONT  TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Monitor_basic (167.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       167.375s
```
