### PR TITLE
support security_token to authenticate with a temporary security credential

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,9 @@ The following arguments are supported:
 * `auth_url` - (Optional, Required before 1.14.0) The Identity authentication URL. If omitted, the
   `HW_AUTH_URL` environment variable is used. This is not required if you use Huawei Cloud.
 
+* `security_token` - (Optional) The security token to authenticate with a
+  [temporary security credential](https://support.huaweicloud.com/intl/en-us/iam_faq/iam_01_0620.html).
+
 * `cloud` - (Optional) The endpoint of the cloud provider. If omitted, the
   `HW_CLOUD` environment variable is used. Defaults to `myhuaweicloud.com`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ The following arguments are supported:
 
 * `security_token` - (Optional) The security token to authenticate with a
   [temporary security credential](https://support.huaweicloud.com/intl/en-us/iam_faq/iam_01_0620.html).
+  If omitted, the `HW_SECURITY_TOKEN` environment variable is used.
 
 * `cloud` - (Optional) The endpoint of the cloud provider. If omitted, the
   `HW_CLOUD` environment variable is used. Defaults to `myhuaweicloud.com`.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5
+	github.com/huaweicloud/golangsdk v0.0.0-20210412080213-f1dcb144bd25
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5 h1:qsDthJ6oyB3Jexl1NTK/d8LePQL+zM7dIVyeeSpSmBs=
 github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210412080213-f1dcb144bd25 h1:nal36cQv+dJUErG3UCFqdQFWdYjAZw9XqJP4Xwnoxf0=
+github.com/huaweicloud/golangsdk v0.0.0-20210412080213-f1dcb144bd25/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	TenantID            string
 	TenantName          string
 	Token               string
+	SecurityToken       string
 	Username            string
 	UserID              string
 	AgencyName          string
@@ -252,6 +253,10 @@ func buildClientByAKSK(c *Config) error {
 		ao.IdentityEndpoint = c.IdentityEndpoint
 		ao.AccessKey = c.AccessKey
 		ao.SecretKey = c.SecretKey
+		if c.SecurityToken != "" {
+			ao.SecurityToken = c.SecurityToken
+			ao.WithUserCatalog = true
+		}
 	}
 	return genClients(c, pao, dao)
 }
@@ -331,6 +336,10 @@ func (c *Config) ObjectStorageClientWithSignature(region string) (*obs.ObsClient
 	}
 
 	obsEndpoint := getObsEndpoint(c, region)
+	if c.SecurityToken != "" {
+		return obs.New(c.AccessKey, c.SecretKey, obsEndpoint,
+			obs.WithSignature("OBS"), obs.WithSecurityToken(c.SecurityToken))
+	}
 	return obs.New(c.AccessKey, c.SecretKey, obsEndpoint, obs.WithSignature("OBS"))
 }
 
@@ -347,6 +356,9 @@ func (c *Config) ObjectStorageClient(region string) (*obs.ObsClient, error) {
 	}
 
 	obsEndpoint := getObsEndpoint(c, region)
+	if c.SecurityToken != "" {
+		return obs.New(c.AccessKey, c.SecretKey, obsEndpoint, obs.WithSecurityToken(c.SecurityToken))
+	}
 	return obs.New(c.AccessKey, c.SecretKey, obsEndpoint)
 }
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -54,6 +54,14 @@ func Provider() terraform.ResourceProvider {
 				}, nil),
 			},
 
+			"security_token": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  descriptions["security_token"],
+				RequiredWith: []string{"access_key"},
+				DefaultFunc:  schema.EnvDefaultFunc("HW_SECURITY_TOKEN", nil),
+			},
+
 			"domain_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -612,6 +620,10 @@ func init() {
 
 		"domain_name": "The name of the Domain to scope to.",
 
+		"access_key":     "The access key of the HuaweiCloud to use.",
+		"secret_key":     "The secret key of the HuaweiCloud to use.",
+		"security_token": "The security token to authenticate with a temporary security credential.",
+
 		"insecure": "Trust self-signed certificates.",
 
 		"cacert_file": "A Custom CA certificate.",
@@ -676,6 +688,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		Insecure:            d.Get("insecure").(bool),
 		Password:            d.Get("password").(string),
 		Token:               d.Get("token").(string),
+		SecurityToken:       d.Get("security_token").(string),
 		Region:              region,
 		TenantID:            tenantID,
 		TenantName:          tenantName,

--- a/vendor/github.com/huaweicloud/golangsdk/auth_aksk_options.go
+++ b/vendor/github.com/huaweicloud/golangsdk/auth_aksk_options.go
@@ -11,15 +11,14 @@ type AKSKAuthOptions struct {
 	// "OS_AUTH_URL" in the information provided by the cloud operator.
 	IdentityEndpoint string `json:"-"`
 
-	// user project id
-	ProjectId string
-
-	ProjectName string
-
 	// region
 	Region string
 
-	// cloud service domain, example: myhwclouds.com
+	// IAM user project id and name
+	ProjectId   string
+	ProjectName string
+
+	// IAM account name and id
 	Domain   string
 	DomainID string
 
@@ -27,8 +26,9 @@ type AKSKAuthOptions struct {
 	BssDomain   string
 	BssDomainID string
 
-	AccessKey string //Access Key
-	SecretKey string //Secret key
+	AccessKey     string //Access Key
+	SecretKey     string //Secret key
+	SecurityToken string //Security Token for temporary Access Key
 
 	// AgencyNmae is the name of agnecy
 	AgencyName string
@@ -38,9 +38,12 @@ type AKSKAuthOptions struct {
 
 	// DelegatedProject is the name of delegated project
 	DelegatedProject string
+
+	// whether using the customer catalog, defaults to false
+	WithUserCatalog bool
 }
 
-// Implements the method of AuthOptionsProvider
+// GetIdentityEndpoint implements the method of AuthOptionsProvider
 func (opts AKSKAuthOptions) GetIdentityEndpoint() string {
 	return opts.IdentityEndpoint
 }

--- a/vendor/github.com/huaweicloud/golangsdk/provider_client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/provider_client.go
@@ -243,6 +243,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 		if client.AKSKAuthOptions.DomainID != "" {
 			req.Header.Set("X-Domain-Id", client.AKSKAuthOptions.DomainID)
 		}
+		if client.AKSKAuthOptions.SecurityToken != "" {
+			req.Header.Set("X-Security-Token", client.AKSKAuthOptions.SecurityToken)
+		}
 	}
 
 	// Issue the request.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,7 +257,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5
+# github.com/huaweicloud/golangsdk v0.0.0-20210412080213-f1dcb144bd25
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fixes #1051 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ export HW_ACCESS_KEY="0BQDG60W2070MQX8UHQ8"
$ export HW_SECRET_KEY="b15kYsk2D5xyOSJTx0UbaEdnVIk9y..."
$ export HW_SECURITY_TOKEN="gQpjbi1ub3J0aC00jB77FN3WYc3d..."
$
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (162.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       162.166s
$
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_basic -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (33.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       33.448s
```
