### PR TITLE
anonymization security fields when logging

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -454,7 +454,6 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 			Nics:             resourceInstanceNicsV2(d),
 			RootVolume:       resourceInstanceRootVolumeV1(d),
 			DataVolumes:      resourceInstanceDataVolumesV1(d),
-			AdminPass:        d.Get("admin_pass").(string),
 			UserData:         []byte(d.Get("user_data").(string)),
 		}
 
@@ -498,6 +497,8 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		}
 
 		log.Printf("[DEBUG] ECS Create Options: %#v", createOpts)
+		// Add password here so it wouldn't go in the above log entry
+		createOpts.AdminPass = d.Get("admin_pass").(string)
 
 		var job_id string
 		if d.Get("charging_mode") == "prePaid" {

--- a/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dcs_instance_v1.go
@@ -321,7 +321,6 @@ func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 		EngineVersion:         d.Get("engine_version").(string),
 		Capacity:              d.Get("capacity").(float64),
 		NoPasswordAccess:      no_password_access,
-		Password:              d.Get("password").(string),
 		AccessUser:            d.Get("access_user").(string),
 		VPCID:                 d.Get("vpc_id").(string),
 		SecurityGroupID:       d.Get("security_group_id").(string),
@@ -336,6 +335,9 @@ func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
+
 	v, err := instances.Create(dcsV1Client, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud instance: %s", err)

--- a/huaweicloud/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_dds_instance_v3.go
@@ -317,7 +317,6 @@ func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 		VpcId:            d.Get("vpc_id").(string),
 		SubnetId:         d.Get("subnet_id").(string),
 		SecurityGroupId:  d.Get("security_group_id").(string),
-		Password:         d.Get("password").(string),
 		DiskEncryptionId: d.Get("disk_encryption_id").(string),
 		Mode:             d.Get("mode").(string),
 		Flavor:           resourceDdsFlavors(d),
@@ -329,6 +328,8 @@ func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 		createOpts.Ssl = "0"
 	}
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
 
 	instance, err := instances.Create(client, createOpts).Extract()
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1.go
@@ -181,7 +181,6 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 		Engine:          d.Get("engine").(string),
 		EngineVersion:   d.Get("engine_version").(string),
 		StorageSpace:    d.Get("storage_space").(int),
-		Password:        d.Get("password").(string),
 		AccessUser:      d.Get("access_user").(string),
 		VPCID:           d.Get("vpc_id").(string),
 		SecurityGroupID: d.Get("security_group_id").(string),
@@ -197,6 +196,9 @@ func resourceDmsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
+
 	v, err := instances.Create(dmsV1Client, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud instance: %s", err)

--- a/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
@@ -239,7 +239,6 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 		Nics:             resourceInstanceNicsV1(d),
 		RootVolume:       resourceInstanceRootVolumeV1(d),
 		DataVolumes:      resourceInstanceDataVolumesV1(d),
-		AdminPass:        d.Get("password").(string),
 		UserData:         []byte(d.Get("user_data").(string)),
 	}
 
@@ -268,6 +267,8 @@ func resourceEcsInstanceV1Create(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.AdminPass = d.Get("password").(string)
 
 	var instance_id string
 	if d.Get("charging_mode") == "prePaid" {

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -315,7 +315,6 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		ConfigurationId:     d.Get("configuration_id").(string),
 		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
-		Password:            d.Get("password").(string),
 		Mode:                "Cluster",
 		Flavor:              resourceGeminiDBFlavor(d),
 		DataStore:           resourceGeminiDBDataStore(d),
@@ -341,6 +340,8 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 		createOpts.ChargeInfo = chargeInfo
 	}
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
 
 	instance, err := instances.Create(client, createOpts).Extract()
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -281,7 +281,6 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	createOpts := instances.CreateTaurusDBOpts{
 		Name:                d.Get("name").(string),
 		Flavor:              d.Get("flavor").(string),
-		Password:            d.Get("password").(string),
 		Region:              GetRegion(d, config),
 		VpcId:               d.Get("vpc_id").(string),
 		SubnetId:            d.Get("subnet_id").(string),
@@ -326,6 +325,8 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
 
 	instance, err := instances.Create(client, createOpts).Extract()
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -355,7 +355,6 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	createOpts := instances.CreateGaussDBOpts{
 		Name:                d.Get("name").(string),
 		Flavor:              d.Get("flavor").(string),
-		Password:            d.Get("password").(string),
 		Region:              GetRegion(d, config),
 		VpcId:               d.Get("vpc_id").(string),
 		SubnetId:            d.Get("subnet_id").(string),
@@ -396,6 +395,9 @@ func resourceOpenGaussInstanceCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
+
 	instance, err := instances.Create(client, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating OpenGauss instance : %s", err)

--- a/huaweicloud/resource_huaweicloud_iec_server.go
+++ b/huaweicloud/resource_huaweicloud_iec_server.go
@@ -291,7 +291,6 @@ func resourceIecServerV1Create(d *schema.ResourceData, meta interface{}) error {
 		Name:           d.Get("name").(string),
 		ImageRef:       d.Get("image_id").(string),
 		FlavorRef:      d.Get("flavor_id").(string),
-		AdminPass:      d.Get("admin_pass").(string),
 		NetConfig:      resourceNetworkConfig(d),
 		SecurityGroups: resourceServerSecGroups(d),
 		RootVolume:     resourceServerRootVolume(d),
@@ -308,6 +307,9 @@ func resourceIecServerV1Create(d *schema.ResourceData, meta interface{}) error {
 		Coverage:     resourceServerCoverage(d),
 	}
 	log.Printf("[DEBUG] Create IEC servers options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.AdminPass = d.Get("admin_pass").(string)
+
 	resp, err := servers.CreateServer(iecClient, createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud IEC server: %s", err)

--- a/huaweicloud/resource_huaweicloud_mrs_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_mrs_cluster_v1.go
@@ -444,33 +444,34 @@ func resourceClusterV1Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	createOpts := &cluster.CreateOpts{
-		DataCenter:          region,
-		BillingType:         d.Get("billing_type").(int),
-		MasterNodeNum:       d.Get("master_node_num").(int),
-		MasterNodeSize:      d.Get("master_node_size").(string),
-		CoreNodeNum:         d.Get("core_node_num").(int),
-		CoreNodeSize:        d.Get("core_node_size").(string),
-		AvailableZoneID:     d.Get("available_zone_id").(string),
-		ClusterName:         d.Get("cluster_name").(string),
-		ClusterVersion:      d.Get("cluster_version").(string),
-		ClusterType:         d.Get("cluster_type").(int),
-		VpcID:               d.Get("vpc_id").(string),
-		SubnetID:            d.Get("subnet_id").(string),
-		Vpc:                 vpc.Name,
-		SubnetName:          subnet.Name,
-		VolumeType:          d.Get("volume_type").(string),
-		VolumeSize:          d.Get("volume_size").(int),
-		SafeMode:            d.Get("safe_mode").(int),
-		LoginMode:           loginMode,
-		NodePublicCertName:  d.Get("node_public_cert_name").(string),
-		ClusterMasterSecret: d.Get("node_password").(string),
-		ClusterAdminSecret:  d.Get("cluster_admin_secret").(string),
-		LogCollection:       d.Get("log_collection").(int),
-		ComponentList:       getAllClusterComponents(d),
-		AddJobs:             getAllClusterJobs(d),
+		DataCenter:         region,
+		BillingType:        d.Get("billing_type").(int),
+		MasterNodeNum:      d.Get("master_node_num").(int),
+		MasterNodeSize:     d.Get("master_node_size").(string),
+		CoreNodeNum:        d.Get("core_node_num").(int),
+		CoreNodeSize:       d.Get("core_node_size").(string),
+		AvailableZoneID:    d.Get("available_zone_id").(string),
+		ClusterName:        d.Get("cluster_name").(string),
+		ClusterVersion:     d.Get("cluster_version").(string),
+		ClusterType:        d.Get("cluster_type").(int),
+		VpcID:              d.Get("vpc_id").(string),
+		SubnetID:           d.Get("subnet_id").(string),
+		Vpc:                vpc.Name,
+		SubnetName:         subnet.Name,
+		VolumeType:         d.Get("volume_type").(string),
+		VolumeSize:         d.Get("volume_size").(int),
+		SafeMode:           d.Get("safe_mode").(int),
+		LoginMode:          loginMode,
+		NodePublicCertName: d.Get("node_public_cert_name").(string),
+		LogCollection:      d.Get("log_collection").(int),
+		ComponentList:      getAllClusterComponents(d),
+		AddJobs:            getAllClusterJobs(d),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.ClusterMasterSecret = d.Get("node_password").(string)
+	createOpts.ClusterAdminSecret = d.Get("cluster_admin_secret").(string)
 
 	clusterCreate, err := cluster.Create(client, createOpts).Extract()
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the security fields include:
- `password` in request JSON body
- `adminPass` in ecs instance request JSON body
- `adminPwd` in css cluster request JSON body
- `X-*-Token` in request header

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (206.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       206.649s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1360.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1360.542s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccRdsInstanceV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (1009.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1009.820s
```
