### PR TITLE
refactor secgroup resource and update docs

### DIFF
--- a/docs/resources/networking_secgroup.md
+++ b/docs/resources/networking_secgroup.md
@@ -20,51 +20,58 @@ resource "huaweicloud_networking_secgroup" "secgroup" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the security group resource. If omitted, the provider-level region will be used. Changing this creates a new security group resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the security group resource.
+  If omitted, the provider-level region will be used. Changing this creates a new security group resource.
 
-* `name` - (Required, String) A unique name for the security group.
+* `name` - (Required, String) Specifies a unique name for the security group.
 
-* `description` - (Optional, String) Description for the security group.
+* `description` - (Optional, String) Specifies the description for the security group.
 
-* `delete_default_rules` - (Optional, Bool, ForceNew) Whether or not to delete the default
-    egress security rules. This is `false` by default. See the below note
-    for more information.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the security group.
+  Changing this creates a new security group.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the security group. Changing this creates a new security group.
+* `delete_default_rules` - (Optional, Bool, ForceNew) Specifies whether or not to delete the default security rules. 
+  This is `false` by default.
+
+-> **Note:** The default security rules are described in [HuaweiCloud](https://support.huaweicloud.com/intl/en-us/usermanual-vpc/SecurityGroup_0003.html).
+  See the below section for more information.
+
+## Default Security Group Rules
+
+In most cases, HuaweiCloud will create some security group rules for each new security group.
+These security group rules will not be managed by Terraform, so if you prefer to have *all*
+aspects of your infrastructure managed by Terraform, set `delete_default_rules` to `true`
+and then create separate security group rules such as the following:
+
+```hcl
+resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_v4" {
+  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+  direction         = "egress"
+  ethertype         = "IPv4"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_v6" {
+  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+  direction         = "egress"
+  ethertype         = "IPv6"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "allow_ssh" {
+  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+```
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
-
-## Default Security Group Rules
-
-In most cases, HuaweiCloud will create some egress security group rules for each
-new security group. These security group rules will not be managed by
-Terraform, so if you prefer to have *all* aspects of your infrastructure
-managed by Terraform, set `delete_default_rules` to `true` and then create
-separate security group rules such as the following:
-
-```hcl
-resource "huaweicloud_networking_secgroup_rule_v2" "secgroup_rule_v4" {
-  direction         = "egress"
-  ethertype         = "IPv4"
-  security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
-}
-
-resource "huaweicloud_networking_secgroup_rule_v2" "secgroup_rule_v6" {
-  direction         = "egress"
-  ethertype         = "IPv6"
-  security_group_id = "${huaweicloud_networking_secgroup_v2.secgroup.id}"
-}
-```
-
-Please note that this behavior may differ depending on the configuration of
-the HuaweiCloud cloud. The above illustrates the current default Neutron
-behavior. Some HuaweiCloud clouds might provide additional rules and some might
-not provide any rules at all (in which case the `delete_default_rules` setting
-is moot).
+* `id` - The resource ID in UUID format.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -16,13 +16,13 @@ resource "huaweicloud_networking_secgroup" "mysecgroup" {
 }
 
 resource "huaweicloud_networking_secgroup_rule" "secgroup_rule" {
+  security_group_id = huaweicloud_networking_secgroup.mysecgroup.id
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 22
-  port_range_max    = 22
+  port_range_min    = 8080
+  port_range_max    = 8080
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = huaweicloud_networking_secgroup.mysecgroup.id
 }
 ```
 
@@ -31,8 +31,12 @@ resource "huaweicloud_networking_secgroup_rule" "secgroup_rule" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to
-    create the security group rule resource. If omitted, the provider-level
-    region will be used.
+    create the security group rule resource.
+    If omitted, the provider-level region will be used.
+    Changing this creates a new security group rule.
+
+* `security_group_id` - (Required, String, ForceNew) Specifies the security
+    group id the rule should belong to.
     Changing this creates a new security group rule.
 
 * `direction` - (Required, String, ForceNew) Specifies the direction of the
@@ -50,34 +54,23 @@ The following arguments are supported:
     Changing this creates a new security group rule.
 
 * `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol
-    type, valid values are following. This is required if you want to specify
-    a port range.
-    * __tcp__
-    * __udp__
-    * __icmp__
+    type, valid values are __tcp__, __udp__ and __icmp__.
+    This is required if you want to specify a port range.
     Changing this creates a new security group rule.
 
-* `port_range_min` - (Optional, String, ForceNew) Specifies the lower part of
-    the allowed port range, valid integer value needs to be between 1 and
-    65535.
+* `port_range_min` - (Optional, Int, ForceNew) Specifies the lower part of
+    the allowed port range, valid integer value needs to be between 1 and 65535.
     Changing this creates a new security group rule.
 
-* `port_range_max` - (Optional, Int, ForceNew) Specifies the higher part of the
-    allowed port range, valid integer value needs to be between 1 and 65535.
+* `port_range_max` - (Optional, Int, ForceNew) Specifies the higher part of
+    the allowed port range, valid integer value needs to be between 1 and 65535.
     Changing this creates a new security group rule.
 
 * `remote_ip_prefix` - (Optional, String, ForceNew) Specifies the remote CIDR,
     the value needs to be a valid CIDR (i.e. 192.168.0.0/16).
     Changing this creates a new security group rule.
 
-* `remote_group_id` - (Optional, String, ForceNew) Specifies the remote group
-    id, the value needs to be an Openstack ID of a security group in the same
-    tenant.
-    Changing this creates a new security group rule.
-
-* `security_group_id` - (Required, String, ForceNew) Specifies the security
-    group id the rule should belong to, the value needs to be an Openstack ID
-    of a security group in the same tenant.
+* `remote_group_id` - (Optional, String, ForceNew) Specifies the remote group id.
     Changing this creates a new security group rule.
 
 ## Attributes Reference


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- refactor secgroup resource
- update acceptance tests
- update docs for **delete_default_rules**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2SecGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2SecGroup_ -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroup_basic
=== PAUSE TestAccNetworkingV2SecGroup_basic
=== RUN   TestAccNetworkingV2SecGroup_withEpsId
=== PAUSE TestAccNetworkingV2SecGroup_withEpsId
=== RUN   TestAccNetworkingV2SecGroup_noDefaultRules
=== PAUSE TestAccNetworkingV2SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV2SecGroup_basic
=== CONT  TestAccNetworkingV2SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV2SecGroup_withEpsId
--- PASS: TestAccNetworkingV2SecGroup_withEpsId (26.12s)
--- PASS: TestAccNetworkingV2SecGroup_noDefaultRules (29.23s)
--- PASS: TestAccNetworkingV2SecGroup_basic (39.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       39.425s
```
