### PR TITLE
remove deprecated tenant_id and admin_state_up in nat resources

### DIFF
--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
@@ -47,10 +47,6 @@ func DataSourceNatGatewayV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -109,7 +105,6 @@ func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("internal_network_id", natgateway.InternalNetworkID)
 	d.Set("spec", natgateway.Spec)
 	d.Set("status", natgateway.Status)
-	d.Set("admin_state_up", natgateway.AdminStateUp)
 	d.Set("enterprise_project_id", natgateway.EnterpriseProjectID)
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -100,11 +100,6 @@ func ResourceNatDnatRuleV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -390,14 +385,6 @@ func resourceNatDnatRuleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err = d.Set("status", statusProp); err != nil {
 		return fmt.Errorf("Error setting Dnat:status, err: %s", err)
-	}
-
-	tenantIDProp, err := navigateValue(res, []string{"read", "dnat_rule", "tenant_id"}, nil)
-	if err != nil {
-		return fmt.Errorf("Error reading Dnat:tenant_id, err: %s", err)
-	}
-	if err = d.Set("tenant_id", tenantIDProp); err != nil {
-		return fmt.Errorf("Error setting Dnat:tenant_id, err: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2.go
@@ -60,13 +60,6 @@ func ResourceNatGatewayV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"tenant_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				ForceNew:   true,
-				Deprecated: "tenant_id is deprecated",
-			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -92,7 +85,6 @@ func resourceNatGatewayV2Create(d *schema.ResourceData, meta interface{}) error 
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
 		Spec:                d.Get("spec").(string),
-		TenantID:            d.Get("tenant_id").(string),
 		RouterID:            d.Get("router_id").(string),
 		InternalNetworkID:   d.Get("internal_network_id").(string),
 		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
@@ -141,7 +133,6 @@ func resourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("spec", natGateway.Spec)
 	d.Set("router_id", natGateway.RouterID)
 	d.Set("internal_network_id", natGateway.InternalNetworkID)
-	d.Set("tenant_id", natGateway.TenantID)
 	d.Set("status", natGateway.Status)
 	d.Set("region", GetRegion(d, config))
 	d.Set("enterprise_project_id", natGateway.EnterpriseProjectID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
` tenant_id` and `admin_state_up` have been marked as **deprecated** for a long while, and they are already remove in the docs.
so we can remove them.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatSnatRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccNatSnatRule_basic
=== PAUSE TestAccNatSnatRule_basic
=== CONT  TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (121.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       121.805s
```
