### PR TITLE
[nat gateway] use unified network parameters

### DIFF
--- a/docs/data-sources/nat_gateway.md
+++ b/docs/data-sources/nat_gateway.md
@@ -17,18 +17,18 @@ data "huaweicloud_nat_gateway" "natgateway" {
 
 ## Argument Reference
 
-* `region` - (Optional, String) Specifies the region in which to create the Nat
-    gateway resource. If omitted, the provider-level region will be used.
+* `region` - (Optional, String) Specifies the region in which to create the NAT gateway resource. 
+    If omitted, the provider-level region will be used.
 
 * `id` - (Optional, String) Specifies the ID of the NAT gateway.
 
-* `name` - (Optional, String) Specifies the nat gateway name. The name can
+* `name` - (Optional, String) Specifies the NAT gateway name. The name can
     contain only digits, letters, underscores (_), and hyphens(-).
 
-* `internal_network_id` - (Optional, String) Specifies the network ID of the
+* `subnet_id` - (Optional, String) Specifies the subnet ID of the
     downstream interface (the next hop of the DVR) of the NAT gateway.
 
-* `router_id` - (Optional, String) Specifies the ID of the router this nat
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC this NAT
     gateway belongs to.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project
@@ -41,7 +41,7 @@ data "huaweicloud_nat_gateway" "natgateway" {
     * `3`: large type, which supports up to 200,000 SNAT connections.
     * `4`: extra-large type, which supports up to 1,000,000 SNAT connections.
 
-* `description` - (Optional, String) Specifies the description of the nat
+* `description` - (Optional, String) Specifies the description of the NAT
    gateway. The value contains 0 to 255 characters, and angle brackets (<)
    and (>) are not allowed.
 

--- a/docs/resources/nat_dnat_rule.md
+++ b/docs/resources/nat_dnat_rule.md
@@ -13,8 +13,8 @@ This is an alternative to `huaweicloud_nat_dnat_rule_v2`
 
 ```hcl
 resource "huaweicloud_nat_dnat_rule" "dnat_1" {
-  floating_ip_id        = "2bd659ab-bbf7-43d7-928b-9ee6a10de3ef"
   nat_gateway_id        = "bf99c679-9f41-4dac-8513-9c9228e713e1"
+  floating_ip_id        = "2bd659ab-bbf7-43d7-928b-9ee6a10de3ef"
   private_ip            = "10.0.0.12"
   protocol              = "tcp"
   internal_service_port = 993
@@ -26,16 +26,25 @@ resource "huaweicloud_nat_dnat_rule" "dnat_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the dnat rule resource. If omitted, the provider-level region will be used. Changing this creates a new Dnat rule resource.
-
-* `floating_ip_id` - (Required, String, ForceNew) Specifies the ID of the floating IP address.
-  Changing this creates a new resource.
-
-* `internal_service_port` - (Required, Int, ForceNew) Specifies port used by ECSs or BMSs
-  to provide services for external systems. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the dnat rule resource.
+  If omitted, the provider-level region will be used. Changing this creates a new dnat rule.
 
 * `nat_gateway_id` - (Required, String, ForceNew) ID of the nat gateway this dnat rule belongs to.
    Changing this creates a new dnat rule.
+
+* `floating_ip_id` - (Required, String, ForceNew) Specifies the ID of the floating IP address.
+  Changing this creates a new dnat rule.
+
+* `protocol` - (Required, String, ForceNew) Specifies the protocol type. Currently,
+  TCP, UDP, and ANY are supported.
+  Changing this creates a new dnat rule.
+
+* `internal_service_port` - (Required, Int, ForceNew) Specifies port used by ECSs or BMSs
+  to provide services for external systems. Changing this creates a new dnat rule.
+
+* `external_service_port` - (Required, Int, ForceNew) Specifies port used by ECSs or
+  BMSs to provide services for external systems.
+  Changing this creates a new dnat rule.
 
 * `port_id` - (Optional, String, ForceNew) Specifies the port ID of an ECS or a BMS.
   This parameter and private_ip are alternative. Changing this creates a
@@ -44,14 +53,6 @@ The following arguments are supported:
 * `private_ip` - (Optional, String, ForceNew) Specifies the private IP address of a
   user, for example, the IP address of a VPC for dedicated connection.
   This parameter and port_id are alternative.
-  Changing this creates a new dnat rule.
-
-* `protocol` - (Required, String, ForceNew) Specifies the protocol type. Currently,
-  TCP, UDP, and ANY are supported.
-  Changing this creates a new dnat rule.
-
-* `external_service_port` - (Required, Int, ForceNew) Specifies port used by ECSs or
-  BMSs to provide services for external systems.
   Changing this creates a new dnat rule.
 
 ## Attributes Reference

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -11,11 +11,11 @@ This is an alternative to `huaweicloud_nat_gateway_v2`
 
 ```hcl
 resource "huaweicloud_nat_gateway" "nat_1" {
-  name                = "Terraform"
-  description         = "test for terraform"
-  spec                = "3"
-  router_id           = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
-  internal_network_id = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  name        = "test"
+  description = "test for terraform"
+  spec        = "3"
+  vpc_id      = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
+  subnet_id   = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
 }
 ```
 
@@ -30,19 +30,19 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the nat gateway name. The name can
     contain only digits, letters, underscores (_), and hyphens(-).
 
-* `internal_network_id` - (Required, String, ForceNew) Specifies the network ID
-    of the downstream interface (the next hop of the DVR) of the NAT gateway.
-    Changing this creates a new nat gateway.
-
-* `router_id` - (Required, String, ForceNew) Specifies the ID of the router
-    this nat gateway belongs to. Changing this creates a new nat gateway.
-
 * `spec` - (Required, String) Specifies the nat gateway type.
     The value can be:
     * `1`: small type, which supports up to 10,000 SNAT connections.
     * `2`: medium type, which supports up to 50,000 SNAT connections.
     * `3`: large type, which supports up to 200,000 SNAT connections.
     * `4`: extra-large type, which supports up to 1,000,000 SNAT connections.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC
+    this nat gateway belongs to. Changing this creates a new nat gateway.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID
+    of the downstream interface (the next hop of the DVR) of the NAT gateway.
+    Changing this creates a new nat gateway.
 
 * `description` - (Optional, String) Specifies the description of the nat
    gateway. The value contains 0 to 255 characters, and angle brackets (<)

--- a/docs/resources/nat_snat_rule.md
+++ b/docs/resources/nat_snat_rule.md
@@ -12,7 +12,7 @@ This is an alternative to `huaweicloud_nat_snat_rule_v2`
 ```hcl
 resource "huaweicloud_nat_snat_rule" "snat_1" {
   nat_gateway_id = "3c0dffda-7c76-452b-9dcc-5bce7ae56b17"
-  network_id     = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  subnet_id      = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
   floating_ip_id = "0a166fc5-a904-42fb-b1ef-cf18afeeddca"
 }
 ```
@@ -21,7 +21,8 @@ resource "huaweicloud_nat_snat_rule" "snat_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the snat rule resource. If omitted, the provider-level region will be used. Changing this creates a new snat rule resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the snat rule resource.
+    If omitted, the provider-level region will be used. Changing this creates a new snat rule resource.
 
 * `nat_gateway_id` - (Required, String, ForceNew) ID of the nat gateway this snat rule belongs to.
     Changing this creates a new snat rule.
@@ -29,11 +30,11 @@ The following arguments are supported:
 * `floating_ip_id` - (Required, String, ForceNew) ID of the floating ip this snat rule connets to.
     Changing this creates a new snat rule.
 
-* `network_id` - (Optional, String, ForceNew) ID of the network this snat rule connects to.
+* `subnet_id` - (Optional, String, ForceNew) ID of the subnet this snat rule connects to.
     This parameter and `cidr` are alternative. Changing this creates a new snat rule.
 
 * `cidr` - (Optional, String, ForceNew) Specifies CIDR, which can be in the format of a network segment or a host IP address.
-    This parameter and `network_id` are alternative. Changing this creates a new snat rule.
+    This parameter and `subnet_id` are alternative. Changing this creates a new snat rule.
 
 * `source_type` - (Optional, Int, ForceNew) Specifies the scenario. The valid value is 0 (VPC scenario) and 1 (Direct Connect scenario).
     Defaults to 0, only `cidr` can be specified over a Direct Connect connection.

--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2.go
@@ -35,11 +35,11 @@ func DataSourceNatGatewayV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"router_id": {
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"internal_network_id": {
+			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -50,6 +50,18 @@ func DataSourceNatGatewayV2() *schema.Resource {
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+
+			// deprecated
+			"router_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "use vpc_id instead",
+			},
+			"internal_network_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "use subnet_id instead",
 			},
 		},
 	}
@@ -62,13 +74,25 @@ func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}
 
+	var vpcID, subnetID string
+	if v1, ok := d.GetOk("vpc_id"); ok {
+		vpcID = v1.(string)
+	} else {
+		vpcID = d.Get("router_id").(string)
+	}
+	if v2, ok := d.GetOk("subnet_id"); ok {
+		subnetID = v2.(string)
+	} else {
+		subnetID = d.Get("internal_network_id").(string)
+	}
+
 	listOpts := natgateways.ListOpts{
 		ID:                  d.Get("id").(string),
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
 		Spec:                d.Get("spec").(string),
-		RouterID:            d.Get("router_id").(string),
-		InternalNetworkID:   d.Get("internal_network_id").(string),
+		RouterID:            vpcID,
+		InternalNetworkID:   subnetID,
 		Status:              d.Get("status").(string),
 		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
 	}
@@ -101,9 +125,9 @@ func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(natgateway.ID)
 	d.Set("name", natgateway.Name)
 	d.Set("description", natgateway.Description)
-	d.Set("router_id", natgateway.RouterID)
-	d.Set("internal_network_id", natgateway.InternalNetworkID)
 	d.Set("spec", natgateway.Spec)
+	d.Set("vpc_id", natgateway.RouterID)
+	d.Set("subnet_id", natgateway.InternalNetworkID)
 	d.Set("status", natgateway.Status)
 	d.Set("enterprise_project_id", natgateway.EnterpriseProjectID)
 

--- a/huaweicloud/data_source_huaweicloud_nat_gateway_v2_test.go
+++ b/huaweicloud/data_source_huaweicloud_nat_gateway_v2_test.go
@@ -71,8 +71,8 @@ resource "huaweicloud_nat_gateway" "nat_1" {
   name                  = "%s"
   description           = "test for terraform"
   spec                  = "1"
-  internal_network_id   = huaweicloud_vpc_subnet.subnet_1.id
-  router_id             = huaweicloud_vpc.vpc_1.id
+  subnet_id             = huaweicloud_vpc_subnet.subnet_1.id
+  vpc_id                = huaweicloud_vpc.vpc_1.id
   enterprise_project_id = data.huaweicloud_enterprise_project.enterprise_project_demo.id
 }
 

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
@@ -141,11 +141,11 @@ func testAccNatV2Gateway_basic(suffix string) string {
 %s
 
 resource "huaweicloud_nat_gateway" "nat_1" {
-  name                = "nat-gateway-basic-%s"
-  description         = "test for terraform"
-  spec                = "1"
-  internal_network_id = huaweicloud_vpc_subnet.subnet_1.id
-  router_id           = huaweicloud_vpc.vpc_1.id
+  name        = "nat-gateway-basic-%s"
+  description = "test for terraform"
+  spec        = "1"
+  vpc_id      = huaweicloud_vpc.vpc_1.id
+  subnet_id   = huaweicloud_vpc_subnet.subnet_1.id
 }
 	`, testAccNatPreCondition(suffix), suffix)
 }
@@ -155,12 +155,11 @@ func testAccNatV2Gateway_update(suffix string) string {
 %s
 
 resource "huaweicloud_nat_gateway" "nat_1" {
-  name                = "nat-gateway-updated-%s"
-  description         = "test for terraform updated"
-  spec                = "2"
-  internal_network_id = huaweicloud_vpc_subnet.subnet_1.id
-  router_id           = huaweicloud_vpc.vpc_1.id
-
+  name        = "nat-gateway-updated-%s"
+  description = "test for terraform updated"
+  spec        = "2"
+  vpc_id      = huaweicloud_vpc.vpc_1.id
+  subnet_id   = huaweicloud_vpc_subnet.subnet_1.id
 }
 	`, testAccNatPreCondition(suffix), suffix)
 }
@@ -173,8 +172,8 @@ resource "huaweicloud_nat_gateway" "nat_1" {
   name                  = "nat-gateway-eps-%s"
   description           = "test for terraform"
   spec                  = "1"
-  internal_network_id   = huaweicloud_vpc_subnet.subnet_1.id
-  router_id             = huaweicloud_vpc.vpc_1.id
+  vpc_id                = huaweicloud_vpc.vpc_1.id
+  subnet_id             = huaweicloud_vpc_subnet.subnet_1.id
   enterprise_project_id = "%s"
 }
 	`, testAccNatPreCondition(suffix), suffix, HW_ENTERPRISE_PROJECT_ID_TEST)

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2.go
@@ -48,16 +48,18 @@ func ResourceNatSnatRuleV2() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 			},
-			"network_id": {
+			"subnet_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"cidr", "network_id"},
+			},
+			"cidr": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ExactlyOneOf: []string{"cidr"},
-			},
-			"cidr": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				ExactlyOneOf: []string{"subnet_id", "network_id"},
 			},
 			"floating_ip_id": {
 				Type:             schema.TypeString,
@@ -73,6 +75,14 @@ func ResourceNatSnatRuleV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			// deprecated
+			"network_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "use subnet_id instead",
+			},
 		},
 	}
 }
@@ -84,18 +94,23 @@ func resourceNatSnatRuleV2Create(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating HuaweiCloud nat client: %s", err)
 	}
 
+	var subnetID string
+	if v, ok := d.GetOk("subnet_id"); ok {
+		subnetID = v.(string)
+	} else {
+		subnetID = d.Get("network_id").(string)
+	}
+
 	sourceType := d.Get("source_type").(int)
-	if sourceType == 1 {
-		if _, ok := d.GetOk("network_id"); ok {
-			return fmt.Errorf("source_type and network_id is incompatible in the Direct Connect scenario (source_type=1)")
-		}
+	if sourceType == 1 && subnetID != "" {
+		return fmt.Errorf("source_type and subnet_id is incompatible in the Direct Connect scenario (source_type=1)")
 	}
 
 	createOpts := &hw_snatrules.CreateOpts{
 		NatGatewayID: d.Get("nat_gateway_id").(string),
 		FloatingIPID: d.Get("floating_ip_id").(string),
-		NetworkID:    d.Get("network_id").(string),
 		Cidr:         d.Get("cidr").(string),
+		NetworkID:    subnetID,
 		SourceType:   sourceType,
 	}
 
@@ -141,7 +156,7 @@ func resourceNatSnatRuleV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("floating_ip_id", snatRule.FloatingIPID)
 	d.Set("floating_ip_address", snatRule.FloatingIPAddress)
 	d.Set("source_type", snatRule.SourceType)
-	d.Set("network_id", snatRule.NetworkID)
+	d.Set("subnet_id", snatRule.NetworkID)
 	d.Set("cidr", snatRule.Cidr)
 	d.Set("status", snatRule.Status)
 	d.Set("region", GetRegion(d, config))

--- a/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_snat_rule_v2_test.go
@@ -106,16 +106,16 @@ resource "huaweicloud_vpc_eip" "eip_1" {
 }
 
 resource "huaweicloud_nat_gateway" "nat_1" {
-  name                = "nat-gateway-basic-%s"
-  description         = "test for terraform"
-  spec                = "1"
-  internal_network_id = huaweicloud_vpc_subnet.subnet_1.id
-  router_id           = huaweicloud_vpc.vpc_1.id
+  name        = "nat-gateway-basic-%s"
+  description = "test for terraform"
+  spec        = "1"
+  vpc_id      = huaweicloud_vpc.vpc_1.id
+  subnet_id   = huaweicloud_vpc_subnet.subnet_1.id
 }
 
 resource "huaweicloud_nat_snat_rule" "snat_1" {
   nat_gateway_id = huaweicloud_nat_gateway.nat_1.id
-  network_id     = huaweicloud_vpc_subnet.subnet_1.id
+  subnet_id      = huaweicloud_vpc_subnet.subnet_1.id
   floating_ip_id = huaweicloud_vpc_eip.eip_1.id
 }
 	`, testAccNatPreCondition(suffix), suffix)


### PR DESCRIPTION
- mark `router_id` as deprecated and use `vpc_id` instead
- mark `internal_network_id` as deprecated and use `subnet_id` instead
- mark `network_id` as deprecated and use `subnet_id` instead

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatGateway'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatGateway -timeout 360m -parallel 4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== RUN   TestAccNatGateway_withEpsId
=== PAUSE TestAccNatGateway_withEpsId
=== CONT  TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGateway_withEpsId
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatGateway_withEpsId (86.75s)
--- PASS: TestAccNatGatewayDataSource_basic (93.17s)
--- PASS: TestAccNatGateway_basic (103.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       103.234s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatSnatRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccNatSnatRule_basic
=== PAUSE TestAccNatSnatRule_basic
=== CONT  TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (110.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       110.804s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNatGatewayDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNatGatewayDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGatewayDataSource_basic
--- PASS: TestAccNatGatewayDataSource_basic (93.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       93.313s
```
