### PR TITLE
Add alarm_level into ces alarm rule

### DIFF
--- a/docs/resources/ces_alarmrule.md
+++ b/docs/resources/ces_alarmrule.md
@@ -57,6 +57,10 @@ The following arguments are supported:
 * `alarm_enabled` - (Optional, Bool) Specifies whether to enable the alarm. The default
     value is true.
 
+* `alarm_type` - (Optional, Int, ForceNew) Specifies the alarm severity. The value can be
+    1, 2, 3 or 4, which indicates *critical*, *major*, *minor*, and *informational*, respectively.
+    The default value is 2. Changing this creates a new resource.
+
 * `alarm_actions` - (Optional, List) Specifies the action triggered by an alarm. The
     structure is described below.
 

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule.go
@@ -166,6 +166,14 @@ func resourceAlarmRule() *schema.Resource {
 				Default:  true,
 			},
 
+			"alarm_level": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 4),
+			},
+
 			"alarm_action_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -285,6 +293,7 @@ func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	createOpts := alarmrule.CreateOpts{
 		AlarmName:               d.Get("alarm_name").(string),
 		AlarmDescription:        d.Get("alarm_description").(string),
+		AlarmLevel:              d.Get("alarm_level").(int),
 		Metric:                  metric,
 		Condition:               getAlarmCondition(d),
 		AlarmActions:            getAlarmAction(d, "alarm_actions"),
@@ -332,6 +341,7 @@ func resourceAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
 	mErr := multierror.Append(nil,
 		d.Set("alarm_name", m["alarm_name"]),
 		d.Set("alarm_description", m["alarm_description"]),
+		d.Set("alarm_level", m["alarm_level"]),
 		d.Set("metric", alarmMetric),
 		d.Set("condition", alarmCondition),
 		d.Set("alarm_actions", m["alarm_actions"]),

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule_test.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule_test.go
@@ -27,6 +27,7 @@ func TestAccCESAlarmRule_basic(t *testing.T) {
 					testCESAlarmRuleExists(resourceName, &ar),
 					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_level", "2"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1085

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCESAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCESAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_basic
=== PAUSE TestAccCESAlarmRule_basic
=== CONT  TestAccCESAlarmRule_basic
--- PASS: TestAccCESAlarmRule_basic (187.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       187.451s
```
