### PR TITLE
fix test cases of networking_vip, networking_vip_associate, networking_eip_associate

### DIFF
--- a/huaweicloud/resource_huaweicloud_networking_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_eip_associate_test.go
@@ -26,7 +26,7 @@ func TestAccNetworkingV2EIPAssociate_basic(t *testing.T) {
 			{
 				Config: testAccNetworkingV2EIPAssociate_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip_v1.test", &eip),
+					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
 					resource.TestCheckResourceAttrPtr(
 						resourceName, "public_ip", &eip.PublicAddress),
 				),
@@ -43,7 +43,7 @@ func testAccCheckNetworkingV2EIPAssociateDestroy(s *terraform.State) error {
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_vpc_eip_v1" {
+		if rs.Type != "huaweicloud_vpc_eip" {
 			continue
 		}
 
@@ -58,28 +58,9 @@ func testAccCheckNetworkingV2EIPAssociateDestroy(s *terraform.State) error {
 
 func testAccNetworkingV2EIPAssociate_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc_v1" "test" {
-  name = "%s"
-  cidr = "192.168.0.0/16"
-}
+%s
 
-resource "huaweicloud_vpc_subnet_v1" "test" {
-  name          = "%s"
-  cidr          = "192.168.0.0/16"
-  gateway_ip    = "192.168.0.1"
-  vpc_id        = huaweicloud_vpc_v1.test.id
-}
-
-resource "huaweicloud_networking_port_v2" "test" {
-  network_id = huaweicloud_vpc_subnet_v1.test.id
-
-  fixed_ip {
-    subnet_id  = huaweicloud_vpc_subnet_v1.test.subnet_id
-    ip_address = "192.168.0.20"
-  }
-}
-
-resource "huaweicloud_vpc_eip_v1" "test" {
+resource "huaweicloud_vpc_eip" "test" {
   publicip {
     type = "5_bgp"
   }
@@ -92,8 +73,8 @@ resource "huaweicloud_vpc_eip_v1" "test" {
 }
 
 resource "huaweicloud_networking_eip_associate" "test" {
-  public_ip = huaweicloud_vpc_eip_v1.test.address
-  port_id     = huaweicloud_networking_port_v2.test.id
+  public_ip   = huaweicloud_vpc_eip.test.address
+  port_id     = huaweicloud_compute_instance.test.network[0].port
 }
-`, rName, rName, rName)
+`, testAccComputeV2Instance_basic(rName), rName)
 }

--- a/huaweicloud/resource_huaweicloud_networking_vip_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_v2_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestAccNetworkingV2VIP_basic(t *testing.T) {
-	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	updateName := rName + "update"
 	resourceName := "huaweicloud_networking_vip.vip_1"
 	var vip ports.Port
 
@@ -23,10 +24,10 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2VIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2VIPConfig_basic(rand),
+				Config: testAccNetworkingV2VIPConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2VIPExists(resourceName, &vip),
-					resource.TestCheckResourceAttr(resourceName, "name", "acc-test-vip"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -35,9 +36,9 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccNetworkingV2VIPConfig_update(rand),
+				Config: testAccNetworkingV2VIPConfig_update(updateName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "acc-test-vip-updated"),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 				),
 			},
 		},
@@ -99,44 +100,44 @@ func testAccCheckNetworkingV2VIPExists(n string, vip *ports.Port) resource.TestC
 	}
 }
 
-func testAccNetworkingV2VIPConfig_basic(rand string) string {
+func testAccNetworkingV2VIPConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "vpc_1" {
-  name = "acc-test-vpc-%s"
+  name = "%s"
   cidr = "192.168.0.0/16"
 }
 
 resource "huaweicloud_vpc_subnet" "subnet_1" {
   vpc_id      = huaweicloud_vpc.vpc_1.id
-  name        = "acc-test-subnet-%s"
+  name        = "%s"
   cidr        = "192.168.0.0/24"
   gateway_ip  = "192.168.0.1"
 }
 
 resource "huaweicloud_networking_vip" "vip_1" {
-  name       = "acc-test-vip"
+  name       = "%s"
   network_id = huaweicloud_vpc_subnet.subnet_1.id
 }
-	`, rand, rand)
+	`, rName, rName, rName)
 }
 
-func testAccNetworkingV2VIPConfig_update(rand string) string {
+func testAccNetworkingV2VIPConfig_update(updateName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "vpc_1" {
-  name = "acc-test-vpc-%s"
+  name = "%s"
   cidr = "192.168.0.0/16"
 }
 
 resource "huaweicloud_vpc_subnet" "subnet_1" {
   vpc_id      = huaweicloud_vpc.vpc_1.id
-  name        = "acc-test-subnet-%s"
+  name        = "%s"
   cidr        = "192.168.0.0/24"
   gateway_ip  = "192.168.0.1"
 }
 
 resource "huaweicloud_networking_vip" "vip_1" {
-  name       = "acc-test-vip-updated"
+  name       = "%s"
   network_id = huaweicloud_vpc_subnet.subnet_1.id
 }
-	`, rand, rand)
+	`, updateName, updateName, updateName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix test cases of networking_vip, networking_vip_associate, networking_eip_associate
So we can run these test cases in TeamCity server.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
related #1104 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2VIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2VIP_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIP_basic
=== PAUSE TestAccNetworkingV2VIP_basic
=== CONT  TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (105.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       105.530s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2VIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2VIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIPAssociate_basic
=== PAUSE TestAccNetworkingV2VIPAssociate_basic
=== CONT  TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (185.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       185.953s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2EIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2EIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2EIPAssociate_basic
=== PAUSE TestAccNetworkingV2EIPAssociate_basic
=== CONT  TestAccNetworkingV2EIPAssociate_basic
--- PASS: TestAccNetworkingV2EIPAssociate_basic (189.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       189.718s
```
