### PR TITLE
improve on docs of identity agency

### DIFF
--- a/docs/resources/identity_agency.md
+++ b/docs/resources/identity_agency.md
@@ -33,16 +33,16 @@ resource "huaweicloud_identity_agency" "agency" {
 resource "huaweicloud_identity_agency" "agency" {
   name                   = "test_agency"
   description            = "test agency"
-  delegated_service_name = "op_svc_obs"
+  delegated_service_name = "op_svc_evs"
 
   project_role {
     project = "cn-north-1"
     roles = [
-      "Tenant Administrator",
+      "SFS FullAccess",
     ]
   }
   domain_roles = [
-    "OBS OperateAccess",
+    "KMS Administrator",
   ]
 }
 ```
@@ -61,6 +61,7 @@ The following arguments are supported:
     This parameter and `delegated_service_name` are alternative.
 
 * `delegated_service_name` - (Optional, String) Specifies the name of delegated cloud service.
+    The value must start with *op_svc_*, for example, *op_svc_obs*.
     This parameter and `delegated_domain_name` are alternative.
 
 * `duration` - (Optional, String) Specifies the validity period of an agency.
@@ -78,7 +79,10 @@ The `project_role` block supports:
 
 * `roles` - (Required, List) Specifies an array of role names.
 
-**note**: one or both of `project_role` and `domain_roles` must be input when creating an agency.
+-> **NOTE**
+    - At least one of `project_role` and `domain_roles` must be specified when creating an agency.
+    - We can get all **System-Defined Roles** form
+[HuaweiCloud](https://support.huaweicloud.com/intl/en-us/usermanual-permissions/iam_01_0001.html).
 
 ## Attributes Reference
 

--- a/huaweicloud/resource_huaweicloud_identity_agency_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_agency_test.go
@@ -31,7 +31,7 @@ func TestAccIdentityAgency_basic(t *testing.T) {
 					testAccCheckIdentityAgencyExists(resourceName, &agency),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "This is a test agency"),
-					resource.TestCheckResourceAttr(resourceName, "delegated_service_name", "op_svc_obs"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_service_name", "op_svc_evs"),
 					resource.TestCheckResourceAttr(resourceName, "duration", "FOREVER"),
 					resource.TestCheckResourceAttr(resourceName, "domain_roles.#", "1"),
 				),
@@ -48,8 +48,8 @@ func TestAccIdentityAgency_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "This is a updated test agency"),
 					resource.TestCheckResourceAttr(resourceName, "delegated_service_name", "op_svc_evs"),
-					resource.TestCheckResourceAttr(resourceName, "duration", "ONEDAY"),
-					resource.TestCheckResourceAttr(resourceName, "domain_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "FOREVER"),
+					resource.TestCheckResourceAttr(resourceName, "domain_roles.#", "2"),
 				),
 			},
 		},
@@ -93,7 +93,7 @@ func TestAccIdentityAgency_domain(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "This is a updated test agency"),
 					resource.TestCheckResourceAttr(resourceName, "delegated_domain_name", HW_DOMAIN_NAME),
-					resource.TestCheckResourceAttr(resourceName, "duration", "ONEDAY"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "FOREVER"),
 					resource.TestCheckResourceAttr(resourceName, "domain_roles.#", "2"),
 				),
 			},
@@ -157,7 +157,7 @@ func testAccIdentityAgency_basic(rName string) string {
 resource "huaweicloud_identity_agency" "test" {
   name                   = "%s"
   description            = "This is a test agency"
-  delegated_service_name = "op_svc_obs"
+  delegated_service_name = "op_svc_evs"
 
   domain_roles = [
     "OBS OperateAccess",
@@ -172,10 +172,9 @@ resource "huaweicloud_identity_agency" "test" {
   name                   = "%s"
   description            = "This is a updated test agency"
   delegated_service_name = "op_svc_evs"
-  duration              = "ONEDAY"
 
   domain_roles = [
-    "Anti-DDoS Administrator",
+    "OBS OperateAccess", "KMS Administrator",
   ]
 }
 `, rName)
@@ -201,7 +200,6 @@ resource "huaweicloud_identity_agency" "test" {
   name                  = "%s"
   description           = "This is a updated test agency"
   delegated_domain_name = "%s"
-  duration              = "ONEDAY"
 
   domain_roles = [
     "Anti-DDoS Administrator",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityAgency_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityAgency_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityAgency_basic
=== PAUSE TestAccIdentityAgency_basic
=== CONT  TestAccIdentityAgency_basic
--- PASS: TestAccIdentityAgency_basic (72.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       72.861s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityAgency_domain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityAgency_domain -timeout 360m -parallel 4
=== RUN   TestAccIdentityAgency_domain
=== PAUSE TestAccIdentityAgency_domain
=== CONT  TestAccIdentityAgency_domain
--- PASS: TestAccIdentityAgency_domain (70.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.891s
```
