### PR TITLE
fix test cases of IAM

### DIFF
--- a/huaweicloud/data_source_huaweicloud_identity_custom_role_test.go
+++ b/huaweicloud/data_source_huaweicloud_identity_custom_role_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccIdentityCustomRoleDataSource_basic(t *testing.T) {
-	var rName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -158,6 +158,12 @@ func testAccPreCheckEpsID(t *testing.T) {
 	}
 }
 
+func testAccPreCheckProject(t *testing.T) {
+	if HW_ENTERPRISE_PROJECT_ID_TEST != "" {
+		t.Skip("This environment does not support project tests")
+	}
+}
+
 func testAccAsConfigPreCheck(t *testing.T) {
 	if HW_FLAVOR_ID == "" {
 		t.Skip("HW_FLAVOR_ID must be set for acceptance tests")

--- a/huaweicloud/resource_huaweicloud_identity_group_membership_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_group_membership_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestAccIdentityV3GroupMembership_basic(t *testing.T) {
-	var groupName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
-	var userName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
-	var userName2 = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	var groupName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	var userName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	var userName2 = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_identity_group_membership.membership_1"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/resource_huaweicloud_identity_group_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_group_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIdentityV3Group_basic(t *testing.T) {
 	var group groups.Group
-	var groupName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	var groupName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_identity_group.group_1"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/resource_huaweicloud_identity_project_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_project_test.go
@@ -21,6 +21,7 @@ func TestAccIdentityV3Project_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAdminOnly(t)
+			testAccPreCheckProject(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIdentityV3ProjectDestroy,

--- a/huaweicloud/resource_huaweicloud_identity_role_assignment_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_role_assignment_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/groups"
@@ -15,6 +16,7 @@ import (
 func TestAccIdentityV3RoleAssignment_basic(t *testing.T) {
 	var role roles.Role
 	var group groups.Group
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_identity_role_assignment.role_assignment_1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,7 +28,7 @@ func TestAccIdentityV3RoleAssignment_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIdentityV3RoleAssignmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityV3RoleAssignment_project,
+				Config: testAccIdentityV3RoleAssignment_project(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3RoleAssignmentExists(resourceName, &role, &group),
 					resource.TestCheckResourceAttrPtr(resourceName, "group_id", &group.ID),
@@ -35,7 +37,7 @@ func TestAccIdentityV3RoleAssignment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIdentityV3RoleAssignment_domain,
+				Config: testAccIdentityV3RoleAssignment_domain(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3RoleAssignmentExists(resourceName, &role, &group),
 					resource.TestCheckResourceAttrPtr(resourceName, "group_id", &group.ID),
@@ -131,13 +133,14 @@ func testAccCheckIdentityV3RoleAssignmentExists(n string, role *roles.Role, grou
 	}
 }
 
-var testAccIdentityV3RoleAssignment_project = fmt.Sprintf(`
+func testAccIdentityV3RoleAssignment_project(rName string) string {
+	return fmt.Sprintf(`
 data "huaweicloud_identity_role" "role_1" {
   name = "rds_adm"
 }
 
 resource "huaweicloud_identity_group" "group_1" {
-  name = "group_1"
+  name = "%s"
 }
 
 resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
@@ -145,15 +148,17 @@ resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
   group_id   = huaweicloud_identity_group.group_1.id
   project_id = "%s"
 }
-`, HW_PROJECT_ID)
+`, rName, HW_PROJECT_ID)
+}
 
-var testAccIdentityV3RoleAssignment_domain = fmt.Sprintf(`
+func testAccIdentityV3RoleAssignment_domain(rName string) string {
+	return fmt.Sprintf(`
 data "huaweicloud_identity_role" "role_1" {
   name = "secu_admin"
 }
 
 resource "huaweicloud_identity_group" "group_1" {
-  name = "group_1"
+  name = "%s"
 }
 
 resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
@@ -161,4 +166,5 @@ resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
   group_id   = huaweicloud_identity_group.group_1.id
   domain_id = "%s"
 }
-`, HW_DOMAIN_ID)
+`, rName, HW_DOMAIN_ID)
+}

--- a/huaweicloud/resource_huaweicloud_identity_role_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_role_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccIdentityRole_basic(t *testing.T) {
 	var role policies.Role
-	var roleName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	var roleName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	var roleNameUpdate = roleName + "update"
 	resourceName := "huaweicloud_identity_role.test"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix test cases of IAM
So we can run these tests in TeamCity server.
The reason of TestAccIdentityV3Project_basic test failing is that our account has activated enterprise management and cannot create a project in IAM. It's just normal.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
related #1104 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentity'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentity -timeout 360m -parallel 4
=== RUN   TestAccIdentityCustomRoleDataSource_basic
=== PAUSE TestAccIdentityCustomRoleDataSource_basic
=== RUN   TestAccIdentityRoleDataSource_basic
=== PAUSE TestAccIdentityRoleDataSource_basic
=== RUN   TestAccIdentityAgency_basic
=== PAUSE TestAccIdentityAgency_basic
=== RUN   TestAccIdentityAgency_domain
=== PAUSE TestAccIdentityAgency_domain
=== RUN   TestAccIdentityV3GroupMembership_basic
=== PAUSE TestAccIdentityV3GroupMembership_basic
=== RUN   TestAccIdentityV3Group_basic
=== PAUSE TestAccIdentityV3Group_basic
=== RUN   TestAccIdentityV3Project_basic
=== PAUSE TestAccIdentityV3Project_basic
=== RUN   TestAccIdentityV3RoleAssignment_basic
=== PAUSE TestAccIdentityV3RoleAssignment_basic
=== RUN   TestAccIdentityRole_basic
=== PAUSE TestAccIdentityRole_basic
=== RUN   TestAccIdentityV3User_basic
=== PAUSE TestAccIdentityV3User_basic
=== CONT  TestAccIdentityCustomRoleDataSource_basic
=== CONT  TestAccIdentityV3Project_basic
=== CONT  TestAccIdentityV3User_basic
=== CONT  TestAccIdentityRole_basic
=== CONT  TestAccIdentityV3Project_basic
    testing.go:705: Step 0 error: errors during apply:
        
        Error: Error creating Huaweicloud project: Bad request with: [POST https://iam.myhuaweicloud.com/v3/projects], error message: {"error": {"message": "projects number over 0.", "code": 400, "error_code": null, "error_msg": null, "title": "Bad Request"}}
        
          on /tmp/tf-test426273981/main.tf line 2:
          (source code not available)
        
        
--- FAIL: TestAccIdentityV3Project_basic (3.46s)
=== CONT  TestAccIdentityAgency_domain
--- PASS: TestAccIdentityCustomRoleDataSource_basic (10.42s)
=== CONT  TestAccIdentityV3Group_basic
--- PASS: TestAccIdentityV3User_basic (15.91s)
=== CONT  TestAccIdentityV3GroupMembership_basic
--- PASS: TestAccIdentityRole_basic (19.33s)
=== CONT  TestAccIdentityV3RoleAssignment_basic
--- PASS: TestAccIdentityV3Group_basic (18.82s)
=== CONT  TestAccIdentityAgency_basic
--- PASS: TestAccIdentityV3RoleAssignment_basic (21.96s)
=== CONT  TestAccIdentityRoleDataSource_basic
--- PASS: TestAccIdentityV3GroupMembership_basic (27.81s)
--- PASS: TestAccIdentityRoleDataSource_basic (16.41s)
--- PASS: TestAccIdentityAgency_domain (72.09s)
--- PASS: TestAccIdentityAgency_basic (64.63s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       93.944s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
