### PR TITLE
Update vault resource

### DIFF
--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -27,6 +27,10 @@ resource "huaweicloud_cbr_vault" "test" {
   resources {
     id = data.huaweicloud_compute_instance.test.id
   }
+
+  tags = {
+    foo = "bar"
+  }
 }
 ```
 
@@ -129,6 +133,8 @@ The following arguments are supported:
 * `resources` - (Optional, List) Specifies an array of one or more resources to attach to the CBR vault.
   The resources structure is documented below.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBR vault.
+
 The `resources` block supports:
 
   * `id` - (Required, String) Specifies the ID of the resource to be backed up.
@@ -171,19 +177,4 @@ In addition to all arguments above, the following attributes are exported:
 Vaults can be imported by their `id`. For example,
 ```
 terraform import huaweicloud_cbr_vault.test 01c33779-7c83-4182-8b6b-24a671fcedf8
-```
-Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
-API response, security or some other reason. The missing attribute is `policy_id`. It is generally recommended running
-`terraform plan` after importing a vault. You can then decide if changes should be applied to the vault, or the
-resource definition should be updated to align with the vault. Also you can ignore changes as below.
-```
-resource "huaweicloud_cbr_vault" "test" {
-  ...
-
-  lifecycle {
-    ignore_changes = [
-      policy_id,
-    ]
-  }
-}
 ```

--- a/huaweicloud/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/resource_huaweicloud_cbr_vault_test.go
@@ -34,6 +34,8 @@ func TestAccCBRV3Vault_serverBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "size", "200"),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
@@ -45,17 +47,17 @@ func TestAccCBRV3Vault_serverBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "server"),
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "size", "300"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"policy_id",
-				},
 			},
 		},
 	})
@@ -86,9 +88,6 @@ func TestAccCBRV3Vault_serverReplication(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"policy_id",
-				},
 			},
 		},
 	})
@@ -128,6 +127,7 @@ func TestAccCBRV3Vault_volumeBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "auto_expand", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -136,9 +136,6 @@ func TestAccCBRV3Vault_volumeBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"policy_id",
-				},
 			},
 		},
 	})
@@ -176,6 +173,7 @@ func TestAccCBRV3Vault_turboBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "turbo"),
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "size", "1000"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -184,9 +182,6 @@ func TestAccCBRV3Vault_turboBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"policy_id",
-				},
 			},
 		},
 	})
@@ -218,9 +213,6 @@ func TestAccCBRV3Vault_turboReplication(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"policy_id",
-				},
 			},
 		},
 	})
@@ -357,6 +349,11 @@ resource "huaweicloud_cbr_vault" "test" {
   protection_type       = "backup"
   size                  = 200
   enterprise_project_id = "%s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, testAccCBRV3Vault_serverBase(rName), rName, HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -378,6 +375,11 @@ resource "huaweicloud_cbr_vault" "test" {
 
   resources {
     id = huaweicloud_compute_instance.test.id
+  }
+
+  tags = {
+    foo1 = "bar"
+    key  = "value_update"
   }
 }
 `, testAccCBRV3Vault_serverBase(rName), testAccCBRV3Vault_policy(rName), rName, HW_ENTERPRISE_PROJECT_ID_TEST)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The cbr vault resource does not currently support the tags parameter and does not support the import of the policy id.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new tags parameter supported.
2. policy id supports import.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCBRV3Vault'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCBRV3Vault -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Vault_serverBasic
=== PAUSE TestAccCBRV3Vault_serverBasic
=== RUN   TestAccCBRV3Vault_serverReplication
=== PAUSE TestAccCBRV3Vault_serverReplication
=== RUN   TestAccCBRV3Vault_volumeBasic
=== PAUSE TestAccCBRV3Vault_volumeBasic
=== RUN   TestAccCBRV3Vault_turboBasic
=== PAUSE TestAccCBRV3Vault_turboBasic
=== RUN   TestAccCBRV3Vault_turboReplication
=== PAUSE TestAccCBRV3Vault_turboReplication
=== CONT  TestAccCBRV3Vault_serverBasic
=== CONT  TestAccCBRV3Vault_turboBasic
=== CONT  TestAccCBRV3Vault_turboReplication
=== CONT  TestAccCBRV3Vault_volumeBasic
--- PASS: TestAccCBRV3Vault_turboReplication (18.92s)
=== CONT  TestAccCBRV3Vault_serverReplication
--- PASS: TestAccCBRV3Vault_serverReplication (16.65s)
--- PASS: TestAccCBRV3Vault_volumeBasic (64.92s)
--- PASS: TestAccCBRV3Vault_serverBasic (239.80s)
--- PASS: TestAccCBRV3Vault_turboBasic (527.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       527.432s
```
