### PR TITLE
Add ELB v3 flavors data source

### DIFF
--- a/docs/data-sources/elb_flavors.md
+++ b/docs/data-sources/elb_flavors.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Dedicated Load Balance (Dedicated ELB)"
+---
+
+# huaweicloud\_elb\_flavors
+
+Use this data source to get the available ELB Flavors.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_elb_flavors" "flavors" {
+  type            = "L7"
+  max_connections = 200000
+  cps             = 2000
+  bandwidth       = 50
+}
+
+# Create Dedicated Load Balancer with the first matched flavor
+
+resource "huaweicloud_elb_loadbalancer" "lb" {
+  l7_flavor_id = data.huaweicloud_elb_flavors.flavors.ids[0]
+
+  # Other properties...
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the flavors. If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the flavor type. Valid values are L4 and L7.
+
+* `max_connections` - (Optional, Int) Specifies the maximum connections in the flavor.
+
+* `bandwidth` - (Optional, Int) Specifies the bandwidth size(Mbit/s) in the flavor.
+
+* `cps` - (Optional, Int) Specifies the cps in the flavor.
+
+* `qps` - (Optional, Int) Specifies the qps in the L7 flavor.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a data source ID in UUID format.
+
+* `ids` - A list of flavor IDs.
+
+* `flavors` - A list of flavors. Each element contains the following attributes:
+  * `id` - ID of the flavor.
+  * `name` - Name of the flavor.
+  * `type` - Type of the flavor.
+  * `max_connections` - Maximum connections of the flavor.
+  * `cps` - Cps of the flavor.
+  * `qps` - Qps of the L7 flavor.
+  * `bandwidth` - Bandwidth size(Mbit/s) of the flavor.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255
+	github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255 h1:2iW/eqhVyyvnFjXX9++3oKO3FPKGkFl49e/xnYaNUwc=
-github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5 h1:YiZrQLNWjvHpcIGpuHqcZX4FJ1J82oAU/F2mUUlbZAE=
+github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/data_source_huaweicloud_elb_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_elb_flavors.go
@@ -1,0 +1,167 @@
+package huaweicloud
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func dataSourceElbFlavorsV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceElbFlavorsV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_connections": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cps": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"qps": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bandwidth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			// Computed values.
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_connections": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cps": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"qps": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bandwidth": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	elbClient, err := config.ElbV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud elb v3 client: %s", err)
+	}
+
+	listOpts := flavors.ListOpts{}
+	if v, ok := d.GetOk("type"); ok {
+		listOpts.Type = []string{v.(string)}
+	}
+
+	pages, err := flavors.List(elbClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve flavors: %s", err)
+	}
+
+	max_connections := d.Get("max_connections").(int)
+	cps := d.Get("cps").(int)
+	qps := d.Get("qps").(int)
+	bandwidth := d.Get("bandwidth").(int)
+
+	var ids []string
+	var s []map[string]interface{}
+	for _, flavor := range allFlavors {
+		if flavor.SoldOut {
+			continue
+		}
+
+		if max_connections > 0 && flavor.Info.Connection != max_connections {
+			continue
+		}
+
+		if cps > 0 && flavor.Info.Cps != cps {
+			continue
+		}
+
+		if qps > 0 && flavor.Info.Qps != qps {
+			continue
+		}
+
+		if bandwidth > 0 && flavor.Info.Bandwidth != bandwidth*1000 {
+			continue
+		}
+
+		ids = append(ids, flavor.ID)
+		mapping := map[string]interface{}{
+			"id":              flavor.ID,
+			"name":            flavor.Name,
+			"type":            flavor.Type,
+			"max_connections": flavor.Info.Connection,
+			"cps":             flavor.Info.Cps,
+			"qps":             flavor.Info.Qps,
+			"bandwidth":       int(flavor.Info.Bandwidth / 1000),
+		}
+		s = append(s, mapping)
+	}
+
+	if len(ids) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	d.SetId(utils.DataResourceIdHash(ids))
+	d.Set("ids", ids)
+	if err := d.Set("flavors", s); err != nil {
+		return err
+	}
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_elb_flavors_test.go
+++ b/huaweicloud/data_source_huaweicloud_elb_flavors_test.go
@@ -1,0 +1,45 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccElbFlavorsDataSource_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElbFlavorDataSourceID("data.huaweicloud_elb_flavors.this"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckElbFlavorDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find elb flavors data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Elb Flavors data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccElbFlavorsDataSource_basic = `
+data "huaweicloud_elb_flavors" "this" {
+  type = "L7"
+}
+`

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -274,6 +274,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_dms_az":                      dataSourceDmsAZV1(),
 			"huaweicloud_dms_product":                 dataSourceDmsProductV1(),
 			"huaweicloud_dms_maintainwindow":          dataSourceDmsMaintainWindowV1(),
+			"huaweicloud_elb_flavors":                 dataSourceElbFlavorsV3(),
 			"huaweicloud_enterprise_project":          DataSourceEnterpriseProject(),
 			"huaweicloud_gaussdb_cassandra_instance":  dataSourceGeminiDBInstance(),
 			"huaweicloud_gaussdb_opengauss_instance":  dataSourceOpenGaussInstance(),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors/requests.go
@@ -1,0 +1,49 @@
+package flavors
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToFlavorListMap() (string, error)
+}
+
+//ListOpts allows the filtering and sorting of paginated collections through the API.
+type ListOpts struct {
+	// Specifies the id.
+	ID []string `q:"id"`
+	// Specifies the name.
+	Name []string `q:"name"`
+	// Specifies whether shared.
+	Shared *bool `q:"shared"`
+	// Specifies the type.
+	Type []string `q:"type"`
+}
+
+// ToFlavorListMap formats a ListOpts into a query string.
+func (opts ListOpts) ToFlavorListMap() (string, error) {
+	s, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return s.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// flavors.
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		queryString, err := opts.ToFlavorListMap()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += queryString
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return FlavorsPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors/results.go
@@ -1,0 +1,62 @@
+package flavors
+
+import (
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type Flavor struct {
+	// Specifies the ID of the flavor.
+	ID string `json:"id"`
+
+	// Specifies the info of the flavor.
+	Info FlavorInfo `json:"info"`
+
+	// Specifies the name of the flavor.
+	Name string `json:"name"`
+
+	// Specifies whether shared.
+	Shared bool `json:"shared"`
+
+	// Specifies the type of the flavor.
+	Type string `json:"type"`
+
+	// Specifies whether sold out.
+	SoldOut bool `json:"flavor_sold_out"`
+}
+
+type FlavorInfo struct {
+	// Specifies the connection
+	Connection int `json:"connection"`
+
+	// Specifies the cps.
+	Cps int `json:"cps"`
+
+	// Specifies the qps
+	Qps int `json:"qps"`
+
+	// Specifies the bandwidth
+	Bandwidth int `json:"bandwidth"`
+}
+
+// FlavorsPage is the page returned by a pager when traversing over a
+// collection of flavor.
+type FlavorsPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a FlavorsPage struct is empty.
+func (r FlavorsPage) IsEmpty() (bool, error) {
+	is, err := ExtractFlavors(r)
+	return len(is) == 0, err
+}
+
+// ExtractFlavors accepts a Page struct, specifically a FlavorsPage struct,
+// and extracts the elements into a slice of flavor structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractFlavors(r pagination.Page) ([]Flavor, error) {
+	var s struct {
+		Flavors []Flavor `json:"flavors"`
+	}
+	err := (r.(FlavorsPage)).ExtractInto(&s)
+	return s.Flavors, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors/urls.go
@@ -1,0 +1,7 @@
+package flavors
+
+import "github.com/huaweicloud/golangsdk"
+
+func listURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL("elb", "flavors")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255
+# github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -326,6 +326,7 @@ github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/flavors
 github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers
+github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors
 github.com/huaweicloud/golangsdk/openstack/elb/v3/loadbalancers
 github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects
 github.com/huaweicloud/golangsdk/openstack/evs/v2/snapshots


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds L4/L7 flavors for dedicated load balancer

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
Related to #1021 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccElbFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccElbFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccElbFlavorsDataSource_basic
=== PAUSE TestAccElbFlavorsDataSource_basic
=== CONT  TestAccElbFlavorsDataSource_basic
--- PASS: TestAccElbFlavorsDataSource_basic (70.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.421s
```
