### PR TITLE
Repair the wrong delete-check reference in acc test

### DIFF
--- a/huaweicloud/resource_huaweicloud_cbr_policy_test.go
+++ b/huaweicloud/resource_huaweicloud_cbr_policy_test.go
@@ -21,7 +21,7 @@ func TestAccCBRV3Policy_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASV1PolicyDestroy,
+		CheckDestroy: testAccCheckCBRV3PolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testCBRV3Policy_basic(rName),
@@ -69,7 +69,7 @@ func TestAccCBRV3Policy_replication(t *testing.T) {
 			testAccPreCheckDestProject(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASV1PolicyDestroy,
+		CheckDestroy: testAccCheckCBRV3PolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testCBRV3Policy_replication(rName),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- The delete delete-check function references are wrong, should be `testAccCheckCBRV3PolicyDestroy`, but now is `testAccCheckASV1PolicyDestroy`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. repair the wrong reference of the CBR policy delete-check function.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

Policy Resource
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCBRV3Policy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCBRV3Policy_ -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== RUN   TestAccCBRV3Policy_replication
=== PAUSE TestAccCBRV3Policy_replication
=== CONT  TestAccCBRV3Policy_basic
=== CONT  TestAccCBRV3Policy_replication
--- PASS: TestAccCBRV3Policy_replication (24.67s)
--- PASS: TestAccCBRV3Policy_basic (41.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       41.485s
```