### PR TITLE
Load balancer support import

### DIFF
--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -74,3 +74,11 @@ This resource provides the following timeouts configuration options:
 - `create` - Default is 10 minute.
 - `update` - Default is 10 minute.
 - `delete` - Default is 5 minute.
+
+## Import
+
+Load balancers can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_lb_loadbalancer.test 3e3632db-36c6-4b28-a92e-e72e6562daa6
+```

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer.go
@@ -23,6 +23,9 @@ func ResourceLoadBalancerV2() *schema.Resource {
 		Update: resourceLoadBalancerV2Update,
 		Delete: resourceLoadBalancerV2Delete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),

--- a/huaweicloud/resource_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_loadbalancer_test.go
@@ -45,6 +45,11 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -99,6 +104,11 @@ func TestAccLBV2LoadBalancer_secGroup(t *testing.T) {
 					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg_2),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -120,6 +130,11 @@ func TestAccLBV2LoadBalancer_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After load balancer supports the import function, users can use existing load balancer resources to build ELB-related services.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. load balancer support the import function. 
2. add import test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccLBV2LoadBalancer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccLBV2LoadBalancer -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== RUN   TestAccLBV2LoadBalancer_secGroup
=== PAUSE TestAccLBV2LoadBalancer_secGroup
=== RUN   TestAccLBV2LoadBalancer_withEpsId
=== PAUSE TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_withEpsId (51.49s)
--- PASS: TestAccLBV2LoadBalancer_basic (82.06s)
--- PASS: TestAccLBV2LoadBalancer_secGroup (101.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       101.353s
```
