### PR TITLE
New add-on template data source supported

### DIFF
--- a/docs/data-sources/cce_addon_template.md
+++ b/docs/data-sources/cce_addon_template.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# huaweicloud\_cce\_addon\_template
+
+Use this data source to get available HuaweiCloud CCE add-on template.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+variable "addon_name" {}
+
+variable "addon_version" {}
+
+data "huaweicloud_cce_addon_template" "test" {
+  cluster_id = var.cluster_id
+  name       = var.addon_name
+  version    = var.addon_version
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the cce add-ons.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` -  (Required, String) Specifies the ID of container cluster.
+
+* `name` -  (Required, String) Specifies the add-on name.
+
+* `version` -  (Required, String) Specifies the add-on version.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource id of the addon template in hashcode format.
+
+* `description` - The description of the add-on.
+
+* `spec` - The detail configuration of the add-on template.

--- a/docs/data-sources/cce_addon_template.md
+++ b/docs/data-sources/cce_addon_template.md
@@ -39,8 +39,14 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource id of the addon template in hashcode format.
+* `id` - The resource id of the addon template.
 
 * `description` - The description of the add-on.
 
 * `spec` - The detail configuration of the add-on template.
+
+* `stable` - Whether the add-on template is a stable version.
+
+* `support_version/virtual_machine` - The cluster (Virtual Machine) version that the add-on template supported.
+
+* `support_version/bare_metal` - The cluster (Bare Metal) version that the add-on template supported.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5
+	github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422
+	github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,10 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5 h1:YiZrQLNWjvHpcIGpuHqcZX4FJ1J82oAU/F2mUUlbZAE=
-github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255 h1:2iW/eqhVyyvnFjXX9++3oKO3FPKGkFl49e/xnYaNUwc=
+github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422 h1:XwFK7LPY/bsGYUIg0b6d5JMb5oIPS39X2JplmB1HyHs=
+github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,10 @@ github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255 h1:2iW/eqhVy
 github.com/huaweicloud/golangsdk v0.0.0-20210510122110-66430a62b255/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422 h1:XwFK7LPY/bsGYUIg0b6d5JMb5oIPS39X2JplmB1HyHs=
 github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210515081555-068e23790b91 h1:0KuxeGQevny8MeM4vKSTJU+N2Ap/LOcloTFLVKbFfC4=
+github.com/huaweicloud/golangsdk v0.0.0-20210515081555-068e23790b91/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0 h1:ap/m0dp+LvmAHQsQmSwYU0yOKxYz2b7iYpbgtUnXO0Y=
+github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/data_source_huaweicloud_cce_addon_template.go
+++ b/huaweicloud/data_source_huaweicloud_cce_addon_template.go
@@ -1,0 +1,109 @@
+package huaweicloud
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/templates"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func DataSourceCCEAddonTemplateV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCCEAddonTemplateV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"spec": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCCEAddonTemplateV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	region := GetRegion(d, config)
+	client, err := config.CceAddonV3Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCE client : %s", err)
+	}
+	// Get all addon templates by List function
+	cluster_id := d.Get("cluster_id").(string)
+	templateList, err := templates.List(client, cluster_id).Extract()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve template list: %s", err)
+	}
+
+	name := d.Get("name").(string)
+	version := d.Get("version").(string)
+	spec, description, err := getTemplateByNameAndVersion(templateList, name, version)
+	if err != nil {
+		return fmt.Errorf("Unable to find specifies template by name (%s) and version (%s): %s", name, version, err)
+	}
+
+	d.SetId(hashcode.Strings([]string{name, version}))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("spec", spec),
+		d.Set("description", description),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func getTemplateByNameAndVersion(templateList []templates.Template, name, version string) (string, string, error) {
+	versions := make([]templates.Versions, 1)
+	var description string
+LOOP:
+	for _, template := range templateList {
+		if template.Metadata.Name != name {
+			continue
+		}
+		for _, ver := range template.Spec.Versions {
+			if version == ver.Version {
+				description = template.Spec.Description
+				versions[0] = ver
+				break LOOP
+			}
+		}
+	}
+	if len(versions) < 1 {
+		return "", "", fmt.Errorf("Your query returned no results, please change your search criteria and try again")
+	}
+
+	specStruct := versions[0].Input
+	// Return a json string to the user, which contains the contents of the basic and custom fields (In add-on values).
+	specBytes, err := json.Marshal(specStruct)
+	if err != nil {
+		return "", "", fmt.Errorf("Error converting input struct")
+	}
+	spec := string(specBytes)
+	return spec, description, nil
+}

--- a/huaweicloud/data_source_huaweicloud_cce_addon_template_test.go
+++ b/huaweicloud/data_source_huaweicloud_cce_addon_template_test.go
@@ -1,0 +1,45 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonTemplateV3DataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.huaweicloud_cce_addon_template.spark_operator_test", "spec"),
+					resource.TestCheckResourceAttrSet("data.huaweicloud_cce_addon_template.nginx_ingress_test", "spec"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCCEAddonTemplateV3DataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cce_addon_template" "spark_operator_test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+  name       = "spark-operator"
+  version    = "1.0.1"
+}
+
+data "huaweicloud_cce_addon_template" "nginx_ingress_test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+  name       = "nginx-ingress"
+  version    = "1.2.2"
+}
+`, testAccCCEClusterV3_basic(rName))
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -258,6 +258,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"huaweicloud_antiddos":                    dataSourceAntiDdosV1(),
 			"huaweicloud_availability_zones":          DataSourceAvailabilityZones(),
+			"huaweicloud_cce_addon_template":          DataSourceCCEAddonTemplateV3(),
 			"huaweicloud_cce_cluster":                 DataSourceCCEClusterV3(),
 			"huaweicloud_cce_node":                    DataSourceCCENodeV3(),
 			"huaweicloud_cce_node_pool":               DataSourceCCENodePoolV3(),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/requests.go
@@ -1,0 +1,8 @@
+package templates
+
+import "github.com/huaweicloud/golangsdk"
+
+func List(client *golangsdk.ServiceClient, cluster_id string) (r ListResutlt) {
+	_, r.Err = client.Get(templateURL(client, cluster_id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/results.go
@@ -1,0 +1,46 @@
+package templates
+
+import "github.com/huaweicloud/golangsdk"
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type ListResutlt struct {
+	commonResult
+}
+
+type Template struct {
+	Kind       string   `json:"kind"`
+	ApiVersion string   `json:"apiVersion"`
+	Metadata   Metadata `json:"metadata"`
+	Spec       Spec     `json:"spec"`
+}
+
+type Metadata struct {
+	UID               string `json:"uid"`
+	Name              string `json:"name"`
+	CreationTimestamp string `json:"creationTimestamp"`
+	UpdateTimestamp   string `json:"updateTimestamp"`
+}
+
+type Spec struct {
+	Type        string     `json:"type"`
+	Labels      []string   `json:"labels"`
+	LogoURL     string     `json:"logoURL"`
+	Description string     `json:"description"`
+	Versions    []Versions `json:"versions"`
+}
+
+type Versions struct {
+	Version string      `json:"version"`
+	Input   interface{} `json:"input"`
+}
+
+func (r ListResutlt) Extract() ([]Template, error) {
+	var s struct {
+		Templates []Template `json:"items"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Templates, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/results.go
@@ -1,6 +1,9 @@
 package templates
 
-import "github.com/huaweicloud/golangsdk"
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/addons"
+)
 
 type commonResult struct {
 	golangsdk.Result
@@ -25,16 +28,11 @@ type Metadata struct {
 }
 
 type Spec struct {
-	Type        string     `json:"type"`
-	Labels      []string   `json:"labels"`
-	LogoURL     string     `json:"logoURL"`
-	Description string     `json:"description"`
-	Versions    []Versions `json:"versions"`
-}
-
-type Versions struct {
-	Version string      `json:"version"`
-	Input   interface{} `json:"input"`
+	Type        string            `json:"type"`
+	Labels      []string          `json:"labels"`
+	LogoURL     string            `json:"logoURL"`
+	Description string            `json:"description"`
+	Versions    []addons.Versions `json:"versions"`
 }
 
 func (r ListResutlt) Extract() ([]Template, error) {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/templates/urls.go
@@ -1,0 +1,12 @@
+package templates
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/addons"
+)
+
+const templatePath = "addontemplates"
+
+func templateURL(client *golangsdk.ServiceClient, cluster_id string) string {
+	return addons.CCEServiceURL(client, cluster_id, templatePath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422
+# github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5
+# github.com/huaweicloud/golangsdk v0.0.0-20210514063328-40b1fa513422
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -283,6 +283,7 @@ github.com/huaweicloud/golangsdk/openstack/cce/v3/addons
 github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters
 github.com/huaweicloud/golangsdk/openstack/cce/v3/nodepools
 github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes
+github.com/huaweicloud/golangsdk/openstack/cce/v3/templates
 github.com/huaweicloud/golangsdk/openstack/cci/v1/networks
 github.com/huaweicloud/golangsdk/openstack/cdn/v1/domains
 github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In resource `huaweicloud_cce_addon`, the users cannot know what should be filled in the `values` field, so supports a data-source for querying specifies addon template by addon version, name and cluster ID.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1039 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new add-on template date source
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCCEAddonTemplateV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCCEAddonTemplateV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEAddonTemplateV3DataSource_basic
=== PAUSE TestAccCCEAddonTemplateV3DataSource_basic
=== CONT  TestAccCCEAddonTemplateV3DataSource_basic
--- PASS: TestAccCCEAddonTemplateV3DataSource_basic (423.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       423.559s
```
