### PR TITLE
support update in fgs_function

### DIFF
--- a/huaweicloud/resource_huaweicloud_fgs_function_v2.go
+++ b/huaweicloud/resource_huaweicloud_fgs_function_v2.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/fgs/v2/function"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -18,6 +19,7 @@ func resourceFgsFunctionV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceFgsFunctionV2Create,
 		Read:   resourceFgsFunctionV2Read,
+		Update: resourceFgsFunctionV2Update,
 		Delete: resourceFgsFunctionV2Delete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -43,79 +45,70 @@ func resourceFgsFunctionV2() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"package": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"app"},
 				Deprecated:    "use app instead",
 			},
 			"app": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"package"},
 			},
 			"code_type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"code_url": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"code_filename": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"handler": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"memory_size": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"runtime": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"timeout": {
 				Type:     schema.TypeInt,
 				Required: true,
-				ForceNew: true,
 			},
 			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"xrole": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"agency"},
 				Deprecated:    "use agency instead",
 			},
 			"agency": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"xrole"},
+			},
+			"app_agency": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"func_code": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Optional: true,
 				StateFunc: func(v interface{}) string {
 					switch v.(type) {
 					case string:
@@ -123,6 +116,77 @@ func resourceFgsFunctionV2() *schema.Resource {
 					default:
 						return ""
 					}
+				},
+			},
+			"depend_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"initializer_handler": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"initializer_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"network_id"},
+			},
+			"network_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"vpc_id"},
+			},
+			"mount_user_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"mount_user_group_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"func_mounts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mount_resource": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mount_share_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"local_mount_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
 				},
 			},
 		},
@@ -138,15 +202,15 @@ func resourceFgsFunctionV2Create(d *schema.ResourceData, meta interface{}) error
 
 	// check app and package
 	app, app_ok := d.GetOk("app")
-	pak, pak_ok := d.GetOk("package")
-	if !app_ok && !pak_ok {
+	pkg, pkg_ok := d.GetOk("package")
+	if !app_ok && !pkg_ok {
 		return fmt.Errorf("One of app or package must be configured")
 	}
 	pack_v := ""
 	if app_ok {
 		pack_v = app.(string)
 	} else {
-		pack_v = pak.(string)
+		pack_v = pkg.(string)
 	}
 
 	// get value from agency or xrole
@@ -158,18 +222,19 @@ func resourceFgsFunctionV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 
 	createOpts := function.CreateOpts{
-		FuncName:     d.Get("name").(string),
-		Package:      pack_v,
-		CodeType:     d.Get("code_type").(string),
-		CodeUrl:      d.Get("code_url").(string),
-		Description:  d.Get("description").(string),
-		CodeFilename: d.Get("code_filename").(string),
-		Handler:      d.Get("handler").(string),
-		MemorySize:   d.Get("memory_size").(int),
-		Runtime:      d.Get("runtime").(string),
-		Timeout:      d.Get("timeout").(int),
-		UserData:     d.Get("user_data").(string),
-		Xrole:        agency_v,
+		FuncName:            d.Get("name").(string),
+		Package:             pack_v,
+		CodeType:            d.Get("code_type").(string),
+		CodeUrl:             d.Get("code_url").(string),
+		Description:         d.Get("description").(string),
+		CodeFilename:        d.Get("code_filename").(string),
+		Handler:             d.Get("handler").(string),
+		MemorySize:          d.Get("memory_size").(int),
+		Runtime:             d.Get("runtime").(string),
+		Timeout:             d.Get("timeout").(int),
+		UserData:            d.Get("user_data").(string),
+		Xrole:               agency_v,
+		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
 	}
 
 	if v, ok := d.GetOk("func_code"); ok {
@@ -187,6 +252,21 @@ func resourceFgsFunctionV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(f.FuncUrn)
+	if hasFilledOpt(d, "vpc_id") || hasFilledOpt(d, "func_mounts") || hasFilledOpt(d, "app_agency") ||
+		hasFilledOpt(d, "initializer_handler") || hasFilledOpt(d, "initializer_timeout") {
+		urn := resourceFgsFunctionUrn(d.Id())
+		err := resourceFgsFunctionV2MetadataUpdate(fgsClient, urn, d)
+		if err != nil {
+			return err
+		}
+	}
+	if hasFilledOpt(d, "depend_list") {
+		urn := resourceFgsFunctionUrn(d.Id())
+		err := resourceFgsFunctionV2CodeUpdate(fgsClient, urn, d)
+		if err != nil {
+			return err
+		}
+	}
 
 	return resourceFgsFunctionV2Read(d, meta)
 }
@@ -227,8 +307,66 @@ func resourceFgsFunctionV2Read(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		d.Set("xrole", f.Xrole)
 	}
+	d.Set("app_agency", f.AppXrole)
+	d.Set("depend_list", f.DependList)
+	d.Set("initializer_handler", f.InitializerHandler)
+	d.Set("initializer_timeout", f.InitializerTimeout)
+	d.Set("enterprise_project_id", f.EnterpriseProjectID)
+
+	// set func_vpc
+	if f.FuncVpc != (function.FuncVpc{}) {
+		d.Set("vpc_id", f.FuncVpc.VpcId)
+		d.Set("network_id", f.FuncVpc.SubnetId)
+	}
+
+	// set mount_config
+	if f.MountConfig.MountUser != (function.MountUser{}) {
+		funcMounts := make([]map[string]string, 0, len(f.MountConfig.FuncMounts))
+		for _, v := range f.MountConfig.FuncMounts {
+			funcMount := map[string]string{
+				"mount_type":       v.MountType,
+				"mount_resource":   v.MountResource,
+				"mount_share_path": v.MountSharePath,
+				"local_mount_path": v.LocalMountPath,
+				"status":           v.Status,
+			}
+			funcMounts = append(funcMounts, funcMount)
+		}
+		d.Set("func_mounts", funcMounts)
+		d.Set("mount_user_id", f.MountConfig.MountUser.UserId)
+		d.Set("mount_user_group_id", f.MountConfig.MountUser.UserGroupId)
+	}
 
 	return nil
+}
+
+func resourceFgsFunctionV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	fgsClient, err := config.FgsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud FGS V2 client: %s", err)
+	}
+
+	urn := resourceFgsFunctionUrn(d.Id())
+
+	//lintignore:R019
+	if d.HasChanges("code_type", "code_url", "code_filename", "depend_list", "func_code") {
+		err := resourceFgsFunctionV2CodeUpdate(fgsClient, urn, d)
+		if err != nil {
+			return err
+		}
+	}
+	//lintignore:R019
+	if d.HasChanges("app", "handler", "depend_list", "memory_size", "runtime", "timeout",
+		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
+		"vpc_id", "network_id", "mount_user_id", "mount_user_group_id", "func_mounts") {
+		err := resourceFgsFunctionV2MetadataUpdate(fgsClient, urn, d)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceFgsFunctionV2Read(d, meta)
 }
 
 func resourceFgsFunctionV2Delete(d *schema.ResourceData, meta interface{}) error {
@@ -238,16 +376,99 @@ func resourceFgsFunctionV2Delete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating HuaweiCloud FGS V2 client: %s", err)
 	}
 
-	urn := d.Id()
-	if strings.HasSuffix(urn, ":latest") {
-		urn = urn[0 : len(urn)-7]
-	}
+	urn := resourceFgsFunctionUrn(d.Id())
 
 	err = function.Delete(fgsClient, urn).ExtractErr()
 	if err != nil {
 		return fmt.Errorf("Error deleting HuaweiCloud function: %s", err)
 	}
 	d.SetId("")
+	return nil
+}
+
+func resourceFgsFunctionV2MetadataUpdate(fgsClient *golangsdk.ServiceClient, urn string, d *schema.ResourceData) error {
+	// check app and package
+	app, app_ok := d.GetOk("app")
+	pkg, pkg_ok := d.GetOk("package")
+	if !app_ok && !pkg_ok {
+		return fmt.Errorf("One of app or package must be configured")
+	}
+	pack_v := ""
+	if app_ok {
+		pack_v = app.(string)
+	} else {
+		pack_v = pkg.(string)
+	}
+
+	// get value from agency or xrole
+	agency_v := ""
+	if v, ok := d.GetOk("agency"); ok {
+		agency_v = v.(string)
+	} else if v, ok := d.GetOk("xrole"); ok {
+		agency_v = v.(string)
+	}
+
+	updateMetadateOpts := function.UpdateMetadataOpts{
+		Handler:            d.Get("handler").(string),
+		MemorySize:         d.Get("memory_size").(int),
+		Timeout:            d.Get("timeout").(int),
+		Runtime:            d.Get("runtime").(string),
+		Package:            pack_v,
+		Description:        d.Get("description").(string),
+		UserData:           d.Get("user_data").(string),
+		Xrole:              agency_v,
+		AppXrole:           d.Get("app_agency").(string),
+		InitializerHandler: d.Get("initializer_handler").(string),
+		InitializerTimeout: d.Get("initializer_timeout").(int),
+	}
+
+	if _, ok := d.GetOk("vpc_id"); ok {
+		updateMetadateOpts.FuncVpc = resourceFgsFunctionFuncVpc(d)
+	}
+
+	if _, ok := d.GetOk("func_mounts"); ok {
+		updateMetadateOpts.MountConfig = resourceFgsFunctionMountConfig(d)
+	}
+
+	log.Printf("[DEBUG] Metaddata Update Options: %#v", updateMetadateOpts)
+	_, err := function.UpdateMetadata(fgsClient, urn, updateMetadateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating metadata of HuaweiCloud function: %s", err)
+	}
+
+	return nil
+}
+
+func resourceFgsFunctionV2CodeUpdate(fgsClient *golangsdk.ServiceClient, urn string, d *schema.ResourceData) error {
+	updateCodeOpts := function.UpdateCodeOpts{
+		CodeType:     d.Get("code_type").(string),
+		CodeUrl:      d.Get("code_url").(string),
+		CodeFileName: d.Get("code_filename").(string),
+	}
+
+	if v, ok := d.GetOk("depend_list"); ok {
+		dependListRaw := v.([]interface{})
+		dependList := make([]string, 0, len(dependListRaw))
+		for _, depend := range dependListRaw {
+			dependList = append(dependList, depend.(string))
+		}
+		updateCodeOpts.DependList = dependList
+	}
+
+	if v, ok := d.GetOk("func_code"); ok {
+		funcCode := funcCodeEncode(v.(string))
+		func_code := function.FunctionCodeOpts{
+			File: funcCode,
+		}
+		updateCodeOpts.FuncCode = func_code
+	}
+
+	log.Printf("[DEBUG] Code Update Options: %#v", updateCodeOpts)
+	_, err := function.UpdateCode(fgsClient, urn, updateCodeOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating code of HuaweiCloud function: %s", err)
+	}
+
 	return nil
 }
 
@@ -269,4 +490,54 @@ func funcCodeEncode(script string) string {
 		return base64.StdEncoding.EncodeToString([]byte(script))
 	}
 	return script
+}
+
+func resourceFgsFunctionFuncVpc(d *schema.ResourceData) *function.FuncVpc {
+	var funcVpc function.FuncVpc
+	funcVpc.VpcId = d.Get("vpc_id").(string)
+	funcVpc.SubnetId = d.Get("network_id").(string)
+	return &funcVpc
+}
+
+func resourceFgsFunctionMountConfig(d *schema.ResourceData) *function.MountConfig {
+	var mountConfig function.MountConfig
+	funcMountsRaw := d.Get("func_mounts").([]interface{})
+	if len(funcMountsRaw) >= 1 {
+		funcMounts := make([]function.FuncMount, 0, len(funcMountsRaw))
+		for _, funcMountRaw := range funcMountsRaw {
+			var funcMount function.FuncMount
+			funcMountMap := funcMountRaw.(map[string]interface{})
+			funcMount.MountType = funcMountMap["mount_type"].(string)
+			funcMount.MountResource = funcMountMap["mount_resource"].(string)
+			funcMount.MountSharePath = funcMountMap["mount_share_path"].(string)
+			funcMount.LocalMountPath = funcMountMap["local_mount_path"].(string)
+
+			funcMounts = append(funcMounts, funcMount)
+		}
+
+		mountConfig.FuncMounts = funcMounts
+
+		mountUser := function.MountUser{
+			UserId:      -1,
+			UserGroupId: -1,
+		}
+
+		if v, ok := d.GetOk("mount_user_id"); ok {
+			mountUser.UserId = v.(int)
+		}
+
+		if v, ok := d.GetOk("mount_user_group_id"); ok {
+			mountUser.UserGroupId = v.(int)
+		}
+
+		mountConfig.MountUser = mountUser
+	}
+	return &mountConfig
+}
+
+func resourceFgsFunctionUrn(urn string) string {
+	if strings.HasSuffix(urn, ":latest") {
+		urn = urn[0 : len(urn)-7]
+	}
+	return urn
 }

--- a/huaweicloud/resource_huaweicloud_fgs_function_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_fgs_function_v2_test.go
@@ -28,6 +28,34 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 					testAccCheckFgsV2FunctionExists(resourceName, &f),
 				),
 			},
+			{
+				Config: testAccFgsV2Function_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFgsV2FunctionExists(resourceName, &f),
+					resource.TestCheckResourceAttr(resourceName, "description", "fuction test update"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_withEpsId(t *testing.T) {
+	var f function.Function
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_fgs_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFgsV2FunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_withEpsId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFgsV2FunctionExists(resourceName, &f),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
 		},
 	})
 }
@@ -46,6 +74,29 @@ func TestAccFgsV2Function_text(t *testing.T) {
 				Config: testAccFgsV2Function_text(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFgsV2FunctionExists(resourceName, &f),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_agency(t *testing.T) {
+	var f function.Function
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_fgs_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFgsV2FunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_agency(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFgsV2FunctionExists(resourceName, &f),
+					resource.TestCheckResourceAttr(resourceName, "agency", rName),
+					resource.TestCheckResourceAttr(resourceName, "func_mounts.0.mount_type", "sfs"),
+					resource.TestCheckResourceAttr(resourceName, "func_mounts.0.status", "active"),
 				),
 			},
 		},
@@ -108,15 +159,31 @@ func testAccCheckFgsV2FunctionExists(n string, ft *function.Function) resource.T
 func testAccFgsV2Function_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_fgs_function" "test" {
-  name = "%s"
-  app = "default"
+  name        = "%s"
+  app         = "default"
   description = "fuction test"
-  handler = "index.handler"
+  handler     = "index.handler"
   memory_size = 128
-  timeout = 3
-  runtime = "Python2.7"
-  code_type = "inline"
-  func_code = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}
+`, rName)
+}
+
+func testAccFgsV2Function_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "fuction test update"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
 }
 `, rName)
 }
@@ -124,14 +191,15 @@ resource "huaweicloud_fgs_function" "test" {
 func testAccFgsV2Function_text(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_fgs_function" "test" {
-  name = "%s"
-  app = "default"
+  name        = "%s"
+  app         = "default"
   description = "fuction test"
-  handler = "index.handler"
+  handler     = "index.handler"
   memory_size = 128
-  timeout = 3
-  runtime = "Python2.7"
-  code_type = "inline"
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+
   func_code = <<EOF
 # -*- coding:utf-8 -*-
 import json
@@ -147,4 +215,80 @@ def handler (event, context):
 EOF
 }
 `, rName)
+}
+
+func testAccFgsV2Function_withEpsId(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%s"
+  app                   = "default"
+  description           = "fuction test"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  enterprise_project_id = "%s"
+  func_code             = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}
+`, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccFgsV2Function_agency(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.1.0/24"
+  gateway_ip = "192.168.1.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_sfs_file_system" "test" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "%s"
+  description = "test sfs for fgs"
+}
+
+resource "huaweicloud_identity_agency" "test" {
+  name                   = "%s"
+  description            = "test agency for fgs"
+  delegated_service_name = "op_svc_cff"
+
+  project_role {
+    project = "cn-north-4"
+    roles = [
+      "VPC Administrator",
+      "SFS Administrator",
+    ]
+  }
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%s"
+  package     = "default"
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+  agency      = huaweicloud_identity_agency.test.name
+  vpc_id      = huaweicloud_vpc.test.id
+  network_id  = huaweicloud_vpc_subnet.test.id
+
+  func_mounts {
+    mount_type       = "sfs"
+    mount_resource   = huaweicloud_sfs_file_system.test.id
+    mount_share_path = huaweicloud_sfs_file_system.test.export_location
+    local_mount_path = "/mnt"
+  }
+}
+`, rName, rName, rName, rName, rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support update in fgs_function

The following new params are supported:
`app_xrole`, `initializer_handler,` `initializer_timeout`, `enterprise_project_id`, `func_vpc`, `mount_config`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1040 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccFgsV2Function'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccFgsV2Function -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== RUN   TestAccFgsV2Function_withEpsId
=== PAUSE TestAccFgsV2Function_withEpsId
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== RUN   TestAccFgsV2Function_agency
=== PAUSE TestAccFgsV2Function_agency
=== CONT  TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_agency
=== CONT  TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_withEpsId
--- PASS: TestAccFgsV2Function_text (20.42s)
--- PASS: TestAccFgsV2Function_withEpsId (20.63s)
--- PASS: TestAccFgsV2Function_basic (39.83s)
--- PASS: TestAccFgsV2Function_agency (87.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       88.019s
```
