### PR TITLE
Power action parameter and method supported

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -283,6 +283,10 @@ The following arguments are supported:
 * `agency_name` - (Optional, String, ForceNew) Specifies the IAM agency name which is created on IAM to provide
     temporary credentials for ECS to access cloud services. Changing this creates a new instance.
 
+* `power_action` - (Optional, String) Specifies the power action to be done for the instance.
+  The valid values are *ON*, *OFF*, *REBOOT*, *FORCE-OFF* and *FORCE-REBOOT*.
+
+  -> **NOTE:** The `power_action` is a one-time action.
 
 The `network` block supports:
 
@@ -346,8 +350,9 @@ terraform import huaweicloud_compute_instance.my_instance b11b407c-e604-4e8d-8bc
 Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
 API response, security or some other reason. The missing attributes include:
 `admin_pass`, `user_data`, `data_disks`, `scheduler_hints`, `stop_before_destroy`, `delete_disks_on_termination`,
-`network/access_network` and arguments for pre-paid. It is generally recommended running `terraform plan` after
-importing an instance. You can then decide if changes should be applied to the instance, or the resource definition
+`network/access_network`, `power_action` and arguments for pre-paid.
+It is generally recommended running `terraform plan` after importing an instance.
+You can then decide if changes should be applied to the instance, or the resource definition
 should be updated to align with the instance. Also you can ignore changes as below.
 ```
 resource "huaweicloud_compute_instance" "myinstance" {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/powers/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/powers/requests.go
@@ -1,0 +1,39 @@
+package powers
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers"
+)
+
+// PowerOpts allows batch update of the ECS instances power state through the API.
+// Parameter 'Type' supports two methods of 'SOFT' and 'HARD' to shut down and reboot the machine's power.
+type PowerOpts struct {
+	Servers []ServerInfo `json:"servers" required:"true"`
+	Type    string       `json:"type,omitempty"`
+}
+
+type ServerInfo struct {
+	ID string `json:"id" required:"true"`
+}
+
+// PowerOptsBuilder allows extensions to add additional parameters to the PowerAction(power on/off and reboot) request.
+type PowerOptsBuilder interface {
+	ToPowerActionMap(option string) (map[string]interface{}, error)
+}
+
+// ToPowerActionMap assembles a request body based on the contents of a PowerOpts and the power option parameter.
+func (opts PowerOpts) ToPowerActionMap(option string) (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, option)
+}
+
+// PowerAction uses a option parameter to control the power state of the ECS instance.
+// The option only supports 'os-start' (power on), 'os-stop' (power off) and 'reboot'.
+func PowerAction(client *golangsdk.ServiceClient, opts PowerOptsBuilder, option string) (r cloudservers.JobResult) {
+	reqBody, err := opts.ToPowerActionMap(option)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client), reqBody, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/powers/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/powers/urls.go
@@ -1,0 +1,9 @@
+package powers
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootURL = "cloudservers"
+
+func actionURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(rootURL, "action")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -326,6 +326,7 @@ github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/flavors
+github.com/huaweicloud/golangsdk/openstack/ecs/v1/powers
 github.com/huaweicloud/golangsdk/openstack/elb/v2/loadbalancers
 github.com/huaweicloud/golangsdk/openstack/elb/v3/flavors
 github.com/huaweicloud/golangsdk/openstack/elb/v3/listeners


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Redundancy of the instance status detection method.
- Power action supports:
  - ON
  - OFF
  - REBOOT
  - FORCE-OFF
  - FORCE-REBOOT

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #914
fixes #1044

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Extract the instance status detection method
2. New power state option and method supported.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2Instance_powerAction'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2Instance_powerAction -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_powerAction
=== PAUSE TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_powerAction
--- PASS: TestAccComputeV2Instance_powerAction (523.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       523.172s
```
