### PR TITLE
Update the secgroup element of ECS instance

### DIFF
--- a/docs/data-sources/compute_instance.md
+++ b/docs/data-sources/compute_instance.md
@@ -45,8 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 * `public_ip` - The EIP address that is associted to the instance.
 * `system_disk_id` - The system disk voume ID.
 * `user_data` -  The user data (information after encoding) configured during instance creation.
-* `security_groups` - An array of one or more security group names
-    to associate with the instance.
+* `security_group_ids` - An array of one or more security group IDs to associate with the instance.
 * `network` - An array of one or more networks to attach to the instance.
     The network object structure is documented below.
 * `volume_attached` - An array of one or more disks to attach to the instance.

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -12,6 +12,8 @@ This is an alternative to `huaweicloud_compute_instance_v2`
 ### Basic Instance
 
 ```hcl
+variable "secgroup_id" {}
+
 data "huaweicloud_availability_zones" "myaz" {}
 
 data "huaweicloud_compute_flavors" "myflavor" {
@@ -31,11 +33,11 @@ data "huaweicloud_images_image" "myimage" {
 }
 
 resource "huaweicloud_compute_instance" "basic" {
-  name              = "basic"
-  image_id          = data.huaweicloud_images_image.myimage.id
-  flavor_id         = data.huaweicloud_compute_flavors.myflavor.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  name               = "basic"
+  image_id           = data.huaweicloud_images_image.myimage.id
+  flavor_id          = data.huaweicloud_compute_flavors.myflavor.ids[0]
+  security_group_ids = [var.secgroup_id]
+  availability_zone  = data.huaweicloud_availability_zones.myaz.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.mynet.id
@@ -46,13 +48,15 @@ resource "huaweicloud_compute_instance" "basic" {
 ### Instance With Associated Eip
 
 ```hcl
+variable "secgroup_id" {}
+
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "myinstance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "myinstance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.secgroup_id]
+  availability_zone  = "cn-north-4a"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -80,6 +84,8 @@ resource "huaweicloud_compute_eip_associate" "associated" {
 ### Instance With Attached Volume
 
 ```hcl
+variable "secgroup_id" {}
+
 resource "huaweicloud_evs_volume" "myvolume" {
   name              = "myvolume"
   availability_zone = "cn-north-4a"
@@ -88,12 +94,12 @@ resource "huaweicloud_evs_volume" "myvolume" {
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "myinstance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "myinstance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.secgroup_id]
+  availability_zone  = "cn-north-4a"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -113,13 +119,15 @@ with multiple data disks, but we can't ensure the volume attached order. So it's
 recommended to use `Instance With Attached Volume` above.
 
 ```hcl
+variable "secgroup_id" {}
+
 resource "huaweicloud_compute_instance" "multi-disk" {
-  name              = "multi-net"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "multi-net"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.secgroup_id]
+  availability_zone  = "cn-north-4a"
 
   system_disk_type = "SAS"
   system_disk_size = 40
@@ -144,13 +152,15 @@ resource "huaweicloud_compute_instance" "multi-disk" {
 ### Instance With Multiple Networks
 
 ```hcl
+variable "secgroup_id" {}
+
 resource "huaweicloud_compute_instance" "multi-net" {
-  name              = "multi-net"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "multi-net"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.secgroup_id]
+  availability_zone  = "cn-north-4a"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -165,14 +175,16 @@ resource "huaweicloud_compute_instance" "multi-net" {
 ### Instance with User Data (cloud-init)
 
 ```hcl
+variable "secgroup_id" {}
+
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "az"
-  user_data         = "#cloud-config\nhostname: instance_1.example.com\nfqdn: instance_1.example.com"
+  name               = "instance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.secgroup_id]
+  availability_zone  = "az"
+  user_data          = "#cloud-config\nhostname: instance_1.example.com\nfqdn: instance_1.example.com"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -205,7 +217,7 @@ The following arguments are supported:
 * `flavor_name` - (Optional, String) Required if `flavor_id` is empty.
     Specifies the name of the desired flavor for the instance.
 
-* `security_groups` - (Optional, String) Specifies a array of one or more security group names to associate with the
+* `security_group_ids` - (Optional, List) Specifies an array of one or more security group IDs to associate with the
     instance.
 
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone in which to create

--- a/huaweicloud/data_source_huaweicloud_compute_instance.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance.go
@@ -71,6 +71,11 @@ func DataSourceComputeInstance() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"system_disk_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -228,6 +233,12 @@ func dataSourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) err
 		secGrpNames[i] = sg.Name
 	}
 	d.Set("security_groups", secGrpNames)
+
+	secGrpIDs := make([]string, len(server.SecurityGroups))
+	for i, sg := range server.SecurityGroups {
+		secGrpIDs[i] = sg.ID
+	}
+	d.Set("security_group_ids", secGrpIDs)
 
 	// set os:scheduler_hints
 	osHints := server.OsSchedulerHints

--- a/huaweicloud/data_source_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance_test.go
@@ -57,11 +57,11 @@ func testAccComputeInstanceDataSource_basic(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
@@ -148,11 +148,11 @@ func testAccComputeV2EIPAssociate_Base(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -328,6 +328,10 @@ data "huaweicloud_images_image" "test" {
   name        = "Ubuntu 18.04 server 64bit"
   most_recent = true
 }
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
 `
 
 func testAccComputeV2Instance_basic(rName string) string {
@@ -335,11 +339,11 @@ func testAccComputeV2Instance_basic(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -353,11 +357,11 @@ func testAccComputeV2Instance_disks(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name                        = "%s"
+  image_id                    = data.huaweicloud_images_image.test.id
+  flavor_id                   = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids          = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone           = data.huaweicloud_availability_zones.test.names[0]
   delete_disks_on_termination = true
 
   system_disk_type = "SAS"
@@ -380,11 +384,11 @@ func testAccComputeV2Instance_prePaid(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -402,11 +406,11 @@ func testAccComputeV2Instance_tags(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -425,11 +429,11 @@ func testAccComputeV2Instance_tags2(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -448,11 +452,11 @@ func testAccComputeV2Instance_notags(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -466,12 +470,12 @@ func testAccComputeV2Instance_powerAction(rName, powerAction string) string {
 %s
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  power_action      = "%s"
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  power_action       = "%s"
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/resource_huaweicloud_compute_interface_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_interface_attach_test.go
@@ -114,11 +114,11 @@ func testAccComputeV2InterfaceAttach_basic(rName string) string {
 %s
 
 resource "huaweicloud_compute_instance" "instance_1" {
-  name = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }

--- a/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
@@ -167,11 +167,11 @@ resource "huaweicloud_compute_servergroup" "sg_1" {
 }
 
 resource "huaweicloud_compute_instance" "instance_1" {
-  name = "%s"
-  image_id = data.huaweicloud_images_image.test.id
-  flavor_id = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   scheduler_hints {
     group = huaweicloud_compute_servergroup.sg_1.id
   }
@@ -193,11 +193,11 @@ resource "huaweicloud_compute_servergroup" "sg_1" {
 }
 
 resource "huaweicloud_compute_instance" "instance_1" {
-  name = "%s"
-  image_id = data.huaweicloud_images_image.test.id
-  flavor_id = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }

--- a/huaweicloud/resource_huaweicloud_compute_volume_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach_test.go
@@ -142,11 +142,11 @@ resource "huaweicloud_evs_volume" "test" {
 }
 
 resource "huaweicloud_compute_instance" "instance_1" {
-  name = "%s"
-  image_id = data.huaweicloud_images_image.test.id
-  flavor_id = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }
@@ -171,11 +171,11 @@ resource "huaweicloud_evs_volume" "test" {
 }
 
 resource "huaweicloud_compute_instance" "instance_1" {
-  name = "%s"
-  image_id = data.huaweicloud_images_image.test.id
-  flavor_id = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }

--- a/huaweicloud/resource_huaweicloud_csbs_backup_policy_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_csbs_backup_policy_v1_test.go
@@ -122,12 +122,16 @@ func testAccCheckCSBSBackupPolicyV1Exists(n string, policy *policies.BackupPolic
 
 func testAccCSBSBackupPolicyV1_basic(rName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance_v2" "instance_1" {
-  name              = "%s"
-  image_id          = "%s"
-  security_groups   = ["default"]
-  availability_zone = "%s"
-  flavor_id         = "%s"
+  name               = "%s"
+  image_id           = "%s"
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = "%s"
+  flavor_id          = "%s"
   metadata = {
     foo = "bar"
   }
@@ -155,12 +159,16 @@ resource "huaweicloud_csbs_backup_policy" "backup_policy" {
 
 func testAccCSBSBackupPolicyV1_update(rName, updateName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance_v2" "instance_1" {
-  name              = "%s"
-  image_id          = "%s"
-  security_groups   = ["default"]
-  availability_zone = "%s"
-  flavor_id         = "%s"
+  name               = "%s"
+  image_id           = "%s"
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = "%s"
+  flavor_id          = "%s"
   metadata = {
     foo = "bar"
   }
@@ -188,12 +196,16 @@ resource "huaweicloud_csbs_backup_policy" "backup_policy" {
 
 func testAccCSBSBackupPolicyV1_timeout(rName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance_v2" "instance_1" {
-  name              = "%s"
-  image_id          = "%s"
-  security_groups   = ["default"]
-  availability_zone = "%s"
-  flavor_id         = "%s"
+  name               = "%s"
+  image_id           = "%s"
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = "%s"
+  flavor_id          = "%s"
   metadata = {
     foo = "bar"
   }

--- a/huaweicloud/resource_huaweicloud_csbs_backup_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_csbs_backup_v1_test.go
@@ -115,12 +115,16 @@ func testAccCSBSBackupV1Exists(n string, backups *backup.Backup) resource.TestCh
 
 func testAccCSBSBackupV1_basic(rName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance_v2" "instance_1" {
-  name              = "%s"
-  image_id          = "%s"
-  security_groups   = ["default"]
-  availability_zone = "%s"
-  flavor_id         = "%s"
+  name               = "%s"
+  image_id           = "%s"
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = "%s"
+  flavor_id          = "%s"
   metadata = {
     foo = "bar"
   }
@@ -139,12 +143,16 @@ resource "huaweicloud_csbs_backup" "csbs" {
 
 func testAccCSBSBackupV1_timeout(rName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance_v2" "instance_1" {
-  name              = "%s"
-  image_id          = "%s"
-  security_groups   = ["default"]
-  availability_zone = "%s"
-  flavor_id         = "%s"
+  name               = "%s"
+  image_id           = "%s"
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = "%s"
+  flavor_id          = "%s"
   metadata = {
     foo = "bar"
   }

--- a/huaweicloud/resource_huaweicloud_images_image_test.go
+++ b/huaweicloud/resource_huaweicloud_images_image_test.go
@@ -135,12 +135,16 @@ data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
 
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_name        = "Ubuntu 18.04 server 64bit"
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -175,12 +179,16 @@ data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
 
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_name        = "Ubuntu 18.04 server 64bit"
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -216,12 +224,16 @@ data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
 
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_name        = "Ubuntu 18.04 server 64bit"
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2_test.go
@@ -141,6 +141,10 @@ func testAccCheckNatDnatExists() resource.TestCheckFunc {
 
 func testAccNatV2DnatRule_base(suffix string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_vpc_eip" "eip_1" {
   publicip {
     type = "5_bgp"
@@ -168,11 +172,11 @@ data "huaweicloud_images_image" "test" {
 }
 
 resource "huaweicloud_compute_instance" "instance_1" {
-  name              = "instance-acc-test-%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "instance-acc-test-%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = huaweicloud_vpc_subnet.subnet_1.id

--- a/huaweicloud/resource_huaweicloud_vpcep_endpoint_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_endpoint_test.go
@@ -140,11 +140,11 @@ data "huaweicloud_vpc" "myvpc" {
 }
 
 resource "huaweicloud_compute_instance" "ecs" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_service_test.go
@@ -153,11 +153,11 @@ data "huaweicloud_vpc" "myvpc" {
 }
 
 resource "huaweicloud_compute_instance" "ecs" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The elements of the `security_groups` list are names, but we want to support ID methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1128

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support `security_group_ids` parameter.
2. replace the`security_groups` in the document with `security_group_ids`.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2Instance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2Instance_ -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== RUN   TestAccComputeV2Instance_disks
=== PAUSE TestAccComputeV2Instance_disks
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== RUN   TestAccComputeV2Instance_tags
=== PAUSE TestAccComputeV2Instance_tags
=== RUN   TestAccComputeV2Instance_powerAction
=== PAUSE TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_tags
=== CONT  TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_prePaid
--- PASS: TestAccComputeV2Instance_basic (198.88s)
=== CONT  TestAccComputeV2Instance_disks
--- PASS: TestAccComputeV2Instance_prePaid (229.71s)
--- PASS: TestAccComputeV2Instance_tags (286.25s)
--- PASS: TestAccComputeV2Instance_disks (227.23s)
--- PASS: TestAccComputeV2Instance_powerAction (459.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       459.741s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (219.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       219.641s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2EIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2EIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2EIPAssociate_basic
=== PAUSE TestAccComputeV2EIPAssociate_basic
=== CONT  TestAccComputeV2EIPAssociate_basic
--- PASS: TestAccComputeV2EIPAssociate_basic (186.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       186.349s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2ServerGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2ServerGroup_ -timeout 360m -parallel 4
=== RUN   TestAccComputeV2ServerGroup_basic
=== PAUSE TestAccComputeV2ServerGroup_basic
=== RUN   TestAccComputeV2ServerGroup_affinity
=== PAUSE TestAccComputeV2ServerGroup_affinity
=== RUN   TestAccComputeV2ServerGroup_members
=== PAUSE TestAccComputeV2ServerGroup_members
=== CONT  TestAccComputeV2ServerGroup_basic
=== CONT  TestAccComputeV2ServerGroup_members
=== CONT  TestAccComputeV2ServerGroup_affinity
--- PASS: TestAccComputeV2ServerGroup_basic (13.88s)
--- PASS: TestAccComputeV2ServerGroup_affinity (165.61s)
--- PASS: TestAccComputeV2ServerGroup_members (176.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       176.365s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2VolumeAttach_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2VolumeAttach_ -timeout 360m -parallel 4
=== RUN   TestAccComputeV2VolumeAttach_basic
=== PAUSE TestAccComputeV2VolumeAttach_basic
=== RUN   TestAccComputeV2VolumeAttach_device
=== PAUSE TestAccComputeV2VolumeAttach_device
=== CONT  TestAccComputeV2VolumeAttach_basic
=== CONT  TestAccComputeV2VolumeAttach_device
--- PASS: TestAccComputeV2VolumeAttach_basic (230.93s)
--- PASS: TestAccComputeV2VolumeAttach_device (237.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud      237.196s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCSBSBackupV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCSBSBackupV1_ -timeout 360m -parallel 4
=== RUN   TestAccCSBSBackupV1_basic
=== PAUSE TestAccCSBSBackupV1_basic
=== RUN   TestAccCSBSBackupV1_timeout
=== PAUSE TestAccCSBSBackupV1_timeout
=== CONT  TestAccCSBSBackupV1_basic
=== CONT  TestAccCSBSBackupV1_timeout
=== CONT  TestAccCSBSBackupV1_basic
    provider_test.go:75: This environment does not support deprecated tests
--- SKIP: TestAccCSBSBackupV1_basic (0.01s)
=== CONT  TestAccCSBSBackupV1_timeout
    provider_test.go:75: This environment does not support deprecated tests
--- SKIP: TestAccCSBSBackupV1_timeout (0.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.046s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccImsImage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccImsImage_ -timeout 360m -parallel 4
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== RUN   TestAccImsImage_withEpsId
=== PAUSE TestAccImsImage_withEpsId
=== CONT  TestAccImsImage_basic
=== CONT  TestAccImsImage_withEpsId
--- PASS: TestAccImsImage_withEpsId (378.73s)
--- PASS: TestAccImsImage_basic (414.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       414.183s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatDnat_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatDnat_basic -timeout 360m -parallel 4
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== CONT  TestAccNatDnat_basic
--- PASS: TestAccNatDnat_basic (216.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       216.534s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEPService_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEPService_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (199.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       199.831s
```

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccVPCEndpoint_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccVPCEndpoint_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Basic
=== PAUSE TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Basic
--- PASS: TestAccVPCEndpoint_Basic (210.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       210.540s
```
