### PR TITLE
support enterprise_project_id in ces alarm rule

### DIFF
--- a/docs/data-sources/enterprise_project.md
+++ b/docs/data-sources/enterprise_project.md
@@ -32,6 +32,7 @@ DCS | huaweicloud_dcs_instance |
 NAT | huaweicloud_nat_gateway | huaweicloud_nat_snat_rule<br>huaweicloud_nat_dnat_rule
 CDM | huaweicloud_cdm_cluster |
 CDN | huaweicloud_cdn_domain |
+CES | huaweicloud_ces_alarmrule |
 GaussDB | huaweicloud_gaussdb_cassandra_instance<br>huaweicloud_gaussdb_mysql_instance<br>huaweicloud_gaussdb_opengauss_instance |
 
 ## Argument Reference

--- a/docs/resources/ces_alarmrule.md
+++ b/docs/resources/ces_alarmrule.md
@@ -70,6 +70,9 @@ The following arguments are supported:
 * `alarm_action_enabled` - (Optional, Bool) Specifies whether to enable the action
     to be triggered by an alarm. The default value is true.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the alarm rule.
+  Changing this creates a new resource.
+
 -> **Note** If alarm_action_enabled is set to true, either alarm_actions or
     ok_actions cannot be empty. If alarm_actions and ok_actions coexist, their
     corresponding notification_list must be of the **same value**.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0
+	github.com/huaweicloud/golangsdk v0.0.0-20210518015043-4abbff8edf44
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0 h1:ap/m0dp+LvmAHQsQmSwYU0yOKxYz2b7iYpbgtUnXO0Y=
-github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210518015043-4abbff8edf44 h1:zaFprOpu3ZXBWJ2OLs4SvVJp4u/RMPImhz1131Hdck0=
+github.com/huaweicloud/golangsdk v0.0.0-20210518015043-4abbff8edf44/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/resource_huaweicloud_ces_alarmrule.go
@@ -184,6 +184,13 @@ func resourceAlarmRule() *schema.Resource {
 				Default:  true,
 			},
 
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
 			"alarm_state": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -305,6 +312,7 @@ func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 		InsufficientdataActions: getAlarmAction(d, "insufficientdata_actions"),
 		AlarmEnabled:            d.Get("alarm_enabled").(bool),
 		AlarmActionEnabled:      d.Get("alarm_action_enabled").(bool),
+		EnterpriseProjectID:     GetEnterpriseProjectID(d, config),
 	}
 	log.Printf("[DEBUG] Create %s Options: %#v", nameCESAR, createOpts)
 
@@ -354,6 +362,7 @@ func resourceAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("alarm_action_enabled", m["alarm_action_enabled"]),
 		d.Set("alarm_state", m["alarm_state"]),
 		d.Set("update_time", m["update_time"]),
+		d.Set("enterprise_project_id", m["enterprise_project_id"]),
 	)
 	if mErr.ErrorOrNil() != nil {
 		return mErr

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
@@ -48,6 +48,7 @@ type CreateOpts struct {
 	OkActions               []ActionOpts  `json:"ok_actions,omitempty"`
 	AlarmEnabled            bool          `json:"alarm_enabled"`
 	AlarmActionEnabled      bool          `json:"alarm_action_enabled"`
+	EnterpriseProjectID     string        `json:"enterprise_project_id,omitempty"`
 }
 
 func (opts CreateOpts) ToAlarmRuleCreateMap() (map[string]interface{}, error) {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/results.go
@@ -58,6 +58,7 @@ type AlarmRule struct {
 	AlarmActionEnabled      bool          `json:"alarm_action_enabled"`
 	UpdateTime              int64         `json:"update_time"`
 	AlarmState              string        `json:"alarm_state"`
+	EnterpriseProjectID     string        `json:"enterprise_project_id"`
 }
 
 type GetResult struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/requests.go
@@ -8,19 +8,20 @@ import (
 )
 
 type CreateOpts struct {
-	Name             string         `json:"name"  required:"true"`
-	DataStore        DataStore      `json:"datastore" required:"true"`
-	Region           string         `json:"region" required:"true"`
-	AvailabilityZone string         `json:"availability_zone" required:"true"`
-	VpcId            string         `json:"vpc_id" required:"true"`
-	SubnetId         string         `json:"subnet_id" required:"true"`
-	SecurityGroupId  string         `json:"security_group_id" required:"true"`
-	Password         string         `json:"password" required:"true"`
-	DiskEncryptionId string         `json:"disk_encryption_id,omitempty"`
-	Ssl              string         `json:"ssl_option,omitempty"`
-	Mode             string         `json:"mode" required:"true"`
-	Flavor           []Flavor       `json:"flavor" required:"true"`
-	BackupStrategy   BackupStrategy `json:"backup_strategy,omitempty"`
+	Name                string         `json:"name"  required:"true"`
+	DataStore           DataStore      `json:"datastore" required:"true"`
+	Region              string         `json:"region" required:"true"`
+	AvailabilityZone    string         `json:"availability_zone" required:"true"`
+	VpcId               string         `json:"vpc_id" required:"true"`
+	SubnetId            string         `json:"subnet_id" required:"true"`
+	SecurityGroupId     string         `json:"security_group_id" required:"true"`
+	Password            string         `json:"password" required:"true"`
+	DiskEncryptionId    string         `json:"disk_encryption_id,omitempty"`
+	Ssl                 string         `json:"ssl_option,omitempty"`
+	Mode                string         `json:"mode" required:"true"`
+	Flavor              []Flavor       `json:"flavor" required:"true"`
+	BackupStrategy      BackupStrategy `json:"backup_strategy,omitempty"`
+	EnterpriseProjectID string         `json:"enterprise_project_id,omitempty"`
 }
 
 type DataStore struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/results.go
@@ -14,20 +14,21 @@ type CreateResult struct {
 }
 
 type Instance struct {
-	Id               string            `json:"id"`
-	Name             string            `json:"name"`
-	DataStore        DataStore         `json:"datastore"`
-	Status           string            `json:"status"`
-	Region           string            `json:"region"`
-	AvailabilityZone string            `json:"availability_zone"`
-	VpcId            string            `json:"vpc_id"`
-	SubnetId         string            `json:"subnet_id"`
-	SecurityGroupId  string            `json:"security_group_id"`
-	DiskEncryptionId string            `json:"disk_encryption_id"`
-	Ssl              string            `json:"ssl_option"`
-	Mode             string            `json:"mode"`
-	Flavor           []FlavorOpt       `json:"flavor"`
-	BackupStrategy   BackupStrategyOpt `json:"backup_strategy"`
+	Id                  string            `json:"id"`
+	Name                string            `json:"name"`
+	DataStore           DataStore         `json:"datastore"`
+	Status              string            `json:"status"`
+	Region              string            `json:"region"`
+	AvailabilityZone    string            `json:"availability_zone"`
+	VpcId               string            `json:"vpc_id"`
+	SubnetId            string            `json:"subnet_id"`
+	SecurityGroupId     string            `json:"security_group_id"`
+	DiskEncryptionId    string            `json:"disk_encryption_id"`
+	Ssl                 string            `json:"ssl_option"`
+	Mode                string            `json:"mode"`
+	Flavor              []FlavorOpt       `json:"flavor"`
+	BackupStrategy      BackupStrategyOpt `json:"backup_strategy"`
+	EnterpriseProjectID string            `json:"enterprise_project_id"`
 }
 
 type FlavorOpt struct {
@@ -77,27 +78,28 @@ type ListInstanceResponse struct {
 }
 
 type InstanceResponse struct {
-	Id                string         `json:"id"`
-	Name              string         `json:"name"`
-	Status            string         `json:"status"`
-	Port              string         `json:"port"`
-	Mode              string         `json:"mode"`
-	Region            string         `json:"region"`
-	DataStore         DataStore      `json:"datastore"`
-	Engine            string         `json:"engine"`
-	Created           string         `json:"created"`
-	Updated           string         `json:"updated"`
-	DbUserName        string         `json:"db_user_name"`
-	Ssl               int            `json:"ssl"`
-	VpcId             string         `json:"vpc_id"`
-	SubnetId          string         `json:"subnet_id"`
-	SecurityGroupId   string         `json:"security_group_id"`
-	BackupStrategy    BackupStrategy `json:"backup_strategy"`
-	MaintenanceWindow string         `json:"maintenance_window"`
-	Groups            []Group        `json:"groups"`
-	DiskEncryptionId  string         `json:"disk_encryption_id"`
-	TimeZone          string         `json:"time_zone"`
-	Actions           []string       `json:"actions"`
+	Id                  string         `json:"id"`
+	Name                string         `json:"name"`
+	Status              string         `json:"status"`
+	Port                string         `json:"port"`
+	Mode                string         `json:"mode"`
+	Region              string         `json:"region"`
+	DataStore           DataStore      `json:"datastore"`
+	Engine              string         `json:"engine"`
+	Created             string         `json:"created"`
+	Updated             string         `json:"updated"`
+	DbUserName          string         `json:"db_user_name"`
+	Ssl                 int            `json:"ssl"`
+	VpcId               string         `json:"vpc_id"`
+	SubnetId            string         `json:"subnet_id"`
+	SecurityGroupId     string         `json:"security_group_id"`
+	BackupStrategy      BackupStrategy `json:"backup_strategy"`
+	MaintenanceWindow   string         `json:"maintenance_window"`
+	Groups              []Group        `json:"groups"`
+	DiskEncryptionId    string         `json:"disk_encryption_id"`
+	TimeZone            string         `json:"time_zone"`
+	Actions             []string       `json:"actions"`
+	EnterpriseProjectID string         `json:"enterprise_project_id"`
 }
 
 type Group struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210517025840-92b32656bde0
+# github.com/huaweicloud/golangsdk v0.0.0-20210518015043-4abbff8edf44
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support enterprise_project_id in ces alarm rule

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
related #1099 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCESAlarmRule_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCESAlarmRule_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_withEpsId
=== PAUSE TestAccCESAlarmRule_withEpsId
=== CONT  TestAccCESAlarmRule_withEpsId
--- PASS: TestAccCESAlarmRule_withEpsId (181.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       182.016s
```
