### PR TITLE
Remove SFS turbo size validation

### DIFF
--- a/huaweicloud/resource_huaweicloud_sfs_turbo.go
+++ b/huaweicloud/resource_huaweicloud_sfs_turbo.go
@@ -43,9 +43,8 @@ func ResourceSFSTurbo() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(4, 64),
 			},
 			"size": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ValidateFunc: validation.IntAtLeast(500),
+				Type:     schema.TypeInt,
+				Required: true,
 			},
 			"share_proto": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
This removes the validation for SFS turbo size, as for
some customers, it can be less than 500.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSFSTurbo_basic
=== PAUSE TestAccSFSTurbo_basic
=== CONT  TestAccSFSTurbo_basic
--- PASS: TestAccSFSTurbo_basic (848.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       848.026s
```
