### PR TITLE
Make list instead of set for ids of vpc data source

### DIFF
--- a/docs/data-sources/vpc_subnet_ids.md
+++ b/docs/data-sources/vpc_subnet_ids.md
@@ -20,7 +20,7 @@ data "huaweicloud_vpc_subnet_ids" "subnet_ids" {
 
 data "huaweicloud_vpc_subnet" "subnet" {
   count = length(data.huaweicloud_vpc_subnet_ids.subnet_ids.ids)
-  id    = tolist(data.huaweicloud_vpc_subnet_ids.subnet_ids.ids)[count.index]
+  id    = data.huaweicloud_vpc_subnet_ids.subnet_ids.ids[count.index]
 }
 
 output "subnet_cidr_blocks" {

--- a/huaweicloud/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_ids.go
@@ -19,10 +19,9 @@ func dataSourceVirtualPrivateCloudVpcIdsV1() *schema.Resource {
 				Computed: true,
 			},
 			"ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}

--- a/huaweicloud/data_source_huaweicloud_vpc_route_ids.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_route_ids.go
@@ -23,10 +23,9 @@ func dataSourceVPCRouteIdsV2() *schema.Resource {
 				Required: true,
 			},
 			"ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}

--- a/huaweicloud/data_source_huaweicloud_vpc_subnet_ids.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_subnet_ids.go
@@ -23,10 +23,9 @@ func DataSourceVpcSubnetIdsV1() *schema.Resource {
 				Required: true,
 			},
 			"ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1141 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccVpcIdsV1DataSource'
...
=== RUN   TestAccVpcIdsV1DataSource_basic
=== PAUSE TestAccVpcIdsV1DataSource_basic
=== CONT  TestAccVpcIdsV1DataSource_basic
--- PASS: TestAccVpcIdsV1DataSource_basic (109.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       109.618s

make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccVpcRouteIdsV2DataSource'
...
=== RUN   TestAccVpcRouteIdsV2DataSource_basic
=== PAUSE TestAccVpcRouteIdsV2DataSource_basic
=== CONT  TestAccVpcRouteIdsV2DataSource_basic
--- PASS: TestAccVpcRouteIdsV2DataSource_basic (218.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       218.235s

make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccVpcSubnetIdsV2DataSource'
...
=== RUN   TestAccVpcSubnetIdsV2DataSource_basic
=== PAUSE TestAccVpcSubnetIdsV2DataSource_basic
=== CONT  TestAccVpcSubnetIdsV2DataSource_basic
--- PASS: TestAccVpcSubnetIdsV2DataSource_basic (201.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       201.573s

```
