### PR TITLE
New AutoScaling lifecycle hook resource supported

### DIFF
--- a/docs/resources/as_lifecycle_hook.md
+++ b/docs/resources/as_lifecycle_hook.md
@@ -4,7 +4,7 @@ subcategory: "Auto Scaling"
 
 # huaweicloud\_as\_lifecycle\_hook
 
-Manages a AS Lifecycle Hook resource within HuaweiCloud.
+Manages an AS Lifecycle Hook resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required, String) Specifies the lifecycle hook name.
   This parameter can contain a maximum of 32 characters, which may consist of letters, digits,
-  underscores(_) and hyphens (-).
+  underscores (_) and hyphens (-).
 
 * `type` - (Required, String) Specifies the lifecycle hook type.
   The valid values are following strings:
@@ -46,14 +46,15 @@ The following arguments are supported:
 
 * `notification_topic_urn` - (Required, String) Specifies a unique topic in SMN.
 
-* `scaling_group_id` - (Required, String, ForceNew) Specifies the AS group ID.
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the ID of the AS group in UUID format.
   Changing this creates a new AS lifecycle hook.
 
 * `default_result` - (Optional, String) Specifies the default lifecycle hook callback operation.
-  This operation is performed when the timeout duration expires. The valid values are *ABANDON* and *CONTINUE*.
+  This operation is performed when the timeout duration expires.
+  The valid values are *ABANDON* and *CONTINUE*, default to *ABANDON*.
 
 * `timeout` - (Optional, Int) Specifies the lifecycle hook timeout duration, which ranges from 300 to 86400 in the
-  unit of second. The default value is 3600.
+  unit of second, default to 3600.
 
 * `notification_message` - (Optional, String) Specifies a customized notification.
   This parameter can contains a maximum of 256 characters, which cannot contain the following characters: <>&'().
@@ -66,11 +67,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `notification_topic_name` - The topic name in SMN.
 
-* `create_time` - The time when the lifecycle hook is created.
+* `create_time` - The server time in UTC format when the lifecycle hook is created.
 
 ## Import
 
-Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.:
+Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.
 
 ```
 $ terraform import huaweicloud_as_lifecycle_hook.test <AS group ID>/<Lifecycle hook ID>

--- a/docs/resources/as_lifecycle_hook.md
+++ b/docs/resources/as_lifecycle_hook.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# huaweicloud\_as\_lifecycle\_hook
+
+Manages a AS Lifecycle Hook resource within HuaweiCloud.
+
+## Example Usage
+
+### Basic Lifecycle Hook
+
+```hcl
+variable "hook_name" {}
+
+variable "as_group_id" {}
+
+variable "smn_topic_urn" {}
+
+resource "huaweicloud_as_lifecycle_hook" "test" {
+  name                   = var.hook_name
+  type                   = "ADD"
+  group_id               = var.as_group_id
+  default_result         = "ABANDON"
+  notification_topic_urn = var.smn_topic_urn
+  notification_message   = "This is a test message"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the AS lifecycle hook.
+  If omitted, the `region` argument of the provider is used.
+  Changing this creates a new AS lifecycle hook.
+
+* `name` - (Required, String) Specifies the lifecycle hook name.
+  This parameter can contain a maximum of 32 characters, which may consist of letters, digits,
+  underscores(_) and hyphens (-).
+
+* `type` - (Required, String) Specifies the lifecycle hook type.
+  The valid values are following strings:
+  * `ADD`: The hook suspends the instance when the instance is started.
+  * `REMOVE`: The hook suspends the instance when the instance is terminated.
+
+* `notification_topic_urn` - (Required, String) Specifies a unique topic in SMN.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the AS group ID.
+  Changing this creates a new AS lifecycle hook.
+
+* `default_result` - (Optional, String) Specifies the default lifecycle hook callback operation.
+  This operation is performed when the timeout duration expires. The valid values are *ABANDON* and *CONTINUE*.
+
+* `timeout` - (Optional, Int) Specifies the lifecycle hook timeout duration, which ranges from 300 to 86400 in the
+  unit of second. The default value is 3600.
+
+* `notification_message` - (Optional, String) Specifies a customized notification.
+  This parameter can contains a maximum of 256 characters, which cannot contain the following characters: <>&'().
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `notification_topic_name` - The topic name in SMN.
+
+* `create_time` - The time when the lifecycle hook is created.
+
+## Import
+
+Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.:
+
+```
+$ terraform import huaweicloud_as_lifecycle_hook.test <AS group ID>/<Lifecycle hook ID>
+```
+

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -362,6 +362,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_api_gateway_group":               resourceAPIGatewayGroup(),
 			"huaweicloud_as_configuration":                ResourceASConfiguration(),
 			"huaweicloud_as_group":                        ResourceASGroup(),
+			"huaweicloud_as_lifecycle_hook":               ResourceASLifecycleHook(),
 			"huaweicloud_as_policy":                       ResourceASPolicy(),
 			"huaweicloud_bms_instance":                    ResourceBmsInstance(),
 			"huaweicloud_bcs_instance":                    resourceBCSInstanceV2(),

--- a/huaweicloud/resource_huaweicloud_as_lifecycle_hook.go
+++ b/huaweicloud/resource_huaweicloud_as_lifecycle_hook.go
@@ -1,0 +1,236 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+var hookTypeMap = map[string]string{
+	"ADD":    "INSTANCE_LAUNCHING",
+	"REMOVE": "INSTANCE_TERMINATING",
+}
+
+func ResourceASLifecycleHook() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceASLifecycleHookCreate,
+		Read:   resourceASLifecycleHookRead,
+		Update: resourceASLifecycleHookUpdate,
+		Delete: resourceASLifecycleHookDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceASLifecycleHookImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ADD", "REMOVE",
+				}, false),
+			},
+			"notification_topic_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scaling_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"default_result": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ABANDON", "CONTINUE",
+				}, false),
+			},
+			"timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(300, 86400),
+			},
+			"notification_message": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^()<>&']{1,256}$"),
+					"The 'notification_message' of the lifecycle hook has special character"),
+			},
+			"notification_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceASLifecycleHookCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
+	}
+	groupId := d.Get("scaling_group_id").(string)
+	createOpts := lifecyclehooks.CreateOpts{
+		Name:                 d.Get("name").(string),
+		DefaultResult:        d.Get("default_result").(string),
+		Timeout:              d.Get("timeout").(int),
+		NotificationTopicURN: d.Get("notification_topic_urn").(string),
+		NotificationMetadata: d.Get("notification_message").(string),
+	}
+	hookType := d.Get("type").(string)
+	v, ok := hookTypeMap[hookType]
+	if !ok {
+		return fmt.Errorf("Lifecycle hook type (%s) is not in the map (%#v)", hookType, hookTypeMap)
+	}
+	createOpts.Type = v
+	hook, err := lifecyclehooks.Create(client, createOpts, groupId).Extract()
+	if err != nil {
+		return fmt.Errorf("Error craeting lifecycle hook: %s", err)
+	}
+	d.SetId(hook.Name)
+
+	return resourceASLifecycleHookRead(d, meta)
+}
+
+func resourceASLifecycleHookRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	region := GetRegion(d, config)
+	client, err := config.AutoscalingV1Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
+	}
+	groupId := d.Get("scaling_group_id").(string)
+	hook, err := lifecyclehooks.Get(client, groupId, d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error getting the specifies lifecycle hook of the Auto Scaling service: %s", err)
+	}
+	d.Set("region", region)
+	if err = setASLifecycleHookToState(d, hook); err != nil {
+		return fmt.Errorf("Error setting lifecycle hook to state: %s", err)
+	}
+	return nil
+}
+
+func resourceASLifecycleHookUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
+	}
+	//lintignore:R019
+	if d.HasChanges("type", "default_result", "timeout", "notification_topic_urn", "notification_message") {
+		updateOpts := lifecyclehooks.UpdateOpts{
+			DefaultResult:        d.Get("default_result").(string),
+			Timeout:              d.Get("timeout").(int),
+			NotificationTopicURN: d.Get("notification_topic_urn").(string),
+			NotificationMetadata: d.Get("notification_message").(string),
+		}
+		hookType := d.Get("type").(string)
+		v, ok := hookTypeMap[hookType]
+		if !ok {
+			return fmt.Errorf("The type (%s) of hook is not in the map (%#v)", hookType, hookTypeMap)
+		}
+		updateOpts.Type = v
+		_, err := lifecyclehooks.Update(client, updateOpts, d.Get("scaling_group_id").(string), d.Id()).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating the lifecycle hook of the AutoScaling service: %s", err)
+		}
+	}
+
+	return resourceASLifecycleHookRead(d, meta)
+}
+
+func resourceASLifecycleHookDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
+	}
+	err = lifecyclehooks.Delete(client, d.Get("scaling_group_id").(string), d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting the lifecycle hook of the AutoScaling service: %s", err)
+	}
+
+	return nil
+}
+
+func setASLifecycleHookToState(d *schema.ResourceData, hook *lifecyclehooks.Hook) error {
+	mErr := multierror.Append(
+		// required && optional parameters
+		d.Set("name", hook.Name),
+		d.Set("default_result", hook.DefaultResult),
+		d.Set("timeout", hook.Timeout),
+		d.Set("notification_topic_urn", hook.NotificationTopicURN),
+		d.Set("notification_message", hook.NotificationMetadata),
+		setASLifecycleHookType(d, hook),
+		// computed parameters
+		d.Set("notification_topic_name", hook.NotificationTopicName),
+		d.Set("create_time", hook.CreateTime),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setASLifecycleHookType(d *schema.ResourceData, hook *lifecyclehooks.Hook) error {
+	for k, v := range hookTypeMap {
+		if v == hook.Type {
+			err := d.Set("type", k)
+			return err
+		}
+	}
+	return fmt.Errorf("The type of hook response is not in the map")
+}
+
+func resourceASLifecycleHookImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmt.Errorf("Invalid format specified for lifecycle hook, must be <scaling_group_id>/<hook_id>")
+		return nil, err
+	}
+
+	config := meta.(*config.Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return nil, fmt.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
+	}
+
+	groupId := parts[0]
+	ID := parts[1]
+	hook, err := lifecyclehooks.Get(client, groupId, ID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting the specifies lifecycle hook of the Auto Scaling service: %s", err)
+	}
+	d.SetId(ID)
+	d.Set("scaling_group_id", groupId)
+	if err = setASLifecycleHookToState(d, hook); err != nil {
+		return nil, fmt.Errorf("Error setting lifecycle hook: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/resource_huaweicloud_as_lifecycle_hook_test.go
+++ b/huaweicloud/resource_huaweicloud_as_lifecycle_hook_test.go
@@ -1,0 +1,262 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccASLifecycleHook_basic(t *testing.T) {
+	var hook lifecyclehooks.Hook
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceGroupName := "huaweicloud_as_group.test"
+	resourceHookName := "huaweicloud_as_lifecycle_hook.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASLifecycleHookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testASLifecycleHook_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASLifecycleHookExists(resourceGroupName, resourceHookName, &hook),
+					resource.TestCheckResourceAttr(resourceHookName, "name", rName),
+					resource.TestCheckResourceAttr(resourceHookName, "type", "ADD"),
+					resource.TestCheckResourceAttr(resourceHookName, "default_result", "ABANDON"),
+					resource.TestCheckResourceAttr(resourceHookName, "timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a test message"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_topic_urn",
+						fmt.Sprintf("urn:smn:%s:%s:default", HW_REGION_NAME, HW_PROJECT_ID)),
+				),
+			},
+			{
+				Config: testASLifecycleHook_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASLifecycleHookExists(resourceGroupName, resourceHookName, &hook),
+					resource.TestCheckResourceAttr(resourceHookName, "name", rName),
+					resource.TestCheckResourceAttr(resourceHookName, "type", "REMOVE"),
+					resource.TestCheckResourceAttr(resourceHookName, "default_result", "CONTINUE"),
+					resource.TestCheckResourceAttr(resourceHookName, "timeout", "600"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_message",
+						"This is a update message"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_topic_urn",
+						fmt.Sprintf("urn:smn:%s:%s:update", HW_REGION_NAME, HW_PROJECT_ID)),
+				),
+			},
+			{
+				ResourceName:      resourceHookName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccASLifecycleHookImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccCheckASLifecycleHookDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating huaweicloud autoscaling client: %s", err)
+	}
+
+	var groupID string
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "huaweicloud_as_group" {
+			groupID = rs.Primary.ID
+			continue
+		}
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_as_lifecycle_hook" {
+			continue
+		}
+
+		_, err := lifecyclehooks.Get(asClient, groupID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("AS lifecycle hook still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckASLifecycleHookExists(resGroup, resHook string, hook *lifecyclehooks.Hook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resGroup]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resGroup)
+		}
+		groupID := rs.Primary.ID
+
+		rs, ok = s.RootModule().Resources[resHook]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resHook)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating huaweicloud autoscaling client: %s", err)
+		}
+		found, err := lifecyclehooks.Get(asClient, groupID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		hook = found
+
+		return nil
+	}
+}
+
+func testAccASLifecycleHookImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		group, ok := s.RootModule().Resources["huaweicloud_as_group.test"]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling group not found: %s", group)
+		}
+		hook, ok := s.RootModule().Resources["huaweicloud_as_lifecycle_hook.test"]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling lifecycle hook not found: %s", hook)
+		}
+		if group.Primary.ID == "" || hook.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", group.Primary.ID, hook.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", group.Primary.ID, hook.Primary.ID), nil
+	}
+}
+
+func testASLifecycleHook_base(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%s"
+}
+
+resource "huaweicloud_compute_keypair" "test" {
+  name = "%s"
+
+  lifecycle {
+    ignore_changes = [
+      public_key,
+    ]
+  }
+}
+
+resource "huaweicloud_lb_loadbalancer" "test" {
+  name          = "%s"
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+}
+
+resource "huaweicloud_lb_listener" "test" {
+  name            = "%s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_lb_loadbalancer.test.id
+}
+
+resource "huaweicloud_lb_pool" "test" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = huaweicloud_lb_listener.test.id
+}
+
+resource "huaweicloud_as_configuration" "test"{
+  scaling_configuration_name = "%s"
+
+  instance_config {
+    image    = data.huaweicloud_images_image.test.id
+    flavor   = data.huaweicloud_compute_flavors.test.ids[0]
+    key_name = huaweicloud_compute_keypair.test.id
+
+    disk {
+      size        = 40
+      volume_type = "SATA"
+      disk_type   = "SYS"
+    }
+  }
+}
+
+resource "huaweicloud_as_group" "test"{
+  scaling_group_name       = "%s"
+  scaling_configuration_id = huaweicloud_as_configuration.test.id
+  vpc_id                   = data.huaweicloud_vpc.test.id
+
+  networks {
+    id = data.huaweicloud_vpc_subnet.test.id
+  }
+  security_groups {
+    id = huaweicloud_networking_secgroup.test.id
+  }
+  lbaas_listeners {
+    pool_id       = huaweicloud_lb_pool.test.id
+    protocol_port = huaweicloud_lb_listener.test.protocol_port
+  }
+}
+`, rName, rName, rName, rName, rName, rName, rName)
+}
+
+// Please make sure the smn topic is exist in specifies region and project.
+func testASLifecycleHook_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_as_lifecycle_hook" "test" {
+  name                   = "%s"
+  type                   = "ADD"
+  scaling_group_id       = huaweicloud_as_group.test.id
+  default_result         = "ABANDON"
+  notification_topic_urn = "%s"
+  notification_message   = "This is a test message"
+}	  
+`, testASLifecycleHook_base(rName), rName, fmt.Sprintf("urn:smn:%s:%s:default", HW_REGION_NAME, HW_PROJECT_ID))
+}
+
+// Please make sure the smn topic is exist in specifies region and project.
+func testASLifecycleHook_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_as_lifecycle_hook" "test" {
+  name                   = "%s"
+  type                   = "REMOVE"
+  scaling_group_id       = huaweicloud_as_group.test.id
+  default_result         = "CONTINUE"
+  notification_topic_urn = "%s"
+  notification_message   = "This is a update message"
+  timeout                = 600
+}	  
+`, testASLifecycleHook_base(rName), rName, fmt.Sprintf("urn:smn:%s:%s:update", HW_REGION_NAME, HW_PROJECT_ID))
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/requests.go
@@ -1,0 +1,108 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+// CreateOpts is a struct which will be used to create a lifecycle hook.
+type CreateOpts struct {
+	// The lifecycle hook name.
+	// The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 32 characters.
+	Name string `json:"lifecycle_hook_name" required:"true"`
+	// The lifecycle hook type.
+	// INSTANCE_TERMINATING: The hook suspends the instance when the instance is terminated.
+	// INSTANCE_LAUNCHING: The hook suspends the instance when the instance is started.
+	Type string `json:"lifecycle_hook_type" required:"true"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	// By default, this operation is performed when the timeout duration expires.
+	DefaultResult string `json:"default_result,omitempty"`
+	// The lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit of second.
+	// The default value is 3600.
+	Timeout int `json:"default_timeout,omitempty"`
+	// The unique topic in SMN.
+	// This parameter specifies a notification object for a lifecycle hook.
+	NotificationTopicURN string `json:"notification_topic_urn" required:"true"`
+	// The customized notification, which contains no more than 256 characters in length.
+	// The message cannot contain the following characters: <>&'().
+	NotificationMetadata string `json:"notification_metadata,omitempty"`
+}
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters.
+type CreateOptsBuilder interface {
+	ToLifecycleHookCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToLifecycleHookCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method which can be able to access to create the hook of autoscaling service.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, groupID string) (r CreateResult) {
+	b, err := opts.ToLifecycleHookCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(rootURL(client, groupID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtains the hook detail of autoscaling service.
+func Get(client *golangsdk.ServiceClient, groupID, hookName string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, groupID, hookName), &r.Body, nil)
+	return
+}
+
+// List is a method to obtains a hook array of the autoscaling service.
+func List(client *golangsdk.ServiceClient, groupID string) (r ListResult) {
+	_, r.Err = client.Get(listURL(client, groupID), &r.Body, nil)
+	return
+}
+
+// UpdateOpts is a struct which will be used to update the existing hook.
+type UpdateOpts struct {
+	// The lifecycle hook type
+	Type string `json:"lifecycle_hook_type,omitempty"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	// By default, this operation is performed when the timeout duration expires.
+	DefaultResult string `json:"default_result,omitempty"`
+	// The lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit of second.
+	// The default value is 3600.
+	Timeout int `json:"default_timeout,omitempty"`
+	// The unique topic in SMN.
+	// This parameter specifies a notification object for a lifecycle hook.
+	NotificationTopicURN string `json:"notification_topic_urn,omitempty"`
+	// The customized notification, which contains no more than 256 characters in length.
+	// The message cannot contain the following characters: <>&'().
+	NotificationMetadata string `json:"notification_metadata,omitempty"`
+}
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters
+type UpdateOptsBuilder interface {
+	ToLifecycleHookUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToLifecycleHookUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method which can be able to access to udpate the existing hook of the autoscaling service.
+func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder, groupID, hookName string) (r UpdateResult) {
+	b, err := opts.ToLifecycleHookUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(resourceURL(client, groupID, hookName), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+//Delete is a method which can be able to access to delete the existing hook of the autoscaling service.
+func Delete(client *golangsdk.ServiceClient, groupID, hookName string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, groupID, hookName), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/results.go
@@ -1,0 +1,64 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+// Hook is a struct that represents the result of API calling.
+type Hook struct {
+	// The lifecycle hook name.
+	Name string `json:"lifecycle_hook_name"`
+	// The lifecycle hook type: INSTANCE_TERMINATING and INSTANCE_LAUNCHING.
+	Type string `json:"lifecycle_hook_type"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	DefaultResult string `json:"default_result"`
+	// The lifecycle hook timeout duration in the unit of second.
+	Timeout int `json:"default_timeout"`
+	// The unique topic in SMN.
+	NotificationTopicURN string `json:"notification_topic_urn"`
+	// The topic name in SMN.
+	NotificationTopicName string `json:"notification_topic_name"`
+	// The notification message.
+	NotificationMetadata string `json:"notification_metadata"`
+	// The UTC-compliant time when the lifecycle hook is created.
+	CreateTime string `json:"create_time"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract will deserialize the result to Hook object.
+func (r commonResult) Extract() (*Hook, error) {
+	var s Hook
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type ListResult struct {
+	commonResult
+}
+
+// Extract will deserialize the result to Hook array.
+func (r ListResult) Extract() (*[]Hook, error) {
+	var s struct {
+		// An array of lifecycle hooks.
+		Hooks []Hook `json:"lifecycle_hooks"`
+	}
+	err := r.Result.ExtractInto(&s)
+	return &s.Hooks, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/urls.go
@@ -1,0 +1,17 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "scaling_lifecycle_hook"
+
+func rootURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(rootPath, groupID)
+}
+
+func resourceURL(client *golangsdk.ServiceClient, groupID, hookName string) string {
+	return client.ServiceURL(rootPath, groupID, hookName)
+}
+
+func listURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(rootPath, groupID, "list")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -279,6 +279,7 @@ github.com/huaweicloud/golangsdk/openstack/apigw/groups
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/instances
+github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/policies
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/tags
 github.com/huaweicloud/golangsdk/openstack/bcs/v2/blockchains


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the description of Issue #1069 , HuaweiCloud should support lifecycle hook resource of autoscaling service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1069 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new lifecycle hook resource supported.
2. add lifecycle hook test and document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccASLifecycleHook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccASLifecycleHook_basic -timeout 360m -parallel 4
=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (123.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       123.533s
```
