### PR TITLE
Make version of opengauss optional

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -98,9 +98,10 @@ The following arguments are supported:
 
 The `datastore` block supports:
 
-* `engine` - (Required, String, ForceNew) Specifies the database engine. Only "GaussDB(openGauss)" is supported now.
+* `engine` - (Required, String, ForceNew) Specifies the database engine. Only "GaussDB(for openGauss)" is supported now.
 
-* `version` - (Required, String, ForceNew) Specifies the database version. Defaults to "1.1". Please reference to the API docs for valid options.
+* `version` - (Optional, String, ForceNew) Specifies the database version. Defaults to the latest version.
+  Please reference to the API docs for valid options.
 
 
 The `volume` block supports:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422
+	github.com/huaweicloud/golangsdk v0.0.0-20210521082833-cb99c7a078d6
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422 h1:2F7ArSZyEoxSf3xswUW8RAso5oaFSHuC3UXTmAM8fBU=
-github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210521082833-cb99c7a078d6 h1:ehrgK4GHKxXTn2aiaCQjTTfB4uPcTlSkPLHnhWg0pBA=
+github.com/huaweicloud/golangsdk v0.0.0-20210521082833-cb99c7a078d6/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -125,13 +125,11 @@ func resourceOpenGaussInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"GaussDB(openGauss)",
-							}, true),
 						},
 						"version": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},
@@ -285,8 +283,7 @@ func resourceOpenGaussDataStore(d *schema.ResourceData) instances.DataStoreOpt {
 		db.Type = datastore["engine"].(string)
 		db.Version = datastore["version"].(string)
 	} else {
-		db.Type = "GaussDB(openGauss)"
-		db.Version = "1.1"
+		db.Type = "GaussDB(for openGauss)"
 	}
 	return db
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances/requests.go
@@ -7,7 +7,7 @@ import (
 
 type DataStoreOpt struct {
 	Type    string `json:"type" required:"true"`
-	Version string `json:"version" required:"true"`
+	Version string `json:"version,omitempty"`
 }
 
 type BackupStrategyOpt struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422
+# github.com/huaweicloud/golangsdk v0.0.0-20210521082833-cb99c7a078d6
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
This makes the version parameter of datastore for opengauss
optional, defaults to the latest version.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
