### PR TITLE
iec: set the default DNS list if it was not specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422
+	github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422 h1:2F7ArSZyEoxSf3xswUW8RAso5oaFSHuC3UXTmAM8fBU=
 github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245 h1:veXYmucbA5VN9sIGBgujbkpT2I/krJm7j6ZR5n9c5jk=
+github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/resource_huaweicloud_iec_vpc_subnet.go
+++ b/huaweicloud/resource_huaweicloud_iec_vpc_subnet.go
@@ -15,6 +15,12 @@ import (
 
 func resourceIecSubnetDNSListV1(d *schema.ResourceData) []string {
 	rawDNSN := d.Get("dns_list").([]interface{})
+
+	// set the default DNS if it was not specified
+	if len(rawDNSN) == 0 {
+		return []string{"114.114.114.114", "8.8.8.8"}
+	}
+
 	dnsn := make([]string, len(rawDNSN))
 	for i, raw := range rawDNSN {
 		dnsn[i] = raw.(string)
@@ -184,7 +190,8 @@ func resourceIecSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.DhcpEnable = &dhcp
 	}
 	if d.HasChange("dns_list") {
-		updateOpts.DNSList = resourceSubnetDNSListV1(d, "")
+		dnsList := resourceSubnetDNSListV1(d, "")
+		updateOpts.DNSList = &dnsList
 	}
 
 	_, err = subnets.Update(subnetClient, d.Id(), updateOpts).Extract()

--- a/huaweicloud/resource_huaweicloud_iec_vpc_subnet_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_vpc_subnet_test.go
@@ -32,6 +32,7 @@ func TestAccIecVPCSubnetV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-subnet", rName)),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.128.0/18"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_ip", "192.168.128.1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_list.#", "2"),
 				),
 			},
 			{

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/subnets/requests.go
@@ -133,7 +133,7 @@ type UpdateOpts struct {
 	// Specifies the DNS server address list of a subnet. This field
 	// is required if you need to use more than two DNS servers. This parameter value is the
 	// superset of both DNS server address 1 and DNS server address 2.
-	DNSList []string `json:"dnsList,omitempty"`
+	DNSList *[]string `json:"dnsList,omitempty"`
 }
 
 type UpdateOptsBuilder interface {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances/requests.go
@@ -7,7 +7,7 @@ import (
 
 type DataStoreOpt struct {
 	Type    string `json:"type" required:"true"`
-	Version string `json:"version" required:"true"`
+	Version string `json:"version,omitempty"`
 }
 
 type BackupStrategyOpt struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422
+# github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

if the `dns_list` was not specified, then we will set the default DNS list to "114.114.114.114, 8.8.8.8"

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecVPCSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecVPCSubnetV1_basic -timeout 360m -parallel 4
=== RUN   TestAccIecVPCSubnetV1_basic
=== PAUSE TestAccIecVPCSubnetV1_basic
=== CONT  TestAccIecVPCSubnetV1_basic
--- PASS: TestAccIecVPCSubnetV1_basic (53.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       53.757s
```
