### PR TITLE
subnets: Allow DNS Nameservers to be cleared

### DIFF
--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `ipv6_enable` (Optional, Bool) - Specifies whether the IPv6 function is enabled for the subnet. Defaults to false.
 
-* `dhcp_enable` (Optional, Bool) - Specifies whether the DHCP function is enabled for the subnet. Defaults to false.
+* `dhcp_enable` (Optional, Bool) - Specifies whether the DHCP function is enabled for the subnet. Defaults to true.
 
 * `primary_dns` (Optional, String) - Specifies the IP address of DNS server 1 on the subnet.
   The value must be a valid IP address.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245
+	github.com/huaweicloud/golangsdk v0.0.0-20210524063831-1e2173276533
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,10 +206,10 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422 h1:2F7ArSZyEoxSf3xswUW8RAso5oaFSHuC3UXTmAM8fBU=
-github.com/huaweicloud/golangsdk v0.0.0-20210521072417-d45cb9bce422/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245 h1:veXYmucbA5VN9sIGBgujbkpT2I/krJm7j6ZR5n9c5jk=
 github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210524063831-1e2173276533 h1:97V3lR3hEIx67aaIXRwMJ25OLT+CgNgxIBZNp5xlQdI=
+github.com/huaweicloud/golangsdk v0.0.0-20210524063831-1e2173276533/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/resource_huaweicloud_vpc_subnet.go
@@ -290,7 +290,8 @@ func resourceVpcSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.SECONDARY_DNS = d.Get("secondary_dns").(string)
 	}
 	if d.HasChange("dns_list") {
-		updateOpts.DnsList = resourceSubnetDNSListV1(d, "")
+		dnsList := resourceSubnetDNSListV1(d, "")
+		updateOpts.DnsList = &dnsList
 	}
 	if d.HasChange("dhcp_enable") {
 		updateOpts.EnableDHCP = d.Get("dhcp_enable").(bool)

--- a/huaweicloud/resource_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/resource_huaweicloud_vpc_subnet_test.go
@@ -32,6 +32,8 @@ func TestAccVpcSubnetV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_ip", "192.168.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "dns_list.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets/requests.go
@@ -196,7 +196,7 @@ type UpdateOpts struct {
 	EnableDHCP    bool           `json:"dhcp_enable"`
 	PRIMARY_DNS   string         `json:"primary_dns,omitempty"`
 	SECONDARY_DNS string         `json:"secondary_dns,omitempty"`
-	DnsList       []string       `json:"dnsList,omitempty"`
+	DnsList       *[]string      `json:"dnsList,omitempty"`
 	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210524034152-8647bdba5245
+# github.com/huaweicloud/golangsdk v0.0.0-20210524063831-1e2173276533
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcSubnetV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_basic (88.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       88.971s
```
