### PR TITLE
Add pvc resource to CCI service

### DIFF
--- a/docs/resources/cci_pvc.md
+++ b/docs/resources/cci_pvc.md
@@ -2,7 +2,7 @@
 subcategory: "Cloud Container Instance (CCI)"
 ---
 
-# huaweicloud\_cci\_pvc
+# huaweicloud_cci_pvc
 
 Manages a CCI Persistent Volume Claim resource within HuaweiCloud.
 
@@ -22,11 +22,10 @@ resource "huaweicloud_cci_pvc" "test" {
   name        = var.pvc_name
   volume_type = "ssd"
   volume_id   = var.volume_id
-  volume_size = 10
 }
 ```
 
-### Import a OBS bucket
+### Import an OBS bucket
 
 ```hcl
 variable "obs_bucket_name" {}
@@ -40,11 +39,10 @@ resource "huaweicloud_cci_pvc" "test" {
   name        = var.pvc_name
   volume_type = "obs"
   volume_id   = var.obs_bucket_name
-  volume_size = 1
 }
 ```
 
-### Import a SFS
+### Import an SFS
 
 ```hcl
 variable "sfs_id" {}
@@ -60,12 +58,11 @@ resource "huaweicloud_cci_pvc" "test" {
   name              = var.pvc_name
   volume_type       = "nfs-rw"
   volume_id         = var.sfs_id
-  volume_size       = 100
   device_mount_path = var.export_location
 }
 ```
 
-### Import a SFS Turbo
+### Import an SFS Turbo
 
 ```hcl
 variable "sfs_turbo_id" {}
@@ -81,7 +78,6 @@ resource "huaweicloud_cci_pvc" "test" {
   name              = var.pvc_name
   volume_type       = "efs-standard"
   volume_id         = var.sfs_turbo_id
-  volume_size       = 500
   device_mount_path = var.export_location
 }
 ```
@@ -102,18 +98,15 @@ The following arguments are supported:
   and must start and end with lowercase letters and digits.
   Changing this will create a new PVC resource.
 
-* `volume_id` - (Required, String, ForceNew) Specifies the ID of the storage.
+* `volume_id` - (Required, String, ForceNew) Specifies the ID of the storage bound to the CCI Namespace.
   Changing this will create a new PVC resource.
 
-* `volume_size` - (Required, Int, ForceNew) Specifies the capacity of the storage.
-  Changing this will create a new PVC resource.
-
-* `volume_type` - (Optional, String, ForceNew) Specifies the type of the storage.
+* `volume_type` - (Optional, String, ForceNew) Specifies the type of the storage bound to the CCI Namespace.
   The valid values are *sas*, *ssd*, *sata*, *obs*, *nfs-rw*, *efs-standard* and *efs-performance*, Defalut to *sas*.
   Changing this will create a new PVC resource.
 
-* `device_mount_path` - (Optional, String, ForceNew) Specifies the share path of the SFS storage.
-  Required if `volume_type` are *nfs-rw*, *efs-standard* and *efs-performance*.
+* `device_mount_path` - (Optional, String, ForceNew) Specifies the share path of the SFS storage bound to the CCI Namespace.
+  Required if `volume_type` is *nfs-rw*, *efs-standard* or *efs-performance*.
   Changing this will create a new PVC resource.
 
 ## Attributes Reference
@@ -138,6 +131,7 @@ $ terraform import huaweicloud_cci_pvc.test <namespace>/<volume_type>/<id>
 ```
 
 ## Timeouts
+
 This resource provides the following timeouts configuration options:
 - `create` - Default is 5 minute.
 - `delete` - Default is 3 minute.

--- a/docs/resources/cci_pvc.md
+++ b/docs/resources/cci_pvc.md
@@ -1,0 +1,143 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+---
+
+# huaweicloud\_cci\_pvc
+
+Manages a CCI Persistent Volume Claim resource within HuaweiCloud.
+
+## Example Usage
+
+### Import an EVS volume
+
+```hcl
+variable "volume_id" {}
+
+variable "namespace" {}
+
+variable "pvc_name" {}
+
+resource "huaweicloud_cci_pvc" "test" {
+  namespace   = var.namespace
+  name        = var.pvc_name
+  volume_type = "ssd"
+  volume_id   = var.volume_id
+  volume_size = 10
+}
+```
+
+### Import a OBS bucket
+
+```hcl
+variable "obs_bucket_name" {}
+
+variable "namespace" {}
+
+variable "pvc_name" {}
+
+resource "huaweicloud_cci_pvc" "test" {
+  namespace   = var.namespace
+  name        = var.pvc_name
+  volume_type = "obs"
+  volume_id   = var.obs_bucket_name
+  volume_size = 1
+}
+```
+
+### Import a SFS
+
+```hcl
+variable "sfs_id" {}
+
+variable "namespace" {}
+
+variable "pvc_name" {}
+
+variable "export_location" {}
+
+resource "huaweicloud_cci_pvc" "test" {
+  namespace         = var.namespace
+  name              = var.pvc_name
+  volume_type       = "nfs-rw"
+  volume_id         = var.sfs_id
+  volume_size       = 100
+  device_mount_path = var.export_location
+}
+```
+
+### Import a SFS Turbo
+
+```hcl
+variable "sfs_turbo_id" {}
+
+variable "namespace" {}
+
+variable "pvc_name" {}
+
+variable "export_location" {}
+
+resource "huaweicloud_cci_pvc" "test" {
+  namespace         = var.namespace
+  name              = var.pvc_name
+  volume_type       = "efs-standard"
+  volume_id         = var.sfs_turbo_id
+  volume_size       = 500
+  device_mount_path = var.export_location
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the PVC resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new PVC resource.
+
+* `namespace` - (Required, String, ForceNew) Specifies the namespace to logically divide your cloud container instances into different group.
+  Changing this will create a new PVC resource.
+
+* `name` - (Required, String, ForceNew) Specifies the unique name of the PVC resource.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and hyphens,
+  and must start and end with lowercase letters and digits.
+  Changing this will create a new PVC resource.
+
+* `volume_id` - (Required, String, ForceNew) Specifies the ID of the storage.
+  Changing this will create a new PVC resource.
+
+* `volume_size` - (Required, Int, ForceNew) Specifies the capacity of the storage.
+  Changing this will create a new PVC resource.
+
+* `volume_type` - (Optional, String, ForceNew) Specifies the type of the storage.
+  The valid values are *sas*, *ssd*, *sata*, *obs*, *nfs-rw*, *efs-standard* and *efs-performance*, Defalut to *sas*.
+  Changing this will create a new PVC resource.
+
+* `device_mount_path` - (Optional, String, ForceNew) Specifies the share path of the SFS storage.
+  Required if `volume_type` are *nfs-rw*, *efs-standard* and *efs-performance*.
+  Changing this will create a new PVC resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The PVC ID in UUID format.
+
+* `access_modes` - The access mode the volume should have.
+
+* `status` - The current phase of the PVC.
+
+* `creation_timestamp` - The server time when PVC was created.
+
+* `enable` - Whether the PVC is available.
+
+## Import
+
+PVCs can be imported using the `namespace`, `volume_type` and `id`, e.g.
+```
+$ terraform import huaweicloud_cci_pvc.test <namespace>/<volume_type>/<id>
+```
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 5 minute.
+- `delete` - Default is 3 minute.

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -590,6 +590,10 @@ func (c *Config) AomV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("aom", region)
 }
 
+func (c *Config) CciV1BetaClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("cciv1_bata", region)
+}
+
 func (c *Config) CciV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("cciv1", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -93,6 +93,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	},
 	"cciv1": {
 		Name:             "cci",
+		Version:          "api/v1",
+		WithOutProjectID: true,
+	},
+	"cciv1_bata": {
+		Name:             "cci",
 		Version:          "apis/networking.cci.io/v1beta1",
 		WithOutProjectID: true,
 	},

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -377,7 +377,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 
 // TestAccServiceEndpoints_Compute test for endpoints of the clients used in ecs
 // include computeV1Client,computeV11Client,computeV2Client,autoscalingV1Client,imageV2Client,
-// cceV3Client,cceAddonV3Client,cciV1Client and FgsV2Client
+// cceV3Client,cceAddonV3Client,cciV1Client,cciV1BetaClient and FgsV2Client
 func TestAccServiceEndpoints_Compute(t *testing.T) {
 
 	testAccPreCheckServiceEndpoints(t)
@@ -465,6 +465,16 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	// test for cciV1Client
 	serviceClient, err = nil, nil
 	serviceClient, err = config.CciV1Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud cci v1 beta1 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://cci.%s.%s/api/v1/", HW_REGION_NAME, config.Cloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	compareURL(expectedURL, actualURL, "cci", "v1", t)
+
+	// test for cciV1BetaClient
+	serviceClient, err = nil, nil
+	serviceClient, err = config.CciV1BetaClient(HW_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud cci v1 client: %s", err)
 	}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -376,6 +376,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_cce_addon":                       ResourceCCEAddonV3(),
 			"huaweicloud_cce_node_pool":                   ResourceCCENodePool(),
 			"huaweicloud_cci_network":                     resourceCCINetworkV1(),
+			"huaweicloud_cci_pvc":                         ResourceCCIPersistentVolumeClaimV1(),
 			"huaweicloud_cdm_cluster":                     resourceCdmClusterV1(),
 			"huaweicloud_cdn_domain":                      resourceCdnDomainV1(),
 			"huaweicloud_ces_alarmrule":                   resourceAlarmRule(),

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -32,6 +32,7 @@ var (
 	HW_SRC_ACCESS_KEY             = os.Getenv("HW_SRC_ACCESS_KEY")
 	HW_SRC_SECRET_KEY             = os.Getenv("HW_SRC_SECRET_KEY")
 	HW_VPC_ID                     = os.Getenv("HW_VPC_ID")
+	HW_CCI_NAMESPACE              = os.Getenv("HW_CCI_NAMESPACE")
 	HW_PROJECT_ID                 = os.Getenv("HW_PROJECT_ID")
 	HW_DOMAIN_ID                  = os.Getenv("HW_DOMAIN_ID")
 	HW_DOMAIN_NAME                = os.Getenv("HW_DOMAIN_NAME")
@@ -137,6 +138,12 @@ func testAccPreCheckKms(t *testing.T) {
 func testAccPreCheckCDN(t *testing.T) {
 	if HW_CDN_DOMAIN_NAME == "" {
 		t.Skip("This environment does not support CDN tests")
+	}
+}
+
+func testAccPreCheckCCINamespace(t *testing.T) {
+	if HW_CCI_NAMESPACE == "" {
+		t.Skip("This environment does not support CCI Namespace tests")
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_cci_network_v1.go
+++ b/huaweicloud/resource_huaweicloud_cci_network_v1.go
@@ -97,7 +97,7 @@ func resourceNetworkAnnotationsV1(d *schema.ResourceData) map[string]string {
 
 func resourceCCINetworkV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	cciClient, err := config.CciV1Client(GetRegion(d, config))
+	cciClient, err := config.CciV1BetaClient(GetRegion(d, config))
 
 	if err != nil {
 		return fmt.Errorf("Unable to create HuaweiCloud CCI client : %s", err)
@@ -149,7 +149,7 @@ func resourceCCINetworkV1Create(d *schema.ResourceData, meta interface{}) error 
 
 func resourceCCINetworkV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	cciClient, err := config.CciV1Client(GetRegion(d, config))
+	cciClient, err := config.CciV1BetaClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud CCI client: %s", err)
 	}
@@ -177,7 +177,7 @@ func resourceCCINetworkV1Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceCCINetworkV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	cciClient, err := config.CciV1Client(GetRegion(d, config))
+	cciClient, err := config.CciV1BetaClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud CCI Client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_cci_network_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_cci_network_v1_test.go
@@ -33,7 +33,7 @@ func TestAccCCINetworkV1_basic(t *testing.T) {
 
 func testAccCheckCCINetworkV1Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
-	cciClient, err := config.CciV1Client(HW_REGION_NAME)
+	cciClient, err := config.CciV1BetaClient(HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud CCI client: %s", err)
 	}
@@ -64,7 +64,7 @@ func testAccCheckCCINetworkV1Exists(n string, network *networks.Network) resourc
 		}
 
 		config := testAccProvider.Meta().(*config.Config)
-		cciClient, err := config.CciV1Client(HW_REGION_NAME)
+		cciClient, err := config.CciV1BetaClient(HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud CCI client: %s", err)
 		}

--- a/huaweicloud/resource_huaweicloud_cci_pvc.go
+++ b/huaweicloud/resource_huaweicloud_cci_pvc.go
@@ -1,0 +1,351 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+var (
+	fsType = map[string]string{
+		"sas":             "ext4",
+		"ssd":             "ext4",
+		"sata":            "ext4",
+		"nfs-rw":          "nfs",
+		"efs-performance": "nfs",
+		"efs-standard":    "nfs",
+		"obs":             "obs",
+	}
+	volumeTypeForList = map[string]string{
+		"sas":             "bs",
+		"ssd":             "bs",
+		"sata":            "bs",
+		"obs":             "obs",
+		"nfs-rw":          "nfs",
+		"efs-performance": "efs",
+		"efs-standard":    "efs",
+	}
+)
+
+type StateRefresh struct {
+	Pending      []string
+	Target       []string
+	Delay        time.Duration
+	Timeout      time.Duration
+	PollInterval time.Duration
+}
+
+func ResourceCCIPersistentVolumeClaimV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCCIPersistentVolumeClaimV1Create,
+		Read:   resourceCCIPersistentVolumeClaimV1Read,
+		Delete: resourceCCIPersistentVolumeClaimV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCCIPvcImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"),
+					"The name consists of 1 to 63 characters, including lowercase letters, digits and hyphens, "+
+						"and must start and end with lowercase letters and digits"),
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"device_mount_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"volume_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "sas",
+				ValidateFunc: validation.StringInSlice([]string{
+					"sas", "ssd", "sata", "obs", "nfs-rw", "efs-standard", "efs-performance",
+				}, false),
+			},
+			"access_modes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_timestamp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCCIPersistentVolumeClaimV1CreateParams(d *schema.ResourceData) (persistentvolumeclaims.CreateOpts, error) {
+	createOpts := persistentvolumeclaims.CreateOpts{
+		Kind:       "PersistentVolumeClaim",
+		ApiVersion: "v1",
+	}
+	volumeType := d.Get("volume_type").(string)
+	fsType, ok := fsType[volumeType]
+	if !ok {
+		return createOpts, fmt.Errorf("The volume type (%s) is not available", volumeType)
+	}
+	createOpts.Metadata = persistentvolumeclaims.Metadata{
+		Namespace: d.Get("namespace").(string),
+		Name:      d.Get("name").(string),
+		Annotations: &persistentvolumeclaims.Annotations{
+			FsType:          fsType,
+			VolumeID:        d.Get("volume_id").(string),
+			DeviceMountPath: d.Get("device_mount_path").(string),
+		},
+	}
+	createOpts.Spec = persistentvolumeclaims.Spec{
+		StorageClassName: volumeType,
+		Resources: persistentvolumeclaims.ResourceRequirement{
+			Requests: &persistentvolumeclaims.ResourceName{
+				Storage: fmt.Sprintf("%dGi", d.Get("volume_size").(int)),
+			},
+		},
+	}
+
+	return createOpts, nil
+}
+
+func resourceCCIPersistentVolumeClaimV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.CciV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCI client: %s", err)
+	}
+
+	createOpts, err := buildCCIPersistentVolumeClaimV1CreateParams(d)
+	if err != nil {
+		return fmt.Errorf("Unable to build createOpts of the Persistent Volume Claim: %s", err)
+	}
+	ns := d.Get("namespace").(string)
+	create, err := persistentvolumeclaims.Create(client, createOpts, ns).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCI PVC: %s", err)
+	}
+	d.SetId(create.Metadata.UID)
+	stateRef := StateRefresh{
+		Pending:      []string{"Pending", "Bound"},
+		Target:       []string{"Bound"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	if err := waitForCCIPersistentVolumeClaimStateRefresh(d, client, ns, stateRef); err != nil {
+		return fmt.Errorf("Create the specifies PVC (%s) timed out: %s", d.Id(), err)
+	}
+
+	return resourceCCIPersistentVolumeClaimV1Read(d, meta)
+}
+
+func saveCCIPersistentVolumeClaimV1State(d *schema.ResourceData, resp *persistentvolumeclaims.ListResp) error {
+	specResp := &resp.PersistentVolume.Spec
+	metadata := &resp.PersistentVolumeClaim.Metadata
+	// The volume size format is 'xGi'.
+	regex := regexp.MustCompile("^([1-9][0-9]*)Gi$")
+	storages := regex.FindStringSubmatch(specResp.Capacity.Storage)
+	if len(storages) < 2 {
+		return fmt.Errorf("The response of volume capacity is not a valid number, need 'xGi', but got '%s'",
+			specResp.Capacity.Storage)
+	}
+	volumeSize, err := strconv.Atoi(storages[1])
+	if err != nil {
+		return fmt.Errorf("The input capacity (%s) is not a number: %s", storages[1], err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("namespace", metadata.Namespace),
+		d.Set("name", metadata.Name),
+		d.Set("volume_id", specResp.FlexVolume.Options.VolumeID),
+		d.Set("volume_size", volumeSize),
+		d.Set("volume_type", specResp.StorageClassName),
+		d.Set("device_mount_path", specResp.FlexVolume.Options.DeviceMountPath),
+		d.Set("access_modes", specResp.AccessModes),
+		d.Set("status", resp.PersistentVolumeClaim.Status.Phase),
+		d.Set("creation_timestamp", metadata.CreationTimestamp),
+		d.Set("enable", metadata.Enable),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+
+	return nil
+}
+
+func resourceCCIPersistentVolumeClaimV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	region := GetRegion(d, config)
+	client, err := config.CciV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCI client: %s", err)
+	}
+
+	ns := d.Get("namespace").(string)
+	volumeType := d.Get("volume_type").(string)
+	response, err := getPvcInfoFromServer(client, ns, volumeType, d.Id())
+	if err != nil {
+		return CheckDeleted(d, err, "Error getting the specifies PVC form server")
+	}
+	if response != nil {
+		d.Set("region", region)
+		if err := saveCCIPersistentVolumeClaimV1State(d, response); err != nil {
+			return fmt.Errorf("Error saving the specifies PVC (%s) to state: %s", d.Id(), err)
+		}
+	}
+
+	return nil
+}
+
+func resourceCCIPersistentVolumeClaimV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.CciV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud CCI Client: %s", err)
+	}
+
+	name := d.Get("name").(string)
+	ns := d.Get("namespace").(string)
+	_, err = persistentvolumeclaims.Delete(client, ns, name).Extract()
+	if err != nil {
+		return fmt.Errorf("Error deleting the specifies PVC (%s): %s", d.Id(), err)
+	}
+
+	stateRef := StateRefresh{
+		Pending:      []string{"Bound"},
+		Target:       []string{"DELETED"},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        3 * time.Second,
+		PollInterval: 2 * time.Second,
+	}
+	if err := waitForCCIPersistentVolumeClaimStateRefresh(d, client, ns, stateRef); err != nil {
+		return fmt.Errorf("Delete the specifies PVC (%s) timed out: %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForCCIPersistentVolumeClaimStateRefresh(d *schema.ResourceData, client *golangsdk.ServiceClient,
+	ns string, s StateRefresh) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      s.Pending,
+		Target:       s.Target,
+		Refresh:      pvcStateRefreshFunc(d, client, ns),
+		Timeout:      s.Timeout,
+		Delay:        s.Delay,
+		PollInterval: s.PollInterval,
+	}
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Waiting for the status of the PVC (%s) to complete timeout: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func pvcStateRefreshFunc(d *schema.ResourceData, client *golangsdk.ServiceClient,
+	ns string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		volumeType := d.Get("volume_type").(string)
+		response, err := getPvcInfoFromServer(client, ns, volumeType, d.Id())
+		if err != nil {
+			return response, "ERROR", nil
+		}
+		if response != nil {
+			return response, response.PersistentVolumeClaim.Status.Phase, nil
+		}
+		return response, "DELETED", nil
+	}
+}
+
+func getPvcInfoFromServer(client *golangsdk.ServiceClient, ns, volumeType,
+	pvcId string) (*persistentvolumeclaims.ListResp, error) {
+	var response *persistentvolumeclaims.ListResp
+	// If the storage of listOpts is not set, the list method will search for all PVCs of evs type.
+	storageType, ok := volumeTypeForList[volumeType]
+	if !ok {
+		return response, fmt.Errorf("The volume type (%s) is not available", volumeType)
+	}
+	listOpts := persistentvolumeclaims.ListOpts{
+		StorageType: storageType,
+	}
+	pages, err := persistentvolumeclaims.List(client, listOpts, ns).AllPages()
+	if err != nil {
+		return response, fmt.Errorf("Error finding the PVCs of type %s: %s", storageType, err)
+	}
+	responses, err := persistentvolumeclaims.ExtractPersistentVolumeClaims(pages)
+	if err != nil {
+		return response, fmt.Errorf("Error retrieving HuaweiCloud CCI PVCs: %s", err)
+	}
+	for _, v := range responses {
+		if v.PersistentVolumeClaim.Metadata.UID == pvcId {
+			response = new(persistentvolumeclaims.ListResp)
+			response = &v
+			break
+		}
+	}
+	return response, nil
+}
+
+func resourceCCIPvcImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid format specified for CCI PVC, must be <namespace>/<volume type>/<pvc id>")
+	}
+	d.SetId(parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("namespace", parts[0]),
+		d.Set("volume_type", parts[1]),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return []*schema.ResourceData{d}, mErr
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/resource_huaweicloud_cci_pvc_test.go
+++ b/huaweicloud/resource_huaweicloud_cci_pvc_test.go
@@ -16,32 +16,31 @@ func TestAccCCIPersistentVolumeClaims_basic(t *testing.T) {
 	var pvc persistentvolumeclaims.ListResp
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_cci_pvc.test"
-	ns := "terraform-test"
 	volumeType := "ssd"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckCCI(t)
+			testAccPreCheckCCINamespace(t)
 			testAccPreCheckEpsID(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(volumeType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCIPersistentVolumeClaims_basic(ns, rName, volumeType),
+				Config: testAccCCIPersistentVolumeClaims_basic(rName, volumeType),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, volumeType, &pvc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "namespace", HW_CCI_NAMESPACE),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "20"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -52,32 +51,31 @@ func TestAccCCIPersistentVolumeClaims_obs(t *testing.T) {
 	rInt := acctest.RandInt()
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_cci_pvc.test"
-	ns := "terraform-test"
 	volumeType := "obs"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckCCI(t)
+			testAccPreCheckCCINamespace(t)
 			testAccPreCheckEpsID(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(volumeType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCIPersistentVolumeClaims_obs(ns, rName, volumeType, rInt),
+				Config: testAccCCIPersistentVolumeClaims_obs(rName, volumeType, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, volumeType, &pvc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "namespace", HW_CCI_NAMESPACE),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "1"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -87,32 +85,31 @@ func TestAccCCIPersistentVolumeClaims_nfs(t *testing.T) {
 	var pvc persistentvolumeclaims.ListResp
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_cci_pvc.test"
-	ns := "terraform-test"
 	volumeType := "nfs-rw"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckCCI(t)
+			testAccPreCheckCCINamespace(t)
 			testAccPreCheckEpsID(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(volumeType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCIPersistentVolumeClaims_nfs(ns, rName, volumeType),
+				Config: testAccCCIPersistentVolumeClaims_nfs(rName, volumeType),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, volumeType, &pvc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "namespace", HW_CCI_NAMESPACE),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -123,35 +120,36 @@ func TestAccCCIPersistentVolumeClaims_efs(t *testing.T) {
 	suffix := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-acc-test-%s", suffix)
 	resourceName := "huaweicloud_cci_pvc.test"
-	ns := "terraform-test"
 	volumeType := "efs-standard"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckCCI(t) },
+		PreCheck: func() {
+			testAccPreCheckCCI(t)
+			testAccPreCheckCCINamespace(t)
+		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(volumeType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCIPersistentVolumeClaims_efs(ns, rName, suffix, volumeType),
+				Config: testAccCCIPersistentVolumeClaims_efs(rName, volumeType, suffix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, volumeType, &pvc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "namespace", HW_CCI_NAMESPACE),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "500"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName),
 			},
 		},
 	})
 }
 
-func testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType string) resource.TestCheckFunc {
+func testAccCheckCCIPersistentVolumeClaimsDestroy(volumeType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.CciV1Client(HW_REGION_NAME)
@@ -162,16 +160,16 @@ func testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType string) resourc
 			if rs.Type != "huaweicloud_cci_pvc" {
 				continue
 			}
-			_, err := getPvcInfoFromServer(client, ns, volumeType, rs.Primary.ID)
-			if err != nil {
-				return fmt.Errorf("Unable to find the specifies PVC (%s) form server: %s", rs.Primary.ID, err)
+			response, err := getCCIPvcInfoById(client, HW_CCI_NAMESPACE, volumeType, rs.Primary.ID)
+			if err == nil && response != nil {
+				return fmt.Errorf("The PVC (%s) still exist", rs.Primary.ID)
 			}
 		}
 		return nil
 	}
 }
 
-func testAccCheckCCIPersistentVolumeClaimsExists(n, ns, volumeType string,
+func testAccCheckCCIPersistentVolumeClaimsExists(n, volumeType string,
 	pvc *persistentvolumeclaims.ListResp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -186,7 +184,7 @@ func testAccCheckCCIPersistentVolumeClaimsExists(n, ns, volumeType string,
 		if err != nil {
 			return fmt.Errorf("Error creating HuaweiCloud CCI Client: %s", err)
 		}
-		response, err := getPvcInfoFromServer(client, ns, volumeType, rs.Primary.ID)
+		response, err := getCCIPvcInfoById(client, HW_CCI_NAMESPACE, volumeType, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Unable to find the specifies PVC (%s) form server: %s", rs.Primary.ID, err)
 		}
@@ -199,21 +197,21 @@ func testAccCheckCCIPersistentVolumeClaimsExists(n, ns, volumeType string,
 	}
 }
 
-func testAccCCIPvcImportStateIdFunc(pvcRes, ns string) resource.ImportStateIdFunc {
+func testAccCCIPvcImportStateIdFunc(pvcRes string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		pvc, ok := s.RootModule().Resources[pvcRes]
 		if !ok {
 			return "", fmt.Errorf("Auto Scaling lifecycle hook not found: %s", pvc)
 		}
-		if ns == "" || pvc.Primary.Attributes["volume_type"] == "" || pvc.Primary.ID == "" {
-			return "", fmt.Errorf("Unable to find the resource by import ID: %s/%s/%s",
-				ns, pvc.Primary.Attributes["volume_type"], pvc.Primary.ID)
+		if pvc.Primary.Attributes["volume_type"] == "" || pvc.Primary.ID == "" {
+			return "", fmt.Errorf("Unable to find the resource by import infos: %s/%s/%s",
+				HW_CCI_NAMESPACE, pvc.Primary.Attributes["volume_type"], pvc.Primary.ID)
 		}
-		return fmt.Sprintf("%s/%s/%s", ns, pvc.Primary.Attributes["volume_type"], pvc.Primary.ID), nil
+		return fmt.Sprintf("%s/%s/%s", HW_CCI_NAMESPACE, pvc.Primary.Attributes["volume_type"], pvc.Primary.ID), nil
 	}
 }
 
-func testAccCCIPersistentVolumeClaims_basic(ns, rName, volumeType string) string {
+func testAccCCIPersistentVolumeClaims_basic(rName, volumeType string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -222,12 +220,11 @@ resource "huaweicloud_cci_pvc" "test" {
   namespace   = "%s"
   volume_type = "%s"
   volume_id   = huaweicloud_evs_volume.test.id
-  volume_size = huaweicloud_evs_volume.test.size
 }
-`, testAccEvsVolume_epsID(rName), rName, ns, volumeType)
+`, testAccEvsVolume_epsID(rName), rName, HW_CCI_NAMESPACE, volumeType)
 }
 
-func testAccCCIPersistentVolumeClaims_obs(ns, rName, volumeType string, suffix int) string {
+func testAccCCIPersistentVolumeClaims_obs(rName, volumeType string, suffix int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -236,12 +233,11 @@ resource "huaweicloud_cci_pvc" "test" {
   namespace   = "%s"
   volume_type = "%s"
   volume_id   = huaweicloud_obs_bucket.bucket.id
-  volume_size = 1
 }
-`, testAccObsBucket_epsId(suffix), rName, ns, volumeType)
+`, testAccObsBucket_epsId(suffix), rName, HW_CCI_NAMESPACE, volumeType)
 }
 
-func testAccCCIPersistentVolumeClaims_nfs(ns, rName, volumeType string) string {
+func testAccCCIPersistentVolumeClaims_nfs(rName, volumeType string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -250,13 +246,12 @@ resource "huaweicloud_cci_pvc" "test" {
   namespace         = "%s"
   volume_type       = "%s"
   volume_id         = huaweicloud_sfs_file_system.sfs_1.id
-  volume_size       = 100
   device_mount_path = huaweicloud_sfs_file_system.sfs_1.export_location
 }
-`, testAccSFSFileSystemV2_epsId(rName), rName, ns, volumeType)
+`, testAccSFSFileSystemV2_epsId(rName), rName, HW_CCI_NAMESPACE, volumeType)
 }
 
-func testAccCCIPersistentVolumeClaims_efs(ns, rName, suffix, volumeType string) string {
+func testAccCCIPersistentVolumeClaims_efs(rName, volumeType, suffix string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -265,8 +260,7 @@ resource "huaweicloud_cci_pvc" "test" {
   namespace         = "%s"
   volume_type       = "%s"
   volume_id         = huaweicloud_sfs_turbo.sfs-turbo1.id
-  volume_size       = 500
   device_mount_path = huaweicloud_sfs_turbo.sfs-turbo1.export_location
 }
-`, testAccSFSTurbo_basic(suffix), rName, ns, volumeType)
+`, testAccSFSTurbo_basic(suffix), rName, HW_CCI_NAMESPACE, volumeType)
 }

--- a/huaweicloud/resource_huaweicloud_cci_pvc_test.go
+++ b/huaweicloud/resource_huaweicloud_cci_pvc_test.go
@@ -1,0 +1,272 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCCIPersistentVolumeClaims_basic(t *testing.T) {
+	var pvc persistentvolumeclaims.ListResp
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cci_pvc.test"
+	ns := "terraform-test"
+	volumeType := "ssd"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCCI(t)
+			testAccPreCheckEpsID(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCIPersistentVolumeClaims_basic(ns, rName, volumeType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "20"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+			},
+		},
+	})
+}
+
+func TestAccCCIPersistentVolumeClaims_obs(t *testing.T) {
+	var pvc persistentvolumeclaims.ListResp
+	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cci_pvc.test"
+	ns := "terraform-test"
+	volumeType := "obs"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCCI(t)
+			testAccPreCheckEpsID(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCIPersistentVolumeClaims_obs(ns, rName, volumeType, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+			},
+		},
+	})
+}
+
+func TestAccCCIPersistentVolumeClaims_nfs(t *testing.T) {
+	var pvc persistentvolumeclaims.ListResp
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cci_pvc.test"
+	ns := "terraform-test"
+	volumeType := "nfs-rw"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCCI(t)
+			testAccPreCheckEpsID(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCIPersistentVolumeClaims_nfs(ns, rName, volumeType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+			},
+		},
+	})
+}
+
+func TestAccCCIPersistentVolumeClaims_efs(t *testing.T) {
+	var pvc persistentvolumeclaims.ListResp
+	suffix := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-acc-test-%s", suffix)
+	resourceName := "huaweicloud_cci_pvc.test"
+	ns := "terraform-test"
+	volumeType := "efs-standard"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckCCI(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCIPersistentVolumeClaims_efs(ns, rName, suffix, volumeType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, ns, volumeType, &pvc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", volumeType),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "500"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCIPvcImportStateIdFunc(resourceName, ns),
+			},
+		},
+	})
+}
+
+func testAccCheckCCIPersistentVolumeClaimsDestroy(ns, volumeType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*config.Config)
+		client, err := config.CciV1Client(HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud CCI client: %s", err)
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "huaweicloud_cci_pvc" {
+				continue
+			}
+			_, err := getPvcInfoFromServer(client, ns, volumeType, rs.Primary.ID)
+			if err != nil {
+				return fmt.Errorf("Unable to find the specifies PVC (%s) form server: %s", rs.Primary.ID, err)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckCCIPersistentVolumeClaimsExists(n, ns, volumeType string,
+	pvc *persistentvolumeclaims.ListResp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := testAccProvider.Meta().(*config.Config)
+		client, err := config.CciV1Client(HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud CCI Client: %s", err)
+		}
+		response, err := getPvcInfoFromServer(client, ns, volumeType, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Unable to find the specifies PVC (%s) form server: %s", rs.Primary.ID, err)
+		}
+		if response != nil {
+			*pvc = *response
+			return nil
+		}
+
+		return fmt.Errorf("PVC (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCCIPvcImportStateIdFunc(pvcRes, ns string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		pvc, ok := s.RootModule().Resources[pvcRes]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling lifecycle hook not found: %s", pvc)
+		}
+		if ns == "" || pvc.Primary.Attributes["volume_type"] == "" || pvc.Primary.ID == "" {
+			return "", fmt.Errorf("Unable to find the resource by import ID: %s/%s/%s",
+				ns, pvc.Primary.Attributes["volume_type"], pvc.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s/%s", ns, pvc.Primary.Attributes["volume_type"], pvc.Primary.ID), nil
+	}
+}
+
+func testAccCCIPersistentVolumeClaims_basic(ns, rName, volumeType string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cci_pvc" "test" {
+  name        = "%s"
+  namespace   = "%s"
+  volume_type = "%s"
+  volume_id   = huaweicloud_evs_volume.test.id
+  volume_size = huaweicloud_evs_volume.test.size
+}
+`, testAccEvsVolume_epsID(rName), rName, ns, volumeType)
+}
+
+func testAccCCIPersistentVolumeClaims_obs(ns, rName, volumeType string, suffix int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cci_pvc" "test" {
+  name        = "%s"
+  namespace   = "%s"
+  volume_type = "%s"
+  volume_id   = huaweicloud_obs_bucket.bucket.id
+  volume_size = 1
+}
+`, testAccObsBucket_epsId(suffix), rName, ns, volumeType)
+}
+
+func testAccCCIPersistentVolumeClaims_nfs(ns, rName, volumeType string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cci_pvc" "test" {
+  name              = "%s"
+  namespace         = "%s"
+  volume_type       = "%s"
+  volume_id         = huaweicloud_sfs_file_system.sfs_1.id
+  volume_size       = 100
+  device_mount_path = huaweicloud_sfs_file_system.sfs_1.export_location
+}
+`, testAccSFSFileSystemV2_epsId(rName), rName, ns, volumeType)
+}
+
+func testAccCCIPersistentVolumeClaims_efs(ns, rName, suffix, volumeType string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cci_pvc" "test" {
+  name              = "%s"
+  namespace         = "%s"
+  volume_type       = "%s"
+  volume_id         = huaweicloud_sfs_turbo.sfs-turbo1.id
+  volume_size       = 500
+  device_mount_path = huaweicloud_sfs_turbo.sfs-turbo1.export_location
+}
+`, testAccSFSTurbo_basic(suffix), rName, ns, volumeType)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/requests.go
@@ -1,0 +1,132 @@
+package persistentvolumeclaims
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type CreateOpts struct {
+	// The version of the persistent API, valid value is 'v1'.
+	ApiVersion string `json:"apiVersion" required:"true"`
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	Kind string `json:"kind" required:"true"`
+	// Standard object's metadata.
+	Metadata Metadata `json:"metadata" required:"true"`
+	// The desired characteristics of a volume.
+	Spec Spec `json:"spec" required:"true"`
+}
+
+type Metadata struct {
+	// The name of the persistent volume claim, must be unique within a namespace. Cannot be updated.
+	Name string `json:"name" required:"true"`
+	// Namespace defines the space within each name must be unique.
+	// An empty namespace is equivalent to the 'default' namespace, but 'default' is the canonical representation.
+	Namespace string `json:"namespace,omitempty"`
+	// An unstructured key value map stored with a resource that may be set by external tools to store and retrieve
+	// arbitrary metadata.
+	Annotations *Annotations `json:"annotations,omitempty"`
+}
+
+type Annotations struct {
+	// The type of the file system.
+	// The valid values are ext4 (EVS disk), obs (OBS bucket) and nfs (SFS or SFS Turbo).
+	FsType string `json:"fsType" required:"true"`
+	// ID of the volume
+	VolumeID string `json:"volumeID" required:"true"`
+	// The Shared path of the SFS and the SFS Turbo.
+	DeviceMountPath string `json:"deviceMountPath,omitempty"`
+}
+
+type Spec struct {
+	// Resources represents the minimum resources the volume should have.
+	Resources ResourceRequirement `json:"resources" required:"true"`
+	// Name of the storage class required by the claim.
+	// The following fields are supported:
+	//     EVS: sas, ssd and sata
+	//     SFS: nfs-rw
+	//     SFS Turbo: efs-performance and efs-standard
+	//     OBS: obs
+	StorageClassName string `json:"storageClassName" required:"true"`
+	// AccessModes contains the actual access modes the volume backing the PVC has.
+	//     ReadWriteOnce: can be mount read/write mode to exactly 1 host.
+	//     ReadOnlyMany: can be mount in read-only mode to many hosts.
+	//     ReadWriteMany: can be mount in read/write mode to many hosts.
+	AccessModes []string `json:"accessModes,omitempty"`
+}
+
+type ResourceRequirement struct {
+	// Minimum amount of compute resources required.
+	// If requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+	// otherwise to an implementation-defined value.
+	Requests *ResourceName `json:"requests,omitempty"`
+}
+
+type ResourceName struct {
+	// Volume size, in GB format: 'xGi'.
+	Storage string `json:"storage,omitempty"`
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToPVCCreateMap() (map[string]interface{}, error)
+}
+
+// ToPVCCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToPVCCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create accepts a CreateOpts struct and uses the namespace name to import a volume into the namespace.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, ns string) (r CreateResult) {
+	reqBody, err := opts.ToPVCCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, ns), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+type ListOpts struct {
+	// Type of the storage, valid values are bs, obs, nfs and efs.
+	StorageType string `q:"storage_type"`
+}
+
+type ListOptsBuilder interface {
+	ToPVCListQuery() (string, error)
+}
+
+func (opts ListOpts) ToPVCListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of the persistent volume claims for specifies namespace.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder, ns string) pagination.Pager {
+	url := rootURL(client, ns)
+	if opts != nil {
+		query, err := opts.ToPVCListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PersistentVolumeClaimPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete accepts to delete the specifies persistent volume claim form the namespace.
+func Delete(client *golangsdk.ServiceClient, ns, name string) (r DeleteResult) {
+	_, r.Err = client.DeleteWithBodyResp(resourceURL(client, ns, name), nil, r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/results.go
@@ -1,0 +1,139 @@
+package persistentvolumeclaims
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type PersistentVolumeClaim struct {
+	Kind       string   `json:"kind"`
+	ApiVersion string   `json:"apiVersion"`
+	Metadata   MetaResp `json:"metadata"`
+	Spec       SpecResp `json:"spec"`
+	Status     Status   `json:"status"`
+}
+
+type MetaResp struct {
+	// The name of the Persistent Volume Claim.
+	Name string `json:"name"`
+	// The namespace where the Persistent Volume Claim is located.
+	Namespace string `json:"namespace"`
+	// An unstructured key value map stored with a resource that may be set by external tools to store and retrieve
+	// arbitrary metadata.
+	Annotations map[string]string `json:"annotations"`
+	// ID of the Persistent Volume Claim in UUID format.
+	UID string `json:"uid"`
+	// String that identifies the server's internal version of this object that can be used by clients to determine
+	// when objects have changed.
+	ResourceVersion string `json:"resourceVersion"`
+	// A timestamp representing the server time when this object was created.
+	CreationTimestamp string `json:"creationTimestamp"`
+	// SelfLink is a URL representing this object.
+	SelfLink string `json:"selfLink"`
+	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+	Labels map[string]string `json:"labels"`
+	// Each finalizer string of array is an identifier for the responsible component that will remove the entry form
+	// the list.
+	Finalizers []string `json:"finalizers"`
+	// Enable identify whether the resource is available.
+	Enable bool `json:"enable"`
+}
+
+// The extra response of Persistent Volume are Capacity, FlexVolume, ClaimRef and PersistentVolumeReclaimPolicy.
+type SpecResp struct {
+	// The name of the volume.
+	VolumeName string `json:"volumeName"`
+	// AccessModes contains the actual access modes the volume backing the PVC has.
+	AccessModes []string `json:"accessModes"`
+	// Resources represents the minimum resources the volume should have.
+	Resources ResourceRequirement `json:"resources"`
+	// Name of the storage class required by the claim.
+	StorageClassName string `json:"storageClassName"`
+	// Mode of the volume.
+	VolumeMode string `json:"volumeMode"`
+	// The capacity of the storage.
+	Capacity ResourceName `json:"capacity"`
+	// PersistentVolumeClaim.
+	FlexVolume FlexVolume `json:"flexVolume"`
+	// Part of a bi-directional binding between persistentVolume and persistentVolumeClaim.
+	ClaimRef ClaimRef `json:"claimRef"`
+	// Specifies what happens to a persistent volume when released form its claim.
+	PersistentVolumeReclaimPolicy string `json:"persistentVolumeReclaimPolicy"`
+}
+
+type FlexVolume struct {
+	Driver  string  `json:"driver"`
+	FsType  string  `json:"fsType"`
+	Options Options `json:"options"`
+}
+
+type Options struct {
+	// The type of the file system.
+	FsType string `json:"fsType"`
+	// ID of the volume.
+	VolumeID string `json:"volumeID"`
+	// The Shared path of the SFS and the SFS Turbo.
+	DeviceMountPath string `json:"deviceMountPath"`
+}
+
+type ClaimRef struct {
+	// Kind of the referent.
+	Kind string `json:"kind"`
+	// Namespace of the referent.
+	Namespace string `json:"namespace"`
+	// Name of the referent.
+	Name string `json:"name"`
+	// UID of the referent.
+	UID string `json:"uid"`
+	// API version of the referent.
+	AapiVersion string `json:"apiVersion"`
+	// Specifies resource version to which this reference is made, If any.
+	ResourceVersion string `json:"resourceVersion"`
+}
+
+type Status struct {
+	// Phase represents the current phase of persistentVolumeClaim.
+	//     pending: used for PersistentVolumeClaims that are not yet bound.
+	//     Bound: used for PersistentVolumeClaims that are bound.
+	//     Lost: used for PersistentVolumeClaims that lost their underlying.
+	Phase string `json:"phase"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r commonResult) Extract() (*PersistentVolumeClaim, error) {
+	var s PersistentVolumeClaim
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type ListResp struct {
+	PersistentVolumeClaim PersistentVolumeClaim `json:"persistentVolumeClaim"`
+	PersistentVolume      PersistentVolumeClaim `json:"persistentVolume"`
+}
+
+type PersistentVolumeClaimPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractPersistentVolumeClaims(r pagination.Page) ([]ListResp, error) {
+	var s []ListResp
+	err := r.(PersistentVolumeClaimPage).Result.ExtractIntoSlicePtr(&s, "")
+	return s, err
+}
+
+type DeleteResult struct {
+	commonResult
+}
+
+func (r DeleteResult) Extract() ([]PersistentVolumeClaim, error) {
+	var s []PersistentVolumeClaim
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/urls.go
@@ -1,0 +1,13 @@
+package persistentvolumeclaims
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "namespaces"
+
+func rootURL(client *golangsdk.ServiceClient, ns string) string {
+	return client.ServiceURL(rootPath, ns, "extended-persistentvolumeclaims")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, ns, name string) string {
+	return client.ServiceURL(rootPath, ns, "persistentvolumeclaims", name)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -295,6 +295,7 @@ github.com/huaweicloud/golangsdk/openstack/cce/v3/nodepools
 github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes
 github.com/huaweicloud/golangsdk/openstack/cce/v3/templates
 github.com/huaweicloud/golangsdk/openstack/cci/v1/networks
+github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims
 github.com/huaweicloud/golangsdk/openstack/cdn/v1/domains
 github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule
 github.com/huaweicloud/golangsdk/openstack/common/structs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To supports binding, listing and unbinding functions of the persistent volume claims for CCI service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1081 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update function name of the cci beta client create.
2. new resource and test supported.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCCIPersistentVolumeClaims'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCCIPersistentVolumeClaims -timeout 360m -parallel 4
=== RUN   TestAccCCIPersistentVolumeClaims_basic
=== PAUSE TestAccCCIPersistentVolumeClaims_basic
=== RUN   TestAccCCIPersistentVolumeClaims_obs
=== PAUSE TestAccCCIPersistentVolumeClaims_obs
=== RUN   TestAccCCIPersistentVolumeClaims_nfs
=== PAUSE TestAccCCIPersistentVolumeClaims_nfs
=== RUN   TestAccCCIPersistentVolumeClaims_efs
=== PAUSE TestAccCCIPersistentVolumeClaims_efs
=== CONT  TestAccCCIPersistentVolumeClaims_basic
=== CONT  TestAccCCIPersistentVolumeClaims_efs
=== CONT  TestAccCCIPersistentVolumeClaims_nfs
=== CONT  TestAccCCIPersistentVolumeClaims_obs
--- PASS: TestAccCCIPersistentVolumeClaims_obs (51.14s)
--- PASS: TestAccCCIPersistentVolumeClaims_basic (77.50s)
--- PASS: TestAccCCIPersistentVolumeClaims_nfs (111.69s)
--- PASS: TestAccCCIPersistentVolumeClaims_efs (621.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       621.949s
```
