### PR TITLE
add iec server data source and volume_attached block into iec server resource

### DIFF
--- a/docs/data-sources/iec_server.md
+++ b/docs/data-sources/iec_server.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud_iec_server
+
+Use this data source to get the details of a specified IEC server.
+
+## Example Usage
+
+```hcl
+variable "server_name" { }
+
+data "huaweicloud_iec_server" "demo" {
+  name = var.server_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the IEC server name, which can be queried with a regular expression.
+
+* `status` - (Optional, String) Specifies the status of IEC server.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The IEC server ID in UUID format.
+* `edgecloud_id` - The ID of the edgecloud service.
+* `edgecloud_name` - The Name of the edgecloud service.
+* `coverage_sites` - An array of site ID and operator for the IEC server.
+    The object structure is documented below.
+* `flavor_id` - The flavor ID of the IEC server.
+* `flavor_name` - The flavor name of the IEC server.
+* `image_name` - The image name of the IEC server.
+* `vpc_id` - The ID of vpc for the IEC server.
+* `security_groups` - An array of one or more security group IDs to associate with the IEC server.
+* `nics` - An array of one or more networks to attach to the IEC server.
+    The object structure is documented below.
+* `volume_attached` - An array of one or more disks to attach to the IEC server.
+    The object structure is documented below.
+* `public_ip` - The EIP address that is associted to the IEC server.
+* `system_disk_id` - The system disk voume ID.
+
+The `coverage_sites` block supports:
+  * `site_id` - The ID of IEC site.
+  * `site_info` - The located information of the IEC site. It contains area, province and city.
+  * `operator` - The operator of the IEC site.
+
+The `nics` block supports:
+  * `port` - The port ID corresponding to the IP address on that network.
+  * `mac` - The MAC address of the NIC on that network.
+  * `address` - The IPv4 address of the server on that network.
+
+The `volume_attached` block supports:
+
+  * `volume_id` - The volume ID on that attachment.
+  * `boot_index` - The volume boot index on that attachment.
+  * `size` - The volume size on that attachment.
+  * `type` - The volume type on that attachment.
+  * `device` - The device name in the IEC server.

--- a/docs/resources/iec_server.md
+++ b/docs/resources/iec_server.md
@@ -43,9 +43,6 @@ resource "huaweicloud_iec_server" "server_test" {
 
 ### Server Instance With Multiple Data Disks
 
-It's possible to specify multiple `data_disks` entries to create an server 
-with multiple data disks.
-
 ```hcl
 variable "iec_server_name" {}
 variable "iec_iamge_id" {}
@@ -164,12 +161,12 @@ The following arguments are supported:
 
 The `coverage_sites` block supports:
 
-  * `site_id` -(Required, String, ForceNew) Specifies the ID of IEC site.
-  * `operator` -(Required, String, ForceNew) Specifies the operator of the IEC site.
+  * `site_id` - (Required, String, ForceNew) Specifies the ID of IEC site.
+  * `operator` - (Required, String, ForceNew) Specifies the operator of the IEC site.
 
 The `data_disks` block supports:
 
-  * `type` -(Required, String, ForceNew) Specifies the type of data disk for the
+  * `type` - (Required, String, ForceNew) Specifies the type of data disk for the
     IEC server binding. Valid value is *SAS*(high I/O disk type).
     Changing this parameter creates a new IEC server resource.
   * `size` - (Required, String, ForceNew) Specifies the size of data disk for the
@@ -182,14 +179,29 @@ In addition to all arguments above, the following attributes are exported:
 
 * `edgecloud_id` - The ID of the edgecloud service.
 * `edgecloud_name` - The Name of the edgecloud service.
-* `nics` - An array of one or more network configuration for IEC server.
-* `origin_server_id` : The ID of origin server.
+* `image_name` - The image name of the IEC server.
+* `flavor_name` - The flavor name of the IEC server.
+* `nics` - An array of one or more networks to attach to the IEC server.
+    The object structure is documented below.
+* `volume_attached` - An array of one or more disks to attach to the IEC server.
+    The object structure is documented below.
+* `public_ip` - The EIP address that is associted to the IEC server.
+* `system_disk_id` - The system disk voume ID.
+* `origin_server_id` - The ID of origin server.
 * `status` - The status of IEC server.
 
 The `nics` block supports:
-  * `port` - The port of IEC server.
-  * `mac` - The mac address of IEC server.
-  * `address` - The address of EIP or VIP.
+  * `port` - The port ID corresponding to the IP address on that network.
+  * `mac` - The MAC address of the NIC on that network.
+  * `address` - The IPv4 address of the server on that network.
+
+The `volume_attached` block supports:
+
+  * `volume_id` - The volume ID on that attachment.
+  * `boot_index` - The volume boot index on that attachment.
+  * `size` - The volume size on that attachment.
+  * `type` - The volume type on that attachment.
+  * `device` - The device name in the IEC server.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/data_source_huaweicloud_iec_server.go
+++ b/huaweicloud/data_source_huaweicloud_iec_server.go
@@ -1,0 +1,183 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/servers"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func dataSourceIECServer() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIECServerRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"edgecloud_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_pair": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"edgecloud_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"coverage_sites": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"site_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"site_info": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"nics":            iecServerNicsSchema,
+			"volume_attached": iecVolumeAttachedSchema,
+			"public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"system_disk_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIECServerRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	iecClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+	}
+
+	listOpts := &servers.ListOpts{
+		Name:        d.Get("name").(string),
+		Status:      d.Get("status").(string),
+		EdgeCloudID: d.Get("edgecloud_id").(string),
+	}
+
+	log.Printf("[DEBUG] searching the IEC server by filter: %#v", listOpts)
+	allServers, err := servers.List(iecClient, listOpts).Extract()
+	if err != nil {
+		return err
+	}
+
+	total := len(allServers.Servers)
+	if total < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+	if total > 1 {
+		return fmt.Errorf("Your query returned more than one result. " +
+			"Please try a more specific search criteria.")
+	}
+
+	server := allServers.Servers[0]
+	log.Printf("[DEBUG] fetching the IEC server: %#v", server)
+
+	d.SetId(server.ID)
+	d.Set("name", server.Name)
+	d.Set("status", server.Status)
+
+	flavorInfo := server.Flavor
+	d.Set("flavor_id", flavorInfo.ID)
+	d.Set("flavor_name", flavorInfo.Name)
+	d.Set("image_id", server.Image.ID)
+	d.Set("image_name", server.Metadata.ImageName)
+
+	if server.KeyName != "" {
+		d.Set("key_pair", server.KeyName)
+	}
+	if server.UserData != "" {
+		d.Set("user_data", server.UserData)
+	}
+
+	// set networking fields
+	d.Set("vpc_id", server.Metadata.VpcID)
+	secGrpIDs := make([]string, len(server.SecurityGroups))
+	for i, sg := range server.SecurityGroups {
+		secGrpIDs[i] = sg.ID
+	}
+	d.Set("security_groups", secGrpIDs)
+
+	allNics, eip := expandIecServerNics(&server)
+	d.Set("nics", allNics)
+	d.Set("public_ip", eip)
+
+	// set volume fields
+	allVolumes, sysDiskID := expandIecServerVolumeAttached(iecClient, &server)
+	d.Set("volume_attached", allVolumes)
+	d.Set("system_disk_id", sysDiskID)
+
+	// set IEC fields
+	location := server.Location
+	siteInfo := fmt.Sprintf("%s/%s/%s/%s", location.Country, location.Area, location.Province, location.City)
+	siteItem := map[string]interface{}{
+		"site_id":   location.ID,
+		"site_info": siteInfo,
+		"operator":  server.Operator.Name,
+	}
+	d.Set("coverage_sites", []map[string]interface{}{siteItem})
+	d.Set("edgecloud_id", server.EdgeCloudID)
+	d.Set("edgecloud_name", server.EdgeCloudName)
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_iec_server_test.go
+++ b/huaweicloud/data_source_huaweicloud_iec_server_test.go
@@ -1,0 +1,53 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccIECServerDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("iec-%s", acctest.RandString(5))
+	resourceName := "data.huaweicloud_iec_server.server_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIecServerDestory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIecServer_basic(rName),
+			},
+			{
+				Config: testAccIECServerDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "server-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "image_name", "Ubuntu 16.04 server 64bit"),
+					resource.TestCheckResourceAttr(resourceName, "nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.0.boot_index", "0"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.0.type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.0.size", "40"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "coverage_sites.0.site_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "coverage_sites.0.site_info"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIECServerDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iec_server" "server_1" {
+  name = huaweicloud_iec_server.server_test.name
+}
+`, testAccIecServer_basic(rName))
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -292,6 +292,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_iec_network_acl":             dataSourceIECNetworkACL(),
 			"huaweicloud_iec_port":                    DataSourceIECPort(),
 			"huaweicloud_iec_security_group":          dataSourceIECSecurityGroup(),
+			"huaweicloud_iec_server":                  dataSourceIECServer(),
 			"huaweicloud_iec_sites":                   dataSourceIecSites(),
 			"huaweicloud_iec_vpc":                     DataSourceIECVpc(),
 			"huaweicloud_iec_vpc_subnets":             DataSourceIECVpcSubnets(),

--- a/huaweicloud/resource_huaweicloud_iec_server_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_server_test.go
@@ -26,12 +26,16 @@ func TestAccIecServerResource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIecServerExists(resourceName, &cloudserver),
 					resource.TestCheckResourceAttr(resourceName, "name", "server-"+rName),
-					resource.TestCheckResourceAttr(resourceName, "nics.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "image_name", "Ubuntu 16.04 server 64bit"),
+					resource.TestCheckResourceAttr(resourceName, "nics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_type", "SAS"),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 				),
 			},
 		},
@@ -111,7 +115,7 @@ resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
   name = "subnet-%s"
   cidr = "192.168.0.0/16"
   gateway_ip = "192.168.0.1"
-  vpc_id = huaweicloud_iec_vpc.vpc_test.id
+  vpc_id  = huaweicloud_iec_vpc.vpc_test.id
   site_id = data.huaweicloud_iec_sites.sites_test.sites[0].id
 }
 
@@ -120,15 +124,15 @@ resource "huaweicloud_iec_keypair" "keypair_test" {
 }
 
 resource "huaweicloud_iec_security_group" "secgroup_test" {
-  name = "secgroup-%s"
+  name        = "secgroup-%s"
   description = "this is a test group"
 }
 
 resource "huaweicloud_iec_security_group_rule" "rule_test" {
-  direction = "ingress"
+  direction      = "ingress"
   port_range_min = 445
   port_range_max = 445
-  protocol = "tcp" 
+  protocol       = "tcp"
   security_group_id = huaweicloud_iec_security_group.secgroup_test.id
   remote_ip_prefix = "0.0.0.0/0"
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes/requests.go
@@ -1,0 +1,61 @@
+package cloudvolumes
+
+import (
+	"net/http"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+func Get(client *golangsdk.ServiceClient, CloudVolumeID string) (r GetResult) {
+	url := GetURL(client, CloudVolumeID)
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	return
+}
+
+func ListVolumeType(client *golangsdk.ServiceClient) (r GetResult) {
+	url := ListVolumeTypeURL(client)
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	return
+}
+
+// ListOpts holds options for listing Voulmes. It is passed to the List
+// function.
+type ListOpts struct {
+	Limit  int    `q:"limit"`
+	Offset int    `q:"offset"`
+	Name   string `q:"name"`
+	Status string `q:"status"`
+}
+
+type ListOptsBuilder interface {
+	ToListVolumesQuery() (string, error)
+}
+
+func (opts ListOpts) ToListVolumesQuery() (string, error) {
+	b, err := golangsdk.BuildQueryString(&opts)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) (r ListResult) {
+	listURL := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToListVolumesQuery()
+		if err != nil {
+			r.Err = err
+			return r
+		}
+		listURL += query
+	}
+
+	_, r.Err = client.Get(listURL, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes/results.go
@@ -1,0 +1,52 @@
+package cloudvolumes
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/iec/v1/common"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type GetResult struct {
+	commonResult
+}
+
+// EdgeVolume 云磁盘
+type EdgeVolume struct {
+	Volume *common.Volume `json:"volume"`
+}
+
+func (r GetResult) Extract() (*EdgeVolume, error) {
+	var entity EdgeVolume
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}
+
+type VolumeType struct {
+	VolumeTypes []common.VolumeType `json:"volume_types"`
+}
+
+func (r GetResult) ExtractVolumeType() (*VolumeType, error) {
+	var entity VolumeType
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}
+
+// Volumes 卷列表对象
+type Volumes struct {
+	Volumes []common.Volume `json:"volumes"`
+	Count   int             `json:"count"`
+}
+
+type ListResult struct {
+	commonResult
+}
+
+func (r ListResult) Extract() (*Volumes, error) {
+	var entity Volumes
+
+	err := r.ExtractInto(&entity)
+	return &entity, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes/urls.go
@@ -1,0 +1,17 @@
+package cloudvolumes
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("cloudvolumes")
+}
+
+func GetURL(c *golangsdk.ServiceClient, CloudVolumeID string) string {
+	return c.ServiceURL("cloudvolumes", CloudVolumeID)
+}
+
+func ListVolumeTypeURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("cloudvolumes", "volume-types")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -369,6 +369,7 @@ github.com/huaweicloud/golangsdk/openstack/identity/v3/projects
 github.com/huaweicloud/golangsdk/openstack/identity/v3/roles
 github.com/huaweicloud/golangsdk/openstack/identity/v3/tokens
 github.com/huaweicloud/golangsdk/openstack/identity/v3/users
+github.com/huaweicloud/golangsdk/openstack/iec/v1/cloudvolumes
 github.com/huaweicloud/golangsdk/openstack/iec/v1/common
 github.com/huaweicloud/golangsdk/openstack/iec/v1/firewalls
 github.com/huaweicloud/golangsdk/openstack/iec/v1/flavors


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
relate #1151 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
* add volume_attached block into iec server resource
* add iec server data source and docs
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecServerResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecServerResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecServerResource_basic
--- PASS: TestAccIecServerResource_basic (156.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       156.566s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIECServerDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIECServerDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIECServerDataSource_basic
=== PAUSE TestAccIECServerDataSource_basic
=== CONT  TestAccIECServerDataSource_basic
--- PASS: TestAccIECServerDataSource_basic (151.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       151.912s
```
