### PR TITLE
[DMS kafka]fix a bug and some doc problems

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -124,7 +124,7 @@ The following arguments are supported:
     Changing this creates a new instance resource.
 
 * `maintain_begin` - (Optional, String) Specifies the time at which a maintenance time window starts.
-    Format: HH:mm:ss.
+    Format: HH:mm.
     The start time and end time of a maintenance time window must indicate the time segment of
 	a supported maintenance time window. The start time must be set to 22:00, 02:00, 06:00, 10:00,
     14:00, or 18:00. Parameters `maintain_begin` and `maintain_end` must be set in pairs. If
@@ -132,7 +132,7 @@ The following arguments are supported:
     the system automatically allocates the default start time 02:00.
 
 * `maintain_end` - (Optional, String) Specifies the time at which a maintenance time window ends.
-    Format: HH:mm:ss.
+    Format: HH:mm.
     The start time and end time of a maintenance time window must indicate the time segment of
 	a supported maintenance time window. The end time is four hours later than the start time.
     For example, if the start time is 22:00, the end time is 02:00. Parameters `maintain_begin`
@@ -177,7 +177,7 @@ In addition to all arguments above, the following attributes are exported:
 * `port` - Indicates the port number of the DMS kafka instance.
 * `status` - Indicates the status of the DMS kafka instance.
 * `ssl_enable` - Indicates whether the SSL-encrypted access is enabled.
-* `enable_publicip` - Indicates whether public access to the DMS kafka instance is enabled.
+* `enable_public_ip` - Indicates whether public access to the DMS kafka instance is enabled.
 * `resource_spec_code` - Indicates a resource specifications identifier.
 * `type` - Indicates the DMS kafka instance type.
 * `user_id` - Indicates the ID of the user who created the DMS kafka instance

--- a/huaweicloud/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/resource_huaweicloud_dms_kafka_instance.go
@@ -40,7 +40,6 @@ func resourceDmsKafkaInstance() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 			"engine_version": {
 				Type:     schema.TypeString,
@@ -412,13 +411,16 @@ func resourceDmsKafkaInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 		"security_group_id", "retention_policy", "enterprise_project_id") {
 		description := d.Get("description").(string)
 		updateOpts := instances.UpdateOpts{
-			Name:                d.Get("name").(string),
 			Description:         &description,
 			MaintainBegin:       d.Get("maintain_begin").(string),
 			MaintainEnd:         d.Get("maintain_end").(string),
 			SecurityGroupID:     d.Get("security_group_id").(string),
 			RetentionPolicy:     d.Get("retention_policy").(string),
 			EnterpriseProjectID: d.Get("enterprise_project_id").(string),
+		}
+
+		if d.HasChange("name") {
+			updateOpts.Name = d.Get("name").(string)
 		}
 
 		err = instances.Update(dmsV2Client, d.Id(), updateOpts).Err
@@ -444,11 +446,6 @@ func resourceDmsKafkaInstanceDelete(d *schema.ResourceData, meta interface{}) er
 	dmsV2Client, err := config.DmsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("error creating HuaweiCloud dms instance client: %s", err)
-	}
-
-	_, err = instances.Get(dmsV2Client, d.Id()).Extract()
-	if err != nil {
-		return CheckDeleted(d, err, "instance")
 	}
 
 	err = instances.Delete(dmsV2Client, d.Id()).ExtractErr()

--- a/huaweicloud/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_dms_kafka_instance_test.go
@@ -131,7 +131,7 @@ func testAccCheckDmsKafkaInstanceExists(n string, instance instances.Instance) r
 	}
 }
 
-func testAccDmsKafkaInstance_basic(rName string) string {
+func testAccDmsKafkaInstance_Base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_dms_az" "test" {}
 
@@ -153,6 +153,12 @@ resource "huaweicloud_networking_secgroup" "test" {
   name        = "%s"
   description = "secgroup for kafka"
 }
+`, rName)
+}
+
+func testAccDmsKafkaInstance_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "huaweicloud_dms_kafka_instance" "test" {
   name              = "%s"
@@ -176,31 +182,12 @@ resource "huaweicloud_dms_kafka_instance" "test" {
     owner = "terraform"
   }
 }
-`, rName, rName)
+`, testAccDmsKafkaInstance_Base(rName), rName)
 }
 
 func testAccDmsKafkaInstance_update(rName, updateName string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_dms_az" "test" {}
-
-data "huaweicloud_vpc" "test" {
-  name = "vpc-default"
-}
-
-data "huaweicloud_vpc_subnet" "test" {
-  name = "subnet-default"
-}
-
-data "huaweicloud_dms_product" "test" {
-  engine        = "kafka"
-  instance_type = "cluster"
-  version       = "2.3.0"
-}
-
-resource "huaweicloud_networking_secgroup" "test" {
-  name        = "%s"
-  description = "secgroup for kafka"
-}
+%s
 
 resource "huaweicloud_dms_kafka_instance" "test" {
   name              = "%s"
@@ -224,31 +211,12 @@ resource "huaweicloud_dms_kafka_instance" "test" {
     owner = "terraform_update"
   }
 }
-`, rName, updateName)
+`, testAccDmsKafkaInstance_Base(rName), updateName)
 }
 
 func testAccDmsKafkaInstance_withEpsId(rName string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_dms_az" "test" {}
-
-data "huaweicloud_vpc" "test" {
-  name = "vpc-default"
-}
-
-data "huaweicloud_vpc_subnet" "test" {
-  name = "subnet-default"
-}
-
-data "huaweicloud_dms_product" "test" {
-  engine        = "kafka"
-  instance_type = "cluster"
-  version       = "2.3.0"
-}
-
-resource "huaweicloud_networking_secgroup" "test" {
-  name        = "%s"
-  description = "secgroup for kafka"
-}
+%s
 
 resource "huaweicloud_dms_kafka_instance" "test" {
   name                  = "%s"
@@ -273,5 +241,5 @@ resource "huaweicloud_dms_kafka_instance" "test" {
     owner = "terraform"
   }
 }
-`, rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccDmsKafkaInstance_Base(rName), rName, HW_ENTERPRISE_PROJECT_ID_TEST)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix a bug in update func, updateops should contains param `name` only if the param `name` has changed. The API will return error if the `name` in update request body is same to the original `name`
2. remove Computed label of `description`, so `description` can be updated to null
3. define the testAccDmsKafkaInstance_Base func to make the code of test cases more concise
4. fix some doc problem

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDmsKafkaInstances'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDmsKafkaInstances -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaInstances_basic
=== PAUSE TestAccDmsKafkaInstances_basic
=== RUN   TestAccDmsKafkaInstances_withEpsId
=== PAUSE TestAccDmsKafkaInstances_withEpsId
=== CONT  TestAccDmsKafkaInstances_basic
=== CONT  TestAccDmsKafkaInstances_withEpsId
--- PASS: TestAccDmsKafkaInstances_basic (932.12s)
--- PASS: TestAccDmsKafkaInstances_withEpsId (976.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       976.495s
```
