### PR TITLE
mark dms_instance as deprecated

### DIFF
--- a/docs/resources/dms_instance.md
+++ b/docs/resources/dms_instance.md
@@ -1,8 +1,11 @@
 ---
-subcategory: "Distributed Message Service (DMS)"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud\_dms\_instance
+
+!> **Warning:** It has been deprecated, use `huaweicloud_dms_kafka_instance` or
+    `huaweicloud_dms_rabbitmq_instance` instead.
 
 Manages a DMS instance in the huaweicloud DMS Service.
 This is an alternative to `huaweicloud_dms_instance_v1`

--- a/huaweicloud/resource_huaweicloud_dms_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1.go
@@ -24,6 +24,7 @@ func resourceDmsInstancesV1() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "use huaweicloud_dms_kafka_instance or huaweicloud_dms_rabbitmq_instance instead",
 
 		Schema: map[string]*schema.Schema{
 			"region": {

--- a/huaweicloud/resource_huaweicloud_dms_instance_v1_test.go
+++ b/huaweicloud/resource_huaweicloud_dms_instance_v1_test.go
@@ -18,7 +18,7 @@ func TestAccDmsInstancesV1_Rabbitmq(t *testing.T) {
 	resourceName := "huaweicloud_dms_instance.instance_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDms(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDmsV1InstanceDestroy,
 		Steps: []resource.TestStep{
@@ -52,7 +52,7 @@ func TestAccDmsInstancesV1_Kafka(t *testing.T) {
 	resourceName := "huaweicloud_dms_instance.instance_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDms(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDmsV1InstanceDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

mark dms_instance as deprecated as dms_kafka_instance and dms_rabbitmq_instance are availiable

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
