### PR TITLE
style: indent two spaces for obs object acc test

### DIFF
--- a/huaweicloud/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/data_source_huaweicloud_obs_bucket_object_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
-func TestAccHuaweiCloudObsBucketObjectDataSource_content(t *testing.T) {
+func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceConf, dataSourceConf := testAccHuaweiCloudObsBucketObjectDataSource_content(rInt)
+	dataSourceName := "data.huaweicloud_obs_bucket_object.obj"
+	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_content(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheckOBS(t) },
@@ -31,16 +32,17 @@ func TestAccHuaweiCloudObsBucketObjectDataSource_content(t *testing.T) {
 			{
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+					testAccCheckAwsObsObjectDataSourceExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccHuaweiCloudObsBucketObjectDataSource_source(t *testing.T) {
+func TestAccObsBucketObjectDataSource_source(t *testing.T) {
+	dataSourceName := "data.huaweicloud_obs_bucket_object.obj"
 	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +60,7 @@ func TestAccHuaweiCloudObsBucketObjectDataSource_source(t *testing.T) {
 	}
 	tmpFile.Close()
 
-	resourceConf, dataSourceConf := testAccHuaweiCloudObsBucketObjectDataSource_source(rInt, tmpFile.Name())
+	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_source(rInt, tmpFile.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheckOBS(t) },
@@ -74,18 +76,19 @@ func TestAccHuaweiCloudObsBucketObjectDataSource_source(t *testing.T) {
 			{
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+					testAccCheckAwsObsObjectDataSourceExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccHuaweiCloudObsBucketObjectDataSource_allParams(t *testing.T) {
+func TestAccObsBucketObjectDataSource_allParams(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceConf, dataSourceConf := testAccHuaweiCloudObsBucketObjectDataSource_allParams(rInt)
+	dataSourceName := "data.huaweicloud_obs_bucket_object.obj"
+	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_allParams(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheckOBS(t) },
@@ -101,9 +104,9 @@ func TestAccHuaweiCloudObsBucketObjectDataSource_allParams(t *testing.T) {
 			{
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsObsObjectDataSourceExists("data.huaweicloud_obs_bucket_object.obj"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "content_type", "application/unknown"),
-					resource.TestCheckResourceAttr("data.huaweicloud_obs_bucket_object.obj", "storage_class", "STANDARD"),
+					testAccCheckAwsObsObjectDataSourceExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "content_type", "application/unknown"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 				),
 			},
 		},
@@ -155,71 +158,80 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccHuaweiCloudObsBucketObjectDataSource_content(randInt int) (string, string) {
+func testAccObsBucketObjectDataSource_content(randInt int) (string, string) {
 	resource := fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-acc-test-bucket-%d"
 }
+
 resource "huaweicloud_obs_bucket_object" "object" {
-	bucket = huaweicloud_obs_bucket.object_bucket.bucket
-	key = "test-key-%d"
-	content = "some_bucket_content"
+  bucket  = huaweicloud_obs_bucket.object_bucket.bucket
+  key     = "test-key-%d"
+  content = "some_bucket_content"
 }
 `, randInt, randInt)
 
-	dataSource := fmt.Sprintf(`%s
+	dataSource := fmt.Sprintf(`
+%s
+
 data "huaweicloud_obs_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "test-key-%d"
+  bucket = "tf-acc-test-bucket-%d"
+  key    = "test-key-%d"
 }`, resource, randInt, randInt)
 
 	return resource, dataSource
 }
 
-func testAccHuaweiCloudObsBucketObjectDataSource_source(randInt int, source string) (string, string) {
+func testAccObsBucketObjectDataSource_source(randInt int, source string) (string, string) {
 	resource := fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-acc-test-bucket-%d"
 }
+
 resource "huaweicloud_obs_bucket_object" "object" {
-	bucket = huaweicloud_obs_bucket.object_bucket.bucket
-	key = "test-key-%d"
-	source = "%s"
-	content_type = "binary/octet-stream"
+  bucket       = huaweicloud_obs_bucket.object_bucket.bucket
+  key          = "test-key-%d"
+  source       = "%s"
+  content_type = "binary/octet-stream"
 }
 `, randInt, randInt, source)
 
-	dataSource := fmt.Sprintf(`%s
+	dataSource := fmt.Sprintf(`
+%s
+
 data "huaweicloud_obs_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "test-key-%d"
+  bucket = "tf-acc-test-bucket-%d"
+  key    = "test-key-%d"
 }`, resource, randInt, randInt)
 
 	return resource, dataSource
 }
 
-func testAccHuaweiCloudObsBucketObjectDataSource_allParams(randInt int) (string, string) {
+func testAccObsBucketObjectDataSource_allParams(randInt int) (string, string) {
 	resource := fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-acc-test-bucket-%d"
 }
+
 resource "huaweicloud_obs_bucket_object" "object" {
-	bucket = huaweicloud_obs_bucket.object_bucket.bucket
-	key = "test-key-%d"
-	content = <<CONTENT
-	{"msg": "Hi there!"}
+  bucket        = huaweicloud_obs_bucket.object_bucket.bucket
+  key           = "test-key-%d"
+  acl           = "private"
+  storage_class = "STANDARD"
+  encryption    = true
+  content_type  = "application/unknown"
+  content       = <<CONTENT
+    {"msg": "Hi there!"}
 CONTENT
-	acl = "private"
-	content_type = "application/unknown"
-	storage_class = "STANDARD"
-	encryption = true
 }
 `, randInt, randInt)
 
-	dataSource := fmt.Sprintf(`%s
+	dataSource := fmt.Sprintf(`
+%s
+
 data "huaweicloud_obs_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "test-key-%d"
+  bucket = "tf-acc-test-bucket-%d"
+  key    = "test-key-%d"
 }`, resource, randInt, randInt)
 
 	return resource, dataSource

--- a/huaweicloud/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_object_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccObsBucketObject_source(t *testing.T) {
+	resourceName := "huaweicloud_obs_bucket_object.object"
 	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
 	if err != nil {
 		t.Fatal(err)
@@ -35,21 +36,17 @@ func TestAccObsBucketObject_source(t *testing.T) {
 			{
 				Config: testAccObsBucketObjectConfigSource(rInt, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObsBucketObjectExists("huaweicloud_obs_bucket_object.object"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_obs_bucket_object.object", "key", "test-key"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_obs_bucket_object.object", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_obs_bucket_object.object", "storage_class", "STANDARD"),
+					testAccCheckObsBucketObjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", "test-key"),
+					resource.TestCheckResourceAttr(resourceName, "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
 				),
 			},
 			{
 				// update with encryption
 				Config: testAccObsBucketObjectConfig_withSSE(rInt, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"huaweicloud_obs_bucket_object.object", "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
 				),
 			},
 		},
@@ -58,6 +55,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 
 func TestAccObsBucketObject_content(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "huaweicloud_obs_bucket_object.object"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckOBS(t) },
@@ -68,11 +66,9 @@ func TestAccObsBucketObject_content(t *testing.T) {
 				PreConfig: func() {},
 				Config:    testAccObsBucketObjectConfigContent(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObsBucketObjectExists("huaweicloud_obs_bucket_object.object"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_obs_bucket_object.object", "key", "test-key"),
-					resource.TestCheckResourceAttr(
-						"huaweicloud_obs_bucket_object.object", "size", "19"),
+					testAccCheckObsBucketObjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", "test-key"),
+					resource.TestCheckResourceAttr(resourceName, "size", "19"),
 				),
 			},
 		},
@@ -166,13 +162,14 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 func testAccObsBucketObjectConfigSource(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
-    bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-acc-test-bucket-%d"
 }
+
 resource "huaweicloud_obs_bucket_object" "object" {
-	bucket = huaweicloud_obs_bucket.object_bucket.bucket
-	key = "test-key"
-	source = "%s"
-	content_type = "binary/octet-stream"
+  bucket       = huaweicloud_obs_bucket.object_bucket.bucket
+  key          = "test-key"
+  source       = "%s"
+  content_type = "binary/octet-stream"
 }
 `, randInt, source)
 }
@@ -180,12 +177,13 @@ resource "huaweicloud_obs_bucket_object" "object" {
 func testAccObsBucketObjectConfigContent(randInt int) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
-        bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-acc-test-bucket-%d"
 }
+
 resource "huaweicloud_obs_bucket_object" "object" {
-        bucket = huaweicloud_obs_bucket.object_bucket.bucket
-        key = "test-key"
-        content = "some_bucket_content"
+  bucket  = huaweicloud_obs_bucket.object_bucket.bucket
+  key     = "test-key"
+  content = "some_bucket_content"
 }
 `, randInt)
 }
@@ -193,15 +191,15 @@ resource "huaweicloud_obs_bucket_object" "object" {
 func testAccObsBucketObjectConfig_withSSE(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-acc-test-bucket-%d"
 }
 
 resource "huaweicloud_obs_bucket_object" "object" {
-	bucket = huaweicloud_obs_bucket.object_bucket.bucket
-	key = "test-key"
-	source = "%s"
-	content_type = "binary/octet-stream"
-	encryption = true
+bucket       = huaweicloud_obs_bucket.object_bucket.bucket
+key          = "test-key"
+source       = "%s"
+content_type = "binary/octet-stream"
+encryption   = true
 }
 `, randInt, source)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucketObjectDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucketObjectDataSource -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObjectDataSource_source
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucketObjectDataSource_allParams
--- PASS: TestAccObsBucketObjectDataSource_content (41.93s)
--- PASS: TestAccObsBucketObjectDataSource_allParams (42.73s)
--- PASS: TestAccObsBucketObjectDataSource_source (44.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       44.360s
```
