### PR TITLE
make acc test of IEC EIPs data source happy

### DIFF
--- a/huaweicloud/data_source_huaweicloud_iec_eips_test.go
+++ b/huaweicloud/data_source_huaweicloud_iec_eips_test.go
@@ -12,9 +12,10 @@ func TestAccIECPublicIPsDataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_iec_eips.site"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIecEIPDestroy,
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		CheckDestroy:              testAccCheckIecEIPDestroy,
+		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIECEipsDataSource_config,
@@ -23,8 +24,6 @@ func TestAccIECPublicIPsDataSource_basic(t *testing.T) {
 				Config: testAccIECEipsDataSource_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccIECPublicIPsDataSourceID(resourceName),
-					// "eips.#" >= 2
-					// resource.TestCheckResourceAttr(resourceName, "eips.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "eips.0.ip_version", "4"),
 					resource.TestCheckResourceAttr(resourceName, "eips.0.bandwidth_share_type", "WHOLE"),
 					resource.TestCheckResourceAttrSet(resourceName, "site_info"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
set `PreventPostDestroyRefresh` to true, then the acc test will be passed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIECPublicIPsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIECPublicIPsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIECPublicIPsDataSource_basic
=== PAUSE TestAccIECPublicIPsDataSource_basic
=== CONT  TestAccIECPublicIPsDataSource_basic
--- PASS: TestAccIECPublicIPsDataSource_basic (52.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       52.946s
```
