### PR TITLE
add import test step for compute relational resources

### DIFF
--- a/docs/resources/compute_eip_associate.md
+++ b/docs/resources/compute_eip_associate.md
@@ -2,10 +2,9 @@
 subcategory: "Elastic Cloud Server (ECS)"
 ---
 
-# huaweicloud\_compute\_eip\_associate
+# huaweicloud_compute_eip_associate
 
-Associate an EIP to an instance. This is an alternative to
-`huaweicloud_compute_floatingip_associate_v2`.
+Associate an EIP to a compute instance.
 
 ## Example Usage
 
@@ -86,11 +85,11 @@ resource "huaweicloud_compute_eip_associate" "associated" {
 
 The following arguments are supported:
 
-* `public_ip` - (Required, String, ForceNew) The EIP to associate.
+* `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate.
 
-* `instance_id` - (Required, String, ForceNew) The instance to associte the EIP with.
+* `instance_id` - (Required, String, ForceNew) Specifies the instance to associte the EIP with.
 
-* `fixed_ip` - (Optional, String, ForceNew) The specific IP address to direct traffic to.
+* `fixed_ip` - (Optional, String, ForceNew) Specifies the IP address to direct traffic to.
 
 ## Attributes Reference
 

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
@@ -128,7 +128,7 @@ func testAccCheckComputeV2EIPAssociateAssociated(
 		// Walk through the instance's addresses and find the match
 		i := 0
 		for _, networkAddresses := range newInstance.Addresses {
-			i += 1
+			i++
 			if i != n {
 				continue
 			}
@@ -177,7 +177,7 @@ func testAccComputeV2EIPAssociate_basic(rName string) string {
 %s
 
 resource "huaweicloud_compute_eip_associate" "test" {
-  public_ip = huaweicloud_vpc_eip.test.address
+  public_ip   = huaweicloud_vpc_eip.test.address
   instance_id = huaweicloud_compute_instance.test.id
 }
 `, testAccComputeV2EIPAssociate_Base(rName))
@@ -188,7 +188,7 @@ func testAccComputeV2EIPAssociate_fixedIP(rName string) string {
 %s
 
 resource "huaweicloud_compute_eip_associate" "test" {
-  public_ip = huaweicloud_vpc_eip.test.address
+  public_ip   = huaweicloud_vpc_eip.test.address
   instance_id = huaweicloud_compute_instance.test.id
   fixed_ip    = huaweicloud_compute_instance.test.access_ip_v4
 }

--- a/huaweicloud/resource_huaweicloud_compute_interface_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_interface_attach.go
@@ -34,31 +34,29 @@ func ResourceComputeInterfaceAttachV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"port_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"network_id"},
-			},
-
-			"network_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"port_id"},
-			},
-
 			"instance_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
+			"network_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"port_id", "network_id"},
+			},
+			"port_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"fixed_ip": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -84,10 +82,6 @@ func resourceComputeInterfaceAttachV2Create(d *schema.ResourceData, meta interfa
 		networkId = v.(string)
 	}
 
-	if networkId == "" && portId == "" {
-		return fmt.Errorf("Must set one of network_id and port_id")
-	}
-
 	// For some odd reason the API takes an array of IPs, but you can only have one element in the array.
 	var fixedIPs []attachinterfaces.FixedIP
 	if v, ok := d.GetOk("fixed_ip"); ok {
@@ -100,8 +94,7 @@ func resourceComputeInterfaceAttachV2Create(d *schema.ResourceData, meta interfa
 		FixedIPs:  fixedIPs,
 	}
 
-	log.Printf("[DEBUG] huaweicloud_compute_interface_attach_v2 attach options: %#v", attachOpts)
-
+	log.Printf("[DEBUG] huaweicloud_compute_interface_attach attach options: %#v", attachOpts)
 	attachment, err := attachinterfaces.Create(computeClient, instanceId, attachOpts).Extract()
 	if err != nil {
 		return err
@@ -117,13 +110,13 @@ func resourceComputeInterfaceAttachV2Create(d *schema.ResourceData, meta interfa
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error creating huaweicloud_compute_interface_attach_v2 %s: %s", instanceId, err)
+		return fmt.Errorf("Error creating huaweicloud_compute_interface_attach %s: %s", instanceId, err)
 	}
 
-	// Use the instance ID and attachment ID as the resource ID.
+	// Use the instance ID and port ID as the resource ID.
 	id := fmt.Sprintf("%s/%s", instanceId, attachment.PortID)
 
-	log.Printf("[DEBUG] Created huaweicloud_compute_interface_attach_v2 %s: %#v", id, attachment)
+	log.Printf("[DEBUG] Created huaweicloud_compute_interface_attach %s: %#v", id, attachment)
 
 	d.SetId(id)
 
@@ -137,23 +130,27 @@ func resourceComputeInterfaceAttachV2Read(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating HuaweiCloud compute client: %s", err)
 	}
 
-	instanceId, attachmentId, err := computeInterfaceAttachV2ParseID(d.Id())
+	instanceId, portId, err := computeInterfaceAttachV2ParseID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	attachment, err := attachinterfaces.Get(computeClient, instanceId, attachmentId).Extract()
+	attachment, err := attachinterfaces.Get(computeClient, instanceId, portId).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving huaweicloud_compute_interface_attach_v2")
+		return CheckDeleted(d, err, "Error retrieving huaweicloud_compute_interface_attach")
 	}
 
-	log.Printf("[DEBUG] Retrieved huaweicloud_compute_interface_attach_v2 %s: %#v", d.Id(), attachment)
+	log.Printf("[DEBUG] Retrieved huaweicloud_compute_interface_attach %s: %#v", d.Id(), attachment)
 
 	d.Set("instance_id", instanceId)
 	d.Set("port_id", attachment.PortID)
 	d.Set("network_id", attachment.NetID)
 	d.Set("region", GetRegion(d, config))
 
+	if len(attachment.FixedIPs) > 0 {
+		firstAddress := attachment.FixedIPs[0].IPAddress
+		d.Set("fixed_ip", firstAddress)
+	}
 	return nil
 }
 
@@ -164,7 +161,7 @@ func resourceComputeInterfaceAttachV2Delete(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating HuaweiCloud compute client: %s", err)
 	}
 
-	instanceId, attachmentId, err := computeInterfaceAttachV2ParseID(d.Id())
+	instanceId, portId, err := computeInterfaceAttachV2ParseID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -172,14 +169,14 @@ func resourceComputeInterfaceAttachV2Delete(d *schema.ResourceData, meta interfa
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{""},
 		Target:     []string{"DETACHED"},
-		Refresh:    computeInterfaceAttachV2DetachFunc(computeClient, instanceId, attachmentId),
+		Refresh:    computeInterfaceAttachV2DetachFunc(computeClient, instanceId, portId),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error detaching huaweicloud_compute_interface_attach_v2 %s: %s", d.Id(), err)
+		return fmt.Errorf("Error detaching huaweicloud_compute_interface_attach %s: %s", d.Id(), err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_compute_interface_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_interface_attach_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccComputeV2InterfaceAttach_Basic(t *testing.T) {
 	var ai attachinterfaces.Interface
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_compute_interface_attach.ai_1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,9 +25,14 @@ func TestAccComputeV2InterfaceAttach_Basic(t *testing.T) {
 			{
 				Config: testAccComputeV2InterfaceAttach_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InterfaceAttachExists("huaweicloud_compute_interface_attach.ai_1", &ai),
+					testAccCheckComputeV2InterfaceAttachExists(resourceName, &ai),
 					testAccCheckComputeV2InterfaceAttachIP(&ai, "192.168.0.199"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -126,8 +132,8 @@ resource "huaweicloud_compute_instance" "instance_1" {
 
 resource "huaweicloud_compute_interface_attach" "ai_1" {
   instance_id = huaweicloud_compute_instance.instance_1.id
-  network_id =  data.huaweicloud_vpc_subnet.test.id
-  fixed_ip = "192.168.0.199"
+  network_id  = data.huaweicloud_vpc_subnet.test.id
+  fixed_ip    = "192.168.0.199"
 }
 `, testAccCompute_data, rName)
 }

--- a/huaweicloud/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach.go
@@ -85,7 +85,6 @@ func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Creating volume attachment: %#v", attachOpts)
-
 	attachment, err := volumeattach.Create(computeClient, instanceId, attachOpts).Extract()
 	if err != nil {
 		return err
@@ -108,8 +107,8 @@ func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{
 
 	// Use the instance ID and attachment ID as the resource ID.
 	// This is because an attachment cannot be retrieved just by its ID alone.
+	// attachment ID equals the volume ID
 	id := fmt.Sprintf("%s/%s", instanceId, attachment.ID)
-
 	d.SetId(id)
 
 	return resourceComputeVolumeAttachV2Read(d, meta)

--- a/huaweicloud/resource_huaweicloud_compute_volume_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccComputeV2VolumeAttach_basic(t *testing.T) {
 	var va volumeattach.VolumeAttachment
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_compute_volume_attach.va_1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,11 +25,11 @@ func TestAccComputeV2VolumeAttach_basic(t *testing.T) {
 			{
 				Config: testAccComputeV2VolumeAttach_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2VolumeAttachExists("huaweicloud_compute_volume_attach.va_1", &va),
+					testAccCheckComputeV2VolumeAttachExists(resourceName, &va),
 				),
 			},
 			{
-				ResourceName:      "huaweicloud_compute_volume_attach.va_1",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
* add import test step for compute_interface_attach
* remove deprecated floating_ip args and make import more flexible for compute_eip_associate
* style: improve on compute_volume_attach resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2EIPAssociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2EIPAssociate -timeout 360m -parallel 4
=== RUN   TestAccComputeV2EIPAssociate_basic
=== PAUSE TestAccComputeV2EIPAssociate_basic
=== RUN   TestAccComputeV2EIPAssociate_fixedIP
=== PAUSE TestAccComputeV2EIPAssociate_fixedIP
=== CONT  TestAccComputeV2EIPAssociate_basic
=== CONT  TestAccComputeV2EIPAssociate_fixedIP
--- PASS: TestAccComputeV2EIPAssociate_basic (174.62s)
--- PASS: TestAccComputeV2EIPAssociate_fixedIP (175.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       175.697s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2InterfaceAttach_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2InterfaceAttach_Basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2InterfaceAttach_Basic
=== PAUSE TestAccComputeV2InterfaceAttach_Basic
=== CONT  TestAccComputeV2InterfaceAttach_Basic
--- PASS: TestAccComputeV2InterfaceAttach_Basic (175.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       175.199s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2VolumeAttach_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2VolumeAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2VolumeAttach_basic
=== PAUSE TestAccComputeV2VolumeAttach_basic
=== CONT  TestAccComputeV2VolumeAttach_basic
--- PASS: TestAccComputeV2VolumeAttach_basic (216.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       216.046s
```
