### PR TITLE
add import test step for networking_eip_associate and vpc_eip resource

### DIFF
--- a/docs/resources/networking_eip_associate.md
+++ b/docs/resources/networking_eip_associate.md
@@ -29,7 +29,7 @@ resource "huaweicloud_vpc_eip" "myeip" {
 
 resource "huaweicloud_networking_eip_associate" "associated" {
   public_ip = huaweicloud_vpc_eip.myeip.address
-  port_id   = huaweicloud_networking_port.myport.id
+  port_id   = data.huaweicloud_networking_port.myport.id
 }
 ```
 

--- a/docs/resources/networking_eip_associate.md
+++ b/docs/resources/networking_eip_associate.md
@@ -2,7 +2,7 @@
 subcategory: "Virtual Private Cloud (VPC)"
 ---
 
-# huaweicloud\_networking\_eip\_associate
+# huaweicloud_networking_eip_associate
 
 Associates an EIP to a port. This can be used instead of the
 `huaweicloud_networking_floatingip_associate_v2` resource.
@@ -10,8 +10,9 @@ Associates an EIP to a port. This can be used instead of the
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_networking_port" "myport" {
+data "huaweicloud_networking_port" "myport" {
   network_id = "a5bbd213-e1d3-49b6-aed1-9df60ea94b9a"
+  fixed_ip   = "192.168.0.100"
 }
 
 resource "huaweicloud_vpc_eip" "myeip" {
@@ -36,10 +37,9 @@ resource "huaweicloud_networking_eip_associate" "associated" {
 
 The following arguments are supported:
 
-* `public_ip` - (Required, String, ForceNew) The EIP to associate.
+* `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate.
 
-* `port_id` - (Required, String, ForceNew) ID of an existing port with at least one IP address to
-    associate with this EIP.
+* `port_id` - (Required, String, ForceNew) Specifies an existing port ID to associate with this EIP.
 
 ## Attributes Reference
 

--- a/huaweicloud/resource_huaweicloud_networking_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_eip_associate_test.go
@@ -31,6 +31,11 @@ func TestAccNetworkingV2EIPAssociate_basic(t *testing.T) {
 						resourceName, "public_ip", &eip.PublicAddress),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -73,8 +78,8 @@ resource "huaweicloud_vpc_eip" "test" {
 }
 
 resource "huaweicloud_networking_eip_associate" "test" {
-  public_ip   = huaweicloud_vpc_eip.test.address
-  port_id     = huaweicloud_compute_instance.test.network[0].port
+  public_ip = huaweicloud_vpc_eip.test.address
+  port_id   = huaweicloud_compute_instance.test.network[0].port
 }
 `, testAccComputeV2Instance_basic(rName), rName)
 }

--- a/huaweicloud/resource_huaweicloud_networking_vip_associate_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_associate_v2.go
@@ -123,7 +123,7 @@ func resourceNetworkingVIPAssociateV2Create(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
 
-	// chech the vip
+	// check the vip port
 	vipID := d.Get("vip_id").(string)
 	_, err = ports.Get(networkingClient, vipID).Extract()
 	if err != nil {
@@ -147,7 +147,7 @@ func resourceNetworkingVIPAssociateV2Update(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
 
-	// chech the vip
+	// check the vip port
 	vipID := d.Get("vip_id").(string)
 	_, err = ports.Get(networkingClient, vipID).Extract()
 	if err != nil {
@@ -169,8 +169,8 @@ func resourceNetworkingVIPAssociateV2Read(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
 
-	vipID := d.Get("vip_id").(string)
 	// check the vip port
+	vipID := d.Get("vip_id").(string)
 	vip, err := ports.Get(networkingClient, vipID).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "vip")
@@ -222,8 +222,8 @@ func resourceNetworkingVIPAssociateV2Delete(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
 
-	vipID := d.Get("vip_id").(string)
 	// check the vip port
+	vipID := d.Get("vip_id").(string)
 	_, err = ports.Get(networkingClient, vipID).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "vip")

--- a/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
@@ -62,48 +62,22 @@ func testAccCheckNetworkingV2VIPAssociateDestroy(s *terraform.State) error {
 		}
 	}
 
-	log.Printf("[DEBUG] testAccCheckNetworkingV2VIPAssociateDestroy success!")
+	log.Printf("[DEBUG] Destroy NetworkingVIPAssociated success!")
 	return nil
 }
 
 func testAccCheckNetworkingV2VIPAssociated(p *ports.Port, vip *ports.Port) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV2Client(HW_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud networking client: %s", err)
-		}
-
-		p, err := ports.Get(networkingClient, p.ID).Extract()
-		if err != nil {
-			// If the error is a 404, then the port does not exist,
-			// and therefore the VIP cannot be associated to it.
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil
-			}
-			return err
-		}
-
-		vipport, err := ports.Get(networkingClient, vip.ID).Extract()
-		if err != nil {
-			// If the error is a 404, then the vip port does not exist,
-			// and therefore the VIP cannot be associated to it.
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil
-			}
-			return err
-		}
-
 		for _, ip := range p.FixedIPs {
-			for _, addresspair := range vipport.AllowedAddressPairs {
+			for _, addresspair := range vip.AllowedAddressPairs {
 				if ip.IPAddress == addresspair.IPAddress {
-					log.Printf("[DEBUG] testAccCheckNetworkingV2VIPAssociated success!")
+					log.Printf("[DEBUG] Check NetworkingVIPAssociated success!")
 					return nil
 				}
 			}
 		}
 
-		return fmt.Errorf("VIP %s was not attached to port %s", vipport.ID, p.ID)
+		return fmt.Errorf("VIP %s was not attached to port %s", vip.ID, p.ID)
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/resource_huaweicloud_vpc_eip_test.go
@@ -29,6 +29,11 @@ func TestAccVpcV1EIP_basic(t *testing.T) {
 					testAccCheckVpcV1EIPExists(resourceName, &eip),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -49,6 +54,11 @@ func TestAccVpcV1EIP_share(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcV1EIPExists(resourceName, &eip),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
- remove deprecated floating_ip args in networking_eip_associate
- add import test step for networking_eip_associate and vpc_eip resource
- improve on networking_vip_associate
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2EIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2EIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2EIPAssociate_basic
=== PAUSE TestAccNetworkingV2EIPAssociate_basic
=== CONT  TestAccNetworkingV2EIPAssociate_basic
--- PASS: TestAccNetworkingV2EIPAssociate_basic (159.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       160.008s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2VIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2VIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIPAssociate_basic
=== PAUSE TestAccNetworkingV2VIPAssociate_basic
=== CONT  TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (174.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       174.457s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcV1EIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcV1EIP_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (36.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       36.888s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcV1EIP_share'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcV1EIP_share -timeout 360m -parallel 4
=== RUN   TestAccVpcV1EIP_share
=== PAUSE TestAccVpcV1EIP_share
=== CONT  TestAccVpcV1EIP_share
--- PASS: TestAccVpcV1EIP_share (49.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       49.443s
```
