### PR TITLE
update docs and acc test for networking_port data source

### DIFF
--- a/docs/data-sources/networking_port.md
+++ b/docs/data-sources/networking_port.md
@@ -2,7 +2,7 @@
 subcategory: "Virtual Private Cloud (VPC)"
 ---
 
-# huaweicloud\_networking\_port
+# huaweicloud_networking_port
 
 Use this data source to get the ID of an available HuaweiCloud port.
 This is an alternative to `huaweicloud_networking_port_v2`
@@ -11,35 +11,25 @@ This is an alternative to `huaweicloud_networking_port_v2`
 
 ```hcl
 data "huaweicloud_networking_port" "port_1" {
-  name = "port_1"
+  network_id = var.network_id
+  fixed_ip   = "192.168.0.100"
 }
 ```
 
 ## Argument Reference
 
-* `region` - (Optional, String) The region in which to obtain the V2 Neutron client.
-  A Neutron client is needed to retrieve port ids. If omitted, the
-  `region` argument of the provider is used.
+* `region` - (Optional, String) Specifies the region in which to obtain the port.
+  If omitted, the provider-level region will be used.
 
-* `project_id` - (Optional, String) The owner of the port.
+* `port_id` - (Optional, String) Specifies the ID of the port.
 
-* `port_id` - (Optional, String) The ID of the port.
+* `network_id` - (Optional, String) Specifies the ID of the network the port belongs to.
 
-* `name` - (Optional, String) The name of the port.
+* `fixed_ip` - (Optional, String) Specifies the port IP address filter.
 
-* `admin_state_up` - (Optional, Bool) The administrative state of the port.
+* `mac_address` - (Optional, String) Specifies the MAC address of the port.
 
-* `network_id` - (Optional, String) The ID of the network the port belongs to.
-
-* `device_owner` - (Optional, String) The device owner of the port.
-
-* `mac_address` - (Optional, String) The MAC address of the port.
-
-* `device_id` - (Optional, String) The ID of the device the port belongs to.
-
-* `fixed_ip` - (Optional, String) The port IP address filter.
-
-* `status` - (Optional, String) The status of the port.
+* `status` - (Optional, String) Specifies the status of the port.
 
 * `security_group_ids` - (Optional, String) The list of port security group IDs to filter.
 
@@ -47,9 +37,16 @@ data "huaweicloud_networking_port" "port_1" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a data source ID in UUID format.
+* `id` - The data source ID in UUID format.
 
-* `all_fixed_ips` - The collection of Fixed IP addresses on the port in the
-  order returned by the Network v2 API.
+* `name` - The name of the port.
 
-* `all_security_group_ids` - The set of security group IDs applied on the port.
+* `admin_state_up` - The administrative state of the port.
+
+* `device_owner` - The device owner of the port.
+
+* `device_id` - The ID of the device the port belongs to.
+
+* `all_fixed_ips` - The collection of Fixed IP addresses on the port.
+
+* `all_security_group_ids` - The collection of security group IDs applied on the port.

--- a/docs/resources/compute_interface_attach.md
+++ b/docs/resources/compute_interface_attach.md
@@ -70,10 +70,9 @@ data "huaweicloud_vpc_subnet" "mynet" {
   name = "subnet-default"
 }
 
-resource "huaweicloud_networking_port" "myport" {
-  name           = "port"
-  network_id     = data.huaweicloud_vpc_subnet.mynet.id
-  admin_state_up = "true"
+data "huaweicloud_networking_port" "myport" {
+  network_id = data.huaweicloud_vpc_subnet.mynet.id
+  fixed_ip   = "192.168.0.100"
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
@@ -91,7 +90,7 @@ resource "huaweicloud_compute_instance" "myinstance" {
 
 resource "huaweicloud_compute_interface_attach" "attached" {
   instance_id = huaweicloud_compute_instance.myinstance.id
-  port_id     = huaweicloud_networking_port.myport.id
+  port_id     = data.huaweicloud_networking_port.myport.id
 }
 
 ```

--- a/huaweicloud/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_port_v2.go
@@ -26,58 +26,49 @@ func DataSourceNetworkingPortV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
 			"network_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"device_owner": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"mac_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"device_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
 			"fixed_ip": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.IsIPAddress,
 			},
-
+			"mac_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
+			// will be deprecated or change to computed
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"admin_state_up": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"device_owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"device_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"security_group_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -85,17 +76,16 @@ func DataSourceNetworkingPortV2() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			// Computed
 			"all_fixed_ips": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"all_security_group_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}
@@ -113,40 +103,32 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("port_id"); ok {
 		listOpts.ID = v.(string)
 	}
-
-	if v, ok := d.GetOk("name"); ok {
-		listOpts.Name = v.(string)
-	}
-
-	if v, ok := d.GetOkExists("admin_state_up"); ok {
-		asu := v.(bool)
-		listOpts.AdminStateUp = &asu
-	}
-
 	if v, ok := d.GetOk("network_id"); ok {
 		listOpts.NetworkID = v.(string)
 	}
-
+	if v, ok := d.GetOk("mac_address"); ok {
+		listOpts.MACAddress = v.(string)
+	}
 	if v, ok := d.GetOk("status"); ok {
 		listOpts.Status = v.(string)
 	}
 
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = v.(string)
+	}
+	if v, ok := d.GetOk("admin_state_up"); ok {
+		asu := v.(bool)
+		listOpts.AdminStateUp = &asu
+	}
 	if v, ok := d.GetOk("tenant_id"); ok {
 		listOpts.TenantID = v.(string)
 	}
-
 	if v, ok := d.GetOk("project_id"); ok {
 		listOpts.ProjectID = v.(string)
 	}
-
 	if v, ok := d.GetOk("device_owner"); ok {
 		listOpts.DeviceOwner = v.(string)
 	}
-
-	if v, ok := d.GetOk("mac_address"); ok {
-		listOpts.MACAddress = v.(string)
-	}
-
 	if v, ok := d.GetOk("device_id"); ok {
 		listOpts.DeviceID = v.(string)
 	}
@@ -164,7 +146,7 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if len(allPorts) == 0 {
-		return fmt.Errorf("No huaweicloud_networking_port_v2 found")
+		return fmt.Errorf("No huaweicloud_networking_port found")
 	}
 
 	var portsList []ports.Port
@@ -179,8 +161,8 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 		if len(portsList) == 0 {
-			log.Printf("No huaweicloud_networking_port_v2 found after the 'fixed_ip' filter")
-			return fmt.Errorf("No huaweicloud_networking_port_v2 found")
+			log.Printf("No huaweicloud_networking_port found after the 'fixed_ip' filter")
+			return fmt.Errorf("No huaweicloud_networking_port found")
 		}
 	} else {
 		portsList = allPorts
@@ -198,29 +180,28 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 		if len(sgPorts) == 0 {
-			log.Printf("[DEBUG] No huaweicloud_networking_port_v2 found after the 'security_group_ids' filter")
-			return fmt.Errorf("No huaweicloud_networking_port_v2 found")
+			log.Printf("[DEBUG] No huaweicloud_networking_port found after the 'security_group_ids' filter")
+			return fmt.Errorf("No huaweicloud_networking_port found")
 		}
 		portsList = sgPorts
 	}
 
 	if len(portsList) > 1 {
-		return fmt.Errorf("More than one huaweicloud_networking_port_v2 found (%d)", len(portsList))
+		return fmt.Errorf("More than one huaweicloud_networking_port found (%d)", len(portsList))
 	}
 
 	port := portsList[0]
 
-	log.Printf("[DEBUG] Retrieved huaweicloud_networking_port_v2 %s: %+v", port.ID, port)
+	log.Printf("[DEBUG] Retrieved huaweicloud_networking_port %s: %+v", port.ID, port)
 	d.SetId(port.ID)
 
 	d.Set("port_id", port.ID)
 	d.Set("name", port.Name)
+	d.Set("status", port.Status)
 	d.Set("admin_state_up", port.AdminStateUp)
 	d.Set("network_id", port.NetworkID)
-	d.Set("tenant_id", port.TenantID)
-	d.Set("project_id", port.ProjectID)
-	d.Set("device_owner", port.DeviceOwner)
 	d.Set("mac_address", port.MACAddress)
+	d.Set("device_owner", port.DeviceOwner)
 	d.Set("device_id", port.DeviceID)
 	d.Set("region", GetRegion(d, config))
 	d.Set("all_security_group_ids", port.SecurityGroups)

--- a/huaweicloud/data_source_huaweicloud_networking_port_v2_test.go
+++ b/huaweicloud/data_source_huaweicloud_networking_port_v2_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccNetworkingV2PortDataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_networking_port.gw_port"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,8 +18,9 @@ func TestAccNetworkingV2PortDataSource_basic(t *testing.T) {
 			{
 				Config: testAccNetworkingV2PortDataSource_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_networking_port.port_3", "all_fixed_ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "all_fixed_ips.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "mac_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
 				),
 			},
 		},
@@ -31,9 +33,9 @@ data "huaweicloud_vpc_subnet" "mynet" {
   name = "subnet-default"
 }
 
-data "huaweicloud_networking_port" "port_3" {
+data "huaweicloud_networking_port" "gw_port" {
   network_id = data.huaweicloud_vpc_subnet.mynet.id
-  fixed_ip = data.huaweicloud_vpc_subnet.mynet.gateway_ip
+  fixed_ip   = data.huaweicloud_vpc_subnet.mynet.gateway_ip
 }
 `)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
- hide some unused arguments and move them to attribute in docs
- add more check in acc test
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2PortDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2PortDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (28.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       28.763s
```
