### PR TITLE
Add volume_size support for gaussdb mysql

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -95,6 +95,9 @@ The following arguments are supported:
 
 * `force_import` - (Optional, Bool) If specified, try to import the instance instead of creating if the name already existed.
 
+* `volume_size` - (Optional, Int) Specifies the volume size of the instance. The new storage space must be greater than
+  the current storage and must be a multiple of 10 GB. Only valid when in prePaid mode.
+
 * `charging_mode` - (Optional, String, ForceNew) The charging mode of the instance.
   Valid values are *prePaid* and *postPaid*, defaults to *postPaid*.
   Changing this creates a new resource.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f
+	github.com/huaweicloud/golangsdk v0.0.0-20210608085437-ebb866377c9f
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,10 +206,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71 h1:o2s9CcW277XbOQp0EolTCWHrNdBUHCjuu0aKtAedF/k=
-github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f h1:7FSmwn+mnDmezxuOjfDotwmyxQCQOU1waZDLORl7kGc=
-github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210608085437-ebb866377c9f h1:uvvd7F4iujOwAP0E0W7H91IrgBt5KI0xE7A6HCwGTj0=
+github.com/huaweicloud/golangsdk v0.0.0-20210608085437-ebb866377c9f/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/requests.go
@@ -2,6 +2,7 @@ package eips
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/structs"
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
@@ -16,6 +17,9 @@ type ApplyOpts struct {
 	IP                  PublicIpOpts  `json:"publicip" required:"true"`
 	Bandwidth           BandwidthOpts `json:"bandwidth" required:"true"`
 	EnterpriseProjectID string        `json:"enterprise_project_id,omitempty"`
+
+	//ExtendParam is only valid by v2.0 client
+	ExtendParam *structs.ChargeInfo `json:"extendParam,omitempty"`
 }
 
 type PublicIpOpts struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/results.go
@@ -11,11 +11,20 @@ type ApplyResult struct {
 }
 
 func (r ApplyResult) Extract() (PublicIp, error) {
-	var ip struct {
-		Ip PublicIp `json:"publicip"`
+	var ipResp struct {
+		IP         PublicIp `json:"publicip"`
+		OrderID    string   `json:"order_id"`
+		PublicipID string   `json:"publicip_id"`
 	}
-	err := r.Result.ExtractInto(&ip)
-	return ip.Ip, err
+	err := r.Result.ExtractInto(&ipResp)
+	if ipResp.PublicipID != "" {
+		ipResp.IP.ID = ipResp.PublicipID
+	}
+	if ipResp.OrderID != "" {
+		ipResp.IP.OrderID = ipResp.OrderID
+	}
+
+	return ipResp.IP, err
 }
 
 //PublicIp is a struct that represents a public ip
@@ -27,6 +36,7 @@ type PublicIp struct {
 	PrivateAddress      string `json:"private_ip_address"`
 	PortID              string `json:"port_id"`
 	TenantID            string `json:"tenant_id"`
+	OrderID             string `json:"order_id"`
 	CreateTime          string `json:"create_time"`
 	BandwidthID         string `json:"bandwidth_id"`
 	BandwidthSize       int    `json:"bandwidth_size"`
@@ -40,11 +50,11 @@ type GetResult struct {
 }
 
 func (r GetResult) Extract() (PublicIp, error) {
-	var Ip struct {
-		Ip PublicIp `json:"publicip"`
+	var getResp struct {
+		IP PublicIp `json:"publicip"`
 	}
-	err := r.Result.ExtractInto(&Ip)
-	return Ip.Ip, err
+	err := r.Result.ExtractInto(&getResp)
+	return getResp.IP, err
 }
 
 //DeleteResult is a struct of delete result

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances/requests.go
@@ -17,6 +17,10 @@ type ChargeInfoOpt struct {
 	IsAutoPay    string `json:"is_auto_pay,omitempty"`
 }
 
+type VolumeOpt struct {
+	Size int `json:"size" required:"true"`
+}
+
 type DataStoreOpt struct {
 	Type    string `json:"type" required:"true"`
 	Version string `json:"version" required:"true"`
@@ -46,6 +50,7 @@ type CreateTaurusDBOpts struct {
 	DataStore           DataStoreOpt       `json:"datastore" required:"true"`
 	BackupStrategy      *BackupStrategyOpt `json:"backup_strategy,omitempty"`
 	ChargeInfo          *ChargeInfoOpt     `json:"charge_info,omitempty"`
+	Volume              *VolumeOpt         `json:"volume,omitempty"`
 }
 
 type CreateTaurusDBBuilder interface {
@@ -261,6 +266,38 @@ func UpdatePass(client *golangsdk.ServiceClient, instanceId string, opts UpdateP
 
 	_, r.Err = client.Post(passwordURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	return
+}
+
+type ExtendVolumeOpts struct {
+	Size      int    `json:"size" required:"true"`
+	IsAutoPay string `json:"is_auto_pay,omitempty"`
+}
+
+type ExtendVolumeBuilder interface {
+	ToVolumeExtendMap() (map[string]interface{}, error)
+}
+
+func (opts ExtendVolumeOpts) ToVolumeExtendMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func ExtendVolume(client *golangsdk.ServiceClient, instanceId string, opts ExtendVolumeBuilder) (r ExtendResult) {
+	b, err := opts.ToVolumeExtendMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(volumeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{201},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances/results.go
@@ -78,16 +78,21 @@ type Volume struct {
 	Used string `json:"used"`
 }
 
+type NodeVolume struct {
+	Size int `json:"size"`
+}
+
 type Nodes struct {
-	Id               string   `json:"id"`
-	Name             string   `json:"name"`
-	Type             string   `json:"type"`
-	Status           string   `json:"status"`
-	PrivateIps       []string `json:"private_read_ips"`
-	Port             int      `json:"port"`
-	Flavor           string   `json:"flavor_ref"`
-	Region           string   `json:"region_code"`
-	AvailabilityZone string   `json:"az_code"`
+	Id               string     `json:"id"`
+	Name             string     `json:"name"`
+	Type             string     `json:"type"`
+	Status           string     `json:"status"`
+	PrivateIps       []string   `json:"private_read_ips"`
+	Port             int        `json:"port"`
+	Flavor           string     `json:"flavor_ref"`
+	Region           string     `json:"region_code"`
+	AvailabilityZone string     `json:"az_code"`
+	Volume           NodeVolume `json:"volume"`
 }
 
 type commonResult struct {
@@ -126,6 +131,10 @@ func (r GetResult) Extract() (*TaurusDBInstance, error) {
 	var instance TaurusDBInstance
 	err := r.ExtractIntoStructPtr(&instance, "instance")
 	return &instance, err
+}
+
+type ExtendResult struct {
+	golangsdk.ErrResult
 }
 
 type ListTaurusDBResult struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/taurusdb/v3/instances/urls.go
@@ -34,6 +34,10 @@ func passwordURL(c *golangsdk.ServiceClient, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "password")
 }
 
+func volumeURL(c *golangsdk.ServiceClient, instanceID string) string {
+	return c.ServiceURL("instances", instanceID, "volume/extend")
+}
+
 func actionURL(c *golangsdk.ServiceClient, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "action")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f
+# github.com/huaweicloud/golangsdk v0.0.0-20210608085437-ebb866377c9f
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
This adds support for specifying/updating volume size of prePaid
gaussdb mysql instance.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1166 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
