### PR TITLE
Fix the exception of empty value conversion

### DIFF
--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -142,6 +142,7 @@ func resourceGeminiDBInstanceV3() *schema.Resource {
 						"keep_days": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -237,15 +238,16 @@ func resourceGeminiDBDataStore(d *schema.ResourceData) instances.DataStore {
 }
 
 func resourceGeminiDBBackupStrategy(d *schema.ResourceData) *instances.BackupStrategyOpt {
-	backupStrategyRaw := d.Get("backup_strategy").([]interface{})
-	if len(backupStrategyRaw) == 1 {
-		strategy := backupStrategyRaw[0].(map[string]interface{})
-		return &instances.BackupStrategyOpt{
-			StartTime: strategy["start_time"].(string),
-			KeepDays:  strconv.Itoa(strategy["keep_days"].(int)),
+	if _, ok := d.GetOk("backup_strategy"); ok {
+		opt := &instances.BackupStrategyOpt{
+			StartTime: d.Get("backup_strategy.0.start_time").(string),
 		}
+		// The default value of keepdays is 7, but empty value of keepdays will be converted to 0.
+		if v, ok := d.GetOk("backup_strategy.0.keep_days"); ok {
+			opt.KeepDays = strconv.Itoa(v.(int))
+		}
+		return opt
 	}
-
 	return nil
 }
 

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -260,6 +260,13 @@ func ResourceRdsInstanceV3() *schema.Resource {
 	}
 }
 
+func buildRdsInstanceV3DBPort(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("db.0.port"); ok {
+		return strconv.Itoa(v.(int))
+	}
+	return ""
+}
+
 func resourceRdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	region := GetRegion(d, config)
@@ -278,7 +285,7 @@ func resourceRdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 		TimeZone:            d.Get("time_zone").(string),
 		FixedIp:             d.Get("fixed_ip").(string),
 		DiskEncryptionId:    d.Get("volume.0.disk_encryption_id").(string),
-		Port:                strconv.Itoa(d.Get("db.0.port").(int)),
+		Port:                buildRdsInstanceV3DBPort(d),
 		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
 		Region:              region,
 		AvailabilityZone:    buildRdsInstanceAvailabilityZone(d),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- When using `d.get ("db.0.port").(int)` to get an optional parameter that is not set, a zero value is obtained.
`d.GetOK()` method can be successfully to fix it.
- Two resources with this problem:
  - huaweicloud_gaussdb_cassandra_instance
  - huaweicloud_rds_instance

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1204 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. check the value whether is exist before conversion.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccGeminiDBInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccGeminiDBInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstance_basic
=== PAUSE TestAccGeminiDBInstance_basic
=== CONT  TestAccGeminiDBInstance_basic
--- PASS: TestAccGeminiDBInstance_basic (1107.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1107.425s
```
