### PR TITLE
Try to delete gaussdb instance when unsubscribe failed

### DIFF
--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -517,7 +517,11 @@ func resourceGeminiDBInstanceV3Delete(d *schema.ResourceData, meta interface{}) 
 	instanceId := d.Id()
 	if d.Get("charging_mode") == "prePaid" {
 		if err := UnsubscribePrePaidResource(d, config, []string{instanceId}); err != nil {
-			return fmt.Errorf("Error unsubscribe HuaweiCloud GaussDB instance: %s", err)
+			// Try to delete resource directly when unsubscrbing failed
+			res := instances.Delete(client, instanceId)
+			if res.Err != nil {
+				return res.Err
+			}
 		}
 	} else {
 		result := instances.Delete(client, instanceId)

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -673,7 +673,11 @@ func resourceGaussDBInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	instanceId := d.Id()
 	if d.Get("charging_mode") == "prePaid" {
 		if err := UnsubscribePrePaidResource(d, config, []string{instanceId}); err != nil {
-			return fmt.Errorf("Error unsubscribe HuaweiCloud GaussDB instance: %s", err)
+			// try to delete the instance directly if unsubscribing failed
+			res := instances.Delete(client, instanceId)
+			if res.Err != nil {
+				return CheckDeleted(d, res.Err, "GaussDB instance")
+			}
 		}
 	} else {
 		result := instances.Delete(client, instanceId)


### PR DESCRIPTION
This makes it possible to delete the prepaid gaussdb instances
directly when unsubscribing failed.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
