### PR TITLE
the new methods remove the character huawei from the format string th…

### DIFF
--- a/huaweicloud/utils/fmtp/errors.go
+++ b/huaweicloud/utils/fmtp/errors.go
@@ -1,0 +1,11 @@
+package fmtp
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Errorf(format string, a ...interface{}) error {
+	newFormat := strings.Replace(format, REPLACE_STR, "", -1)
+	return fmt.Errorf(newFormat, a)
+}

--- a/huaweicloud/utils/fmtp/print.go
+++ b/huaweicloud/utils/fmtp/print.go
@@ -1,0 +1,13 @@
+package fmtp
+
+import (
+	"fmt"
+	"strings"
+)
+
+const REPLACE_STR = "huawei"
+
+func Sprintf(format string, a ...interface{}) string {
+	newFormat := strings.Replace(format, REPLACE_STR, "", -1)
+	return fmt.Sprintf(newFormat, a)
+}

--- a/huaweicloud/utils/logp/log.go
+++ b/huaweicloud/utils/logp/log.go
@@ -1,0 +1,14 @@
+package logp
+
+import (
+	"log"
+	"strings"
+)
+
+const REPLACE_STR = "huawei"
+
+func Printf(format string, v ...interface{}) {
+	newFormat := strings.Replace(format, REPLACE_STR, "", -1)
+	log.Printf(newFormat, v)
+
+}


### PR DESCRIPTION
the new methods remove the character huawei from the format string that the args of  fmt.Sprintf,fmt.Errorf, log.printf

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
