### PR TITLE
New APIG application resoruce supported

### DIFF
--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -1,0 +1,71 @@
+---
+subcategory: "API Gateway (APIG)"
+---
+
+# huaweicloud_apig_application
+
+Manages an APIG application resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "app_name" {}
+variable "app_code" {}
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = var.instance_id
+  name        = var.app_name
+  description = "Created by script"
+
+  app_codes = [var.app_code]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the APIG application resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new APIG application resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the APIG
+  application belongs to.
+  Changing this will create a new APIG application resource.
+
+* `name` - (Required, String) Specifies the name of the API application.
+  The API group name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `description` - (Optional, String) Specifies the description about the APIG application.
+  The description contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `app_codes` - (Required, List) Specifies an array of one or more application codes which the APIG application
+  belongs to.
+  Up to five application codes can be created.
+  The code consists of 64 to 180 characters, starting with a letter, digit, plus sign (+) or slash (/).
+  Only letters, digits and following special special characters are allowed: !@#$%+-_/=
+
+* `secret_action` - (Optional, String) Specifies the secret action to be done for the APIG application.
+  The valid values is *RESET*.
+
+  -> **NOTE:** The `secret_action` is a one-time action.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG application.
+* `registraion_time` - Registration time, in RFC-3339 format.
+* `update_time` - Time when the API group was last modified, in RFC-3339 format.
+
+## Import
+
+APIG Applications can be imported using their `id` and ID of the APIG dedicated instance to which the application
+belongs, separated by a slash, e.g.
+```
+$ terraform import huaweicloud_apig_application.test <instance id>/<id>
+```

--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -50,7 +50,7 @@ The following arguments are supported:
   Only letters, digits and following special special characters are allowed: !@#$%+-_/=
 
 * `secret_action` - (Optional, String) Specifies the secret action to be done for the APIG application.
-  The valid values is *RESET*.
+  The valid action is *RESET*.
 
   -> **NOTE:** The `secret_action` is a one-time action.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
+	github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,12 +206,10 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210608085437-ebb866377c9f h1:uvvd7F4iujOwAP0E0W7H91IrgBt5KI0xE7A6HCwGTj0=
-github.com/huaweicloud/golangsdk v0.0.0-20210608085437-ebb866377c9f/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210618111817-9c67059b7682 h1:BdVmP7j7kdtRau+JV6QjAMg2sMgsQIbYg9uAqOlt+j8=
-github.com/huaweicloud/golangsdk v0.0.0-20210618111817-9c67059b7682/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172 h1:6OLBFIxdht5gTP3AVkKM4CngryJSwRrFGX43xqAPAu4=
-github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210621093751-3dd439dd31e3 h1:RF1TuFSkplWinbZpl6BfVJ+r394k4xOkVKXUt09IjJo=
+github.com/huaweicloud/golangsdk v0.0.0-20210621093751-3dd439dd31e3/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21 h1:S6MdycKYfaCv/e4+xsIiDQE1HsZ3RqsrqKgCq8/3keg=
+github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -364,6 +364,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_api_gateway_api":                 ResourceAPIGatewayAPI(),
 			"huaweicloud_api_gateway_group":               ResourceAPIGatewayGroup(),
 			"huaweicloud_apig_instance":                   ResourceApigInstanceV2(),
+			"huaweicloud_apig_application":                ResourceApigApplicationV2(),
 			"huaweicloud_as_configuration":                ResourceASConfiguration(),
 			"huaweicloud_as_group":                        ResourceASGroup(),
 			"huaweicloud_as_lifecycle_hook":               ResourceASLifecycleHook(),

--- a/huaweicloud/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/resource_huaweicloud_apig_application.go
@@ -1,0 +1,300 @@
+package huaweicloud
+
+import (
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceApigApplicationV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApigApplicationV2Create,
+		Read:   resourceApigApplicationV2Read,
+		Update: resourceApigApplicationV2Update,
+		Delete: resourceApigApplicationV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceApigInstanceSubResourceImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[\u4e00-\u9fa5A-Za-z][\u4e00-\u9fa5A-Za-z_0-9]{2,63}$"),
+					"The name consists of 3 to 64 characters, starting with a letter. "+
+						"Only letters, digits and underscores (_) are allowed. "+
+						"Chinese characters must be in UTF-8 or Unicode format."),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+					"The description contain a maximum of 255 characters, "+
+						"and the angle brackets (< and >) are not allowed."),
+			},
+			"app_codes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringMatch(
+						regexp.MustCompile("^[A-Za-z0-9+=][\\w!@#$%+-/=]{63,179}$"),
+						"The code consists of 64 to 180 characters, starting with a letter, digit, "+
+							"plus sign (+) or slash (/). Only letters, digits and following special special "+
+							"characters are allowed: !@#$%+-_/="),
+				},
+			},
+			"secret_action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"RESET",
+				}, false),
+			},
+			"registraion_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildApigApplicaitonParameters(d *schema.ResourceData) applications.AppOpts {
+	return applications.AppOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+}
+
+func createApigV2ApplicationCode(client *golangsdk.ServiceClient, instanceId, appId, code string) error {
+	opt := applications.AppCodeOpts{
+		AppCode: code,
+	}
+	if _, err := applications.CreateAppCode(client, instanceId, appId, opt).Extract(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createApigV2ApplicationCodes(client *golangsdk.ServiceClient, instanceId, appId string, codes []interface{}) error {
+	for _, v := range codes {
+		if err := createApigV2ApplicationCode(client, instanceId, appId, v.(string)); err != nil {
+			return fmtp.Errorf("Error creating APIG v2 application code: %s", err)
+		}
+	}
+	return nil
+}
+
+func resourceApigApplicationV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opts := buildApigApplicaitonParameters(d)
+	log.Printf("[DEBUG] Create Options: %#v", opts)
+	instanceId := d.Get("instance_id").(string)
+	resp, err := applications.Create(client, instanceId, opts).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 application at the instance (%s): %s", instanceId, err)
+	}
+	d.SetId(resp.Id)
+	if v, ok := d.GetOk("app_codes"); ok {
+		if err := createApigV2ApplicationCodes(client, instanceId, d.Id(), v.(*schema.Set).List()); err != nil {
+			return fmtp.Errorf("Error creating APIG v2 application codes: %s", err)
+		}
+	}
+	return resourceApigApplicationV2Read(d, meta)
+}
+
+func getApigApplicationCodeList(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]applications.AppCode, error) {
+	allPages, err := applications.ListAppCode(client, d.Get("instance_id").(string), d.Id(),
+		applications.ListCodeOpts{}).AllPages()
+	if err != nil {
+		return []applications.AppCode{}, err
+	}
+	results, err := applications.ExtractAppCodes(allPages)
+	if err != nil {
+		return results, err
+	}
+	return results, nil
+}
+
+func setApigApplicationCodes(d *schema.ResourceData, config *config.Config, resp *applications.Application) error {
+	client, err := config.ApigV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	results, err := getApigApplicationCodeList(d, client)
+	if err != nil {
+		return fmtp.Errorf("Error getting APIG v2 application codes: %s", err)
+	}
+	codes := make([]interface{}, len(results))
+	for i, v := range results {
+		codes[i] = v.Code
+	}
+	// The application code is sort by create time on server, not code.
+	return d.Set("app_codes", schema.NewSet(schema.HashString, codes))
+}
+
+func setApigApplicationParamters(d *schema.ResourceData, config *config.Config, resp *applications.Application) error {
+	mErr := multierror.Append(nil,
+		d.Set("region", GetRegion(d, config)),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("registraion_time", resp.RegistraionTime),
+		d.Set("update_time", resp.UpdateTime),
+		setApigApplicationCodes(d, config, resp),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func resourceApigApplicationV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	resp, err := applications.Get(client, instanceId, d.Id()).Extract()
+
+	return setApigApplicationParamters(d, config, resp)
+}
+
+func isCodeInApplication(codes []applications.AppCode, code string) (string, bool) {
+	for _, s := range codes {
+		if s.Code == code {
+			return s.Id, true
+		}
+	}
+	return "", false
+}
+
+func removeApigV2ApplicationCode(d *schema.ResourceData, client *golangsdk.ServiceClient,
+	results []applications.AppCode, code string) error {
+	instanceId := d.Get("instance_id").(string)
+	id, ok := isCodeInApplication(results, code)
+	if !ok {
+		return fmtp.Errorf("Code is not in the application (%s)", d.Id())
+	}
+	if err := applications.RemoveAppCode(client, instanceId, d.Id(), id).ExtractErr(); err != nil {
+		return fmtp.Errorf("Error removing code (%s) form the application (%s) : %s", code, d.Id(), err)
+	}
+	return nil
+}
+
+func updateApigApplicationCodes(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	oldRaws, newRaws := d.GetChange("app_codes")
+	addRaws := newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set))
+	removeRaws := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set))
+	if len(removeRaws.List()) != 0 {
+		results, err := getApigApplicationCodeList(d, client)
+		if err != nil {
+			return fmtp.Errorf("Error getting APIG v2 application codes: %s", err)
+		}
+		for _, v := range removeRaws.List() {
+			if err := removeApigV2ApplicationCode(d, client, results, v.(string)); err != nil {
+				return err
+			}
+		}
+	}
+	instanceId := d.Get("instance_id").(string)
+	if len(addRaws.List()) != 0 {
+		for _, v := range addRaws.List() {
+			if err := createApigV2ApplicationCode(client, instanceId, d.Id(), v.(string)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func resourceApigApplicationV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opt := applications.AppOpts{}
+	if d.HasChange("name") {
+		opt.Name = d.Get("name").(string)
+	}
+	if d.HasChange("description") {
+		opt.Description = d.Get("description").(string)
+	}
+	if opt != (applications.AppOpts{}) {
+		log.Printf("[DEBUG] Update Options: %#v", opt)
+		instanceId := d.Get("instance_id").(string)
+		_, err = applications.Update(client, instanceId, d.Id(), opt).Extract()
+		if err != nil {
+			return fmtp.Errorf("Error updating HuaweiCloud APIG v2 application (%s): %s", d.Id(), err)
+		}
+	}
+	if d.HasChange("app_codes") {
+		err = updateApigApplicationCodes(d, client)
+		if err != nil {
+			return fmtp.Errorf("Updating HuaweiCloud APIG v2 application code failed: %s", err)
+		}
+	}
+	if d.HasChange("secret_action") {
+		if v, ok := d.GetOk("secret_action"); ok && v.(string) == "RESET" {
+			if _, err := applications.ResetAppSecret(client, d.Get("instance_id").(string), d.Id(),
+				applications.SecretResetOpts{}).Extract(); err != nil {
+				return fmtp.Errorf("Reseting HuaweiCloud APIG v2 application secret failed: %s", err)
+			}
+		}
+	}
+	return resourceApigApplicationV2Read(d, meta)
+}
+
+func resourceApigApplicationV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	err = applications.Delete(client, instanceId, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("Error deleting HuaweiCloud APIG v2 application from the instance (%s): %s", instanceId, err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func resourceApigInstanceSubResourceImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmtp.Errorf("Invalid format specified for import id, must be <instance_id>/<id>")
+	}
+	d.SetId(parts[1])
+	d.Set("instance_id", parts[0])
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/resource_huaweicloud_apig_application_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccApigApplicationV2_basic(t *testing.T) {
@@ -57,7 +56,7 @@ func testAccCheckApigApplicationDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
 	client, err := config.ApigV2Client(HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "huaweicloud_apig_application" {
@@ -65,7 +64,7 @@ func testAccCheckApigApplicationDestroy(s *terraform.State) error {
 		}
 		_, err := applications.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("APIG v2 application (%s) is still exists", rs.Primary.ID)
+			return fmt.Errorf("APIG v2 application (%s) is still exists", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -75,16 +74,16 @@ func testAccCheckApigApplicationExists(appName string, app *applications.Applica
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[appName]
 		if !ok {
-			return fmtp.Errorf("Resource %s not found", appName)
+			return fmt.Errorf("Resource %s not found", appName)
 		}
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No APIG V2 application Id")
+			return fmt.Errorf("No APIG V2 application Id")
 		}
 
 		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.ApigV2Client(HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 		}
 		found, err := applications.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
 		if err != nil {
@@ -99,10 +98,10 @@ func testAccApigInstanceSubResourceImportStateIdFunc(name string) resource.Impor
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return "", fmtp.Errorf("Resource (%s) not found: %s", name, rs)
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
 		}
 		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
-			return "", fmtp.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID)
 		}
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
 	}

--- a/huaweicloud/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/resource_huaweicloud_apig_application_test.go
@@ -1,0 +1,137 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccApigApplicationV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_application.test"
+		application  applications.Application
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckApigApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigApplication_basic(rName, acctest.RandString(64)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigApplicationExists(resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+				),
+			},
+			{
+				// update name, description and app_code.
+				Config: testAccApigApplication_update(rName, acctest.RandString(64)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigApplicationExists(resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigInstanceSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigApplicationDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(HW_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_apig_application" {
+			continue
+		}
+		_, err := applications.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("APIG v2 application (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigApplicationExists(appName string, app *applications.Application) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[appName]
+		if !ok {
+			return fmtp.Errorf("Resource %s not found", appName)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No APIG V2 application Id")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(HW_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		}
+		found, err := applications.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigInstanceSubResourceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmtp.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmtp.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccApigApplication_basic(rName, code string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_application" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+
+  app_codes = ["%s"]
+}
+`, testAccApigInstance_basic(rName), rName, utils.EncodeBase64String(code))
+}
+
+func testAccApigApplication_update(rName, code string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_application" "test" {
+  name        = "%s_update"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Updated by script"
+
+  app_codes = ["%s"]
+}
+`, testAccApigInstance_basic(rName), rName, utils.EncodeBase64String(code))
+}

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -231,4 +232,10 @@ func IsResourceNotFound(err error) bool {
 func FormatTimeStampRFC3339(timestamp int64) string {
 	createTime := time.Unix(timestamp, 0)
 	return createTime.Format(time.RFC3339)
+}
+
+// Method EncodeBase64String is used to encode a string by base64.
+func EncodeBase64String(str string) string {
+	strByte := []byte(str)
+	return base64.StdEncoding.EncodeToString(strByte)
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications/requests.go
@@ -1,0 +1,228 @@
+package applications
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// AppOpts allows to create or update an application using given parameters.
+type AppOpts struct {
+	// Application name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits and underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Description of the application, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark,omitempty"`
+	// Application key, which can contain 8 to 64 characters, starting with a letter or digit.
+	// Only letters, digits, hyphens (-) and underscores (_) are allowed.
+	AppKey string `json:"app_key,omitempty"`
+	// Application secret, which can contain 8 to 64 characters, starting with a letter or digit.
+	// Only letters, digits and the following special characters are allowed: _-!@#$%
+	AppSecret string `json:"app_secret,omitempty"`
+}
+
+type AppOptsBuilder interface {
+	ToAppOptsMap() (map[string]interface{}, error)
+}
+
+func (opts AppOpts) ToAppOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a APIG application.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts AppOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToAppOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+func Update(client *golangsdk.ServiceClient, instanceId, appId string, opts AppOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToAppOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, appId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+//Get is a method to obtain the specified application according to the instanceId and appId.
+func Get(client *golangsdk.ServiceClient, instanceId, appId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, appId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// App ID.
+	Id string `q:"id"`
+	// App name.
+	Name string `q:"name"`
+	// App status.
+	Status string `q:"status"`
+	// App key.
+	AppKey string `q:"app_key"`
+	// Creator of the application.
+	//     USER: The app is created by the API user.
+	//     MARKET: The app is allocated by the marketplace.
+	Creator string `q:"creator"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	Limit int `q:"limit"`
+	// Parameter name (name) for exact matching.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListOptsBuilder interface {
+	ToAppListQuery() (string, error)
+}
+
+func (opts ListOpts) ToAppListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more APIG applications according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToAppListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ApplicationPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// SecretResetOpts allows to reset application secret value using given parameters.
+type SecretResetOpts struct {
+	AppSecret string `json:"app_secret"`
+}
+
+type SecretResetOptsBuilder interface {
+	ToSecretResetOptsMap() (map[string]interface{}, error)
+}
+
+func (opts SecretResetOpts) ToSecretResetOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func ResetAppSecret(client *golangsdk.ServiceClient, instanceId, appId string,
+	opts SecretResetOptsBuilder) (r ResetSecretResult) {
+	reqBody, err := opts.ToSecretResetOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resetSecretURL(client, instanceId, appId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete is a method to delete an existing application.
+func Delete(client *golangsdk.ServiceClient, instanceId, appId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, appId), nil)
+	return
+}
+
+// AppCodeOpts allows to create an application code using given parameters.
+type AppCodeOpts struct {
+	// AppCode value, which contains 64 to 180 characters, starting with a letter, plus sign (+) or slash (/).
+	// Only letters and the following special characters are allowed: +-_!@#$%/=
+	AppCode string `json:"app_code" required:"true"`
+}
+
+type AppCodeOptsBuilder interface {
+	ToAppCodeOptsMap() (map[string]interface{}, error)
+}
+
+func (opts AppCodeOpts) ToAppCodeOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// CreateAppCode is a method by which to create function that create a code at sepcified APIG application using
+// instanceId, appId and AppCodeOpts (code value).
+func CreateAppCode(client *golangsdk.ServiceClient, instanceId, appId string,
+	opts AppCodeOptsBuilder) (r CreateCodeResult) {
+	reqBody, err := opts.ToAppCodeOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(codeURL(client, instanceId, appId), reqBody, &r.Body, nil)
+	return
+}
+
+// AutoGenerateAppCode is a method used to automatically create code in a specified application.
+func AutoGenerateAppCode(client *golangsdk.ServiceClient, instanceId, appId string) (r AutoGenerateCodeResult) {
+	_, r.Err = client.Put(codeURL(client, instanceId, appId), nil, &r.Body, nil)
+	return
+}
+
+// GetAppCode is a method to obtain the specified code of the specified application of the specified instance using
+// instanceId, appId and codeId.
+func GetAppCode(client *golangsdk.ServiceClient, instanceId, appId, codeId string) (r GetCodeResult) {
+	_, r.Err = client.Get(codeResourceURL(client, instanceId, appId, codeId), &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// ListCodeOpts allows to filter application code list data using given parameters.
+type ListCodeOpts struct {
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	Limit int `q:"limit"`
+}
+
+type ListCodeOptsBuilder interface {
+	ToAppCodeListQuery() (string, error)
+}
+
+func (opts ListCodeOpts) ToAppCodeListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// ListAppCode is a method to obtain the application code list of the specified application of the specified instance.
+func ListAppCode(client *golangsdk.ServiceClient, instanceId, appId string, opts ListCodeOptsBuilder) pagination.Pager {
+	url := codeURL(client, instanceId, appId)
+	if opts != nil {
+		query, err := opts.ToAppCodeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AppCodePage{pagination.SinglePageBase(r)}
+	})
+}
+
+//RemoveAppCode is a method to delete an existing code from a specified application.
+func RemoveAppCode(client *golangsdk.ServiceClient, instanceId, appId, codeId string) (r DeleteResult) {
+	_, r.Err = client.Delete(codeResourceURL(client, instanceId, appId, codeId), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications/results.go
@@ -1,0 +1,127 @@
+package applications
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// ResetSecretResult represents a result of the ResetAppSecret operation.
+type ResetSecretResult struct {
+	commonResult
+}
+
+type Application struct {
+	// Creator of the application.
+	//     USER: The app is created by the API user.
+	//     MARKET: The app is allocated by the marketplace.
+	Creator string `json:"creator"`
+	// Registraion time.
+	RegistraionTime string `json:"register_time"`
+	// Update time.
+	UpdateTime string `json:"update_time"`
+	// App key.
+	AppKey string `json:"app_key"`
+	// App name.
+	Name string `json:"name"`
+	// Description.
+	Description string `json:"remark"`
+	// ID.
+	Id string `json:"id"`
+	// App secret.
+	AppSecret string `json:"app_secret"`
+	// App status.
+	Status int `json:"status"`
+	// App type, Currently only supports 'apig'. List method are not support.
+	Type string `json:"app_type"`
+	// Number of APIs. Only used for List method.
+	BindNum int `json:"bind_num"`
+}
+
+func (r commonResult) Extract() (*Application, error) {
+	var s Application
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ApplicationPage represents the response pages of the List operation.
+type ApplicationPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractApplications(r pagination.Page) ([]Application, error) {
+	var s []Application
+	err := r.(ApplicationPage).Result.ExtractIntoSlicePtr(&s, "apps")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type AppCode struct {
+	// AppCode value, which contains 64 to 180 characters, starting with a letter, plus sign (+) or slash (/).
+	// Only letters and the following special characters are allowed: +-_!@#$%/=
+	Code string `json:"app_code"`
+	// AppCode ID.
+	Id string `json:"id"`
+	// App ID.
+	AppId string `json:"app_id"`
+	// Creation time, in UTC format.
+	CreateTime string `json:"create_time"`
+}
+
+// CreateCodeResult represents a result of the CreateAppCode method.
+type CreateCodeResult struct {
+	CodeResult
+}
+
+// AutoGenerateCodeResult represents a result of the AutoGenerateAppCode method.
+type AutoGenerateCodeResult struct {
+	CodeResult
+}
+
+// GetCodeResult represents a result of the GetAppCode method.
+type GetCodeResult struct {
+	CodeResult
+}
+
+type CodeResult struct {
+	golangsdk.Result
+}
+
+func (r CodeResult) Extract() (*AppCode, error) {
+	var s AppCode
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// AppCodePage represents the response pages of the ListAppCode operation.
+type AppCodePage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractAppCodes(r pagination.Page) ([]AppCode, error) {
+	var s []AppCode
+	err := r.(AppCodePage).Result.ExtractIntoSlicePtr(&s, "app_codes")
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications/urls.go
@@ -1,0 +1,25 @@
+package applications
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(rootPath, instanceId, "apps")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, appId string) string {
+	return c.ServiceURL(rootPath, instanceId, "apps", appId)
+}
+
+func resetSecretURL(c *golangsdk.ServiceClient, instanceId, appId string) string {
+	return c.ServiceURL(rootPath, instanceId, "apps/secret", appId)
+}
+
+func codeURL(c *golangsdk.ServiceClient, instanceId, appId string) string {
+	return c.ServiceURL(rootPath, instanceId, "apps", appId, "app-codes")
+}
+
+func codeResourceURL(c *golangsdk.ServiceClient, instanceId, appId, codeId string) string {
+	return c.ServiceURL(rootPath, instanceId, "apps", appId, "app-codes", codeId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
+# github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -277,6 +277,7 @@ github.com/huaweicloud/golangsdk/openstack/aom/v1/icagents
 github.com/huaweicloud/golangsdk/openstack/apigw/apis
 github.com/huaweicloud/golangsdk/openstack/apigw/groups
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances
+github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/instances


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
An application is an identity for accessing an API and can call the APIs to which it has been authorized.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1221 
fixes: #1198 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. New application resource support up to five application codes to be bound.
2. New acc test for application.
3. Document supported.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
Basic test
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccApigApplicationV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccApigApplicationV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigApplicationV2_basic
=== PAUSE TestAccApigApplicationV2_basic
=== CONT  TestAccApigApplicationV2_basic
--- PASS: TestAccApigApplicationV2_basic (479.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud  479.755s
```