### PR TITLE
the new methods remove the character huawei from the format string th…

### DIFF
--- a/huaweicloud/utils/fmtp/errors.go
+++ b/huaweicloud/utils/fmtp/errors.go
@@ -1,0 +1,12 @@
+package fmtp
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func Errorf(format string, a ...interface{}) error {
+	newFormat := utils.BuildNewFormatByConfig(format)
+	return fmt.Errorf(newFormat, a)
+}

--- a/huaweicloud/utils/fmtp/print.go
+++ b/huaweicloud/utils/fmtp/print.go
@@ -1,0 +1,12 @@
+package fmtp
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func Sprintf(format string, a ...interface{}) string {
+	newFormat := utils.BuildNewFormatByConfig(format)
+	return fmt.Sprintf(newFormat, a)
+}

--- a/huaweicloud/utils/formatByConfig.go
+++ b/huaweicloud/utils/formatByConfig.go
@@ -1,0 +1,17 @@
+package utils
+
+import "regexp"
+
+const REPLACE_REG = "(?i)huaweicloud"
+
+var buildCloudCompany string
+
+var re = regexp.MustCompile(REPLACE_REG)
+
+func BuildNewFormatByConfig(format string) string {
+	newFormat := format
+	if buildCloudCompany != "" {
+		newFormat = re.ReplaceAllString(format, buildCloudCompany)
+	}
+	return newFormat
+}

--- a/huaweicloud/utils/formatByConfig.go
+++ b/huaweicloud/utils/formatByConfig.go
@@ -4,14 +4,14 @@ import "regexp"
 
 const REPLACE_REG = "(?i)huaweicloud"
 
-var buildCloudCompany string
+var PackageName string
 
 var re = regexp.MustCompile(REPLACE_REG)
 
 func BuildNewFormatByConfig(format string) string {
 	newFormat := format
-	if buildCloudCompany != "" {
-		newFormat = re.ReplaceAllString(format, buildCloudCompany)
+	if PackageName != "" {
+		newFormat = re.ReplaceAllString(format, PackageName)
 	}
 	return newFormat
 }

--- a/huaweicloud/utils/logp/log.go
+++ b/huaweicloud/utils/logp/log.go
@@ -1,0 +1,12 @@
+package logp
+
+import (
+	"log"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func Printf(format string, v ...interface{}) {
+	newFormat := utils.BuildNewFormatByConfig(format)
+	log.Printf(newFormat, v)
+}


### PR DESCRIPTION
the new methods remove the character huawei from the format string that the args of fmt.Sprintf,fmt.Errorf, log.printf
when build the provider you can set your companyName by
-ldflags="-X 'github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils.buildCloudCompany=yourCompanyName"

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
