### PR TITLE
remove the  discarded field of config

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -46,7 +46,6 @@ type Config struct {
 	AgencyDomainName    string
 	DelegatedProject    string
 	Cloud               string
-	CloudName           string
 	MaxRetries          int
 	TerraformVersion    string
 	RegionClient        bool

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -669,8 +669,6 @@ func init() {
 
 		"cloud": "The endpoint of cloud provider, defaults to myhuaweicloud.com",
 
-		"cloudName": "The endpoint of cloud provider name, defaults to empty",
-
 		"endpoints": "The custom endpoints used to override the default endpoint URL.",
 
 		"max_retries": "How many times HTTP connection should be retried until giving up.",
@@ -729,7 +727,6 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		AgencyDomainName:    d.Get("agency_domain_name").(string),
 		DelegatedProject:    delegated_project,
 		Cloud:               d.Get("cloud").(string),
-		CloudName:           d.Get("cloudName").(string),
 		MaxRetries:          d.Get("max_retries").(int),
 		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
 		TerraformVersion:    terraformVersion,


### PR DESCRIPTION
remove the  discarded field of config: cloudName
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
