### PR TITLE
revert fmtp.Sprintf in resource files

### DIFF
--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
@@ -1,11 +1,12 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func dataSourceGaussdbMysqlFlavors() *schema.Resource {
@@ -73,7 +74,8 @@ func dataSourceGaussdbMysqlFlavorsRead(d *schema.ResourceData, meta interface{})
 		return fmtp.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
 	}
 
-	link := fmtp.Sprintf("flavors/%s?version_name=%s&availability_zone_mode=%s", d.Get("engine").(string), d.Get("version").(string), d.Get("availability_zone_mode").(string))
+	link := fmt.Sprintf("flavors/%s?version_name=%s&availability_zone_mode=%s",
+		d.Get("engine").(string), d.Get("version").(string), d.Get("availability_zone_mode").(string))
 	url := client.ServiceURL(link)
 
 	r, err := sendGaussdbMysqlFlavorsListRequest(client, url)

--- a/huaweicloud/data_source_huaweicloud_iec_port.go
+++ b/huaweicloud/data_source_huaweicloud_iec_port.go
@@ -1,14 +1,15 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/huaweicloud/golangsdk/openstack/iec/v1/ports"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceIECPort() *schema.Resource {
@@ -71,7 +72,7 @@ func dataSourceIECPortRead(d *schema.ResourceData, meta interface{}) error {
 
 	var ipFilter bool
 	if v, ipFilter := d.GetOk("fixed_ip"); ipFilter {
-		listOpts.FixedIPs = []string{fmtp.Sprintf("ip_address=%s", v)}
+		listOpts.FixedIPs = []string{fmt.Sprintf("ip_address=%s", v)}
 	}
 
 	allPorts, err := ports.List(iecClient, listOpts).Extract()

--- a/huaweicloud/data_source_huaweicloud_iec_server.go
+++ b/huaweicloud/data_source_huaweicloud_iec_server.go
@@ -1,12 +1,13 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/iec/v1/servers"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func dataSourceIECServer() *schema.Resource {
@@ -169,7 +170,7 @@ func dataSourceIECServerRead(d *schema.ResourceData, meta interface{}) error {
 
 	// set IEC fields
 	location := server.Location
-	siteInfo := fmtp.Sprintf("%s/%s/%s/%s", location.Country, location.Area, location.Province, location.City)
+	siteInfo := fmt.Sprintf("%s/%s/%s/%s", location.Country, location.Area, location.Province, location.City)
 	siteItem := map[string]interface{}{
 		"site_id":   location.ID,
 		"site_info": siteInfo,

--- a/huaweicloud/data_source_huaweicloud_rds_flavors_v3.go
+++ b/huaweicloud/data_source_huaweicloud_rds_flavors_v3.go
@@ -1,12 +1,13 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceRdsFlavorV3() *schema.Resource {
@@ -73,7 +74,8 @@ func dataSourceRdsFlavorV3Read(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("Error creating HuaweiCloud rds client: %s", err)
 	}
 
-	link := fmtp.Sprintf("flavors/%s?version_name=%s", d.Get("db_type").(string), d.Get("db_version").(string))
+	link := fmt.Sprintf("flavors/%s?version_name=%s",
+		d.Get("db_type").(string), d.Get("db_version").(string))
 	url := client.ServiceURL(link)
 
 	r, err := sendRdsFlavorV3ListRequest(client, url)

--- a/huaweicloud/networking_port_v2.go
+++ b/huaweicloud/networking_port_v2.go
@@ -2,6 +2,7 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
@@ -10,7 +11,6 @@ import (
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func resourceNetworkingPortV2StateRefreshFunc(client *golangsdk.ServiceClient, portID string) resource.StateRefreshFunc {
@@ -167,7 +167,7 @@ func expandNetworkingPortFixedIPV2(d *schema.ResourceData) interface{} {
 func resourceNetworkingPortV2AllowedAddressPairsHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmtp.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
 
 	return hashcode.String(buf.String())
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1,6 +1,8 @@
 package huaweicloud
 
 import (
+	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -9,17 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 const defaultCloud string = "myhuaweicloud.com"
 
 // This is a global MutexKV for use within this plugin.
 var osMutexKV = mutexkv.NewMutexKV()
-
-//store the provider config tobe used within this plugin.
-var providerCfg *config.Config
 
 // Provider returns a schema.Provider for HuaweiCloud.
 func Provider() terraform.ResourceProvider {
@@ -226,7 +223,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"HW_AUTH_URL",
 					"OS_AUTH_URL",
-				}, fmtp.Sprintf("https://iam.%s:443/v3", defaultCloud)),
+				}, fmt.Sprintf("https://iam.%s:443/v3", defaultCloud)),
 			},
 
 			"cloud": {
@@ -745,9 +742,6 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		return nil, err
 	}
 
-	// store the config to Global
-	providerCfg = &config
-
 	return &config, nil
 }
 
@@ -759,15 +753,15 @@ func flattenProviderEndpoints(d *schema.ResourceData) (map[string]string, error)
 		endpoint := strings.TrimSpace(val.(string))
 		// check empty string
 		if endpoint == "" {
-			return nil, fmtp.Errorf("the value of customer endpoint %s must be specified", key)
+			return nil, fmt.Errorf("the value of customer endpoint %s must be specified", key)
 		}
 
 		// add prefix "https://" and suffix "/"
 		if !strings.HasPrefix(endpoint, "http") {
-			endpoint = fmtp.Sprintf("https://%s", endpoint)
+			endpoint = fmt.Sprintf("https://%s", endpoint)
 		}
 		if !strings.HasSuffix(endpoint, "/") {
-			endpoint = fmtp.Sprintf("%s/", endpoint)
+			endpoint = fmt.Sprintf("%s/", endpoint)
 		}
 		epMap[key] = endpoint
 	}
@@ -791,11 +785,6 @@ func flattenProviderEndpoints(d *schema.ResourceData) (map[string]string, error)
 		epMap["security_group"] = endpoint
 	}
 
-	logp.Printf("[DEBUG] customer endpoints: %+v", epMap)
+	log.Printf("[DEBUG] customer endpoints: %+v", epMap)
 	return epMap, nil
-}
-
-//
-func GetProviderCfg() *config.Config {
-	return providerCfg
 }

--- a/huaweicloud/resource_huaweicloud_bcs_instance.go
+++ b/huaweicloud/resource_huaweicloud_bcs_instance.go
@@ -2,11 +2,9 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -16,6 +14,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters"
 	"github.com/huaweicloud/golangsdk/openstack/dms/v1/instances"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceBCSInstanceV2() *schema.Resource {
@@ -724,7 +724,7 @@ func resourceChannelsHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if m["name"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["name"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	}
 
 	return hashcode.String(buf.String())
@@ -735,7 +735,7 @@ func resourcePeerOrgsHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if m["org_name"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["org_name"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["org_name"].(string)))
 	}
 
 	return hashcode.String(buf.String())

--- a/huaweicloud/resource_huaweicloud_blockstorage_volume_v2.go
+++ b/huaweicloud/resource_huaweicloud_blockstorage_volume_v2.go
@@ -2,10 +2,8 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -15,6 +13,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceBlockStorageVolumeV2() *schema.Resource {
@@ -395,7 +395,7 @@ func resourceVolumeV2AttachmentHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	if m["instance_id"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["instance_id"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["instance_id"].(string)))
 	}
 	return hashcode.String(buf.String())
 }

--- a/huaweicloud/resource_huaweicloud_cbr_policy.go
+++ b/huaweicloud/resource_huaweicloud_cbr_policy.go
@@ -1,18 +1,18 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/huaweicloud/golangsdk/openstack/cbr/v3/policies"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceCBRPolicyV3() *schema.Resource {
@@ -265,7 +265,7 @@ func makeSchedule(frequency, backupType, duration, time string) (string, error) 
 	if len(timeSlice) != 2 {
 		return "", fmtp.Errorf("Wrong time format (%s), should be HH:MM", time)
 	}
-	schedule := fmtp.Sprintf("FREQ=%s;%s=%s;BYHOUR=%s;BYMINUTE=%s",
+	schedule := fmt.Sprintf("FREQ=%s;%s=%s;BYHOUR=%s;BYMINUTE=%s",
 		frequency, backupType, duration, timeSlice[0], timeSlice[1])
 	return schedule, nil
 }

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate.go
@@ -1,11 +1,9 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -14,6 +12,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceComputeFloatingIPAssociateV2() *schema.Resource {
@@ -93,13 +93,13 @@ func resourceComputeFloatingIPAssociateV2Create(d *schema.ResourceData, meta int
 		return fmtp.Errorf("Error associating Floating IP: %s", err)
 	}
 
-	id := fmtp.Sprintf("%s/%s/%s", floatingIP, instanceID, fixedIP)
+	id := fmt.Sprintf("%s/%s/%s", floatingIP, instanceID, fixedIP)
 	d.SetId(id)
 
 	logp.Printf("[DEBUG] Waiting for eip associate to instance %s", id)
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{""},
-		Target:     []string{fmtp.Sprintf("floating/%s", floatingIP), fmtp.Sprintf("fixed/%s", floatingIP)},
+		Target:     []string{fmt.Sprintf("floating/%s", floatingIP), fmt.Sprintf("fixed/%s", floatingIP)},
 		Refresh:    resourceComputeFloatingIPAssociateStateRefreshFunc(d, config, instanceID, floatingIP),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      10 * time.Second,
@@ -266,7 +266,7 @@ func resourceComputeFloatingIPAssociateStateRefreshFunc(d *schema.ResourceData, 
 		for _, networkAddresses := range instance.Addresses {
 			for _, address := range networkAddresses {
 				if address.Type == "floating" && address.Addr == floatingIP {
-					return instance, fmtp.Sprintf("floating/%s", floatingIP), nil
+					return instance, fmt.Sprintf("floating/%s", floatingIP), nil
 				}
 			}
 		}

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -33,6 +31,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 var (
@@ -1372,15 +1372,15 @@ func resourceComputeSchedulerHintsHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if m["group"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["group"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
 	}
 
 	if m["tenancy"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["tenancy"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["tenancy"].(string)))
 	}
 
 	if m["deh_id"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["deh_id"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["deh_id"].(string)))
 	}
 
 	return hashcode.String(buf.String())

--- a/huaweicloud/resource_huaweicloud_compute_interface_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_interface_attach.go
@@ -1,16 +1,16 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
-
-	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/attachinterfaces"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/attachinterfaces"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceComputeInterfaceAttachV2() *schema.Resource {
@@ -115,7 +115,7 @@ func resourceComputeInterfaceAttachV2Create(d *schema.ResourceData, meta interfa
 	}
 
 	// Use the instance ID and port ID as the resource ID.
-	id := fmtp.Sprintf("%s/%s", instanceId, attachment.PortID)
+	id := fmt.Sprintf("%s/%s", instanceId, attachment.PortID)
 
 	logp.Printf("[DEBUG] Created huaweicloud_compute_interface_attach %s: %#v", id, attachment)
 

--- a/huaweicloud/resource_huaweicloud_compute_secgroup_v2.go
+++ b/huaweicloud/resource_huaweicloud_compute_secgroup_v2.go
@@ -2,11 +2,9 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -14,6 +12,8 @@ import (
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/secgroups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceComputeSecGroupV2() *schema.Resource {
@@ -357,12 +357,12 @@ func rulesToMap(computeClient *golangsdk.ServiceClient, d *schema.ResourceData, 
 func secgroupRuleV2Hash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmtp.Sprintf("%d-", m["from_port"].(int)))
-	buf.WriteString(fmtp.Sprintf("%d-", m["to_port"].(int)))
-	buf.WriteString(fmtp.Sprintf("%s-", m["ip_protocol"].(string)))
-	buf.WriteString(fmtp.Sprintf("%s-", strings.ToLower(m["cidr"].(string))))
-	buf.WriteString(fmtp.Sprintf("%s-", m["from_group_id"].(string)))
-	buf.WriteString(fmtp.Sprintf("%t-", m["self"].(bool)))
+	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-", m["ip_protocol"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["cidr"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", m["from_group_id"].(string)))
+	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
 
 	return hashcode.String(buf.String())
 }

--- a/huaweicloud/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach.go
@@ -1,11 +1,9 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -14,6 +12,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceComputeVolumeAttachV2() *schema.Resource {
@@ -109,7 +109,7 @@ func resourceComputeVolumeAttachV2Create(d *schema.ResourceData, meta interface{
 	// Use the instance ID and attachment ID as the resource ID.
 	// This is because an attachment cannot be retrieved just by its ID alone.
 	// attachment ID equals the volume ID
-	id := fmtp.Sprintf("%s/%s", instanceId, attachment.ID)
+	id := fmt.Sprintf("%s/%s", instanceId, attachment.ID)
 	d.SetId(id)
 
 	return resourceComputeVolumeAttachV2Read(d, meta)

--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -1,11 +1,9 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -17,6 +15,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/zones"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceDNSRecordSetV2() *schema.Resource {
@@ -118,7 +118,7 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 		return fmtp.Errorf("Error creating HuaweiCloud DNS record set: %s", err)
 	}
 
-	id := fmtp.Sprintf("%s/%s", zoneID, n.ID)
+	id := fmt.Sprintf("%s/%s", zoneID, n.ID)
 	d.SetId(id)
 
 	logp.Printf("[DEBUG] Waiting for DNS record set (%s) to become available", n.ID)

--- a/huaweicloud/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/resource_huaweicloud_dws_cluster.go
@@ -15,15 +15,15 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"reflect"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceDwsCluster() *schema.Resource {
@@ -414,11 +414,11 @@ func resourceDwsClusterRead(d *schema.ResourceData, meta interface{}) error {
 		url, &r.Body,
 		&golangsdk.RequestOpts{MoreHeaders: map[string]string{"Content-Type": "application/json"}})
 	if r.Err != nil {
-		return fmtp.Errorf("Error reading %s: %s", fmtp.Sprintf("DwsCluster %q", d.Id()), r.Err)
+		return fmtp.Errorf("Error reading %s: %s", fmt.Sprintf("DwsCluster %q", d.Id()), r.Err)
 	}
 	v, err := navigateMap(r.Body, []string{"cluster"})
 	if err != nil {
-		return fmtp.Errorf("Error reading %s: the result does not contain cluster", fmtp.Sprintf("DwsCluster %q", d.Id()))
+		return fmtp.Errorf("Error reading %s: the result does not contain cluster", fmt.Sprintf("DwsCluster %q", d.Id()))
 	}
 	res := v.(map[string]interface{})
 

--- a/huaweicloud/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/resource_huaweicloud_evs_volume.go
@@ -2,10 +2,8 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -16,6 +14,8 @@ import (
 	volumes_v2 "github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes"
 	"github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceEvsStorageVolumeV3() *schema.Resource {
@@ -146,7 +146,7 @@ func resourceVolumeAttachmentHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	if m["instance_id"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["instance_id"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["instance_id"].(string)))
 	}
 	return hashcode.String(buf.String())
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -1,12 +1,10 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -15,6 +13,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/opengauss/v3/backups"
 	"github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceOpenGaussInstance() *schema.Resource {
@@ -468,7 +468,7 @@ func resourceOpenGaussInstanceRead(d *schema.ResourceData, meta interface{}) err
 		endpoints := []string{}
 		for i := 0; i < len(ip_list); i++ {
 			ip_list[i] = strings.Trim(ip_list[i], " ")
-			endpoint := fmtp.Sprintf("%s:%d", ip_list[i], instance.Port)
+			endpoint := fmt.Sprintf("%s:%d", ip_list[i], instance.Port)
 			endpoints = append(endpoints, endpoint)
 		}
 		d.Set("private_ips", ip_list)

--- a/huaweicloud/resource_huaweicloud_identity_access_key.go
+++ b/huaweicloud/resource_huaweicloud_identity_access_key.go
@@ -2,11 +2,9 @@ package huaweicloud
 
 import (
 	"encoding/csv"
+	"fmt"
 	"os"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/encryption"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -14,6 +12,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3.0/credentials"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3.0/users"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceIdentityKey() *schema.Resource {
@@ -111,7 +111,7 @@ func resourceIdentityKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("secret_file"); ok {
 		outputFile = v.(string)
 	} else {
-		outputFile = fmtp.Sprintf("credentials-%s.csv", userName)
+		outputFile = fmt.Sprintf("credentials-%s.csv", userName)
 	}
 
 	if err := writeToCSVFile(outputFile, accessKey); err != nil {

--- a/huaweicloud/resource_huaweicloud_identity_acl.go
+++ b/huaweicloud/resource_huaweicloud_identity_acl.go
@@ -2,6 +2,7 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
@@ -230,7 +231,7 @@ func resourceACLPolicyCIDRHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if m["cidr"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["cidr"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["cidr"].(string)))
 	}
 
 	return hashcode.String(buf.String())
@@ -241,7 +242,7 @@ func resourceACLPolicyRangeHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if m["range"] != nil {
-		buf.WriteString(fmtp.Sprintf("%s-", m["range"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["range"].(string)))
 	}
 
 	return hashcode.String(buf.String())

--- a/huaweicloud/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/resource_huaweicloud_identity_agency.go
@@ -2,12 +2,10 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -19,6 +17,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/roles"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceIAMAgencyV3() *schema.Resource {
@@ -110,7 +110,7 @@ func ResourceIAMAgencyV3() *schema.Resource {
 func resourceIAMAgencyProRoleHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmtp.Sprintf("%s-", m["project"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["project"].(string)))
 
 	r := m["roles"].(*schema.Set).List()
 	s := make([]string, len(r))

--- a/huaweicloud/resource_huaweicloud_identity_role_assignment.go
+++ b/huaweicloud/resource_huaweicloud_identity_role_assignment.go
@@ -1,9 +1,7 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
-
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -11,6 +9,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/roles"
 	"github.com/huaweicloud/golangsdk/pagination"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceIdentityRoleAssignmentV3() *schema.Resource {
@@ -152,7 +152,7 @@ func getRoleAssignment(identityClient *golangsdk.ServiceClient, d *schema.Resour
 
 // Role assignments have no ID in HuaweiCloud. Build an ID out of the IDs that make up the role assignment
 func buildRoleAssignmentID(domainID, projectID, groupID, roleID string) string {
-	return fmtp.Sprintf("%s/%s/%s/%s", domainID, projectID, groupID, roleID)
+	return fmt.Sprintf("%s/%s/%s/%s", domainID, projectID, groupID, roleID)
 }
 
 func extractRoleAssignmentID(roleAssignmentID string) (string, string, string, string) {

--- a/huaweicloud/resource_huaweicloud_images_image_v2.go
+++ b/huaweicloud/resource_huaweicloud_images_image_v2.go
@@ -3,14 +3,12 @@ package huaweicloud
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -19,6 +17,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceImagesImageV2() *schema.Resource {
@@ -76,7 +76,7 @@ func resourceImagesImageV2() *schema.Resource {
 			"image_cache_path": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  fmtp.Sprintf("%s/.terraform/image_cache", os.Getenv("HOME")),
+				Default:  fmt.Sprintf("%s/.terraform/image_cache", os.Getenv("HOME")),
 			},
 
 			"image_source_url": {
@@ -446,7 +446,7 @@ func resourceImagesImageV2File(d *schema.ResourceData) (string, error) {
 	} else if furl := d.Get("image_source_url").(string); furl != "" {
 		dir := d.Get("image_cache_path").(string)
 		os.MkdirAll(dir, 0700)
-		filename := filepath.Join(dir, fmtp.Sprintf("%x.img", md5.Sum([]byte(furl))))
+		filename := filepath.Join(dir, fmt.Sprintf("%x.img", md5.Sum([]byte(furl))))
 
 		if _, err := os.Stat(filename); err != nil {
 			if !os.IsNotExist(err) {
@@ -488,10 +488,10 @@ func resourceImagesImageV2RefreshFunc(client *golangsdk.ServiceClient, id string
 		// Huawei Provider doesn't have this set initially.
 		/*
 			if img.Checksum != checksum || int64(img.SizeBytes) != fileSize {
-				return img, fmtp.Sprintf("%s", img.Status), fmtp.Errorf("Error wrong size %v or checksum %q", img.SizeBytes, img.Checksum)
+				return img, fmt.Sprintf("%s", img.Status), fmtp.Errorf("Error wrong size %v or checksum %q", img.SizeBytes, img.Checksum)
 			}
 		*/
-		return img, fmtp.Sprintf("%s", img.Status), nil
+		return img, fmt.Sprintf("%s", img.Status), nil
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_mls_instance.go
+++ b/huaweicloud/resource_huaweicloud_mls_instance.go
@@ -15,15 +15,15 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"reflect"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceMlsInstance() *schema.Resource {
@@ -338,11 +338,11 @@ func resourceMlsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		url, &r.Body,
 		&golangsdk.RequestOpts{MoreHeaders: map[string]string{"Content-Type": "application/json"}})
 	if r.Err != nil {
-		return fmtp.Errorf("Error reading %s: %s", fmtp.Sprintf("MlsInstance %q", d.Id()), r.Err)
+		return fmtp.Errorf("Error reading %s: %s", fmt.Sprintf("MlsInstance %q", d.Id()), r.Err)
 	}
 	v, err := navigateMap(r.Body, []string{"instance"})
 	if err != nil {
-		return fmtp.Errorf("Error reading %s: the result does not contain instance", fmtp.Sprintf("MlsInstance %q", d.Id()))
+		return fmtp.Errorf("Error reading %s: the result does not contain instance", fmt.Sprintf("MlsInstance %q", d.Id()))
 	}
 	res := v.(map[string]interface{})
 

--- a/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
+++ b/huaweicloud/resource_huaweicloud_nat_dnat_rule_v2.go
@@ -15,15 +15,15 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"reflect"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceNatDnatRuleV2() *schema.Resource {
@@ -248,11 +248,11 @@ func resourceNatDnatRuleRead(d *schema.ResourceData, meta interface{}) error {
 		url, &r.Body,
 		&golangsdk.RequestOpts{MoreHeaders: map[string]string{"Accept": "application/json"}})
 	if r.Err != nil {
-		return fmtp.Errorf("Error reading %s: %s", fmtp.Sprintf("NatDnat %q", d.Id()), r.Err)
+		return fmtp.Errorf("Error reading %s: %s", fmt.Sprintf("NatDnat %q", d.Id()), r.Err)
 	}
 	v, ok := r.Body.(map[string]interface{})
 	if !ok {
-		return fmtp.Errorf("Error reading %s: the result is not map", fmtp.Sprintf("NatDnat %q", d.Id()))
+		return fmtp.Errorf("Error reading %s: the result is not map", fmt.Sprintf("NatDnat %q", d.Id()))
 	}
 
 	res := map[string]interface{}{"read": v}

--- a/huaweicloud/resource_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_port_v2.go
@@ -2,10 +2,8 @@ package huaweicloud
 
 import (
 	"bytes"
+	"fmt"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -15,6 +13,8 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceNetworkingPortV2() *schema.Resource {
@@ -503,7 +503,7 @@ func resourcePortAdminStateUpV2(d *schema.ResourceData) *bool {
 func allowedAddressPairsHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmtp.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-%s", m["ip_address"].(string), m["mac_address"].(string)))
 
 	return hashcode.String(buf.String())
 }

--- a/huaweicloud/resource_huaweicloud_networking_router_route_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_router_route_v2.go
@@ -1,16 +1,16 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func resourceNetworkingRouterRouteV2() *schema.Resource {
@@ -103,7 +103,7 @@ func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return fmtp.Errorf("Error updating HuaweiCloud Neutron Router: %s", err)
 		}
-		d.SetId(fmtp.Sprintf("%s-route-%s-%s", routerId, destCidr, nextHop))
+		d.SetId(fmt.Sprintf("%s-route-%s-%s", routerId, destCidr, nextHop))
 
 	} else {
 		logp.Printf("[DEBUG] Router %s has route already", routerId)

--- a/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -3,6 +3,7 @@ package huaweicloud
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
@@ -694,7 +695,7 @@ func resourceObsBucketLifecycleUpdate(obsClient *obs.ObsClient, d *schema.Resour
 		rules[i].Prefix = r["prefix"].(string)
 
 		// Expiration
-		expiration := d.Get(fmtp.Sprintf("lifecycle_rule.%d.expiration", i)).(*schema.Set).List()
+		expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.expiration", i)).(*schema.Set).List()
 		if len(expiration) > 0 {
 			raw := expiration[0].(map[string]interface{})
 			exp := &rules[i].Expiration
@@ -705,7 +706,7 @@ func resourceObsBucketLifecycleUpdate(obsClient *obs.ObsClient, d *schema.Resour
 		}
 
 		// Transition
-		transitions := d.Get(fmtp.Sprintf("lifecycle_rule.%d.transition", i)).([]interface{})
+		transitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.transition", i)).([]interface{})
 		list := make([]obs.Transition, len(transitions))
 		for j, tran := range transitions {
 			raw := tran.(map[string]interface{})
@@ -720,7 +721,7 @@ func resourceObsBucketLifecycleUpdate(obsClient *obs.ObsClient, d *schema.Resour
 		rules[i].Transitions = list
 
 		// NoncurrentVersionExpiration
-		nc_expiration := d.Get(fmtp.Sprintf("lifecycle_rule.%d.noncurrent_version_expiration", i)).(*schema.Set).List()
+		nc_expiration := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_expiration", i)).(*schema.Set).List()
 		if len(nc_expiration) > 0 {
 			raw := nc_expiration[0].(map[string]interface{})
 			nc_exp := &rules[i].NoncurrentVersionExpiration
@@ -731,7 +732,7 @@ func resourceObsBucketLifecycleUpdate(obsClient *obs.ObsClient, d *schema.Resour
 		}
 
 		// NoncurrentVersionTransition
-		nc_transitions := d.Get(fmtp.Sprintf("lifecycle_rule.%d.noncurrent_version_transition", i)).([]interface{})
+		nc_transitions := d.Get(fmt.Sprintf("lifecycle_rule.%d.noncurrent_version_transition", i)).([]interface{})
 		nc_list := make([]obs.NoncurrentVersionTransition, len(nc_transitions))
 		for j, nc_tran := range nc_transitions {
 			raw := nc_tran.(map[string]interface{})
@@ -1280,10 +1281,10 @@ func expirationHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	if v, ok := m["days"]; ok {
-		buf.WriteString(fmtp.Sprintf("%d-", v.(int)))
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
 	if v, ok := m["storage_class"]; ok {
-		buf.WriteString(fmtp.Sprintf("%s-", v.(string)))
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 	return hashcode.String(buf.String())
 }
@@ -1352,7 +1353,7 @@ func normalizeWebsiteRoutingRules(w []obs.RoutingRule) (string, error) {
 }
 
 func bucketDomainNameWithCloud(bucket, region, cloud string) string {
-	return fmtp.Sprintf("%s.obs.%s.%s", bucket, region, cloud)
+	return fmt.Sprintf("%s.obs.%s.%s", bucket, region, cloud)
 }
 
 type Condition struct {

--- a/huaweicloud/resource_huaweicloud_swr_organization.go
+++ b/huaweicloud/resource_huaweicloud_swr_organization.go
@@ -1,6 +1,7 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -109,7 +110,7 @@ func resourceSWROrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("creator", n.CreatorName)
 	d.Set("permission", permission)
 
-	login := fmtp.Sprintf("swr.%s.%s", GetRegion(d, config), config.Cloud)
+	login := fmt.Sprintf("swr.%s.%s", GetRegion(d, config), config.Cloud)
 	d.Set("login_server", login)
 
 	return nil

--- a/huaweicloud/transport.go
+++ b/huaweicloud/transport.go
@@ -1,14 +1,13 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -34,7 +33,7 @@ func isEmptyValue(v reflect.Value) (bool, error) {
 	case reflect.Invalid:
 		return true, nil
 	}
-	return false, fmtp.Errorf("isEmptyValue:: unknown type")
+	return false, fmt.Errorf("isEmptyValue:: unknown type")
 }
 
 func addQueryParams(rawurl string, params map[string]string) (string, error) {
@@ -107,11 +106,11 @@ func navigateMap(d interface{}, index []string) (interface{}, error) {
 	for _, i := range index {
 		d1, ok := d.(map[string]interface{})
 		if !ok {
-			return nil, fmtp.Errorf("navigateMap:: Can not convert to map")
+			return nil, fmt.Errorf("navigateMap:: Can not convert to map")
 		}
 		d, ok = d1[i]
 		if !ok {
-			return nil, fmtp.Errorf("navigateMap:: '%s' may not exist", i)
+			return nil, fmt.Errorf("navigateMap:: '%s' may not exist", i)
 		}
 	}
 	return d, nil
@@ -125,12 +124,12 @@ func navigateValue(d interface{}, index []string, arrayIndex map[string]int) (in
 		if d1, ok := d.(map[string]interface{}); ok {
 			d, ok = d1[i]
 			if !ok {
-				msg := fmtp.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
-				return nil, fmtp.Errorf("%s: '%s' may not exist", msg, i)
+				msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+				return nil, fmt.Errorf("%s: '%s' may not exist", msg, i)
 			}
 		} else {
-			msg := fmtp.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
-			return nil, fmtp.Errorf("%s: Can not convert (%s) to map", msg, reflect.TypeOf(d))
+			msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+			return nil, fmt.Errorf("%s: Can not convert (%s) to map", msg, reflect.TypeOf(d))
 		}
 
 		if arrayIndex != nil {
@@ -143,14 +142,14 @@ func navigateValue(d interface{}, index []string, arrayIndex map[string]int) (in
 						return nil, nil
 					}
 					if j >= len(d2) {
-						msg := fmtp.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
-						return nil, fmtp.Errorf("%s: The index is out of array", msg)
+						msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+						return nil, fmt.Errorf("%s: The index is out of array", msg)
 					}
 
 					d = d2[j]
 				} else {
-					msg := fmtp.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
-					return nil, fmtp.Errorf("%s: Can not convert (%s) to array, index=%s.%v", msg, reflect.TypeOf(d), i, j)
+					msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+					return nil, fmt.Errorf("%s: Can not convert (%s) to array, index=%s.%v", msg, reflect.TypeOf(d), i, j)
 				}
 			}
 		}
@@ -175,7 +174,7 @@ func isUserInput(d *schema.ResourceData, index []string, arrayIndex map[string]i
 }
 
 func convertToInt(v interface{}) (int64, error) {
-	s := fmtp.Sprintf("%v", v)
+	s := fmt.Sprintf("%v", v)
 	r, err := strconv.ParseInt(s, 10, 64)
 	if err == nil {
 		return r, err
@@ -191,11 +190,11 @@ func convertToInt(v interface{}) (int64, error) {
 		return int64(i), nil
 	}
 
-	return 0, fmtp.Errorf("can not convert to integer")
+	return 0, fmt.Errorf("can not convert to integer")
 }
 
 func convertToStr(v interface{}) string {
-	return fmtp.Sprintf("%v", v)
+	return fmt.Sprintf("%v", v)
 }
 
 func convertSeconds2Str(v int64) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
there is unnecessary to convert the string as fmt.Sprintf is only used to assemble strings. so revert it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
