### PR TITLE
support pre-paid changing mode for vpc eip

### DIFF
--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -2,12 +2,14 @@
 subcategory: "Elastic IP (EIP)"
 ---
 
-# huaweicloud\_vpc\_eip
+# huaweicloud_vpc_eip
 
-Manages a EIP resource within Huawei Cloud.
+Manages a EIP resource within HuaweiCloud.
 This is an alternative to `huaweicloud_vpc_eip_v1`
 
 ## Example Usage
+
+### EIP with Dedicated Bandwidth
 
 ```hcl
 resource "huaweicloud_vpc_eip" "eip_1" {
@@ -15,15 +17,15 @@ resource "huaweicloud_vpc_eip" "eip_1" {
     type = "5_bgp"
   }
   bandwidth {
-    name        = "test"
-    size        = 8
     share_type  = "PER"
+    name        = "test"
+    size        = 10
     charge_mode = "traffic"
   }
 }
 ```
 
-## Example Usage of Share Bandwidth
+### EIP with Shared Bandwidth
 
 ```hcl
 resource "huaweicloud_vpc_bandwidth" "bandwidth_1" {
@@ -36,8 +38,8 @@ resource "huaweicloud_vpc_eip" "eip_1" {
     type = "5_bgp"
   }
   bandwidth {
-    id         = huaweicloud_vpc_bandwidth.bandwidth_1.id
     share_type = "WHOLE"
+    id         = huaweicloud_vpc_bandwidth.bandwidth_1.id
   }
 }
 ```
@@ -46,14 +48,31 @@ resource "huaweicloud_vpc_eip" "eip_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the eip resource. If omitted, the provider-level region will be used. Changing this creates a new eip resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the eip resource.
+  If omitted, the provider-level region will be used. Changing this creates a new eip resource.
 
 * `publicip` - (Required, List) The elastic IP address object.
 
 * `bandwidth` - (Required, List) The bandwidth object.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the elastic IP. Changing this creates a new eip.
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the elastic IP.
+  Changing this creates a new eip.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the elastic IP.
+  Valid values are *prePaid* and *postPaid*, defaults to *postPaid*.
+  Changing this creates a new eip.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the elastic IP.
+  Valid values are *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*.
+  Changing this creates a new eip.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the elastic IP.
+  If `period_unit` is set to *month*, the value ranges from 1 to 9.
+  If `period_unit` is set to *year*, the value ranges from 1 to 3.
+  This parameter is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new resource.
+
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+  Valid values are "true" and "false". Changing this creates a new resource.
 
 The `publicip` block supports:
 
@@ -68,27 +87,31 @@ The `publicip` block supports:
 
 The `bandwidth` block supports:
 
+* `share_type` - (Required, String, ForceNew) Whether the bandwidth is dedicated or shared.
+    Changing this creates a new eip. Possible values are as follows:
+    - *PER*: Dedicated bandwidth
+    - *WHOLE*: Shared bandwidth
+
 * `name` - (Optional, String) The bandwidth name, which is a string of 1 to 64 characters
     that contain letters, digits, underscores (_), and hyphens (-).
+    This parameter is mandatory when `share_type` is set to *PER*.
 
 * `size` - (Optional, Int) The bandwidth size. The value ranges from 1 to 300 Mbit/s.
+    This parameter is mandatory when `share_type` is set to *PER*.
 
-* `id` - (Optional, String, ForceNew) The share bandwidth id. Changing this creates a new eip.
+* `id` - (Optional, String, ForceNew) The shared bandwidth id. This parameter is mandatory when
+    `share_type` is set to *WHOLE*. Changing this creates a new eip.
 
-* `share_type` - (Required, String, ForceNew) Whether the bandwidth is shared or exclusive. Changing
-    this creates a new eip.
-
-* `charge_mode` - (Optional, String, ForceNew) This is a reserved field. If the system supports charging
-    by traffic and this field is specified, then you are charged by traffic for elastic
-    IP addresses. Changing this creates a new eip.
+* `charge_mode` - (Optional, String, ForceNew) Specifies whether the bandwidth is billed by traffic or by bandwidth size.
+    The value can be *traffic* or *bandwidth*. Changing this creates a new eip.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
-
+* `id` - The resource ID in UUID format.
 * `address` - The IP address of the eip.
+* `status` - The status of eip.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -44,6 +44,7 @@ var (
 	HW_CCI_ENVIRONMENT            = os.Getenv("HW_CCI_ENVIRONMENT")
 	HW_CDN_DOMAIN_NAME            = os.Getenv("HW_CDN_DOMAIN_NAME")
 	HW_ADMIN                      = os.Getenv("HW_ADMIN")
+	HW_CHARGING_MODE              = os.Getenv("HW_CHARGING_MODE")
 	HW_ENTERPRISE_PROJECT_ID_TEST = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
 	HW_USER_ID                    = os.Getenv("HW_USER_ID")
 
@@ -75,6 +76,12 @@ func testAccPreCheck(t *testing.T) {
 func testAccPrecheckCustomRegion(t *testing.T) {
 	if HW_CUSTOM_REGION_NAME == "" {
 		t.Skip("This environment does not support custom region tests")
+	}
+}
+
+func testAccPreCheckChargingMode(t *testing.T) {
+	if HW_CHARGING_MODE != "prePaid" {
+		t.Skip("This environment does not support prepaid tests")
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/resource_huaweicloud_vpc_eip.go
@@ -105,11 +105,6 @@ func ResourceVpcEIPV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"value_specs": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 		},
 	}
 }
@@ -121,16 +116,12 @@ func resourceVpcEIPV1Create(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("Error creating networking client: %s", err)
 	}
 
-	createOpts := EIPCreateOpts{
-		eips.ApplyOpts{
-			IP:        resourcePublicIP(d),
-			Bandwidth: resourceBandWidth(d),
-		},
-		MapValueSpecs(d),
+	createOpts := eips.ApplyOpts{
+		IP:        resourcePublicIP(d),
+		Bandwidth: resourceBandWidth(d),
 	}
 
 	epsID := GetEnterpriseProjectID(d, config)
-
 	if epsID != "" {
 		createOpts.EnterpriseProjectID = epsID
 	}

--- a/huaweicloud/value_specs.go
+++ b/huaweicloud/value_specs.go
@@ -5,7 +5,6 @@ import (
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets"
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/zones"
-	"github.com/huaweicloud/golangsdk/openstack/networking/v1/eips"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/firewall_groups"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/policies"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/fwaas_v2/routerinsertion"
@@ -197,12 +196,6 @@ func (opts ZoneCreateOpts) ToZoneCreateMap() (map[string]interface{}, error) {
 	}
 
 	return nil, fmtp.Errorf("Expected map but got %T", b[""])
-}
-
-// EIPCreateOpts represents the attributes used when creating a new eip.
-type EIPCreateOpts struct {
-	eips.ApplyOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
 }
 
 // VpnIPSecPolicyCreateOpts represents the attributes used when creating a new IPSec policy.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #963 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support pre-paid changing mode for vpc eip
2. add status attribute
3. update acc test
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcV1EIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcV1EIP_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (33.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       33.990s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcV1EIP_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcV1EIP_prePaid -timeout 360m -parallel 4
=== RUN   TestAccVpcV1EIP_prePaid
=== PAUSE TestAccVpcV1EIP_prePaid
=== CONT  TestAccVpcV1EIP_prePaid
--- PASS: TestAccVpcV1EIP_prePaid (186.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       186.924s
```
