### PR TITLE
expand PollInterval in WaitForState for cce resources

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_addon_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_addon_v3.go
@@ -114,7 +114,6 @@ func getValuesValues(d *schema.ResourceData) (basic, custom, flavor map[string]i
 func resourceCCEAddonV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	cceClient, err := config.CceAddonV3Client(GetRegion(d, config))
-
 	if err != nil {
 		return fmtp.Errorf("Unable to create HuaweiCloud CCE client : %s", err)
 	}
@@ -122,7 +121,6 @@ func resourceCCEAddonV3Create(d *schema.ResourceData, meta interface{}) error {
 	var cluster_id = d.Get("cluster_id").(string)
 
 	basic, custom, flavor, err := getValuesValues(d)
-
 	if err != nil {
 		return fmtp.Errorf("error getting values for CCE addon: %s", err)
 	}
@@ -148,7 +146,6 @@ func resourceCCEAddonV3Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	create, err := addons.Create(cceClient, createOpts, cluster_id).Extract()
-
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCEAddon: %s", err)
 	}
@@ -156,14 +153,13 @@ func resourceCCEAddonV3Create(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(create.Metadata.Id)
 
 	logp.Printf("[DEBUG] Waiting for HuaweiCloud CCEAddon (%s) to become available", create.Metadata.Id)
-
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"installing", "abnormal"},
-		Target:     []string{"running"},
-		Refresh:    waitForCCEAddonActive(cceClient, create.Metadata.Id, cluster_id),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Pending:      []string{"installing", "abnormal"},
+		Target:       []string{"running"},
+		Refresh:      waitForCCEAddonActive(cceClient, create.Metadata.Id, cluster_id),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
@@ -177,7 +173,6 @@ func resourceCCEAddonV3Create(d *schema.ResourceData, meta interface{}) error {
 func resourceCCEAddonV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	cceClient, err := config.CceAddonV3Client(GetRegion(d, config))
-
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
@@ -206,7 +201,6 @@ func resourceCCEAddonV3Read(d *schema.ResourceData, meta interface{}) error {
 func resourceCCEAddonV3Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	cceClient, err := config.CceAddonV3Client(GetRegion(d, config))
-
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCEAddon Client: %s", err)
 	}
@@ -218,12 +212,12 @@ func resourceCCEAddonV3Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("Error deleting HuaweiCloud CCE Addon: %s", err)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"Deleting", "Available", "Unavailable"},
-		Target:     []string{"Deleted"},
-		Refresh:    waitForCCEAddonDelete(cceClient, d.Id(), cluster_id),
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Pending:      []string{"Deleting", "Available", "Unavailable"},
+		Target:       []string{"Deleted"},
+		Refresh:      waitForCCEAddonDelete(cceClient, d.Id(), cluster_id),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -680,12 +680,12 @@ func waitForCCEClusterDelete(cceClient *golangsdk.ServiceClient, clusterId strin
 func getCCEClusterIDFromJob(client *golangsdk.ServiceClient, jobID string) (string, error) {
 	stateJob := &resource.StateChangeConf{
 		Pending: []string{"Initializing"},
-		Target:  []string{"Running"},
+		Target:  []string{"Running", "Success"},
 		Refresh: waitForJobStatus(client, jobID),
 		Timeout: 5 * time.Minute,
 		// waiting for 35 seconds to avoid 401 response code
 		Delay:        35 * time.Second,
-		PollInterval: 5 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	v, err := stateJob.WaitForState()

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -525,12 +525,12 @@ func resourceCCENodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"Synchronizing"},
-		Target:     []string{""},
-		Refresh:    waitForCceNodePoolActive(nodePoolClient, clusterid, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      15 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Pending:      []string{"Synchronizing"},
+		Target:       []string{""},
+		Refresh:      waitForCceNodePoolActive(nodePoolClient, clusterid, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        15 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 	_, err = stateConf.WaitForState()
 	if err != nil {
@@ -601,11 +601,11 @@ func waitForCceNodePoolDelete(cceClient *golangsdk.ServiceClient, clusterId, nod
 func recursiveNodePoolCreate(cceClient *golangsdk.ServiceClient, opts nodepools.CreateOptsBuilder, ClusterID string, errCode int) (*nodepools.NodePool, string) {
 	if errCode == 403 {
 		stateCluster := &resource.StateChangeConf{
-			Target:     []string{"Available"},
-			Refresh:    waitForClusterAvailable(cceClient, ClusterID),
-			Timeout:    15 * time.Minute,
-			Delay:      15 * time.Second,
-			MinTimeout: 3 * time.Second,
+			Target:       []string{"Available"},
+			Refresh:      waitForClusterAvailable(cceClient, ClusterID),
+			Timeout:      15 * time.Minute,
+			Delay:        15 * time.Second,
+			PollInterval: 10 * time.Second,
 		}
 		_, stateErr := stateCluster.WaitForState()
 		if stateErr != nil {

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -519,11 +519,11 @@ func resourceCCENodeV3Create(d *schema.ResourceData, meta interface{}) error {
 	// wait for the cce cluster to become available
 	clusterid := d.Get("cluster_id").(string)
 	stateCluster := &resource.StateChangeConf{
-		Target:     []string{"Available"},
-		Refresh:    waitForClusterAvailable(nodeClient, clusterid),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Target:       []string{"Available"},
+		Refresh:      waitForClusterAvailable(nodeClient, clusterid),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
 	}
 	_, err = stateCluster.WaitForState()
 
@@ -819,11 +819,11 @@ func getResourceIDFromJob(client *golangsdk.ServiceClient, jobID string) (string
 	// prePaid: waiting for the job to become running
 	stateJob := &resource.StateChangeConf{
 		Pending:      []string{"Initializing"},
-		Target:       []string{"Running"},
+		Target:       []string{"Running", "Success"},
 		Refresh:      waitForJobStatus(client, jobID),
 		Timeout:      5 * time.Minute,
-		Delay:        5 * time.Second,
-		PollInterval: 3 * time.Second,
+		Delay:        20 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	v, err := stateJob.WaitForState()
@@ -923,11 +923,11 @@ func waitForJobStatus(cceClient *golangsdk.ServiceClient, jobID string) resource
 func recursiveCreate(cceClient *golangsdk.ServiceClient, opts nodes.CreateOptsBuilder, ClusterID string, errCode int) (*nodes.Nodes, string) {
 	if errCode == 403 {
 		stateCluster := &resource.StateChangeConf{
-			Target:     []string{"Available"},
-			Refresh:    waitForClusterAvailable(cceClient, ClusterID),
-			Timeout:    15 * time.Minute,
-			Delay:      15 * time.Second,
-			MinTimeout: 3 * time.Second,
+			Target:       []string{"Available"},
+			Refresh:      waitForClusterAvailable(cceClient, ClusterID),
+			Timeout:      15 * time.Minute,
+			Delay:        20 * time.Second,
+			PollInterval: 10 * time.Second,
 		}
 		_, stateErr := stateCluster.WaitForState()
 		if stateErr != nil {


### PR DESCRIPTION
expand PollInterval to avoid the API rate limits when querying the resource status
or job status.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1842.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1842.551s
```
