### PR TITLE
Move APIG service to services directory

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
 )
 
@@ -363,8 +364,8 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"huaweicloud_api_gateway_api":                 ResourceAPIGatewayAPI(),
 			"huaweicloud_api_gateway_group":               ResourceAPIGatewayGroup(),
-			"huaweicloud_apig_instance":                   ResourceApigInstanceV2(),
-			"huaweicloud_apig_application":                ResourceApigApplicationV2(),
+			"huaweicloud_apig_instance":                   apig.ResourceApigInstanceV2(),
+			"huaweicloud_apig_application":                apig.ResourceApigApplicationV2(),
 			"huaweicloud_as_configuration":                ResourceASConfiguration(),
 			"huaweicloud_as_group":                        ResourceASGroup(),
 			"huaweicloud_as_lifecycle_hook":               ResourceASLifecycleHook(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -18,13 +18,14 @@ var (
 	HW_DOMAIN_ID         = os.Getenv("HW_DOMAIN_ID")
 	HW_DOMAIN_NAME       = os.Getenv("HW_DOMAIN_NAME")
 
-	HW_FLAVOR_ID   = os.Getenv("HW_FLAVOR_ID")
-	HW_FLAVOR_NAME = os.Getenv("HW_FLAVOR_NAME")
-	HW_IMAGE_ID    = os.Getenv("HW_IMAGE_ID")
-	HW_IMAGE_NAME  = os.Getenv("HW_IMAGE_NAME")
-	HW_VPC_ID      = os.Getenv("HW_VPC_ID")
-	HW_NETWORK_ID  = os.Getenv("HW_NETWORK_ID")
-	HW_SUBNET_ID   = os.Getenv("HW_SUBNET_ID")
+	HW_FLAVOR_ID             = os.Getenv("HW_FLAVOR_ID")
+	HW_FLAVOR_NAME           = os.Getenv("HW_FLAVOR_NAME")
+	HW_IMAGE_ID              = os.Getenv("HW_IMAGE_ID")
+	HW_IMAGE_NAME            = os.Getenv("HW_IMAGE_NAME")
+	HW_VPC_ID                = os.Getenv("HW_VPC_ID")
+	HW_NETWORK_ID            = os.Getenv("HW_NETWORK_ID")
+	HW_SUBNET_ID             = os.Getenv("HW_SUBNET_ID")
+	HW_ENTERPRISE_PROJECT_ID = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
 
 	HW_DEPRECATED_ENVIRONMENT = os.Getenv("HW_DEPRECATED_ENVIRONMENT")
 )
@@ -62,4 +63,11 @@ func TestAccPreCheckDeprecated(t *testing.T) {
 	}
 
 	preCheckRequiredEnvVars(t)
+}
+
+//lintignore:AT003
+func TestAccPreCheckEpsID(t *testing.T) {
+	if HW_ENTERPRISE_PROJECT_ID == "" {
+		t.Fatal("HW_ENTERPRISE_PROJECT_ID must be set for acceptance tests")
+	}
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package apig
 
 import (
 	"fmt"
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
@@ -19,10 +20,10 @@ func TestAccApigInstanceV2_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    testAccProviders,
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckApigInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -31,7 +32,7 @@ func TestAccApigInstanceV2_basic(t *testing.T) {
 					testAccCheckApigInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
@@ -44,7 +45,7 @@ func TestAccApigInstanceV2_basic(t *testing.T) {
 					testAccCheckApigInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
 					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "18:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "22:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "description", "updated by acc test"),
@@ -67,10 +68,10 @@ func TestAccApigInstanceV2_egress(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    testAccProviders,
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckApigInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -130,10 +131,10 @@ func TestAccApigInstanceV2_ingress(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    testAccProviders,
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckApigInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -185,8 +186,8 @@ func TestAccApigInstanceV2_ingress(t *testing.T) {
 }
 
 func testAccCheckApigInstanceDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	client, err := config.ApigV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
@@ -214,8 +215,8 @@ func testAccCheckApigInstanceExists(n string, instance *instances.Instance) reso
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		client, err := config.ApigV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 		}
@@ -269,7 +270,7 @@ resource "huaweicloud_apig_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0],
   ]
 }
-`, testAccApigInstance_base(rName), rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccApigInstance_base(rName), rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
 }
 
 func testAccApigInstance_update(rName string) string {
@@ -294,7 +295,7 @@ resource "huaweicloud_apig_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0],
   ]
 }
-`, testAccApigInstance_base(rName), rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccApigInstance_base(rName), rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
 }
 
 func testAccApigInstance_egress(rName string) string {
@@ -320,7 +321,7 @@ resource "huaweicloud_apig_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0],
   ]
 }
-`, testAccApigInstance_base(rName), rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccApigInstance_base(rName), rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
 }
 
 func testAccApigInstance_egressUpdate(rName string) string {
@@ -346,7 +347,7 @@ resource "huaweicloud_apig_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0],
   ]
 }
-`, testAccApigInstance_base(rName), rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccApigInstance_base(rName), rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
 }
 
 func testAccApigInstance_ingress(rName string) string {
@@ -384,7 +385,7 @@ resource "huaweicloud_apig_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0],
   ]
 }
-`, testAccApigInstance_base(rName), rName, rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccApigInstance_base(rName), rName, rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
 }
 
 func testAccApigInstance_ingressUpdate(rName string) string {
@@ -422,5 +423,5 @@ resource "huaweicloud_apig_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0],
   ]
 }
-`, testAccApigInstance_base(rName), rName, rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccApigInstance_base(rName), rName, rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package apig
 
 import (
 	"log"
@@ -113,7 +113,7 @@ func createApigV2ApplicationCodes(client *golangsdk.ServiceClient, instanceId, a
 
 func resourceApigApplicationV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(GetRegion(d, config))
+	client, err := config.ApigV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
@@ -148,7 +148,7 @@ func getApigApplicationCodesFromServer(d *schema.ResourceData,
 }
 
 func setApigApplicationCodes(d *schema.ResourceData, config *config.Config, resp *applications.Application) error {
-	client, err := config.ApigV2Client(GetRegion(d, config))
+	client, err := config.ApigV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
@@ -166,7 +166,7 @@ func setApigApplicationCodes(d *schema.ResourceData, config *config.Config, resp
 
 func setApigApplicationParamters(d *schema.ResourceData, config *config.Config, resp *applications.Application) error {
 	mErr := multierror.Append(nil,
-		d.Set("region", GetRegion(d, config)),
+		d.Set("region", config.GetRegion(d)),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
 		d.Set("registraion_time", resp.RegistraionTime),
@@ -181,7 +181,7 @@ func setApigApplicationParamters(d *schema.ResourceData, config *config.Config, 
 
 func resourceApigApplicationV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(GetRegion(d, config))
+	client, err := config.ApigV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
@@ -241,7 +241,7 @@ func updateApigApplicationCodes(d *schema.ResourceData, client *golangsdk.Servic
 
 func resourceApigApplicationV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(GetRegion(d, config))
+	client, err := config.ApigV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
@@ -279,7 +279,7 @@ func resourceApigApplicationV2Update(d *schema.ResourceData, meta interface{}) e
 
 func resourceApigApplicationV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(GetRegion(d, config))
+	client, err := config.ApigV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
All APIG resources should be in the services directory.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. move apig dedicated instance and application resources to services directory.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigInstanceV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigInstanceV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigInstanceV2_basic
=== PAUSE TestAccApigInstanceV2_basic
=== CONT  TestAccApigInstanceV2_basic
--- PASS: TestAccApigInstanceV2_basic (464.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      464.949s
```

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigApplicationV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigApplicationV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigApplicationV2_basic
=== PAUSE TestAccApigApplicationV2_basic
=== CONT  TestAccApigApplicationV2_basic
--- PASS: TestAccApigApplicationV2_basic (453.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      453.682s
```
