### PR TITLE
New APIG environment resource support

### DIFF
--- a/docs/resources/apig_environment.md
+++ b/docs/resources/apig_environment.md
@@ -1,0 +1,56 @@
+---
+subcategory: "API Gateway (APIG)"
+---
+
+# huaweicloud_apig_environment
+
+Manages an APIG environment resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "environment_name" {}
+variable "description" {}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = var.instance_id
+  name        = var.environment_name
+  description = var.description
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the APIG environment resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new APIG environment resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the
+  API environment belongs to.
+  Changing this will create a new APIG environment resource.
+
+* `name` - (Required, String) Specifies the name of the API environment.
+  The API environment name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+
+* `description` - (Optional, String) Specifies the description about the API environment.
+  The description contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG environment.
+* `create_time` - Time when the APIG environment was created, in RFC-3339 format.
+
+## Import
+
+Environments can be imported using their `id` and the ID of the APIG instance to which the environment belongs,
+separated by a slash, e.g.
+```
+$ terraform import huaweicloud_apig_environment.test <instance ID>/<id>
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d
+	github.com/huaweicloud/golangsdk v0.0.0-20210715061636-f0d85a483f0b
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d h1:GJFDZ3hxptdDs10RjT1+Tq4oDsWXu+e2yNoHzLRgJ38=
 github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210715061636-f0d85a483f0b h1:s3ZJgf61mC4EaZp3OEMrC7hbZixXMr9JbFL5cgATB/o=
+github.com/huaweicloud/golangsdk v0.0.0-20210715061636-f0d85a483f0b/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -367,6 +367,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_api_gateway_group":               ResourceAPIGatewayGroup(),
 			"huaweicloud_apig_instance":                   apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_application":                apig.ResourceApigApplicationV2(),
+			"huaweicloud_apig_environment":                apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_vpc_channel":                apig.ResourceApigVpcChannelV2(),
 			"huaweicloud_as_configuration":                ResourceASConfiguration(),
 			"huaweicloud_as_group":                        ResourceASGroup(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
@@ -49,7 +49,7 @@ func TestAccApigEnvironmentV2_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigInstanceSubResourceImportStateIdFunc(resourceName),
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
 			},
 		},
 	})

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
@@ -1,0 +1,122 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func TestAccApigEnvironmentV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_environment.test"
+		env          environments.Environment
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigEnvironment_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigEnvironmentExists(resourceName, &env),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+				),
+			},
+			{
+				Config: testAccApigEnvironment_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigEnvironmentExists(resourceName, &env),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigInstanceSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigEnvironmentDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_apig_environment" {
+			continue
+		}
+		_, err := apig.GetEnvironmentFormServer(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("APIG v2 API environment (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigEnvironmentExists(name string, env *environments.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No APIG V2 API group Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		}
+		found, err := apig.GetEnvironmentFormServer(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error getting APIG v2 API environment (%s): %s", rs.Primary.ID, err)
+		}
+		*env = *found
+		return nil
+	}
+}
+
+func testAccApigEnvironment_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_environment" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigEnvironment_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_environment" "test" {
+  name        = "%s_update"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Updated by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
@@ -56,7 +56,7 @@ func TestAccApigVpcChannelV2_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigVpcChannelResourceImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
 			},
 		},
 	})
@@ -100,7 +100,7 @@ func TestAccApigVpcChannelV2_withEipMembers(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigVpcChannelResourceImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
 			},
 		},
 	})
@@ -148,7 +148,7 @@ func testAccCheckApigVpcChannelExists(n string, app *channels.VpcChannel) resour
 	}
 }
 
-func testAccApigVpcChannelResourceImportStateFunc(name string) resource.ImportStateIdFunc {
+func testAccApigSubResNameImportStateFunc(name string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
@@ -1,0 +1,165 @@
+package apig
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceApigEnvironmentV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApigEnvironmentV2Create,
+		Read:   resourceApigEnvironmentV2Read,
+		Update: resourceApigEnvironmentV2Update,
+		Delete: resourceApigEnvironmentV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceApigInstanceSubResourceImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[A-Za-z][\\w0-9]{2,63}$"),
+					"The name consists of 3 to 64 characters, starting with a letter. "+
+						"Only letters, digits and underscores (_) are allowed."),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+					"The description contain a maximum of 255 characters, "+
+						"and the angle brackets (< and >) are not allowed."),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildApigEnvironmentParameters(d *schema.ResourceData) environments.EnvironmentOpts {
+	return environments.EnvironmentOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+}
+
+func resourceApigEnvironmentV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opts := buildApigEnvironmentParameters(d)
+	instanceId := d.Get("instance_id").(string)
+	resp, err := environments.Create(client, instanceId, opts).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "Error creating HuaweiCloud APIG environment")
+	}
+	d.SetId(resp.Id)
+	return resourceApigEnvironmentV2Read(d, meta)
+}
+
+func setApigEnvironmentParamters(d *schema.ResourceData, config *config.Config, resp *environments.Environment) error {
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("create_time", resp.CreateTime),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+// The GetEnvironmentFormServer is a method to get specifies environment form server by instance id and environment id.
+func GetEnvironmentFormServer(client *golangsdk.ServiceClient, instanceId,
+	envId string) (*environments.Environment, error) {
+	allPages, err := environments.List(client, instanceId, environments.ListOpts{}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	envs, err := environments.ExtractEnvironments(allPages)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range envs {
+		if v.Id == envId {
+			return &v, nil
+		}
+	}
+	return nil, fmtp.Errorf("The environment does not exist")
+}
+
+func resourceApigEnvironmentV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	env, err := GetEnvironmentFormServer(client, instanceId, d.Id())
+	if err != nil {
+		return fmtp.Errorf("Unable to get the environment (%s) form server: %s", d.Id(), err)
+	}
+	return setApigEnvironmentParamters(d, config, env)
+}
+
+func resourceApigEnvironmentV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opt := environments.EnvironmentOpts{}
+	if d.HasChange("name") {
+		opt.Name = d.Get("name").(string)
+	}
+	if d.HasChange("description") {
+		opt.Description = d.Get("description").(string)
+	}
+	instanceId := d.Get("instance_id").(string)
+	_, err = environments.Update(client, instanceId, d.Id(), opt).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error updating HuaweiCloud APIG environment (%s): %s", d.Id(), err)
+	}
+
+	return resourceApigEnvironmentV2Read(d, meta)
+}
+
+func resourceApigEnvironmentV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	err = environments.Delete(client, instanceId, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("Error deleting HuaweiCloud APIG environment from the instance (%s): %s", instanceId, err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
@@ -59,9 +59,10 @@ func ResourceApigEnvironmentV2() *schema.Resource {
 }
 
 func buildApigEnvironmentParameters(d *schema.ResourceData) environments.EnvironmentOpts {
+	desc := d.Get("description").(string)
 	return environments.EnvironmentOpts{
 		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
+		Description: &desc,
 	}
 }
 
@@ -133,12 +134,12 @@ func resourceApigEnvironmentV2Update(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
 	}
-	opt := environments.EnvironmentOpts{}
-	if d.HasChange("name") {
-		opt.Name = d.Get("name").(string)
+	opt := environments.EnvironmentOpts{
+		Name: d.Get("name").(string), // Due to API restrictions, the name must be provided.
 	}
 	if d.HasChange("description") {
-		opt.Description = d.Get("description").(string)
+		desc := d.Get("description").(string)
+		opt.Description = &desc
 	}
 	instanceId := d.Get("instance_id").(string)
 	_, err = environments.Update(client, instanceId, d.Id(), opt).Extract()

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/requests.go
@@ -1,0 +1,188 @@
+package environments
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// EnvironmentOpts allows to create a new environment or update an existing environment using given parameters.
+type EnvironmentOpts struct {
+	// Environment name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// Description of the environment, which can contain a maximum of 255 characters,
+	// and the angle brackets (< and >) are not allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+}
+
+type EnvironmentOptsBuilder interface {
+	ToEnvironmentOptsMap() (map[string]interface{}, error)
+}
+
+func (opts EnvironmentOpts) ToEnvironmentOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new environment.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts EnvironmentOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToEnvironmentOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId, "envs"), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to udpate an existing environment.
+func Update(client *golangsdk.ServiceClient, instanceId, envId string, opts EnvironmentOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToEnvironmentOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, "envs", envId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Environment name.
+	Name string `q:"name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more groups according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId, "envs")
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return EnvironmentPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing group.
+func Delete(client *golangsdk.ServiceClient, instanceId, envId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, "envs", envId), nil)
+	return
+}
+
+// CreateVariableOpts allows to create a new envirable variable for an existing group using given parameters.
+type CreateVariableOpts struct {
+	// Variable name, which can contain 3 to 32 characters, starting with a letter.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// In the definition of an API, #Name# (case-sensitive) indicates a variable.
+	// It is replaced by the actual value when the API is published in an environment.
+	Name string `json:"variable_name" required:"true"`
+	// Variable value, which can contain 1 to 255 characters.
+	// Only letters, digits, and special characters (_-/.:) are allowed.
+	Value string `json:"variable_value" required:"true"`
+	// Environment ID.
+	EnvId string `json:"env_id" required:"true"`
+	// Group ID.
+	GroupId string `json:"group_id" required:"true"`
+}
+
+type CreateVariableOptsBuilder interface {
+	ToCreateVariableOptsMap() (map[string]interface{}, error)
+}
+
+func (opts CreateVariableOpts) ToCreateVariableOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// CreateVariable is a method by which to create function that create a new environment variable.
+func CreateVariable(client *golangsdk.ServiceClient, instanceId string,
+	opts CreateVariableOptsBuilder) (r VariableCreateResult) {
+	reqBody, err := opts.ToCreateVariableOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId, "env-variables"), reqBody, &r.Body, nil)
+	return
+}
+
+// GetVariable is a method to obtain the specified environment variable according to the instance id and variable id.
+func GetVariable(client *golangsdk.ServiceClient, instanceId, varId string) (r VariableGetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, "env-variables", varId), &r.Body, nil)
+	return
+}
+
+// ListVariablesOpts allows to filter list data using given parameters.
+type ListVariablesOpts struct {
+	// API group ID.
+	GroupId string `q:"group_id"`
+	// Environment ID.
+	EnvId string `q:"env_id"`
+	// Variable name.
+	Name string `q:"variable_name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name for exact matching. Only API variable names are supported.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListVariablesOptsBuilder interface {
+	ToListVariablesQuery() (string, error)
+}
+
+func (opts ListVariablesOpts) ToListVariablesQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// ListVariables is a method to obtain an array of one or more variables according to the query parameters.
+func ListVariables(client *golangsdk.ServiceClient, instanceId string, opts ListVariablesOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId, "env-variables")
+	if opts != nil {
+		query, err := opts.ToListVariablesQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VariablePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// DeleteVariable is a method to delete an existing variable.
+func DeleteVariable(client *golangsdk.ServiceClient, instanceId, varId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, "env-variables", varId), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/results.go
@@ -1,0 +1,97 @@
+package environments
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+type Environment struct {
+	// Environment ID.
+	Id string `json:"id"`
+	// Environment name.
+	Name string `json:"name"`
+	// Description.
+	Description string `json:"remark"`
+	// Create time, in RFC-3339 format.
+	CreateTime string `json:"create_time"`
+}
+
+func (r commonResult) Extract() (*Environment, error) {
+	var s Environment
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// EnvironmentPage represents the response pages of the List method.
+type EnvironmentPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractEnvironments(r pagination.Page) ([]Environment, error) {
+	var s []Environment
+	err := r.(EnvironmentPage).Result.ExtractIntoSlicePtr(&s, "envs")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete and DeleteVariable method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type VariableResult struct {
+	golangsdk.Result
+}
+
+// VariableCreateResult represents a result of the CreateVariable method.
+type VariableCreateResult struct {
+	VariableResult
+}
+
+// VariableGetResult represents a result of the GetVariable operation.
+type VariableGetResult struct {
+	VariableResult
+}
+
+type Variable struct {
+	// Environment variable ID.
+	Id string `json:"id"`
+	// Variable name.
+	Name string `json:"variable_name"`
+	// Variable value.
+	Value string `json:"variable_value"`
+	// API group ID.
+	GroupId string `json:"group_id"`
+	// Environment ID.
+	EnvId string `json:"env_id"`
+}
+
+func (r VariableResult) Extract() (*Variable, error) {
+	var s Variable
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// VariablePage represents the response pages of the List operation.
+type VariablePage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractVariables(r pagination.Page) ([]Variable, error) {
+	var s []Variable
+	err := r.(VariablePage).Result.ExtractIntoSlicePtr(&s, "variables")
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/urls.go
@@ -1,0 +1,13 @@
+package environments
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId, path string) string {
+	return c.ServiceURL(rootPath, instanceId, path)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, path, id string) string {
+	return c.ServiceURL(rootPath, instanceId, path, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d
+# github.com/huaweicloud/golangsdk v0.0.0-20210715061636-f0d85a483f0b
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -278,6 +278,7 @@ github.com/huaweicloud/golangsdk/openstack/apigw/apis
 github.com/huaweicloud/golangsdk/openstack/apigw/groups
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels
+github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In order to support APIG group binding variables and API usage, HuaweiCloud needs an environment resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1249

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. New environment resource supports variables binding.
2. New related acc test.
  - unit test for name and description for updates.
3. New related document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigEnvironmentV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigEnvironmentV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigEnvironmentV2_basic
=== PAUSE TestAccApigEnvironmentV2_basic
=== CONT  TestAccApigEnvironmentV2_basic

--- PASS: TestAccApigEnvironmentV2_basic (448.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      449.007s
```
