### PR TITLE
Add WAF policy management support

### DIFF
--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_policy
+
+Manages a WAF policy resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_waf_policy" "policy_1" {
+  name            = "policy_1"
+  protection_mode = "log"
+  level           = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF policy resource.
+  If omitted, the provider-level region will be used.
+  Changing this setting will push a new certificate.
+
+* `name` - (Required, String) Specifies the policy name. The maximum length is 256 characters. Only digits, letters,
+  underscores(_), and hyphens(-) are allowed.
+
+* `protection_mode` - (Optional, String) Specifies the protective action after a rule is matched. Defaults to `log`.
+  Valid values are:
+  * `block`: WAF blocks and logs detected attacks.
+  * `log`: WAF logs detected attacks only.
+
+* `level` - (Optional, Int) Specifies the protection level. Defaults to `2`. Valid values are:
+  * `1`: low
+  * `2`: medium
+  * `3`: high
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The policy ID in UUID format.
+
+* `full_detection` - The detection mode in Precise Protection.
+  * `true`: full detection, Full detection finishes all threat detections before blocking requests that meet Precise
+    Protection specified conditions.
+  * `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that meets
+    Precise Protection specified conditions.
+
+* `options` - The protection switches. The options object structure is documented below.
+
+The `options` block supports:
+
+* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
+
+* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
+
+* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+
+* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
+
+* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
+
+* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
+
+* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
+
+* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
+
+* `cc_attack_protection` - Indicates whether CC Attack Protection is enabled.
+
+* `precise_protection` - Indicates whether Precise Protection is enabled.
+
+* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
+
+* `data_masking` - Indicates whether Data Masking is enabled.
+
+* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
+
+* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
+
+## Import
+
+Policies can be imported using the `id`, e.g.
+
+```sh
+terraform import huaweicloud_waf_policy.policy_2 25e1df831bea4022a6e22bebe678915a
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740
+	github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740 h1:RCAJI5jVLah5GJkr1lk9I0g6+PdTjUMCwzY5pUUd7fA=
-github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d h1:GJFDZ3hxptdDs10RjT1+Tq4oDsWXu+e2yNoHzLRgJ38=
+github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -506,6 +506,8 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_scm_certificate":                 resourceScmCertificateV3(),
 			"huaweicloud_waf_certificate":                 waf.ResourceWafCertificateV1(),
 			"huaweicloud_waf_domain":                      waf.ResourceWafDomainV1(),
+			"huaweicloud_waf_policy":                      waf.ResourceWafPolicyV1(),
+
 			// Legacy
 			"huaweicloud_compute_instance_v2":                ResourceComputeInstanceV2(),
 			"huaweicloud_compute_interface_attach_v2":        ResourceComputeInterfaceAttachV2(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
@@ -1,0 +1,122 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies"
+)
+
+func TestAccWafPolicyV1_basic(t *testing.T) {
+	var policy policies.Policy
+	randName := acctest.RandString(5)
+	resourceName := "huaweicloud_waf_policy.policy_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckWafPolicyV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPolicyV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("policy-%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "level", "1"),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+				),
+			},
+			{
+				Config: testAccWafPolicyV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("policy_%s_updated", randName)),
+					resource.TestCheckResourceAttr(resourceName, "protection_mode", "block"),
+					resource.TestCheckResourceAttr(resourceName, "level", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckWafPolicyV1Destroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_waf_policy" {
+			continue
+		}
+		_, err := policies.Get(wafClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("Waf policy still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckWafPolicyV1Exists(n string, policy *policies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("error creating huaweicloud WAF client: %s", err)
+		}
+
+		found, err := policies.Get(wafClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmtp.Errorf("Waf policy not found")
+		}
+
+		*policy = *found
+		return nil
+	}
+}
+
+func testAccWafPolicyV1_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name  = "policy-%s"
+  level = 1
+}
+`, name)
+}
+
+func testAccWafPolicyV1_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name            = "policy_%s_updated"
+  protection_mode = "block"
+  level           = 3
+}
+`, name)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
@@ -1,0 +1,281 @@
+package waf
+
+import (
+	"strings"
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies"
+)
+
+const (
+	PROTECTION_MODE_LOG   = "log"
+	PROTECTION_MODE_BLOCK = "block"
+)
+
+func ResourceWafPolicyV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafPolicyV1Create,
+		Read:   resourceWafPolicyV1Read,
+		Update: resourceWafPolicyV1Update,
+		Delete: resourceWafPolicyV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					PROTECTION_MODE_LOG, PROTECTION_MODE_BLOCK,
+				}, false),
+			},
+			"level": {
+				Type:         schema.TypeInt,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 3),
+			},
+			"options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"basic_web_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"general_check": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_engine": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_scanner": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_script": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_other": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"webshell": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"cc_attack_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"precise_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"blacklist": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"data_masking": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"false_alarm_masking": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"web_tamper_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"full_detection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	createOpts := policies.CreateOpts{
+		Name: d.Get("name").(string),
+	}
+	policy, err := policies.Create(wafClient, createOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error creating waf policy: %s", err)
+	}
+
+	logp.Printf("[DEBUG] Waf policy created: %#v", policy)
+	d.SetId(policy.Id)
+	d.Set("name", policy.Name)
+
+	level := d.Get("level").(int)
+	protectionMode := d.Get("protection_mode").(string)
+
+	// Get the policy details, then check if need to update 'protection_mode' or 'level.
+	err = resourceWafPolicyV1Read(d, meta)
+
+	// If the vlaue of 'protection_mode' or 'level' is not equal to the value returned by the server,
+	// then update the policy.
+	err = checkAndUpdateDefaultVal(wafClient, d, protectionMode, level)
+	if err != nil {
+		return fmtp.Errorf("the Waf Policy was created successfully, "+
+			"but failed to update protection_mode or level : %s", err)
+	} else {
+		d.Set("protection_mode", protectionMode)
+		d.Set("level", level)
+	}
+
+	return err
+}
+
+// checkAndUpdateDefaultVal check the vlaue of 'protection_mode' or 'level' is not equal to
+// the value returned by the server.
+// If the value is not equal to the value returned by the server, call the update API to make changes.
+func checkAndUpdateDefaultVal(wafClient *golangsdk.ServiceClient, d *schema.ResourceData,
+	protectionMode string, level int) error {
+
+	needUpdate := false
+	updateOpts := policies.UpdateOpts{}
+
+	if strings.Compare(d.Get("protection_mode").(string), protectionMode) != 0 && len(protectionMode) != 0 {
+		needUpdate = true
+		updateOpts.Action = &policies.Action{
+			Category: protectionMode,
+		}
+	}
+	if d.Get("level").(int) != level && level != 0 {
+		needUpdate = true
+		updateOpts.Level = level
+	}
+
+	if needUpdate {
+		logp.Printf("[DEBUG] update default protection_mode or level: %#v", updateOpts)
+		_, err := policies.Update(wafClient, d.Id(), updateOpts).Extract()
+		return err
+	}
+	return nil
+}
+
+func resourceWafPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	n, err := policies.Get(wafClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "Waf Policy")
+	}
+
+	d.Set("region", config.GetRegion(d))
+	d.Set("name", n.Name)
+	d.Set("level", n.Level)
+	d.Set("protection_mode", n.Action.Category)
+	d.Set("full_detection", n.FullDetection)
+
+	options := []map[string]interface{}{
+		{
+			"basic_web_protection":  n.Options.Webattack,
+			"general_check":         n.Options.Common,
+			"crawler":               n.Options.Crawler,
+			"crawler_engine":        n.Options.CrawlerEngine,
+			"crawler_scanner":       n.Options.CrawlerScanner,
+			"crawler_script":        n.Options.CrawlerScript,
+			"crawler_other":         n.Options.CrawlerOther,
+			"webshell":              n.Options.Webshell,
+			"cc_attack_protection":  n.Options.Cc,
+			"precise_protection":    n.Options.Custom,
+			"blacklist":             n.Options.Whiteblackip,
+			"false_alarm_masking":   n.Options.Ignore,
+			"data_masking":          n.Options.Privacy,
+			"web_tamper_protection": n.Options.Antitamper,
+		},
+	}
+	d.Set("options", options)
+	return nil
+}
+
+func resourceWafPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+
+	if d.HasChanges("name", "level", "protection_mode") {
+		updateOpts := policies.UpdateOpts{
+			Name:  d.Get("name").(string),
+			Level: d.Get("level").(int),
+			Action: &policies.Action{
+				Category: d.Get("protection_mode").(string),
+			},
+		}
+
+		logp.Printf("[DEBUG] updateOpts: %#v", updateOpts)
+		_, err = policies.Update(wafClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmtp.Errorf("error updating WAF Policy: %s", err)
+		}
+	}
+	return resourceWafPolicyV1Read(d, meta)
+}
+
+func resourceWafPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	err = policies.Delete(wafClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("error deleting WAF Policy: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies/requests.go
@@ -108,7 +108,11 @@ func UpdateHosts(c *golangsdk.ServiceClient, policyId string, opts UpdateHostsOp
 
 // Get retrieves a particular policy based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, reqOpt)
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210706092920-c12079d6a740
+# github.com/huaweicloud/golangsdk v0.0.0-20210714031135-2f101c51a35d
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add WAF policy management support.
	- Support the creation and management of policies.
	
	- Support the use of existing policies to create domain.
	
	  
	
- Add test cases to domain management: 

  - create a domain using an existing policy.



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
resolves #1257

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:

1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

- Create a domain with an existing policy.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_policy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_policy -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_policy
=== PAUSE TestAccWafDomainV1_policy
=== CONT  TestAccWafDomainV1_policy
--- PASS: TestAccWafDomainV1_policy (29.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       29.194s
```

- Create policy and change policy.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1 -timeout 360m -parallel 4
=== RUN   TestAccWafPolicyV1_basic
--- PASS: TestAccWafPolicyV1_basic (24.81s)
=== RUN   TestAccWafPolicyV1_update
--- PASS: TestAccWafPolicyV1_update (34.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       59.422s

```