### PR TITLE
Add querying WAF certificates support.

### DIFF
--- a/docs/data-sources/waf_certificate.md
+++ b/docs/data-sources/waf_certificate.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_certificate
+
+Get the certificate in the WAF, including the one pushed from SCM.
+
+
+## Example Usage
+
+```hcl
+data "huaweicloud_waf_certificate" "certificate_1" {
+  name = "certificate name"
+}
+
+resource "huaweicloud_waf_domain" "domain_1" {
+  domain           = "www.domainname.com"
+  certificate_id   = data.huaweicloud_waf_certificate.certificate_1.id
+  certificate_name = data.huaweicloud_waf_certificate.certificate_1.name
+  keep_policy      = false
+  proxy            = false
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "192.168.10.1"
+    port            = 8080
+  }
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the WAF. If omitted, the provider-level region will be used.
+ 
+* `name` - (Required, String) The name of certificate. The value is case sensitive and supports fuzzy matching.
+  
+  -> **NOTE:** The certificate name is not unique. Only returns the last created one when matched multiple certificates.
+
+* `expire_status` - (Optional, Int) The expire status of certificate. Defaults is `0`.
+  The value can be:
+  * `0`: not expire
+  * `1`: has expired
+  * `2`: wil expired soon
+  
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `expiration` - Indicates the time when the certificate expires.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -320,6 +320,8 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_vpc_subnet":                  DataSourceVpcSubnetV1(),
 			"huaweicloud_vpc_subnet_ids":              DataSourceVpcSubnetIdsV1(),
 			"huaweicloud_vpcep_public_services":       DataSourceVPCEPPublicServices(),
+			"huaweicloud_waf_certificate":             waf.DataSourceWafCertificateV1(),
+
 			// Legacy
 			"huaweicloud_images_image_v2":           DataSourceImagesImageV2(),
 			"huaweicloud_networking_port_v2":        DataSourceNetworkingPortV2(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
@@ -1,0 +1,56 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDataSourceWafCertificateV1_basic(t *testing.T) {
+	name := fmt.Sprintf("cert-%s", acctest.RandString(5))
+	dataSourceName := "data.huaweicloud_waf_certificate.cert_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafCertificateListV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafCertDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWafCertDataSourceID(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmtp.Errorf("Can't find waf data source: %s ", r)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("The Waf Certificate data source ID not set ")
+		}
+		return nil
+	}
+}
+
+func testAccWafCertificateListV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_certificate" "cert_1" {
+  name = huaweicloud_waf_certificate.certificate_1.name
+}
+`, testAccWafCertificateV1_conf(name))
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
@@ -1,0 +1,94 @@
+package waf
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+const (
+	// EXP_STATUS_NOT_EXPIRED not expired
+	EXP_STATUS_NOT_EXPIRED = 0
+	// EXP_STATUS_EXPIRED has expired
+	EXP_STATUS_EXPIRED = 1
+	// EXP_STATUS_EXPIRED_SOON will expire soon
+	EXP_STATUS_EXPIRED_SOON = 2
+
+	DEFAULT_PAGE_NUM  = 1
+	DEFAULT_PAGE_SIZE = 5
+)
+
+func DataSourceWafCertificateV1() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceWafCertificateV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"expire_status": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  EXP_STATUS_NOT_EXPIRED,
+				ValidateFunc: validation.IntInSlice([]int{
+					EXP_STATUS_NOT_EXPIRED, EXP_STATUS_EXPIRED, EXP_STATUS_EXPIRED_SOON,
+				}),
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceWafCertificateV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+
+	expStatus := d.Get("expire_status").(int)
+	listOpts := certificates.ListOpts{
+		Page:      DEFAULT_PAGE_NUM,
+		Pagesize:  DEFAULT_PAGE_SIZE,
+		Name:      d.Get("name").(string),
+		ExpStatus: &expStatus,
+	}
+
+	page, err := certificates.List(wafClient, listOpts).AllPages()
+
+	listCertificates, err := certificates.ExtractCertificates(page)
+	if err != nil {
+		return fmtp.Errorf("Unable to retrieve certificates: %s", err)
+	}
+	logp.Printf("[DEBUG] Get certificate list: %#v", listCertificates)
+
+	if len(listCertificates) > 0 {
+		c := listCertificates[0]
+		d.SetId(c.Id)
+		d.Set("name", c.Name)
+		d.Set("expire_status", c.ExpStatus)
+
+		expires := time.Unix(int64(c.ExpireTime/1000), 0).UTC().Format("2006-01-02 15:04:05 MST")
+		d.Set("expiration", expires)
+	} else {
+		return fmtp.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	return nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates/results.go
@@ -2,6 +2,7 @@ package certificates
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
 )
 
 type Certificate struct {
@@ -42,6 +43,46 @@ type UpdateResult struct {
 // method to interpret it as a Certificate.
 type GetResult struct {
 	commonResult
+}
+
+// CertificateDetail reprersents the result of list certificates.
+type CertificateDetail struct {
+	// Certificate ID
+	Id string `json:"id"`
+	// Certificate Name
+	Name string `json:"name"`
+	// Certificate Id
+	CertificateId string `json:"certificateid"`
+	// Certificate name
+	CertificateName string `json:"certificatename"`
+	// the key of the certificate
+	Timestamp int64 `json:"timestamp"`
+	// the privite key of the certificate
+	BindHosts []BindHost `json:"bind_host,omitempty"`
+	// the time when the certificate expires in unix timestamp
+	ExpireTime int `json:"expire_time"`
+	// the expire status of the certificate
+	// 0-not expired, 1-expired, 2-expired soon
+	ExpStatus int `json:"exp_status"`
+}
+
+type BindHost struct {
+	Id       string `json:"id"`
+	Hostname string `json:"hostname"`
+	WafType  string `json:"waf_type"`
+	Mode     string `json:"mode"`
+}
+
+type CertificatePage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractCertificates(r pagination.Page) ([]CertificateDetail, error) {
+	var s struct {
+		Certificates []CertificateDetail `json:"items"`
+	}
+	err := (r.(CertificatePage)).ExtractInto(&s)
+	return s.Certificates, err
 }
 
 // DeleteResult represents the result of a delete operation. Call its ExtractErr


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The WAF certificate pushed by SCM requires a `Data Source` to query the ID, otherwise it cannot be used in Terraform.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1278

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Added Data Source('huaweicloud_waf_certificate') for querying the id of WAF Certificate. 
2. New acc test for each parameters.
3. New document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafCertificateV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafCertificateV1_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafCertificateV1_basic
=== PAUSE TestAccDataSourceWafCertificateV1_basic
=== CONT  TestAccDataSourceWafCertificateV1_basic
--- PASS: TestAccDataSourceWafCertificateV1_basic (14.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       14.664s

```
