### PR TITLE
Add WAF policy rule management supports

### DIFF
--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_rule_blacklist
+
+Manages a WAF blacklist and whitelist rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "huaweicloud_waf_rule_blacklist" "rule_1" {
+  policy_id  = huaweicloud_waf_policy.policy_1.id
+  ip_address = "192.168.0.0/24"
+  action     = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF blacklist and whitelist rule resource.
+  If omitted, the provider-level region will be used. Changing this setting will push a new certificate.
+  
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+  Please make sure that the region which the policy belongs to be consistent with the `region`.
+
+* `ip_address` - (Required, String) Specifies the IP address or range. For example, 192.168.0.125 or 192.168.0.0/24.
+
+* `action` - (Optional, Int) Specifies the protective action. Defaults is `0`.
+  The value can be:
+  * `0`: block the request.
+  * `1`: allow the request.
+  * `2`: log the request only.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Blacklist and Whiltelist Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+
+```sh
+terraform import huaweicloud_waf_rule_blacklist.rule_1 d78b439fd5e54ea08886e5f63ee7b3f5/ac01a092d50e4e6ba3cd622c1128ba2c
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -508,6 +508,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_waf_certificate":                 waf.ResourceWafCertificateV1(),
 			"huaweicloud_waf_domain":                      waf.ResourceWafDomainV1(),
 			"huaweicloud_waf_policy":                      waf.ResourceWafPolicyV1(),
+			"huaweicloud_waf_rule_blacklist":              waf.ResourceWafRuleBlackListV1(),
 
 			// Legacy
 			"huaweicloud_compute_instance_v2":                ResourceComputeInstanceV2(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -1,0 +1,176 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules"
+)
+
+func TestAccWafRuleBlackList_basic(t *testing.T) {
+	var rule rules.WhiteBlackIP
+	randName := acctest.RandString(5)
+	rName1 := "huaweicloud_waf_rule_blacklist.rule_1"
+	rName2 := "huaweicloud_waf_rule_blacklist.rule_2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckWafRuleBlackListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleBlackList_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(rName1, &rule),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.0/24"),
+					resource.TestCheckResourceAttr(rName1, "action", "0"),
+
+					testAccCheckWafRuleBlackListExists(rName2, &rule),
+					resource.TestCheckResourceAttr(rName2, "ip_address", "192.165.0.0/24"),
+					resource.TestCheckResourceAttr(rName2, "action", "1"),
+				),
+			},
+			{
+				Config: testAccWafRuleBlackList_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(rName1, &rule),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.125"),
+					resource.TestCheckResourceAttr(rName1, "action", "2"),
+
+					testAccCheckWafRuleBlackListExists(rName2, &rule),
+					resource.TestCheckResourceAttr(rName2, "ip_address", "192.150.0.0/24"),
+					resource.TestCheckResourceAttr(rName2, "action", "0"),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(rName1),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleBlackListDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_waf_rule_blacklist" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleBlackListExists(n string, rule *rules.WhiteBlackIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF black list rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+// testAccWafRuleImportStateIdFunc is used to test exporting rule information from the HuaweiCloud to terraform.
+// It is also called by other rules unit tests.
+func testAccWafRuleImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		policy, ok := s.RootModule().Resources["huaweicloud_waf_policy.policy_1"]
+		if !ok {
+			return "", fmt.Errorf("WAF policy not found")
+		}
+		rule, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("WAF rule not found")
+		}
+
+		if policy.Primary.ID == "" || rule.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", policy.Primary.ID, rule.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", policy.Primary.ID, rule.Primary.ID), nil
+	}
+}
+
+func testAccWafRuleBlackList_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "huaweicloud_waf_rule_blacklist" "rule_1" {
+  policy_id  = huaweicloud_waf_policy.policy_1.id
+  ip_address = "192.168.0.0/24"
+}
+
+resource "huaweicloud_waf_rule_blacklist" "rule_2" {
+  policy_id  = huaweicloud_waf_policy.policy_1.id
+  ip_address = "192.165.0.0/24"
+  action     = 1
+}
+
+`, name)
+}
+
+func testAccWafRuleBlackList_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "huaweicloud_waf_rule_blacklist" "rule_1" {
+  policy_id  = huaweicloud_waf_policy.policy_1.id
+  ip_address = "192.168.0.125"
+  action     = 2
+}
+
+resource "huaweicloud_waf_rule_blacklist" "rule_2" {
+  policy_id  = huaweicloud_waf_policy.policy_1.id
+  ip_address = "192.150.0.0/24"
+  action     = 0
+}
+
+`, name)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
@@ -1,0 +1,175 @@
+package waf
+
+import (
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	rules "github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+const (
+	// PROTECTION_ACTION_BLOCK block the request
+	PROTECTION_ACTION_BLOCK = 0
+	// PROTECTION_ACTION_ALLOW allow the request
+	PROTECTION_ACTION_ALLOW = 1
+	// PROTECTION_ACTION_LOG log the request only
+	PROTECTION_ACTION_LOG = 2
+)
+
+func ResourceWafRuleBlackListV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleBlackListCreate,
+		Read:   resourceWafRuleBlackListRead,
+		Update: resourceWafRuleBlackListUpdate,
+		Delete: resourceWafRuleBlackListDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  PROTECTION_ACTION_BLOCK,
+				ValidateFunc: validation.IntInSlice([]int{
+					PROTECTION_ACTION_BLOCK, PROTECTION_ACTION_ALLOW, PROTECTION_ACTION_LOG,
+				}),
+			},
+		},
+	}
+}
+
+func resourceWafRuleBlackListCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	createOpts := rules.CreateOpts{
+		Addr:  d.Get("ip_address").(string),
+		White: d.Get("action").(int),
+	}
+
+	logp.Printf("[DEBUG] WAF black list rule creating opts: %#v", createOpts)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("error creating WAF black list rule: %s", err)
+	}
+	logp.Printf("[DEBUG] WAF black list rule created: %#v", rule)
+	// After the creation is successful, set the value id of the schema.
+	d.SetId(rule.Id)
+
+	return resourceWafRuleBlackListRead(d, meta)
+}
+
+func resourceWafRuleBlackListRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "WAF Black List Rule")
+	}
+	logp.Printf("[DEBUG] fetching WAF black list rule: %#v", n)
+
+	d.SetId(n.Id)
+	d.Set("policy_id", n.PolicyID)
+	d.Set("ip_address", n.Addr)
+	d.Set("action", n.White)
+
+	return nil
+}
+
+func resourceWafRuleBlackListUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+
+	// Only support to modify 'ip_address' and 'action'.
+	// After modifying 'policy_id', it will deleted and created.
+	if d.HasChanges("ip_address", "action") {
+		white := d.Get("action").(int)
+		updateOpts := rules.UpdateOpts{
+			Addr:  d.Get("ip_address").(string),
+			White: &white,
+		}
+		logp.Printf("[DEBUG] updating blacklist and whitelist rule, updateOpts: %#v", updateOpts)
+
+		policyID := d.Get("policy_id").(string)
+		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmtp.Errorf("error updating HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
+		}
+	}
+
+	return resourceWafRuleBlackListRead(d, meta)
+}
+
+func resourceWafRuleBlackListDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("error deleting HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// resourceWafRulesImport query the rules from HuaweiCloud and imports them to Terraform.
+// It is a common function in waf and is also called by other rule resources.
+func resourceWafRulesImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmtp.Errorf("Invalid format specified for WAF rule. Format must be <policy id>/<rule id>")
+		return nil, err
+	}
+
+	policyID := parts[0]
+	ruleID := parts[1]
+
+	d.SetId(ruleID)
+	d.Set("policy_id", policyID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/requests.go
@@ -1,0 +1,89 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package whiteblackip_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToWhiteBlackIPCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new whiteblackip rule.
+type CreateOpts struct {
+	Addr  string `json:"addr" required:"true"`
+	White int    `json:"white,omitempty"`
+}
+
+// ToWhiteBlackIPCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToWhiteBlackIPCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new whiteblackip rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToWhiteBlackIPCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToWhiteBlackIPUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a whiteblackip rule.
+type UpdateOpts struct {
+	Addr  string `json:"addr" required:"true"`
+	White *int   `json:"white" required:"true"`
+}
+
+// ToWhiteBlackIPUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToWhiteBlackIPUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a rule.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToWhiteBlackIPUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular whiteblackip rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular whiteblackip rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders}
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/results.go
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package whiteblackip_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type WhiteBlackIP struct {
+	// WhiteBlackIP Rule ID
+	Id string `json:"id"`
+	// WhiteBlackIP Rule Addr
+	Addr string `json:"addr"`
+	// IP address type
+	White int `json:"white"`
+	// Policy ID
+	PolicyID string `json:"policyid"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a whiteblackip rule.
+func (r commonResult) Extract() (*WhiteBlackIP, error) {
+	var response WhiteBlackIP
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a WhiteBlackIP rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a WhiteBlackIP rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a WhiteBlackIP rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/urls.go
@@ -1,0 +1,15 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package whiteblackip_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "whiteblackip")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "whiteblackip", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,6 +461,7 @@ github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies
+github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules
 github.com/huaweicloud/golangsdk/pagination
 github.com/huaweicloud/golangsdk/testhelper
 # github.com/imdario/mergo v0.3.9


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Support the management of the blacklist and whitelist rules of the policy.
  - Create blacklist or whitelist rules.
  - Modify the blacklist or whitelist rules.
  - Delete existing blacklist or whitelist rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


**Special notes for your reviewer**:

- Issue: #1280
- This PR is only part of the issue, do not close it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Added resource('huaweicloud_waf_rule_blacklist') for manging the rules of policy. 
2. New acc test for each parameters.
3. New document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```bash
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleBlackList_basic
=== PAUSE TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_basic
--- PASS: TestAccWafRuleBlackList_basic (32.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       32.131s
```
