### PR TITLE
use cloud value as basis for auth_url

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -225,7 +225,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"HW_AUTH_URL",
 					"OS_AUTH_URL",
-				}, fmt.Sprintf("https://iam.%s:443/v3", defaultCloud)),
+				}, nil),
 			},
 
 			"cloud": {
@@ -684,8 +684,9 @@ func init() {
 }
 
 func configureProvider(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
-	var tenantName, tenantID, delegated_project string
+	var tenantName, tenantID, delegated_project, identityEndpoint string
 	region := d.Get("region").(string)
+	cloud := d.Get("cloud").(string)
 
 	// project_name is prior to tenant_name
 	// if neither of them was set, use region as the default project
@@ -711,6 +712,18 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		delegated_project = region
 	}
 
+	// use auth_url as identityEndpoint if provided
+	if v, ok := d.GetOk("auth_url"); ok {
+		identityEndpoint = v.(string)
+	} else {
+		// use cloud as basis for identityEndpoint
+		if cloud == defaultCloud {
+			identityEndpoint = fmt.Sprintf("https://iam.%s:443/v3", cloud)
+		} else {
+			identityEndpoint = fmt.Sprintf("https://iam.%s.%s:443/v3", region, cloud)
+		}
+	}
+
 	config := config.Config{
 		AccessKey:           d.Get("access_key").(string),
 		SecretKey:           d.Get("secret_key").(string),
@@ -719,7 +732,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		ClientKeyFile:       d.Get("key").(string),
 		DomainID:            d.Get("domain_id").(string),
 		DomainName:          d.Get("domain_name").(string),
-		IdentityEndpoint:    d.Get("auth_url").(string),
+		IdentityEndpoint:    identityEndpoint,
 		Insecure:            d.Get("insecure").(bool),
 		Password:            d.Get("password").(string),
 		Token:               d.Get("token").(string),
@@ -732,7 +745,7 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		AgencyName:          d.Get("agency_name").(string),
 		AgencyDomainName:    d.Get("agency_domain_name").(string),
 		DelegatedProject:    delegated_project,
-		Cloud:               d.Get("cloud").(string),
+		Cloud:               cloud,
 		MaxRetries:          d.Get("max_retries").(int),
 		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
 		TerraformVersion:    terraformVersion,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
when I specify `cloud` value for provider configuration, it is ignored in the identity endpoint and I have to set `auth_url` as well.
this PR use the `cloud` as basis for `auth_url` when it is specified.

before changes
```
provider "huaweicloud" {
  auth_url   = "iam.cn-north-1.somedomain.com"
  cloud       = "somedomain.com"
  region      = "cn-north-1"
}
```

after changes
```
provider "huaweicloud" {
  cloud       = "somedomain.com"
  region      = "cn-north-1"
}
```



## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.


