### PR TITLE
fix docs and test cases of data_source dms_az

### DIFF
--- a/docs/data-sources/dms_az.md
+++ b/docs/data-sources/dms_az.md
@@ -12,9 +12,7 @@ This is an alternative to `huaweicloud_dms_az_v1`
 ```hcl
 
 data "huaweicloud_dms_az" "az1" {
-  name = "可用区1"
-  port = "8002"
-  code = "cn-north-1a"
+  code = "cn-north-4a"
 }
 ```
 
@@ -22,16 +20,14 @@ data "huaweicloud_dms_az" "az1" {
 
 * `region` - (Optional, String) The region in which to obtain the dms az. If omitted, the provider-level region will be used.
 
-* `name` - (Required, String) Indicates the name of an AZ.
-
-* `code` - (Optional, String) Indicates the code of an AZ.
-
-* `port` - (Required, String) Indicates the port number of an AZ.
-
+* `code` - (Optional, String) Specifies the code of an AZ.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a data source ID in UUID format.
+* `id` - Indicates a data source ID in UUID format.
 
+* `name` - Indicates the name of an AZ.
+
+* `port` - Indicates the port number of an AZ.

--- a/huaweicloud/data_source_huaweicloud_dms_az_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dms_az_v1.go
@@ -64,6 +64,11 @@ func dataSourceDmsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 				continue
 			}
 
+			code := d.Get("code").(string)
+			if code != "" && newAZ.Code != code {
+				continue
+			}
+
 			port := d.Get("port").(string)
 			if port != "" && newAZ.Port != port {
 				continue

--- a/huaweicloud/data_source_huaweicloud_dms_az_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_dms_az_v1_test.go
@@ -18,13 +18,9 @@ func TestAccDmsAZV1DataSource_basic(t *testing.T) {
 			{
 				Config: testAccDmsAZV1DataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDmsAZV1DataSourceID("data.huaweicloud_dms_az_v1.az1"),
+					testAccCheckDmsAZV1DataSourceID("data.huaweicloud_dms_az.az1"),
 					resource.TestCheckResourceAttr(
-						"data.huaweicloud_dms_az_v1.az1", "name", "可用区1"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_dms_az_v1.az1", "port", "8002"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_dms_az_v1.az1", "code", HW_AVAILABILITY_ZONE),
+						"data.huaweicloud_dms_az.az1", "code", "cn-north-4a"),
 				),
 			},
 		},
@@ -47,9 +43,7 @@ func testAccCheckDmsAZV1DataSourceID(n string) resource.TestCheckFunc {
 }
 
 var testAccDmsAZV1DataSource_basic = fmt.Sprintf(`
-data "huaweicloud_dms_az_v1" "az1" {
-name = "可用区1"
-port = "8002"
-code = "%s"
+data "huaweicloud_dms_az" "az1" {
+  code = "cn-north-4a"
 }
-`, HW_AVAILABILITY_ZONE)
+`)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix docs and test cases of data_source dms_az

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  move arguments `name` and `port` to attributes in docs.
2. remove Chinese characters "可用区1" to make the docs more friendly for users who don't understand Chinese.
3. the test case is also updated
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDmsAZV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDmsAZV1DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsAZV1DataSource_basic
=== PAUSE TestAccDmsAZV1DataSource_basic
=== CONT  TestAccDmsAZV1DataSource_basic
--- PASS: TestAccDmsAZV1DataSource_basic (17.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       17.162s
```
