### PR TITLE
New APIG custom response resource supported

### DIFF
--- a/docs/resources/apig_response.md
+++ b/docs/resources/apig_response.md
@@ -1,0 +1,87 @@
+---
+subcategory: "API Gateway (APIG)"
+---
+
+# huaweicloud_apig_response
+
+Manages an APIG (API) custom response resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+variable "response_name" {}
+
+resource "huaweicloud_apig_response" "test" {
+  name        = var.response_name
+  instance_id = var.instance_id
+  group_id    = var.group_id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API custom response resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new API custom response resource.
+
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the API group to which the API response belongs to.
+  Changing this will create a new API custom response resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the APIG dedicated instance to which the API group
+  where the API custom response belongs.
+  Changing this will create a new API custom response resource.
+
+* `name` - (Required, String) Specifies the name of the API custom response.
+  The name consists of 1 to 64 characters, and only letters, digits, hyphens(-), and underscores (_) are allowed.
+
+* `rule` - (Optional, List) Specifies the API custom response rules definition.
+  The object structure is documented below.
+
+The `rule` block supports:
+
+* `error_type` - (Required, String) Specifies the type of the API custom response rule.
+  - **AUTH_FAILURE**: Authentication failed.
+  - **AUTH_HEADER_MISSING**: The identity source is missing.
+  - **AUTHORIZER_FAILURE**: Custom authentication failed.
+  - **AUTHORIZER_CONF_FAILURE**: There has been a custom authorizer error.
+  - **AUTHORIZER_IDENTITIES_FAILURE**: The identity source of the custom authorizer is invalid.
+  - **BACKEND_UNAVAILABLE**: The backend service is unavailable.
+  - **BACKEND_TIMEOUT**: Communication with the backend service timed out.
+  - **THROTTLED**: The request was rejected due to request throttling.
+  - **UNAUTHORIZED**: The app you are using has not been authorized to call the API.
+  - **ACCESS_DENIED**: Access denied.
+  - **NOT_FOUND**: No API is found.
+  - **REQUEST_PARAMETERS_FAILURE**: The request parameters are incorrect.
+  - **DEFAULT_4XX**: Another 4XX error occurred.
+  - **DEFAULT_5XX**: Another 5XX error occurred.
+
+* `body` - (Required, String) Specifies the body template of the API response rule, e.g.
+  `{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}`
+
+* `status_code` - (Optional, Int) Specifies the HTTP status code of the API response rule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the API custom response.
+* `create_time` - Time when the API custom response is created.
+* `update_time` - Time when the API custom response was last modified.
+
+## Import
+
+API Responses can be imported using their `name` and IDs of the APIG dedicated instances and API groups to which
+the API response belongs, separated by a slash, e.g.
+```
+$ terraform import huaweicloud_apig_response.test <instance id>/<group id>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -371,6 +371,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_apig_application":                apig.ResourceApigApplicationV2(),
 			"huaweicloud_apig_environment":                apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_group":                      apig.ResourceApigGroupV2(),
+			"huaweicloud_apig_response":                   apig.ResourceApigResponseV2(),
 			"huaweicloud_apig_vpc_channel":                apig.ResourceApigVpcChannelV2(),
 			"huaweicloud_as_configuration":                ResourceASConfiguration(),
 			"huaweicloud_as_group":                        ResourceASGroup(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go
@@ -1,0 +1,260 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigResponseV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_response.test"
+		resp         responses.Response
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigResponseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigResponse_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				Config: testAccApigResponse_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigGroupSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigResponseV2_customRules(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_response.test"
+		resp         responses.Response
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigResponseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigResponse_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				// Add two custom rule.
+				Config: testAccApigResponse_rules(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
+				),
+			},
+			{
+				// Remove one and update another.
+				Config: testAccApigResponse_rulesUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigGroupSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigResponseDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_apig_response" {
+			continue
+		}
+		_, err := responses.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["group_id"],
+			rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API custom response (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigResponseExists(n string, resp *responses.Response) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No APIG V2 API custom response Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		}
+		found, err := responses.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["group_id"],
+			rs.Primary.ID).Extract()
+		if err != nil {
+			return fmt.Errorf("APIG v2 API custom response not exist: %s", err)
+		}
+		*resp = *found
+		return nil
+	}
+}
+
+func isResponseImportIdValid(rs *terraform.ResourceState) bool {
+	if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["group_id"] == "" ||
+		rs.Primary.Attributes["name"] == "" {
+		return false
+	}
+	return true
+}
+
+func testAccApigGroupSubResourceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if isResponseImportIdValid(rs) {
+			return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["group_id"],
+				rs.Primary.Attributes["name"]), nil
+		}
+		return "", fmt.Errorf("resource not found: %s/%s/%s", rs.Primary.Attributes["instance_id"],
+			rs.Primary.Attributes["group_id"], rs.Primary.Attributes["name"])
+	}
+}
+
+func testAccApigResponse_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigResponse_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_response" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = huaweicloud_apig_group.test.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}
+
+func testAccApigResponse_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_response" "test" {
+  name        = "%s_update"
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = huaweicloud_apig_group.test.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}
+
+func testAccApigResponse_rules(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_response" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = huaweicloud_apig_group.test.id
+
+  rule {
+    error_type  = "ACCESS_DENIED"
+    body        = "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\"}"
+    status_code = 400
+  }
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}
+
+func testAccApigResponse_rulesUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_response" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = huaweicloud_apig_group.test.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 403
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
@@ -1,0 +1,259 @@
+package apig
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceApigResponseV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApigResponseV2Create,
+		Read:   resourceApigResponseV2Read,
+		Update: resourceApigResponseV2Update,
+		Delete: resourceApigResponseV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceApigResponseResourceImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[A-Za-z0-9_-]{1,64}$"), "The name consists of 1 to 64 characters. "+
+						"Only letters, digits, hyphens(-), and underscores (_) are allowed."),
+			},
+			"rule": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"error_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"AUTH_FAILURE", "AUTH_HEADER_MISSING", "AUTHORIZER_FAILURE", "AUTHORIZER_CONF_FAILURE",
+								"AUTHORIZER_IDENTITIES_FAILURE", "BACKEND_UNAVAILABLE", "BACKEND_TIMEOUT", "THROTTLED",
+								"UNAUTHORIZED", "ACCESS_DENIED", "NOT_FOUND", "REQUEST_PARAMETERS_FAILURE",
+								"DEFAULT_4XX", "DEFAULT_5XX",
+							}, false),
+						},
+						"body": {
+							Type: schema.TypeString,
+							// If parameter body omitted, The API will return 'The parameters must be specified'.
+							Required: true,
+						},
+						"status_code": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(200, 599),
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// 'error_type' is the key of the response mapping, and 'body' and 'status_code' are the structural elements of the
+// mapping value.
+func buildApigGroupCustomResponses(d *schema.ResourceData) map[string]responses.ResponseInfo {
+	result := make(map[string]responses.ResponseInfo)
+	respSet := d.Get("rule").(*schema.Set)
+	for _, response := range respSet.List() {
+		rule := response.(map[string]interface{})
+		errorType := rule["error_type"].(string)
+		result[errorType] = responses.ResponseInfo{
+			Body:   rule["body"].(string),
+			Status: rule["status_code"].(int),
+		}
+	}
+	return result
+}
+
+func resourceApigResponseV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opt := responses.ResponseOpts{
+		Name:       d.Get("name").(string),
+		Responses:  buildApigGroupCustomResponses(d),
+		InstanceId: d.Get("instance_id").(string),
+		GroupId:    d.Get("group_id").(string),
+	}
+	resp, err := responses.Create(client, opt).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG group: %s", err)
+	}
+	d.SetId(resp.Id)
+
+	return resourceApigResponseV2Read(d, meta)
+}
+
+func setApigGroupCustomResponses(d *schema.ResourceData, respMap map[string]responses.ResponseInfo) error {
+	result := make([]map[string]interface{}, 0)
+	for errorType, rule := range respMap {
+		if rule.IsDefault {
+			// The IsDefault of the modified response will be marked as false,
+			// record these responses and skip other unmodified responses (IsDefault is true).
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"error_type":  errorType,
+			"body":        rule.Body,
+			"status_code": rule.Status,
+		})
+	}
+	return d.Set("rule", result)
+}
+
+func setApigResponseParamters(d *schema.ResourceData, config *config.Config, resp *responses.Response) error {
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", resp.Name),
+		setApigGroupCustomResponses(d, resp.Responses),
+		d.Set("create_time", resp.CreateTime),
+		d.Set("update_time", resp.UpdateTime),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func resourceApigResponseV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	groupId := d.Get("group_id").(string)
+	resp, err := responses.Get(client, instanceId, groupId, d.Id()).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error getting custom response from server: %s", err)
+	}
+	if err = setApigResponseParamters(d, config, resp); err != nil {
+		return fmtp.Errorf("Error saving custom response to state: %s", err)
+	}
+	return nil
+}
+
+func resourceApigResponseV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	// Only updating the name will cause all the response rules that have been set to be reset, so no matter whether
+	// the response rules are updated or not, the response rules must be carried in the update opt.
+	opt := responses.ResponseOpts{
+		Name:       d.Get("name").(string),
+		Responses:  buildApigGroupCustomResponses(d),
+		InstanceId: d.Get("instance_id").(string),
+		GroupId:    d.Get("group_id").(string),
+	}
+	_, err = responses.Update(client, d.Id(), opt).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error updating HuaweiCloud APIG custom response: %s", err)
+	}
+	return resourceApigResponseV2Read(d, meta)
+}
+
+func resourceApigResponseV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	groupId := d.Get("group_id").(string)
+	err = responses.Delete(client, instanceId, groupId, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("Error deleting HuaweiCloud custom response (%s) from the APIG group (%s): %s",
+			d.Id(), groupId, err)
+	}
+	d.SetId("")
+	return nil
+}
+
+// Some resources of the APIG service are associated with dedicated instances and groups,
+// but their IDs cannot be found on the console.
+// This method is used to solve the above problem by importing resources by associating ID and their name.
+func resourceApigResponseResourceImportState(d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 3)
+	if len(parts) != 3 {
+		return nil, fmtp.Errorf("Invalid format specified for import ids and name, " +
+			"must be <instance_id>/<group_id>/<name>")
+	}
+
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := parts[0]
+	groupId := parts[1]
+	opt := responses.ListOpts{
+		InstanceId: instanceId,
+		GroupId:    groupId,
+	}
+	pages, err := responses.List(client, opt).AllPages()
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error getting custom response list from server: %s", err)
+	}
+	resp, err := responses.ExtractResponses(pages)
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error extract custom responses: %s", err)
+	}
+	if len(resp) < 1 {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Unable to find any custom response from server")
+	}
+	// Since there are no parameters about custom responses in the query options, we need to get the response list and
+	// filter by the response name.
+	name := parts[2]
+	for _, val := range resp {
+		if val.Name == name {
+			d.SetId(val.Id)
+			d.Set("instance_id", instanceId)
+			d.Set("group_id", groupId)
+			return []*schema.ResourceData{d}, nil
+		}
+	}
+	return []*schema.ResourceData{d}, fmtp.Errorf("Unable to find the custom response (%s) from server")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses/requests.go
@@ -1,0 +1,213 @@
+package responses
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// ResponseOpts allows to create a new custom response or update the existing custom response using given parameters.
+type ResponseOpts struct {
+	// APIG group name, which can contain 1 to 64 characters, only letters, digits, hyphens (-) and
+	// underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Response type definition, which includes a key and value. Options of the key:
+	//     AUTH_FAILURE: Authentication failed.
+	//     AUTH_HEADER_MISSING: The identity source is missing.
+	//     AUTHORIZER_FAILURE: Custom authentication failed.
+	//     AUTHORIZER_CONF_FAILURE: There has been a custom authorizer error.
+	//     AUTHORIZER_IDENTITIES_FAILURE: The identity source of the custom authorizer is invalid.
+	//     BACKEND_UNAVAILABLE: The backend service is unavailable.
+	//     BACKEND_TIMEOUT: Communication with the backend service timed out.
+	//     THROTTLED: The request was rejected due to request throttling.
+	//     UNAUTHORIZED: The app you are using has not been authorized to call the API.
+	//     ACCESS_DENIED: Access denied.
+	//     NOT_FOUND: No API is found.
+	//     REQUEST_PARAMETERS_FAILURE: The request parameters are incorrect.
+	//     DEFAULT_4XX: Another 4XX error occurred.
+	//     DEFAULT_5XX: Another 5XX error occurred.
+	// Each error type is in JSON format.
+	Responses map[string]ResponseInfo `json:"responses,omitempty"`
+	// APIG dedicated instance ID.
+	InstanceId string `json:"-"`
+	// APIG group ID.
+	GroupId string `json:"-"`
+}
+
+type ResponseInfo struct {
+	// Response body template.
+	Body string `json:"body" required:"true"`
+	// HTTP status code of the response. If omitted, the status will be cancelled.
+	Status int `json:"status,omitempty"`
+	// Indicates whether the response is the default response.
+	// Only the response of the API call is supported.
+	IsDefault bool `json:"default,omitempty"`
+}
+
+type ResponseOptsBuilder interface {
+	ToResponseOptsMap() (map[string]interface{}, error)
+	GetInstanceId() string
+	GetGroupId() string
+}
+
+func (opts ResponseOpts) ToResponseOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func (opts ResponseOpts) GetInstanceId() string {
+	return opts.InstanceId
+}
+
+func (opts ResponseOpts) GetGroupId() string {
+	return opts.GroupId
+}
+
+// Create is a method by which to create function that create a new custom response.
+func Create(client *golangsdk.ServiceClient, opts ResponseOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToResponseOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId())),
+		reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to create function that udpate the existing custom response.
+func Update(client *golangsdk.ServiceClient, respId string, opts ResponseOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToResponseOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId()), respId),
+		reqBody, &r.Body, &golangsdk.RequestOpts{
+			OkCodes: []int{200},
+		})
+	return
+}
+
+// Get is a method to obtain the specified custom response according to the instanceId, appId and respId.
+func Get(client *golangsdk.ServiceClient, instanceId, groupId, respId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, buildResponsesPath(instanceId, groupId), respId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// APIG dedicated instance ID.
+	InstanceId string `json:"-"`
+	// APIG group ID.
+	GroupId string `json:"-"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+	GetInstanceId() string
+	GetGroupId() string
+}
+
+func (opts ListOpts) GetInstanceId() string {
+	return opts.InstanceId
+}
+
+func (opts ListOpts) GetGroupId() string {
+	return opts.GroupId
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more custom reponses according to the query parameters.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId()))
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ResponsePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete the existing custom response.
+func Delete(client *golangsdk.ServiceClient, instanceId, groupId, respId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, buildResponsesPath(instanceId, groupId), respId), nil)
+	return
+}
+
+// SpecRespOpts is used to build the APIG response url. All parameters are required.
+type SpecRespOpts struct {
+	InstanceId string
+	GroupId    string
+	RespId     string
+}
+
+type SpecRespOptsBuilder interface {
+	GetInstanceId() string
+	GetGroupId() string
+	GetResponseId() string
+}
+
+func (opts SpecRespOpts) GetInstanceId() string {
+	return opts.InstanceId
+}
+
+func (opts SpecRespOpts) GetGroupId() string {
+	return opts.GroupId
+}
+
+func (opts SpecRespOpts) GetResponseId() string {
+	return opts.RespId
+}
+
+// GetSpecResp is a method to get the specifies custom response configuration from an group.
+func GetSpecResp(client *golangsdk.ServiceClient, respType string, opts SpecRespOptsBuilder) (r GetSpecRespResult) {
+	_, r.Err = client.Get(specResponsesURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId()),
+		opts.GetResponseId(), respType), &r.Body, nil)
+	return
+}
+
+type UpdateSpecRespBuilder interface {
+	ToSpecRespUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts ResponseInfo) ToSpecRespUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// UpdateSpecResp is a method to update an existing custom response configuration from an group.
+func UpdateSpecResp(client *golangsdk.ServiceClient, respType string, specOpts SpecRespOptsBuilder,
+	respOpts UpdateSpecRespBuilder) (r UpdateSpecRespResult) {
+	reqBody, err := respOpts.ToSpecRespUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(specResponsesURL(client, buildResponsesPath(specOpts.GetInstanceId(), specOpts.GetGroupId()),
+		specOpts.GetResponseId(), respType), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DeleteSpecResp is a method to delete an existing custom response configuration from an group.
+func DeleteSpecResp(client *golangsdk.ServiceClient, respType string, specOpts SpecRespOptsBuilder) (r DeleteResult) {
+	_, r.Err = client.Delete(specResponsesURL(client, buildResponsesPath(specOpts.GetInstanceId(),
+		specOpts.GetGroupId()), specOpts.GetResponseId(), respType), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses/results.go
@@ -1,0 +1,100 @@
+package responses
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+type Response struct {
+	// Response ID.
+	Id string `json:"id"`
+	// Response name.
+	Name string `json:"name"`
+	// Response type definition, which includes a key and value. Options of the key:
+	//     AUTH_FAILURE: Authentication failed.
+	//     AUTH_HEADER_MISSING: The identity source is missing.
+	//     AUTHORIZER_FAILURE: Custom authentication failed.
+	//     AUTHORIZER_CONF_FAILURE: There has been a custom authorizer error.
+	//     AUTHORIZER_IDENTITIES_FAILURE: The identity source of the custom authorizer is invalid.
+	//     BACKEND_UNAVAILABLE: The backend service is unavailable.
+	//     BACKEND_TIMEOUT: Communication with the backend service timed out.
+	//     THROTTLED: The request was rejected due to request throttling.
+	//     UNAUTHORIZED: The app you are using has not been authorized to call the API.
+	//     ACCESS_DENIED: Access denied.
+	//     NOT_FOUND: No API is found.
+	//     REQUEST_PARAMETERS_FAILURE: The request parameters are incorrect.
+	//     DEFAULT_4XX: Another 4XX error occurred.
+	//     DEFAULT_5XX: Another 5XX error occurred.
+	// Each error type is in JSON format.
+	Responses map[string]ResponseInfo `json:"responses"`
+	// Indicates whether the group response is the default response.
+	IsDefault bool `json:"default"`
+	// Creation time.
+	CreateTime string `json:"create_time"`
+	// Update time.
+	UpdateTime string `json:"update_time"`
+}
+
+// Extract is a method to extract an response struct.
+func (r commonResult) Extract() (*Response, error) {
+	var s Response
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ResponsePage represents the response pages of the List operation.
+type ResponsePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractResponses is a method to extract an response struct list.
+func ExtractResponses(r pagination.Page) ([]Response, error) {
+	var s []Response
+	err := r.(ResponsePage).Result.ExtractIntoSlicePtr(&s, "responses")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete and DeleteSpecResp method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type SpecRespResult struct {
+	commonResult
+}
+
+// GetSpecRespResult represents a result of the GetSpecResp method.
+type GetSpecRespResult struct {
+	SpecRespResult
+}
+
+// UpdateSpecRespResult represents a result of the UpdateSpecResp method.
+type UpdateSpecRespResult struct {
+	SpecRespResult
+}
+
+// ExtractSpecResp is a method to extract an response struct using a specifies key.
+func (r SpecRespResult) ExtractSpecResp(key string) (*ResponseInfo, error) {
+	var s ResponseInfo
+	err := r.ExtractIntoStructPtr(&s, key)
+	return &s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses/urls.go
@@ -1,0 +1,23 @@
+package responses
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+func buildResponsesPath(instanceId, groupId string) string {
+	return fmt.Sprintf("instances/%s/api-groups/%s/gateway-responses", instanceId, groupId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, path string) string {
+	return c.ServiceURL(path)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, path, respId string) string {
+	return c.ServiceURL(path, respId)
+}
+
+func specResponsesURL(c *golangsdk.ServiceClient, path, respId, respType string) string {
+	return c.ServiceURL(path, respId, respType)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -281,6 +281,7 @@ github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances
+github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/instances


### PR DESCRIPTION
- support response rules management, contains status code and body

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For API creation, the configuration support custom response to return the specifies failure message and status code.
The resource support params are as following:
  - name
  - response rules (If omitted, the response will be restored as default value)
    - response type
    - response body template
    - status code

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1249

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. New custom responses resource supported.
2. Related document supported.
3. New acc unit test for each params.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigResponseV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigResponseV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigResponseV2_basic
=== PAUSE TestAccApigResponseV2_basic
=== CONT  TestAccApigResponseV2_basic
--- PASS: TestAccApigResponseV2_basic (444.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      445.070s
```
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigResponseV2_customRules'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigResponseV2_customRules -timeout 360m -parallel 4
=== RUN   TestAccApigResponseV2_customRules
=== PAUSE TestAccApigResponseV2_customRules
=== CONT  TestAccApigResponseV2_customRules
--- PASS: TestAccApigResponseV2_customRules (450.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig 450.288s
```