### PR TITLE
[WAF] add Data Masking rule resource

### DIFF
--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_rule_data_masking
+
+Manages a WAF Data Masking Rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "huaweicloud_waf_rule_data_masking" "rule_1" {
+  policy_id  = huaweicloud_waf_policy.policy_1.id
+  path       = "/login"
+  field      = "params"
+  subfield   = "password"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF Data Masking rule resource.
+  If omitted, the provider-level region will be used. Changing this setting will create a new rule.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `path` - (Required, String) Specifies the URL to which the data masking rule applies (exact match by default).
+
+* `field` - (Required, String) The position where the masked field stored.
+  Valid values are:
+    * `params`: The field in the parameter.
+    * `header`: The field in the header.
+    * `form`: The field in the form.
+    * `cookie`: The field in the cookie.
+
+* `subfield` - (Required, String) Specifies the name of the masked field, e.g.: password.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Data Masking Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import huaweicloud_waf_rule_data_masking.rule_1 d78b439fd5e54ea08886e5f63ee7b3f5/ac01a092d50e4e6ba3cd622c1128ba2c
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -513,6 +513,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_waf_domain":                      waf.ResourceWafDomainV1(),
 			"huaweicloud_waf_policy":                      waf.ResourceWafPolicyV1(),
 			"huaweicloud_waf_rule_blacklist":              waf.ResourceWafRuleBlackListV1(),
+			"huaweicloud_waf_rule_data_masking":           waf.ResourceWafRuleDataMaskingV1(),
 
 			// Legacy
 			"huaweicloud_compute_instance_v2":                ResourceComputeInstanceV2(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -1,0 +1,186 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules"
+)
+
+func TestAccWafRuleDataMasking_basic(t *testing.T) {
+	var rule rules.DataMasking
+	policyName := "policy-" + acctest.RandString(5)
+	resourceName1 := "huaweicloud_waf_rule_data_masking.rule_1"
+	resourceName2 := "huaweicloud_waf_rule_data_masking.rule_2"
+	resourceName3 := "huaweicloud_waf_rule_data_masking.rule_3"
+	resourceName4 := "huaweicloud_waf_rule_data_masking.rule_4"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckWafRuleDataMaskingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleDataMasking_basic(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName1, &rule),
+					resource.TestCheckResourceAttr(resourceName1, "path", "/login"),
+					resource.TestCheckResourceAttr(resourceName1, "subfield", "password"),
+					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName2, "field", "header"),
+					resource.TestCheckResourceAttr(resourceName3, "field", "form"),
+					resource.TestCheckResourceAttr(resourceName4, "field", "cookie"),
+				),
+			},
+			{
+				Config: testAccWafRuleDataMasking_update(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName1, &rule),
+					resource.TestCheckResourceAttr(resourceName1, "path", "/login_new"),
+					resource.TestCheckResourceAttr(resourceName1, "subfield", "secret"),
+					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName2, "field", "header"),
+					resource.TestCheckResourceAttr(resourceName3, "field", "form"),
+					resource.TestCheckResourceAttr(resourceName4, "field", "cookie"),
+				),
+			},
+			{
+				ResourceName:      resourceName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName1),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleDataMaskingDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_waf_rule_data_masking" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF data masking rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleDataMaskingExists(n string, rule *rules.DataMasking) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF data masking rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleDataMasking_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "%s"
+}
+
+resource "huaweicloud_waf_rule_data_masking" "rule_1" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "params"
+  subfield  = "password"
+}
+resource "huaweicloud_waf_rule_data_masking" "rule_2" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "header"
+  subfield  = "password"
+}
+resource "huaweicloud_waf_rule_data_masking" "rule_3" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "form"
+  subfield  = "password"
+}
+resource "huaweicloud_waf_rule_data_masking" "rule_4" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "cookie"
+  subfield  = "password"
+}
+`, name)
+}
+
+func testAccWafRuleDataMasking_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "%s"
+}
+
+resource "huaweicloud_waf_rule_data_masking" "rule_1" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login_new"
+  field     = "params"
+  subfield  = "secret"
+}
+resource "huaweicloud_waf_rule_data_masking" "rule_2" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "header"
+  subfield  = "secret"
+}
+resource "huaweicloud_waf_rule_data_masking" "rule_3" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "form"
+  subfield  = "secret"
+}
+resource "huaweicloud_waf_rule_data_masking" "rule_4" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "cookie"
+  subfield  = "secret"
+}
+`, name)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
@@ -1,0 +1,161 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package waf
+
+import (
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules"
+)
+
+const (
+	FIELD_POSITION_HEADER = "header"
+	FIELD_POSITION_PARAMS = "params"
+	FIELD_POSITION_COOKIE = "cookie"
+	FIELD_POSITION_FORM   = "form"
+)
+
+// ResourceWafRuleDataMaskingV1 the resource of managing a WAF Data Masking Rule within HuaweiCloud.
+func ResourceWafRuleDataMaskingV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleDataMaskingCreate,
+		Read:   resourceWafRuleDataMaskingRead,
+		Update: resourceWafRuleDataMaskingUpdate,
+		Delete: resourceWafRuleDataMaskingDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"field": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					FIELD_POSITION_HEADER, FIELD_POSITION_PARAMS, FIELD_POSITION_COOKIE, FIELD_POSITION_FORM,
+				}, false),
+			},
+			"subfield": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+// resourceWafRuleDataMaskingCreate create a rule
+func resourceWafRuleDataMaskingCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	createOpts := rules.CreateOpts{
+		Path:     d.Get("path").(string),
+		Category: d.Get("field").(string),
+		Index:    d.Get("subfield").(string),
+	}
+
+	logp.Printf("[DEBUG] WAF Data Masking Rule creating opts: %#v", createOpts)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Data Masking Rule: %s", err)
+	}
+
+	logp.Printf("[DEBUG] WAF data masking rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleDataMaskingRead(d, meta)
+}
+
+// resourceWafRuleDataMaskingRead get rule detail from HuaweiCloud by id and policy_id
+func resourceWafRuleDataMaskingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "WAF Data Masking Rule")
+	}
+	logp.Printf("[DEBUG] fetching WAF data masking rule: %#v", n)
+
+	d.SetId(n.Id)
+	d.Set("path", n.Path)
+	d.Set("field", n.Category)
+	d.Set("subfield", n.Index)
+
+	return nil
+}
+
+// resourceWafRuleDataMaskingUpdate update the existing rules.
+// Supported fields: path, field, subfield
+func resourceWafRuleDataMaskingUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+
+	if d.HasChanges("path", "field", "subfield") {
+		policyID := d.Get("policy_id").(string)
+		updateOpts := rules.UpdateOpts{
+			Path:     d.Get("path").(string),
+			Category: d.Get("field").(string),
+			Index:    d.Get("subfield").(string),
+		}
+
+		logp.Printf("[DEBUG] WAF Data Masking Rule updating opts: %#v", updateOpts)
+		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmtp.Errorf("error updating HuaweiCloud WAF Data Masking Rule: %s", err)
+		}
+	}
+
+	return resourceWafRuleDataMaskingRead(d, meta)
+}
+
+// resourceWafRuleDataMaskingDelete delete the rules from HuaweiCloud by id
+func resourceWafRuleDataMaskingDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("error deleting HuaweiCloud WAF Data Masking Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules/requests.go
@@ -1,0 +1,95 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package datamasking_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToDataMaskingCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new datamasking rule.
+type CreateOpts struct {
+	Path        string `json:"url" required:"true"`
+	Category    string `json:"category" required:"true"`
+	Index       string `json:"index" required:"true"`
+	Description string `json:"description,omitempty"`
+}
+
+// ToDataMaskingCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToDataMaskingCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new datamasking rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToDataMaskingCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToDataMaskingUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a datamasking rule.
+type UpdateOpts struct {
+	Path        string `json:"url" required:"true"`
+	Category    string `json:"category" required:"true"`
+	Index       string `json:"index" required:"true"`
+	Description string `json:"description,omitempty"`
+}
+
+// ToDataMaskingUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToDataMaskingUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a rule.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToDataMaskingUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular datamasking rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular datamasking rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules/results.go
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package datamasking_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type DataMasking struct {
+	// DataMasking Rule ID
+	Id string `json:"id"`
+	// DataMaksing Rule URL
+	Path string `json:"url"`
+	// Masked Field
+	Category string `json:"category"`
+	// Masked Subfield
+	Index string `json:"index"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a datamasking rule.
+func (r commonResult) Extract() (*DataMasking, error) {
+	var response DataMasking
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a DataMasking rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a DataMasking rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a DataMasking rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules/urls.go
@@ -1,0 +1,15 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package datamasking_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policy_id string) string {
+	return c.ServiceURL("policy", policy_id, "privacy")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policy_id, id string) string {
+	return c.ServiceURL("policy", policy_id, "privacy", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,6 +461,7 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/tags
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates
+github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/datamasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support the management of the data masking rules of the policy.

- Create rules for the specified policy.
- Update the rules.
- Delete the existing rule.
- Support for importing existing rules from HUAWEI CLOUD to Terraform.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1280

**Special notes for your reviewer**:

- The `field` supports 4 parameters: `header`, `params`, `form` and `cookie`, which are not fully supplemented in the API documentation.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Added resource('huaweicloud_waf_rule_data_masking') for manging the rules of policy. 
2. For complete use, it needs to be released together with WAF policy management.  And WAF policy management has been merged into master.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleDataMasking_basic
=== PAUSE TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_basic
--- PASS: TestAccWafRuleDataMasking_basic (33.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       33.540s

```
