### PR TITLE
New APIG throttling policy resource supported

### DIFF
--- a/docs/resources/apig_throttling_policy.md
+++ b/docs/resources/apig_throttling_policy.md
@@ -1,0 +1,137 @@
+---
+subcategory: "API Gateway (APIG)"
+---
+
+# huaweicloud_apig_throttling_policy
+
+Manages an APIG (API) throttling policy resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a basic throttling policy
+```hcl
+variable "instance_id" {}
+variable "policy_name" {}
+variable "description" {}
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = var.instance_id
+  name              = var.policy_name
+  description       = var.description
+  type              = "API-based"
+  period            = 10
+  period_unit       = "MINUTE"
+  max_api_requests  = 70
+  max_user_requests = 45
+  max_app_requests  = 45
+  max_ip_requests   = 45
+}
+```
+
+### Create a throttling policy with a special throttle
+```hcl
+variable "instance_id" {}
+variable "policy_name" {}
+variable "description" {}
+variable "application_id" {}
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = var.instance_id
+  name              = var.policy_name
+  description       = var.description
+  type              = "API-based"
+  period            = 10
+  period_unit       = "MINUTE"
+  max_api_requests  = 70
+  max_user_requests = 45
+  max_app_requests  = 45
+  max_ip_requests   = 45
+
+  app_throttles {
+    max_api_requests     = 40
+    throttling_object_id = var.application_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API throttling policy resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new API throttling policy resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the
+  API throttling policy belongs to.
+  Changing this will create a new API throttling policy resource.
+
+* `name` - (Required, String) Specifies the name of the API throttling policy.
+  The policy name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+
+* `period` - (Required, Int) Specifies the period of time for limiting the number of API calls.
+  This parameter applies with each of the API call limits: `max_api_requests`, `max_app_requests`, `max_ip_requests`
+  and `max_user_requests`.
+
+* `max_api_requests` - (Required, Int) Specifies the maximum number of times an API can be accessed within a specified
+  period.
+  The value of this parameter cannot exceed the default limit 200 TPS.
+
+* `type` - (Optional, String) Specifies the type of the request throttling policy.
+  The valid values are as following:
+  - API-based: limiting the maximum number of times a single API bound to the policy can be called within the specified
+  period.
+  - API-shared: limiting the maximum number of times all APIs bound to the policy can be called within the specified
+  period.
+
+* `description` - (Optional, String) Specifies the description about the API throttling policy.
+  The description contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `period_unit` - (Optional, String) Specifies the time unit for limiting the number of API calls.
+  The valid values are *SECOND*, *MINUTE*, *HOUR* and *DAY*, default to *MINUTE*.
+
+* `max_app_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an app within
+  the same period.
+  The value of this parameter must be less than or equal to the value of `max_user_requests`.
+
+* `max_ip_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an IP address
+  within the same period.
+  The value of this parameter must be less than or equal to the value of `max_api_requests`.
+
+* `max_user_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by a user within
+  the same period.
+  The value of this parameter must be less than or equal to the value of `max_api_requests`.
+
+* `user_throttles` - (Optional, List) Specifies an array of one or more special throttling policies for IAM user limit.
+  The `throttle` object of the `user_throttles` structure is documented below.
+
+* `app_throttles` - (Optional, List) Specifies an array of one or more special throttling policies for APP limit.
+  The `throttle` object of the `user_throttles` structure is documented below.
+
+The `throttle` block supports:
+
+* `max_api_requests` - (Required, Int) Specifies the maximum number of times an API can be accessed within a specified
+  period.
+
+* `throttling_object_id` - (Required, String) Specifies the object ID which the special throttling policy belongs.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the API throttling policy.
+* `user_throttles/throttling_object_name` - The object name which the special user throttling policy belongs.
+* `user_throttles/id` - ID of the special user throttling policy.
+* `app_throttles/throttling_object_name` - The object name which the special application throttling policy belongs.
+* `app_throttles/id` - ID of the special application throttling policy.
+* `create_time` - Time when the API throttling policy was created.
+
+## Import
+
+API Throttling Policies of APIG can be imported using their `name` and the ID of the APIG instances to which the
+environment belongs, separated by a slash, e.g.
+```
+$ terraform import huaweicloud_apig_throttling_policy.test <instance ID>/<name>
+```

--- a/docs/resources/apig_throttling_policy.md
+++ b/docs/resources/apig_throttling_policy.md
@@ -79,7 +79,7 @@ The following arguments are supported:
   The value of this parameter cannot exceed the default limit 200 TPS.
 
 * `type` - (Optional, String) Specifies the type of the request throttling policy.
-  The valid values are as following:
+  The valid values are as follows:
   - API-based: limiting the maximum number of times a single API bound to the policy can be called within the specified
   period.
   - API-shared: limiting the maximum number of times all APIs bound to the policy can be called within the specified
@@ -122,10 +122,15 @@ The `throttle` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the API throttling policy.
-* `user_throttles/throttling_object_name` - The object name which the special user throttling policy belongs.
-* `user_throttles/id` - ID of the special user throttling policy.
-* `app_throttles/throttling_object_name` - The object name which the special application throttling policy belongs.
-* `app_throttles/id` - ID of the special application throttling policy.
+
+* `user_throttles` - An array of one or more special throttling policies for IAM user limit.
+  - `throttling_object_name` - The object name which the special user throttling policy belongs.
+  - `id` - ID of the special user throttling policy.
+
+* `app_throttles` - An array of one or more special throttling policies for APP limit.
+  - `throttling_object_name` - The object name which the special application throttling policy belongs.
+  - `id` - ID of the special application throttling policy.
+
 * `create_time` - Time when the API throttling policy was created.
 
 ## Import

--- a/docs/resources/apig_throttling_policy.md
+++ b/docs/resources/apig_throttling_policy.md
@@ -78,6 +78,18 @@ The following arguments are supported:
   period.
   The value of this parameter cannot exceed the default limit 200 TPS.
 
+* `max_app_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an app within
+  the same period.
+  The value of this parameter must be less than or equal to the value of `max_user_requests`.
+
+* `max_ip_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an IP address
+  within the same period.
+  The value of this parameter must be less than or equal to the value of `max_api_requests`.
+
+* `max_user_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by a user within
+  the same period.
+  The value of this parameter must be less than or equal to the value of `max_api_requests`.
+
 * `type` - (Optional, String) Specifies the type of the request throttling policy.
   The valid values are as follows:
   - API-based: limiting the maximum number of times a single API bound to the policy can be called within the specified
@@ -91,18 +103,6 @@ The following arguments are supported:
 
 * `period_unit` - (Optional, String) Specifies the time unit for limiting the number of API calls.
   The valid values are *SECOND*, *MINUTE*, *HOUR* and *DAY*, default to *MINUTE*.
-
-* `max_app_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an app within
-  the same period.
-  The value of this parameter must be less than or equal to the value of `max_user_requests`.
-
-* `max_ip_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an IP address
-  within the same period.
-  The value of this parameter must be less than or equal to the value of `max_api_requests`.
-
-* `max_user_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by a user within
-  the same period.
-  The value of this parameter must be less than or equal to the value of `max_api_requests`.
 
 * `user_throttles` - (Optional, List) Specifies an array of one or more special throttling policies for IAM user limit.
   The `throttle` object of the `user_throttles` structure is documented below.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -377,6 +377,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_apig_environment":                apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_group":                      apig.ResourceApigGroupV2(),
 			"huaweicloud_apig_response":                   apig.ResourceApigResponseV2(),
+			"huaweicloud_apig_throttling_policy":          apig.ResourceApigThrottlingPolicyV2(),
 			"huaweicloud_apig_vpc_channel":                apig.ResourceApigVpcChannelV2(),
 			"huaweicloud_as_configuration":                ResourceASConfiguration(),
 			"huaweicloud_as_group":                        ResourceASGroup(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
@@ -1,0 +1,280 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestAccApigThrottlingPolicyV2_basic(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_throttling_policy.test"
+		policy       throttles.ThrottlingPolicy
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigThrottlingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigThrottlingPolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "type", "API-based"),
+					resource.TestCheckResourceAttr(resourceName, "period", "15000"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "SECOND"),
+					resource.TestCheckResourceAttr(resourceName, "max_api_requests", "100"),
+					resource.TestCheckResourceAttr(resourceName, "max_user_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_app_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_ip_requests", "60"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "type", "API-shared"),
+					resource.TestCheckResourceAttr(resourceName, "period", "10"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "MINUTE"),
+					resource.TestCheckResourceAttr(resourceName, "max_api_requests", "70"),
+					resource.TestCheckResourceAttr(resourceName, "max_user_requests", "45"),
+					resource.TestCheckResourceAttr(resourceName, "max_app_requests", "45"),
+					resource.TestCheckResourceAttr(resourceName, "max_ip_requests", "45"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigThrottlingPolicyV2_spec(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_throttling_policy.test"
+		policy       throttles.ThrottlingPolicy
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigThrottlingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigThrottlingPolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "type", "API-based"),
+					resource.TestCheckResourceAttr(resourceName, "period", "15000"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "SECOND"),
+					resource.TestCheckResourceAttr(resourceName, "max_api_requests", "100"),
+					resource.TestCheckResourceAttr(resourceName, "max_user_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_app_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_ip_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "0"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_spec(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_specUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigThrottlingPolicyDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_apig_throttling_policy" {
+			continue
+		}
+		_, err := throttles.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 throttling policy (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigThrottlingPolicyExists(n string, app *throttles.ThrottlingPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no throttling policy id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		}
+		found, err := throttles.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigThrottlingPolicy_base(rName, code string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_application" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+
+  app_codes = ["%s"]
+}
+`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+}
+
+func testAccApigThrottlingPolicy_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigThrottlingPolicy_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%s_update"
+  type              = "API-shared"
+  period            = 10
+  period_unit       = "MINUTE"
+  max_api_requests  = 70
+  max_user_requests = 45
+  max_app_requests  = 45
+  max_ip_requests   = 45
+  description       = "Updated by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigThrottlingPolicy_spec(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Updated by script"
+  
+  app_throttles {
+    max_api_requests     = 30
+    throttling_object_id = huaweicloud_apig_application.test.id
+  }
+}
+`, testAccApigThrottlingPolicy_base(rName, acctest.RandString(64)), rName)
+}
+
+func testAccApigThrottlingPolicy_specUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Updated by script"
+
+  app_throttles {
+    max_api_requests     = 45
+    throttling_object_id = huaweicloud_apig_application.test.id
+  }
+}
+`, testAccApigThrottlingPolicy_base(rName, acctest.RandString(64)), rName)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
@@ -1,0 +1,458 @@
+package apig
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+const (
+	timeSecond = "SECOND"
+	timeMinute = "MINUTE"
+	timeHour   = "HOUR"
+	timeDay    = "DAY"
+
+	typeExclusive   = "API-based"
+	typeShared      = "API-shared"
+	typeUser        = "USER"
+	typeApplication = "APP"
+)
+
+var (
+	policyType = map[string]int{
+		typeExclusive: 1,
+		typeShared:    2,
+	}
+)
+
+// ResourceApigThrottlingPolicyV2 is a provider resource of the APIG throttling policy.
+func ResourceApigThrottlingPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApigThrottlingPolicyV2Create,
+		Read:   resourceApigThrottlingPolicyV2Read,
+		Update: resourceApigThrottlingPolicyV2Update,
+		Delete: resourceApigThrottlingPolicyV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceApigThrottlingPolicyResourceImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^([\u4e00-\u9fa5A-Za-z][\u4e00-\u9fa5A-Za-z_0-9]{2,63})$"),
+					"The name contains of 3 to 64 characters, starting with a letter. Only letters, digits "+
+						"and underscore (_) are allowed."),
+			},
+			"period": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"max_api_requests": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+					"The description contain a maximum of 255 characters, "+
+						"and the angle brackets (< and >) are not allowed."),
+			},
+			"max_app_requests": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_ip_requests": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_user_requests": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"period_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  timeMinute,
+				ValidateFunc: validation.StringInSlice([]string{
+					timeSecond, timeMinute, timeHour, timeDay,
+				}, false),
+			},
+			"user_throttles": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 30,
+				Elem:     specialThrottleSchemaResource(),
+			},
+			"app_throttles": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 30,
+				Elem:     specialThrottleSchemaResource(),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  typeExclusive,
+				ValidateFunc: validation.StringInSlice([]string{
+					typeExclusive, typeShared,
+				}, false),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func specialThrottleSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"max_api_requests": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"throttling_object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"throttling_object_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildApigThrottlingPolicyParameters(d *schema.ResourceData,
+	config *config.Config) (throttles.ThrottlingPolicyOpts, error) {
+	opt := throttles.ThrottlingPolicyOpts{
+		Name:           d.Get("name").(string),
+		TimeInterval:   d.Get("period").(int),
+		TimeUnit:       d.Get("period_unit").(string),
+		ApiCallLimits:  d.Get("max_api_requests").(int),
+		UserCallLimits: d.Get("max_user_requests").(int),
+		AppCallLimits:  d.Get("max_app_requests").(int),
+		IpCallLimits:   d.Get("max_ip_requests").(int),
+		Description:    d.Get("description").(string),
+	}
+	pType := d.Get("type").(string)
+	if val, ok := policyType[pType]; ok {
+		opt.Type = val
+	} else {
+		return opt, fmtp.Errorf("Wrong throttling policy type: %s", pType)
+	}
+	return opt, nil
+}
+
+func addSpecThrottlingPolicies(client *golangsdk.ServiceClient, policies *schema.Set,
+	instanceId, policyId, specType string) error {
+	for _, policy := range policies.List() {
+		raw := policy.(map[string]interface{})
+		specOpts := throttles.SpecThrottleCreateOpts{
+			ObjectType: specType,
+			ObjectId:   raw["throttling_object_id"].(string),
+			CallLimits: raw["max_api_requests"].(int),
+		}
+		_, err := throttles.CreateSpecThrottle(client, instanceId, policyId, specOpts).Extract()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeSpecThrottlingPolicies(client *golangsdk.ServiceClient, policies *schema.Set,
+	instanceId, policyId string) error {
+	for _, policy := range policies.List() {
+		raw := policy.(map[string]interface{})
+		err := throttles.DeleteSpecThrottle(client, instanceId, policyId, raw["id"].(string)).ExtractErr()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateSpecThrottlingPolicieCallLimit(client *golangsdk.ServiceClient, instanceId, policyId, strategyId string,
+	limit int) error {
+	opts := &throttles.SpecThrottleUpdateOpts{
+		CallLimits: limit,
+	}
+	_, err := throttles.UpdateSpecThrottle(client, instanceId, policyId, strategyId, opts).Extract()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceApigThrottlingPolicyV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	opts, err := buildApigThrottlingPolicyParameters(d, config)
+	if err != nil {
+		return fmtp.Errorf("Unable to get the create option of the throttling policy: %s", err)
+	}
+	v, err := throttles.Create(client, instanceId, opts).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "Error creating HuaweiCloud throttling policy")
+	}
+	d.SetId(v.Id)
+	if policies, ok := d.GetOk("user_throttles"); ok {
+		err := addSpecThrottlingPolicies(client, policies.(*schema.Set), instanceId, d.Id(), typeUser)
+		if err != nil {
+			return fmtp.Errorf("Error creating special user throttling policy: %s", err)
+		}
+	}
+	if policies, ok := d.GetOk("app_throttles"); ok {
+		err := addSpecThrottlingPolicies(client, policies.(*schema.Set), instanceId, d.Id(), typeApplication)
+		if err != nil {
+			return fmtp.Errorf("Error creating special application throttling policy: %s", err)
+		}
+	}
+	return resourceApigThrottlingPolicyV2Read(d, meta)
+}
+
+func setApigThrottlingPolicyType(d *schema.ResourceData, pType int) error {
+	for k, v := range policyType {
+		if v == pType {
+			return d.Set("type", k)
+		}
+	}
+	return fmtp.Errorf("The member type (%d) is not supported", pType)
+}
+
+func setApigThrottlingPolicyParameters(d *schema.ResourceData, config *config.Config, resp throttles.ThrottlingPolicy) error {
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", resp.Name),
+		d.Set("period", resp.TimeInterval),
+		d.Set("period_unit", resp.TimeUnit),
+		d.Set("max_api_requests", resp.ApiCallLimits),
+		d.Set("max_user_requests", resp.UserCallLimits),
+		d.Set("max_app_requests", resp.AppCallLimits),
+		d.Set("max_ip_requests", resp.IpCallLimits),
+		d.Set("description", resp.Description),
+		d.Set("create_time", resp.CreateTime),
+		setApigThrottlingPolicyType(d, resp.Type),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func setSpecThrottlingPolicies(d *schema.ResourceData, specThrottles []throttles.SpecThrottle) error {
+	if len(specThrottles) == 0 {
+		return nil
+	}
+	// According to the rules of append method, the maximum memory is expanded to 32,
+	// and the average waste of memory is less than the waste caused by directly setting it to 30.
+	users := make([]map[string]interface{}, 0)
+	for i, throttle := range specThrottles {
+		// The special throttling policies contain user throttles and app throttles.
+		if throttle.ObjectType == typeApplication {
+			continue
+		}
+		users = append(users, map[string]interface{}{
+			"max_api_requests":       throttle.CallLimits,
+			"throttling_object_id":   throttle.ObjectId,
+			"throttling_object_name": throttle.ObjectName,
+			"id":                     throttle.ID,
+		})
+		specThrottles = append(specThrottles[:i], specThrottles[i+1:]...)
+	}
+	if err := d.Set("user_throttles", users); err != nil {
+		return fmtp.Errorf("Error saving special user throttles to state: %s", err)
+	}
+	apps := make([]map[string]interface{}, len(specThrottles))
+	for i, throttle := range specThrottles {
+		apps[i] = map[string]interface{}{
+			"max_api_requests":       throttle.CallLimits,
+			"throttling_object_id":   throttle.ObjectId,
+			"throttling_object_name": throttle.ObjectName,
+			"id":                     throttle.ID,
+		}
+	}
+	return d.Set("app_throttles", apps)
+}
+
+func resourceApigThrottlingPolicyV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	resp, err := throttles.Get(client, instanceId, d.Id()).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error getting throttles form server: %s", d.Id(), err)
+	}
+	err = setApigThrottlingPolicyParameters(d, config, *resp)
+	if err != nil {
+		return fmtp.Errorf("Error setting throttles to state: %s", d.Id(), err)
+	}
+	// Set special throttling policies for IAM user and application to state.
+	pages, err := throttles.ListSpecThrottles(client, instanceId, d.Id(), throttles.SpecThrottlesListOpts{}).AllPages()
+	if err != nil {
+		return fmtp.Errorf("Error retrieving special throttle: %s", err)
+	}
+	specResp, err := throttles.ExtractSpecThrottles(pages)
+	if err != nil {
+		return fmtp.Errorf("Unable to find the special throttles from policy: %s", err)
+	}
+	return setSpecThrottlingPolicies(d, specResp)
+}
+
+func isBasicParamsChanged(d *schema.ResourceData) bool {
+	// lintignore:R019
+	if d.HasChanges("name", "period", "max_api_requests", "description", "period_unit") ||
+		d.HasChanges("max_app_requests", "max_ip_requests", "max_user_requests", "type") {
+		return true
+	}
+	return false
+}
+
+func updateSpecThrottlingPolicies(d *schema.ResourceData, client *golangsdk.ServiceClient,
+	paramName, specType string) error {
+	oldRaws, newRaws := d.GetChange(paramName)
+	instanceId := d.Get("instance_id").(string)
+	addRaws := newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set))
+	removeRaws := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set))
+	// If only max API requests update, the ID should be the same after the special throttling policy is updated.
+	for _, rm := range removeRaws.List() {
+		rmPolicy := rm.(map[string]interface{})
+		rmObject := rmPolicy["throttling_object_id"].(string)
+		for _, add := range addRaws.List() {
+			addPolicy := add.(map[string]interface{})
+			if rmObject == addPolicy["throttling_object_id"].(string) {
+				strategyId := rmPolicy["id"].(string)
+				limit := addPolicy["max_api_requests"].(int)
+				// Update specifies special throttling policy by strategy ID.
+				err := updateSpecThrottlingPolicieCallLimit(client, instanceId, d.Id(), strategyId, limit)
+				if err != nil {
+					return err
+				}
+				removeRaws.Remove(rm)
+				addRaws.Remove(add)
+			}
+		}
+	}
+	err := removeSpecThrottlingPolicies(client, removeRaws, instanceId, d.Id())
+	if err != nil {
+		return err
+	}
+	err = addSpecThrottlingPolicies(client, addRaws, instanceId, d.Id(), specType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceApigThrottlingPolicyV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	if isBasicParamsChanged(d) {
+		opt, err := buildApigThrottlingPolicyParameters(d, config)
+		if err != nil {
+			return fmtp.Errorf("Unable to get the update option of the throttling policy: %s", err)
+		}
+		instanceId := d.Get("instance_id").(string)
+		_, err = throttles.Update(client, instanceId, d.Id(), opt).Extract()
+		if err != nil {
+			return fmtp.Errorf("Error updating throttling policy: %s", err)
+		}
+	}
+	if d.HasChange("user_throttles") {
+		err = updateSpecThrottlingPolicies(d, client, "user_throttles", typeUser)
+		if err != nil {
+			return fmtp.Errorf("Error updating special user throttles: %s", err)
+		}
+	}
+	if d.HasChange("app_throttles") {
+		err = updateSpecThrottlingPolicies(d, client, "app_throttles", typeApplication)
+		if err != nil {
+			return fmtp.Errorf("Error updating special app throttles: %s", err)
+		}
+	}
+
+	return resourceApigThrottlingPolicyV2Read(d, meta)
+}
+
+func resourceApigThrottlingPolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	if err = throttles.Delete(client, instanceId, d.Id()).ExtractErr(); err != nil {
+		return fmtp.Errorf("Unable to delete the throttling policy (%s): %s", d.Id(), err)
+	}
+	d.SetId("")
+	return nil
+}
+
+// The ID cannot find on the console, so we need to import by throttling policy name.
+func resourceApigThrottlingPolicyResourceImportState(d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmtp.Errorf("Invalid format specified for import id, must be <instance_id>/<name>")
+	}
+	instanceId := parts[0]
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	name := parts[1]
+	opt := throttles.ListOpts{
+		Name: name,
+	}
+	pages, err := throttles.List(client, instanceId, opt).AllPages()
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error retrieving throttling policies: %s", err)
+	}
+	resp, err := throttles.ExtractPolicies(pages)
+	if len(resp) < 1 {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Unable to find the throttling policy (%s) form server: %s", name, err)
+	}
+	d.SetId(resp[0].Id)
+	d.Set("instance_id", instanceId)
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/requests.go
@@ -1,0 +1,253 @@
+package throttles
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type ThrottlingPolicyOpts struct {
+	// Maximum number of times an API can be accessed within a specified period.
+	// The value of this parameter cannot exceed the default limit 200 TPS.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	ApiCallLimits int `json:"api_call_limits" required:"true"`
+	// Request throttling policy name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// Period of time for limiting the number of API calls.
+	// This parameter applies with each of the preceding three API call limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	TimeInterval int `json:"time_interval" required:"true"`
+	// Time unit for limiting the number of API calls.
+	// The valid values are as following:
+	//     SECOND
+	//     MINUTE
+	//     HOUR
+	//     DAY
+	TimeUnit string `json:"time_unit" required:"true"`
+	// Maximum number of times the API can be accessed by an app within the same period.
+	// The value of this parameter must be less than that of user_call_limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	AppCallLimits int `json:"app_call_limits,omitempty"`
+	// Description of the request throttling policy, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark,omitempty"`
+	// Type of the request throttling policy.
+	// 1: exclusive, limiting the maximum number of times a single API bound to the policy can be called within
+	// the specified period.
+	// 2: shared, limiting the maximum number of times all APIs bound to the policy can be called within the
+	// specified period.
+	Type int `json:"type,omitempty"`
+	// Maximum number of times the API can be accessed by a user within the same period.
+	// The value of this parameter must be less than that of api_call_limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	UserCallLimits int `json:"user_call_limits,omitempty"`
+	// Maximum number of times the API can be accessed by an IP address within the same period.
+	// The value of this parameter must be less than that of api_call_limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	IpCallLimits int `json:"ip_call_limits,omitempty"`
+}
+
+type ThrottlingPolicyOptsBuilder interface {
+	ToThrottlingPolicyOptsMap() (map[string]interface{}, error)
+}
+
+func (opts ThrottlingPolicyOpts) ToThrottlingPolicyOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new throttling policy.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts ThrottlingPolicyOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToThrottlingPolicyOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to udpate an existing throttle policy.
+func Update(client *golangsdk.ServiceClient, instanceId, policyId string,
+	opts ThrottlingPolicyOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToThrottlingPolicyOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, policyId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain an existing APIG throttling policy by policy ID.
+func Get(client *golangsdk.ServiceClient, instanceId, policyId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, policyId), &r.Body, nil)
+	return
+}
+
+type ListOpts struct {
+	// Request throttling policy ID.
+	Id string `q:"id"`
+	// Request throttling policy name.
+	Name string `q:"name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name (name) for exact matching.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more throttling policies according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ThorttlePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing throttling policy.
+func Delete(client *golangsdk.ServiceClient, instanceId, policyId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, policyId), nil)
+	return
+}
+
+// SpecThrottleCreateOpts is a struct which will be used to create a new special throttling policy.
+type SpecThrottleCreateOpts struct {
+	// Maximum number of times the excluded object can access an API within the throttling period.
+	CallLimits int `json:"call_limits" required:"true"`
+	// Excluded app ID or excluded account ID.
+	ObjectId string `json:"object_id" required:"true"`
+	// Excluded object type, which supports APP and USER.
+	ObjectType string `json:"object_type" required:"true"`
+}
+
+// SpecThrottleCreateOptsBuilder is an interface which to support request body build of
+// the special throttling policy creation.
+type SpecThrottleCreateOptsBuilder interface {
+	ToSpecThrottleCreateOptsMap() (map[string]interface{}, error)
+}
+
+// ToSpecThrottleCreateOptsMap is a method which to build a request body by the SpecThrottleCreateOpts.
+func (opts SpecThrottleCreateOpts) ToSpecThrottleCreateOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// CreateSpecThrottle is a method by which to create a new special throttling policy.
+func CreateSpecThrottle(client *golangsdk.ServiceClient, instanceId, policyId string,
+	opts SpecThrottleCreateOptsBuilder) (r SpecThrottleResult) {
+	reqBody, err := opts.ToSpecThrottleCreateOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(specRootURL(client, instanceId, policyId), reqBody, &r.Body, nil)
+	return
+}
+
+// SpecThrottleUpdateOpts is a struct which will be used to update an existing special throttling policy.
+type SpecThrottleUpdateOpts struct {
+	// Maximum number of times the excluded object can access an API within the throttling period.
+	CallLimits int `json:"call_limits" required:"true"`
+}
+
+// SpecThrottleUpdateOptsBuilder is an interface which to support request body build of
+// the special throttling policy updation.
+type SpecThrottleUpdateOptsBuilder interface {
+	ToSpecThrottleUpdateOptsMap() (map[string]interface{}, error)
+}
+
+// ToSpecThrottleUpdateOptsMap is a method which to build a request body by the SpecThrottleUpdateOpts.
+func (opts SpecThrottleUpdateOpts) ToSpecThrottleUpdateOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// UpdateSpecThrottle is a method by which to update an existing special throttle policy.
+func UpdateSpecThrottle(client *golangsdk.ServiceClient, instanceId, policyId, strategyId string,
+	opts SpecThrottleUpdateOptsBuilder) (r SpecThrottleResult) {
+	reqBody, err := opts.ToSpecThrottleUpdateOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(specResourceURL(client, instanceId, policyId, strategyId), reqBody, &r.Body,
+		&golangsdk.RequestOpts{
+			OkCodes: []int{200},
+		})
+	return
+}
+
+// SpecThrottlesListOpts allows to filter list data using given parameters.
+type SpecThrottlesListOpts struct {
+	// Object type, which can be APP or USER.
+	ObjectType string `q:"object_type"`
+	// Name of an excluded app.
+	AppName string `q:"app_name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+// SpecThrottlesListOptsBuilder is an interface which to support request query build of
+// the special throttling policies search.
+type SpecThrottlesListOptsBuilder interface {
+	ToSpecThrottlesListQuery() (string, error)
+}
+
+// ToSpecThrottlesListQuery is a method which to build a request query by the SpecThrottlesListOpts.
+func (opts SpecThrottlesListOpts) ToSpecThrottlesListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// ListSpecThrottles is a method to obtain an array of one or more special throttling policies
+// according to the query parameters.
+func ListSpecThrottles(client *golangsdk.ServiceClient, instanceId, policyId string,
+	opts SpecThrottlesListOptsBuilder) pagination.Pager {
+	url := specRootURL(client, instanceId, policyId)
+	if opts != nil {
+		query, err := opts.ToSpecThrottlesListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SpecThrottlePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// DeleteSpecThrottle is a method to delete an existing special throttling policy.
+func DeleteSpecThrottle(client *golangsdk.ServiceClient, instanceId, policyId, strategyId string) (r DeleteResult) {
+	_, r.Err = client.Delete(specResourceURL(client, instanceId, policyId, strategyId), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/results.go
@@ -1,0 +1,144 @@
+package throttles
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get method.
+type GetResult struct {
+	commonResult
+}
+
+type ThrottlingPolicy struct {
+	// Number of APIs to which the request throttling policy has been bound.
+	BindNum int `json:"bind_num"`
+	// Indicates whether an excluded request throttling configuration has been created.
+	// 1: yes
+	// 2: no
+	IsIncludeSpecialThrottle int `json:"is_include_special_throttle"`
+	// Creation time.
+	CreateTime string `json:"create_time"`
+	// Description.
+	Description string `json:"remark"`
+	// Type of the request throttling policy.
+	// 1: exclusive, limiting the maximum number of times a single API bound to the policy can be called within
+	// the specified period.
+	// 2: shared, limiting the maximum number of times all APIs bound to the policy can be called within the
+	// specified period.
+	Type int `json:"type"`
+	// Period of time for limiting the number of API calls.
+	TimeInterval int `json:"time_interval"`
+	// Maximum number of times the API can be accessed by an IP address within the same period.
+	IpCallLimits int `json:"ip_call_limits"`
+	// Maximum number of times the API can be accessed by an app within the same period.
+	AppCallLimits int `json:"app_call_limits"`
+	// Request throttling policy name.
+	Name string `json:"name"`
+	// Time unit for limiting the number of API calls.
+	// The valid values are as following:
+	//     SECOND
+	//     MINUTE
+	//     HOUR
+	//     DAY
+	TimeUnit string `json:"time_unit"`
+	// Maximum number of times an API can be accessed within a specified period.
+	ApiCallLimits int `json:"api_call_limits"`
+	// Request throttling policy ID.
+	Id string `json:"id"`
+	// Maximum number of times the API can be accessed by a user within the same period.
+	UserCallLimits int `json:"user_call_limits"`
+}
+
+func (r commonResult) Extract() (*ThrottlingPolicy, error) {
+	var s ThrottlingPolicy
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// The ThorttlePage represents the result of a List operation.
+type ThorttlePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractPolicies its Extract method to interpret it as a throttling policy array.
+func ExtractPolicies(r pagination.Page) ([]ThrottlingPolicy, error) {
+	var s []ThrottlingPolicy
+	err := r.(ThorttlePage).Result.ExtractIntoSlicePtr(&s, "throttles")
+	return s, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// SpecThrottle is a struct that represents the result of CreateSpecThrottle, UpdateSpecThrottle and
+// ListSpecThrottles methods.
+type SpecThrottle struct {
+	// Maximum number of times the excluded object can access an API within the throttling period.
+	CallLimits int `json:"call_limits"`
+	// Name of the app to which the excluded request throttling configuration applies.
+	AppName string `json:"app_name"`
+	// Name of an app or a tenant to which the excluded request throttling configuration applies.
+	ObjectName string `json:"object_name"`
+	// ID of an object specified in the excluded request throttling configuration.
+	ObjectId string `json:"object_id"`
+	// Request throttling policy ID.
+	ThrottleId string `json:"throttle_id"`
+	// Time when the excluded request throttling configuration is created.
+	ApplyTime string `json:"apply_time"`
+	// Excluded request throttling configuration ID.
+	ID string `json:"id"`
+	// ID of the app to which the excluded request throttling configuration applies.
+	AppId string `json:"app_id"`
+	// Excluded object type, which can be APP or USER.
+	ObjectType string `json:"object_type"`
+}
+
+// The SpecThrottleResult represents the base result of the each special throttling polciy methods.
+type SpecThrottleResult struct {
+	commonResult
+}
+
+// The CreateSpecThrottleResult represents the result of the CreateSpecThrottle method.
+type CreateSpecThrottleResult struct {
+	SpecThrottleResult
+}
+
+// The UpdateSpecThrottleResult represents the result of the UpdateSpecThrottle method.
+type UpdateSpecThrottleResult struct {
+	SpecThrottleResult
+}
+
+// Extract is a method which to extract the response to a special throttling policy.
+func (r SpecThrottleResult) Extract() (*SpecThrottle, error) {
+	var s SpecThrottle
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// The SpecThrottlePage represents the result of a List operation.
+type SpecThrottlePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractSpecThrottles its Extract method to interpret it as a special throttling policy array.
+func ExtractSpecThrottles(r pagination.Page) ([]SpecThrottle, error) {
+	var s []SpecThrottle
+	err := r.(SpecThrottlePage).Result.ExtractIntoSlicePtr(&s, "throttle_specials")
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/urls.go
@@ -1,0 +1,27 @@
+package throttles
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+func buildRootPath(instanceId string) string {
+	return fmt.Sprintf("instances/%s/throttles", instanceId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId))
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), policyId)
+}
+
+func specRootURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), policyId, "throttle-specials")
+}
+
+func specResourceURL(c *golangsdk.ServiceClient, instanceId, policyId, strategyId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), policyId, "throttle-specials", strategyId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -283,6 +283,7 @@ github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses
+github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/instances


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The throttling policy controls the number of times APIs can be called by a user, an app, or an IP address during a specific period to protect backend services.
- For different services and users, custom can control the request frequency at which an API can be called by a user, an app, and an IP address. This ensures that backend services can run stably.
- The throttling can be accurate to the second, minute, hour, or day.
- Excluded apps and tenants can be configured to limit the number of API calls from specific apps and tenants, respectively.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1249 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. New throttling policy resource support:
  a. support base type and share type
  b. support four kinds of call limit
2. Related acc unit test for each parameters.
3. Related document support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigThrottlingPolicyV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigThrottlingPolicyV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigThrottlingPolicyV2_basic
=== PAUSE TestAccApigThrottlingPolicyV2_basic
=== CONT  TestAccApigThrottlingPolicyV2_basic
--- PASS: TestAccApigThrottlingPolicyV2_basic (466.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig  466.161s
```
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigThrottlingPolicyV2_spec'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigThrottlingPolicyV2_spec -timeout 360m -parallel 4
=== RUN   TestAccApigThrottlingPolicyV2_spec
=== PAUSE TestAccApigThrottlingPolicyV2_spec
=== CONT  TestAccApigThrottlingPolicyV2_spec
--- PASS: TestAccApigThrottlingPolicyV2_spec (485.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      485.731s
```