### PR TITLE
New APIG custom authorizer resource supported

### DIFF
--- a/docs/resources/apig_custom_authorizer.md
+++ b/docs/resources/apig_custom_authorizer.md
@@ -1,0 +1,97 @@
+---
+subcategory: "API Gateway (APIG)"
+---
+
+# huaweicloud_apig_custom_authorizer
+
+Manages an APIG custom authorizer resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "authorizer_name" {}
+variable "function_urn" {}
+
+resource "huaweicloud_apig_custom_authorizer" "test" {
+  instance_id  = var.instance_id
+  name         = var.authorizer_name
+  function_urn = var.function_urn
+  type         = "FRONTEND"
+  cache_age    = 60
+
+  identity {
+    name     = "user_name"
+    location = "QUERY"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the custom authorizer resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new custom authorizer resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the
+  custom authorizer belongs to.
+  Changing this will create a new custom authorizer resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the custom authorizer.
+  The custom authorizer name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+  Changing this will create a new custom authorizer resource.
+
+* `type` - (Required, String, ForceNew) Specifies the custom authoriz type.
+  The valid values are *FRONTEND* and *BACKEND*.
+  Changing this will create a new custom authorizer resource.
+
+* `function_urn` - (Required, String, ForceNew) Specifies the uniform function URN of the function graph resource.
+  Changing this will create a new custom authorizer resource.
+
+* `is_body_send` - (Optional, Bool, ForceNew) Specifies whether to send the body.
+  Changing this will create a new custom authorizer resource.
+
+* `ttl` - (Optional, String) Specifies the maximum cache age.
+  Changing this will create a new custom authorizer resource.
+
+* `user_data` - (Optional, String, ForceNew) Specifies the user data, which can contain a maximum of 2,048 characters.
+  The user data is used by APIG to invoke the specified authentication function when accessing the backend service.
+  Changing this will create a new custom authorizer resource.
+
+  -> **NOTE:** The user data will be displayed in plain text on the console.
+
+* `identity` - (Optional, List, ForceNew) Specifies an array of one or more APIG environments of the associated APIG group.
+  Changing this will create a new custom authorizer resource.
+  The object structure is documented below.
+
+The `identity` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the parameter name.
+  The parameter includes front-end and back-end parameters.
+  Changing this will create a new custom authorizer resource.
+
+* `location` - (Required, String, ForceNew) Specifies the parameter location, which support 'HEADER' and 'QUERY'.
+  Changing this will create a new custom authorizer resource.
+
+* `validation` - (Required, String, ForceNew) Specifies the parameter verification expression.
+  If omitted, the custom authorizer will not perform verification.
+  The valid value is range form 1 to 2,048.
+  Changing this will create a new custom authorizer resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the custom authorizer.
+* `update_time` - Time when the APIG environment was created.
+
+## Import
+
+Custom Authorizers of the APIG can be imported using their `name` and the ID of the APIG instance to which the group belongs,
+separated by a slash, e.g.
+```
+$ terraform import huaweicloud_apig_custom_authorizer.test <instance id>/<name>
+```

--- a/docs/resources/apig_custom_authorizer.md
+++ b/docs/resources/apig_custom_authorizer.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `is_body_send` - (Optional, Bool, ForceNew) Specifies whether to send the body.
   Changing this will create a new custom authorizer resource.
 
-* `ttl` - (Optional, String) Specifies the maximum cache age.
+* `cache_age` - (Optional, String) Specifies the maximum cache age.
   Changing this will create a new custom authorizer resource.
 
 * `user_data` - (Optional, String, ForceNew) Specifies the user data, which can contain a maximum of 2,048 characters.
@@ -63,13 +63,12 @@ The following arguments are supported:
 
   -> **NOTE:** The user data will be displayed in plain text on the console.
 
-* `identity` - (Optional, List, ForceNew) Specifies an array of one or more APIG environments of the associated APIG group.
-  Changing this will create a new custom authorizer resource.
+* `identity` - (Optional, List) Specifies an array of one or more parameter identities of the custom authorizer.
   The object structure is documented below.
 
 The `identity` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the parameter name.
+* `name` - (Required, String, ForceNew) Specifies the name of the parameter to be verified.
   The parameter includes front-end and back-end parameters.
   Changing this will create a new custom authorizer resource.
 
@@ -86,7 +85,7 @@ The `identity` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the custom authorizer.
-* `update_time` - Time when the APIG environment was created.
+* `create_time` - Time when the APIG custom authorizer was created.
 
 ## Import
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -373,6 +373,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_api_gateway_group":               ResourceAPIGatewayGroup(),
 			"huaweicloud_apig_instance":                   apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_application":                apig.ResourceApigApplicationV2(),
+			"huaweicloud_apig_custom_authorizer":          apig.ResourceApigCustomAuthorizerV2(),
 			"huaweicloud_apig_environment":                apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_group":                      apig.ResourceApigGroupV2(),
 			"huaweicloud_apig_response":                   apig.ResourceApigResponseV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -1,0 +1,253 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_custom_authorizer.test"
+		auth         authorizers.CustomAuthorizer
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigCustomAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigCustomAuthorizer_front(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "FRONTEND"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "60"),
+				),
+			},
+			{
+				Config: testAccApigCustomAuthorizer_frontUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "FRONTEND"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "45"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigCustomAuthorizerV2_backend(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_custom_authorizer.test"
+		auth         authorizers.CustomAuthorizer
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigCustomAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigCustomAuthorizer_backend(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "BACKEND"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "60"),
+				),
+			},
+			{
+				Config: testAccApigCustomAuthorizer_backendUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "BACKEND"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "45"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigCustomAuthorizerDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_apig_custom_authorizer" {
+			continue
+		}
+		_, err := authorizers.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API custom authorizer (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigCustomAuthorizerExists(name string, env *authorizers.CustomAuthorizer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No custom authorizer Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		}
+		found, err := authorizers.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return fmt.Errorf("Error getting custom authorizer (%s): %s", rs.Primary.ID, err)
+		}
+		*env = *found
+		return nil
+	}
+}
+
+func testAccApigCustomAuthorizer_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "API custom authorization test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python3.6"
+  code_type   = "inline"
+  
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler(event, context):
+    if event["headers"]["authorization"]=='Basic dXNlcjE6cGFzc3dvcmQ=':
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                "status":"allow",
+                "context":{
+                    "user_name":"user1"
+                }
+            })
+        }
+    else:
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                "status":"deny",
+                "context":{
+                    "code":"1001",
+                    "message":"incorrect username or password"
+                }
+            })
+        }
+EOF
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_front(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_custom_authorizer" "test" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  name         = "%s"
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "FRONTEND"
+  cache_age    = 60
+  
+  identity {
+    name     = "user_name"
+    location = "QUERY"
+  }
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_frontUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_custom_authorizer" "test" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  name         = "%s_update"
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "FRONTEND"
+  cache_age    = 45
+  
+  identity {
+    name     = "user_name"
+    location = "HEADER"
+  }
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_backend(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_custom_authorizer" "test" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  name         = "%s"
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "BACKEND"
+  cache_age    = 60
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_backendUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_custom_authorizer" "test" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  name         = "%s_update"
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "BACKEND"
+  cache_age    = 45
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
 	var (
-		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		// Only letters, digits and underscores (_) are allowed in the authorizer name, environment name
+		// and dedicated instance name.
 		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
 		resourceName = "huaweicloud_apig_custom_authorizer.test"
 		auth         authorizers.CustomAuthorizer

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -1,0 +1,277 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+const (
+	FRONT_AUTH   = "FRONTEND"
+	BACKEND_AUTH = "BACKEND"
+)
+
+func ResourceApigCustomAuthorizerV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApigCustomAuthorizerV2Create,
+		Read:   resourceApigCustomAuthorizerV2Read,
+		Update: resourceApigCustomAuthorizerV2Update,
+		Delete: resourceApigCustomAuthorizerV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceApigCustomAuthorizerResourceImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[A-Za-z][\\w0-9]{2,63}$"),
+					"The name consists of 3 to 64 characters, starting with a letter. "+
+						"Only letters, digits and underscores (_) are allowed."),
+			},
+			"function_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					FRONT_AUTH, BACKEND_AUTH,
+				}, false),
+			},
+			"is_body_send": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"cache_age": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 3600),
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The parameter identity only required if type is 'FRONTEND'.
+			"identity": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"HEADER", "QUERY",
+							}, false),
+						},
+						"validation": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 2048),
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildApigIdentities(identities *schema.Set) []authorizers.AuthCreateIdentitiesReq {
+	result := make([]authorizers.AuthCreateIdentitiesReq, identities.Len())
+	for i, val := range identities.List() {
+		identity := val.(map[string]interface{})
+		validContent := identity["validation"].(string)
+		result[i] = authorizers.AuthCreateIdentitiesReq{
+			Name:       identity["name"].(string),
+			Location:   identity["location"].(string),
+			Validation: &validContent,
+		}
+	}
+	return result
+}
+
+func buildApigCustomAuthorizerParameters(d *schema.ResourceData) (authorizers.CustomAuthOpts, error) {
+	isBodySend := d.Get("is_body_send").(bool)
+	userData := d.Get("user_data").(string)
+	t := d.Get("type").(string) // The 'authType' is easily confused with 'AuthorizerType', and 'type' is a keyword.
+	identities := d.Get("identity").(*schema.Set)
+	if identities.Len() > 0 && t != FRONT_AUTH {
+		return authorizers.CustomAuthOpts{}, fmt.Errorf("The identities can only be set when the type is 'FRONTEND'")
+	}
+	return authorizers.CustomAuthOpts{
+		Name:           d.Get("name").(string),
+		Type:           t,
+		AuthorizerType: "FUNC", // The custom authorizer only support 'FUNC'.
+		AuthorizerUri:  d.Get("function_urn").(string),
+		IsBodySend:     &isBodySend,
+		TTL:            golangsdk.IntToPointer(d.Get("cache_age").(int)),
+		UserData:       &userData,
+		Identities:     buildApigIdentities(identities),
+	}, nil
+}
+
+func resourceApigCustomAuthorizerV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opt, err := buildApigCustomAuthorizerParameters(d)
+	if err != nil {
+		return err
+	}
+	instanceId := d.Get("instance_id").(string)
+	resp, err := authorizers.Create(client, instanceId, opt).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "Error creating HuaweiCloud APIG custom authorizer")
+	}
+	d.SetId(resp.Id)
+	return resourceApigCustomAuthorizerV2Read(d, meta)
+}
+
+func setApigCustomAuthorizerIdentities(d *schema.ResourceData,
+	identities []authorizers.Identity) error {
+	result := make([]map[string]interface{}, len(identities))
+	for i, val := range identities {
+		result[i] = map[string]interface{}{
+			"name":       val.Name,
+			"location":   val.Location,
+			"validation": val.Validation,
+		}
+	}
+	return d.Set("identity", result)
+}
+
+func setApigCustomAuthorizerParamters(d *schema.ResourceData, config *config.Config,
+	resp *authorizers.CustomAuthorizer) error {
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", resp.Name),
+		d.Set("function_urn", resp.AuthorizerUri),
+		d.Set("type", resp.Type),
+		d.Set("is_body_send", resp.IsBodySend),
+		d.Set("cache_age", resp.CacheAge),
+		d.Set("user_data", resp.UserData),
+		d.Set("create_time", resp.CreateTime),
+		setApigCustomAuthorizerIdentities(d, resp.Identities),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func resourceApigCustomAuthorizerV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	resp, err := authorizers.Get(client, instanceId, d.Id()).Extract()
+	if err != nil {
+		return fmtp.Errorf("Unable to get the custom authorizer (%s) form server: %s", d.Id(), err)
+	}
+	return setApigCustomAuthorizerParamters(d, config, resp)
+}
+
+func resourceApigCustomAuthorizerV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	opt, err := buildApigCustomAuthorizerParameters(d)
+	if err != nil {
+		return err
+	}
+	instanceId := d.Get("instance_id").(string)
+	_, err = authorizers.Update(client, instanceId, d.Id(), opt).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error updating HuaweiCloud APIG custom authorizer (%s): %s", d.Id(), err)
+	}
+
+	return resourceApigCustomAuthorizerV2Read(d, meta)
+}
+
+func resourceApigCustomAuthorizerV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	err = authorizers.Delete(client, instanceId, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("Error deleting HuaweiCloud APIG custom authorizer from the instance (%s): %s",
+			instanceId, err)
+	}
+	d.SetId("")
+	return nil
+}
+
+// The ID cannot find on console, so we need to import by authorizer name.
+func resourceApigCustomAuthorizerResourceImportState(d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmtp.Errorf("Invalid format specified for import id, must be <instance_id>/<name>")
+	}
+	instanceId := parts[0]
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	name := parts[1]
+	opt := authorizers.ListOpts{
+		Name: name,
+	}
+	pages, err := authorizers.List(client, instanceId, opt).AllPages()
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error retrieving custom authorizer: %s", err)
+	}
+	resp, err := authorizers.ExtractCustomAuthorizers(pages)
+	if len(resp) < 1 {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Unable to find the custom authorizer (%s) form server: %s",
+			name, err)
+	}
+	d.SetId(resp[0].Id)
+	d.Set("instance_id", instanceId)
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/requests.go
@@ -1,0 +1,134 @@
+package authorizers
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// CustomAuthOpts is a struct which will be used to create a new custom authorizer or
+// update an existing custom authorizer.
+type CustomAuthOpts struct {
+	// Custom authorizer name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Custom authorizer type, which support 'FRONTEND' and 'BACKEND'.
+	Type string `json:"type" required:"true"`
+	// Authorizer type, and the value is 'FUNC'.
+	AuthorizerType string `json:"authorizer_type" required:"true"`
+	// Function URN.
+	AuthorizerURI string `json:"authorizer_uri" required:"true"`
+	// Indicates whether to send the body.
+	IsBodySend *bool `json:"need_body,omitempty"`
+	// Identity source.
+	Identities []AuthCreateIdentitiesReq `json:"identities,omitempty"`
+	// Maximum cache age. The maximum value is 3,600.
+	// The maximum length of time that authentication results can be cached for.
+	// A value of 0 means that results are not cached.
+	TTL *int `json:"ttl,omitempty"`
+	// User data.
+	UserData *string `json:"user_data,omitempty"`
+}
+
+// AuthCreateIdentitiesReq is an object which will be build up a indentities list.
+type AuthCreateIdentitiesReq struct {
+	// Parameter name.
+	Name string `json:"name" required:"true"`
+	// Parameter location, which support 'HEADER' and 'QUERY'.
+	Location string `json:"location" required:"true"`
+	// Parameter verification expression. The default value is null, indicating that no verification is performed.
+	Validation *string `json:"validation,omitempty"`
+}
+
+// CustomAuthOptsBuilder is an interface which to support request body build of
+// the custom authorizer creation and updation.
+type CustomAuthOptsBuilder interface {
+	ToCustomAuthOptsMap() (map[string]interface{}, error)
+}
+
+// ToCustomAuthOptsMap is a method which to build a request body by the CustomAuthOpts.
+func (opts CustomAuthOpts) ToCustomAuthOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method to create a new custom authorizer.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts CustomAuthOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToCustomAuthOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method to update an existing custom authorizer.
+func Update(client *golangsdk.ServiceClient, instanceId, authId string, opts CustomAuthOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToCustomAuthOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, authId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain an existing custom authorizer.
+func Get(client *golangsdk.ServiceClient, instanceId, authId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, authId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// ID.
+	ID string `q:"id"`
+	// Name.
+	Name string `q:"name"`
+	// Custom authorizer type.
+	Type string `q:"type"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+// ListOptsBuilder is an interface which to support request query build of
+// the custom authorizer search.
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+// ToListQuery is a method which to build a request query by the ListOpts.
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more custom authorizers for the instance according to the
+// query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return CustomAuthPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing custom authorizer.
+func Delete(client *golangsdk.ServiceClient, instanceId, authId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, authId), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/results.go
@@ -1,0 +1,84 @@
+package authorizers
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Update method.
+type GetResult struct {
+	commonResult
+}
+
+// CustomAuthorizer is a struct that represents the result of Create, Update and Get methods.
+type CustomAuthorizer struct {
+	// Custom authorizer name., which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	Name string `json:"name"`
+	// Custom authorizer type, which support 'FRONTEND' and 'BACKEND'.
+	Type string `json:"type"`
+	// Authorizer type, and the value is 'FUNC'.
+	AuthorizerType string `json:"authorizer_type"`
+	// Function URN.
+	AuthorizerURI string `json:"authorizer_uri"`
+	// Identity source.
+	Identities []Identity `json:"identities"`
+	// Maximum cache age.
+	TTL int `json:"ttl"`
+	// User data.
+	UserData string `json:"user_data"`
+	// Indicates whether to send the body.
+	IsBodySend bool `json:"need_body"`
+	// Custom authorizer ID
+	ID string `json:"id"`
+	// Creation time.
+	CreateTime string `json:"create_time"`
+}
+
+// Identity is an object struct that represents the elements of the Identities parameter.
+type Identity struct {
+	// Parameter name.
+	Name string `json:"name"`
+	// Parameter location, which support 'HEADER' and 'QUERY'.
+	Location string `json:"location"`
+	// Parameter verification expression.
+	// The default value is null, indicating that no verification is performed.
+	Validation string `json:"validation"`
+}
+
+func (r commonResult) Extract() (*CustomAuthorizer, error) {
+	var s CustomAuthorizer
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// CustomAuthPage represents the response pages of the List method.
+type CustomAuthPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractCustomAuthorizers is a method which to extract the response to a custom authorizer list.
+func ExtractCustomAuthorizers(r pagination.Page) ([]CustomAuthorizer, error) {
+	var s []CustomAuthorizer
+	err := r.(CustomAuthPage).Result.ExtractIntoSlicePtr(&s, "authorizer_list")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/urls.go
@@ -1,0 +1,13 @@
+package authorizers
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(rootPath, instanceId, "authorizers")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, id string) string {
+	return c.ServiceURL(rootPath, instanceId, "authorizers", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -278,6 +278,7 @@ github.com/huaweicloud/golangsdk/openstack/apigw/apis
 github.com/huaweicloud/golangsdk/openstack/apigw/groups
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/apigroups
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications
+github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
A mechanism defined with custom rules for API Gateway to verify the validity and integrity of requests initiated by API callers. The mechanism is also used for backend services to verify the requests forwarded by API Gateway.
The following two types of custom authentication are provided:
- Frontend custom authentication: A custom authorizer is configured with a function to authenticate requests for an API.
- Backend custom authentication: A custom authorizer can be configured to authenticate requests for different backend services, eliminating the need to customize APIs for different authentication systems and simplifying API development. You only need to create a function-based custom authorizer in API Gateway to connect to the backend authentication system.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1249 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. New custom authorizer resource, which support fornt and backend auth management.
2. Related acc unit test supported.
3. New document supported.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigCustomAuthorizerV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigCustomAuthorizerV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigCustomAuthorizerV2_basic
=== PAUSE TestAccApigCustomAuthorizerV2_basic
=== CONT  TestAccApigCustomAuthorizerV2_basic
--- PASS: TestAccApigCustomAuthorizerV2_basic (475.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      475.968s
```
