### PR TITLE
[WAF] add Web Tamper Protection rule resource

### DIFF
--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_rule_web_tamper_protection
+
+Manages a WAF web tamper protection rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  domain    = "www.your-domain.com"
+  path      = "/payment"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF web tamper protection rules resource.
+  If omitted, the provider-level region will be used. Changing this creates a new rule.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `domain` - (Required, String, ForceNew) Specifies the domain name. Changing this creates a new rule.
+
+* `path` - (Required, String, ForceNew) Specifies the URL protected by the web tamper protection rule,
+  excluding a domain name. Changing this creates a new rule.
+  
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Web Tamper Protection Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import huaweicloud_waf_rule_web_tamper_protection.rule_1 840c6dfdd5604c1781eea033eae2004f/c6dbc13bb7e74788ae53ecc9254b3ea8
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -513,6 +513,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_waf_domain":                      waf.ResourceWafDomainV1(),
 			"huaweicloud_waf_policy":                      waf.ResourceWafPolicyV1(),
 			"huaweicloud_waf_rule_blacklist":              waf.ResourceWafRuleBlackListV1(),
+			"huaweicloud_waf_rule_web_tamper_protection":  waf.ResourceWafRuleWebTamperProtectionV1(),
 
 			// Legacy
 			"huaweicloud_compute_instance_v2":                ResourceComputeInstanceV2(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -1,0 +1,116 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules"
+)
+
+func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
+	var rule rules.WebTamper
+	randName := acctest.RandString(5)
+	resourceName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafWafRuleWebTamperProtection_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_waf_rule_web_tamper_protection" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTamper) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF web tamper protection rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafWafRuleWebTamperProtection_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id = huaweicloud_waf_policy.policy_1.id
+  domain    = "www.abc.com"
+  path      = "/a"
+}
+`, name)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
@@ -1,0 +1,122 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package waf
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	rules "github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules"
+)
+
+// ResourceWafRuleWebTamperProtectionV1 manages the resources for web tamper protection rules
+func ResourceWafRuleWebTamperProtectionV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleWebTamperProtectionCreate,
+		Read:   resourceWafRuleWebTamperProtectionRead,
+		Delete: resourceWafRuleWebTamperProtectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+// resourceWafRuleWebTamperProtectionCreate create rules
+func resourceWafRuleWebTamperProtectionCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+	}
+	// create options
+	createOpts := rules.CreateOpts{
+		Hostname: d.Get("domain").(string),
+		Url:      d.Get("path").(string),
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF Web Tamper Protection Rule: %s", err)
+	}
+
+	logp.Printf("[DEBUG] WAF web tamper protection rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleWebTamperProtectionRead(d, meta)
+}
+
+// resourceWafRuleWebTamperProtectionRead read rules from HuaweiCloud by id and policyid
+func resourceWafRuleWebTamperProtectionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "WAF Web Tamper Protection Rule")
+	}
+
+	d.SetId(n.Id)
+	mErr := multierror.Append(nil,
+		d.Set("policy_id", n.PolicyID),
+		d.Set("domain", n.Hostname),
+		d.Set("path", n.Url),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+
+	return nil
+}
+
+// resourceWafRuleWebTamperProtectionDelete delete the rules from HuaweiCloud by id
+func resourceWafRuleWebTamperProtectionDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("error deleting HuaweiCloud WAF Web Tamper Protection Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/requests.go
@@ -1,0 +1,64 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package webtamperprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToWebTamperCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new web tamper protection rule.
+type CreateOpts struct {
+	Hostname    string `json:"hostname" required:"true"`
+	Url         string `json:"url" required:"true"`
+	Description string `json:"description,omitempty"`
+}
+
+// ToWebTamperCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToWebTamperCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new web tamper protection rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToWebTamperCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular web tamper protection rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular web tamper protection rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/results.go
@@ -1,0 +1,54 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package webtamperprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type WebTamper struct {
+	Id          string `json:"id"`
+	PolicyID    string `json:"policyid"`
+	Hostname    string `json:"hostname"`
+	Url         string `json:"url"`
+	TimeStamp   int64  `json:"timestamp"`
+	Description string `json:"description"`
+	Status      int    `json:"status"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a web tamper protection rule.
+func (r commonResult) Extract() (*WebTamper, error) {
+	var response WebTamper
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Web Tamper Protection rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a Web Tamper Protection rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Web Tamper Protection rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/urls.go
@@ -1,0 +1,15 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package webtamperprotection_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "antitamper")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "antitamper", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -463,6 +463,7 @@ github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies
+github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules
 github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/whiteblackip_rules
 github.com/huaweicloud/golangsdk/pagination
 github.com/huaweicloud/golangsdk/testhelper


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Manages a WAF web tamper protection rule resource within HuaweiCloud. 
The following operating functions should be provided.
- Create rules for the specified policy.
- Update the rules.
- Delete the existing rule.
- Support for importing existing rules from HUAWEI CLOUD to Terraform.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1280

**Special notes for your reviewer**:

- Because the modifying API can modify the status  only, so all fields of schema are set to `ForceNew: true`.
- The rule status is unnecessary and will not be put to the attribute.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Added resource('huaweicloud_waf_rule_web_tamper_protection') for manging the rules of policy. 
2. For complete use, it needs to be released together with WAF policy management.  And WAF policy management has been merged into master.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_basic
--- PASS: TestAccWafRuleWebTamperProtection_basic (27.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       27.948s

```
