### PR TITLE
Add data source for Dedicated ELB certificates.

### DIFF
--- a/docs/data-sources/elb_certificate.md
+++ b/docs/data-sources/elb_certificate.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Dedicated Load Balance (Dedicated ELB)"
+---
+
+# huaweicloud_elb_certificate
+
+Use this data source to get the certificate in HuaweiCloud Dedicated Load Balance (Dedicated ELB).
+
+## Example Usage
+
+```hcl
+variable "certificate_name" {}
+
+data "huaweicloud_elb_certificate" "test" {
+  name = var.certificate_name
+}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the Dedicated ELB certificate. 
+  If omitted, the provider-level region will be used.
+ 
+* `name` - (Required, String) The name of certificate. 
+  The value is case sensitive and does not supports fuzzy matching.
+  
+  -> **NOTE:** The certificate name is not unique. 
+  Only returns the last created one when matched multiple certificates.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `domain` - The domain of the Certificate. This parameter is valid only when `type` is "server".
+
+* `type` - Specifies the certificate type. The value can be one of the following:
+  * `server`: indicates the server certificate.
+  * `client`: indicates the CA certificate.
+  
+* `description` - Human-readable description for the Certificate.
+
+* `expiration` - Indicates the time when the certificate expires.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
 )
 
@@ -302,6 +303,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_kms_key":                     DataSourceKmsKeyV1(),
 			"huaweicloud_kms_data_key":                DataSourceKmsDataKeyV1(),
 			"huaweicloud_lb_loadbalancer":             DataSourceELBV2Loadbalancer(),
+			"huaweicloud_elb_certificate":             elb.DataSourceELBCertificateV3(),
 			"huaweicloud_nat_gateway":                 DataSourceNatGatewayV2(),
 			"huaweicloud_networking_port":             DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":         DataSourceNetworkingSecGroupV2(),

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_certificate_test.go
@@ -1,0 +1,120 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package elb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDataSourceELbCertificateV3_basic(t *testing.T) {
+	name := fmt.Sprintf("cert-%s", acctest.RandString(6))
+	dataSourceName := "data.huaweicloud_elb_certificate.cert_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccELbCertDataSourceV3_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckELBCertDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "domain"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckELBCertDataSourceID(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmtp.Errorf("Can't find Dedicated ELB data source: %s ", r)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("The Dedicated ELB Certificate data source ID not set.")
+		}
+		return nil
+	}
+}
+
+func testAccELbCertDataSourceV3_conf(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_elb_certificate" "cert_1" {
+  name = huaweicloud_elb_certificate.certificate_1.name
+}
+
+resource "huaweicloud_elb_certificate" "certificate_1" {
+  name        = "%s"
+  description = "terraform test certificate"
+  domain      = "www.elb.com"
+  private_key = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----
+EOT
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----
+EOT
+}
+`, name)
+}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_certificate.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_certificate.go
@@ -1,0 +1,109 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package elb
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/elb/v3/certificates"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+// DataSourceELBCertificateV3 the data source of "huaweicloud_elb_certificate"
+// Dedicated ELB
+func DataSourceELBCertificateV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceELbCertificateV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceELbCertificateV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ElbV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud Dedicated ELB(V3) Client: %s", err)
+	}
+
+	listOpts := certificates.ListOpts{
+		Name: d.Get("name").(string),
+	}
+	r, err := certificates.List(client, listOpts).AllPages()
+	certs, err := certificates.ExtractCertificates(r)
+	if err != nil {
+		return fmtp.Errorf("Unable to retrieve certs from Dedicated ELB(V3): %s", err)
+	}
+	logp.Printf("[DEBUG] Get certificate list: %#v", certs)
+
+	if len(certs) > 0 {
+		setCertificateAttributes(d, certs[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmtp.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	return nil
+}
+
+func setCertificateAttributes(d *schema.ResourceData, c certificates.Certificate) error {
+	d.SetId(c.ID)
+
+	var expiration string
+	tm, err := time.Parse(time.RFC3339, c.ExpireTime)
+	if err != nil {
+		// If the format of ExpireTime is not expected, set the original value directly.
+		expiration = c.ExpireTime
+		logp.Printf("[WAIN] The format of the ExpireTime field of the Dedicated ELB certificate "+
+			"is not expected:%s", c.ExpireTime)
+	} else {
+		expiration = tm.Format("2006-01-02 15:04:05 MST")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", c.Name),
+		d.Set("domain", c.Domain),
+		d.Set("description", c.Description),
+		d.Set("type", c.Type),
+		d.Set("expiration", expiration),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.Errorf("error setting Dedicated ELB Certificate fields: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

I'd like to add data source for Dedicated ELB Certificates.
`huaweicloud_elb_certificate`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1264

**Special notes for your reviewer**:

- The SDK of ELB V3 has been imported to vendor.
- The parameters are the same as the WAF certificate data source parameters.
- Only our test account can use  the Dedicated ELB services in Beijing4 region.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/elb' TESTARGS='-run TestAccDataSourceELbCertificateV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccDataSourceELbCertificateV3_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceELbCertificateV3_basic
--- PASS: TestAccDataSourceELbCertificateV3_basic (10.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       10.088s

```
