### PR TITLE
Fix gaussdb mysql scaling up issue

### DIFF
--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -98,6 +98,7 @@ func resourceGaussDBInstance() *schema.Resource {
 			},
 			"volume_size": {
 				Type:     schema.TypeInt,
+				Computed: true,
 				Optional: true,
 			},
 			"time_zone": {
@@ -528,7 +529,7 @@ func resourceGaussDBInstanceRead(d *schema.ResourceData, meta interface{}) error
 			volume_size = raw.Volume.Size
 		}
 		nodesList = append(nodesList, node)
-		if raw.Type == "slave" && raw.Status == "ACTIVE" {
+		if raw.Type == "slave" && (raw.Status == "ACTIVE" || raw.Status == "BACKING UP") {
 			slave_count += 1
 		}
 		if flavor == "" {
@@ -704,7 +705,7 @@ func resourceGaussDBInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				}
 				slave_count := 0
 				for _, raw := range instance.Nodes {
-					if raw.Type == "slave" && raw.Status == "ACTIVE" {
+					if raw.Type == "slave" && (raw.Status == "ACTIVE" || raw.Status == "BACKING UP") {
 						slave_count += 1
 					}
 				}


### PR DESCRIPTION
This takes BACKING UP status nodes into account when checking
sclaing up operation.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
