### PR TITLE
support enterprise_project_id in  CSS, DWS,DIS

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -2,7 +2,7 @@
 subcategory: "Cloud Search Service (CSS)"
 ---
 
-# huaweicloud\_css\_cluster
+# huaweicloud_css_cluster
 
 CSS cluster management
 This is an alternative to `huaweicloud_css_cluster_v1`
@@ -71,6 +71,11 @@ The following arguments are supported:
 * `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the cluster.
+
+* `enterprise_project_id` - (Optional, String, ForceNew)  Enterprise project ID. When creating a cluster,
+    associate the enterprise project ID with the cluster. 
+    Value 0 indicates the default enterprise project.
+    Changing this parameter will create a new resource.
 
 The `node_config` block supports:
 

--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -72,8 +72,7 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the cluster.
 
-* `enterprise_project_id` - (Optional, String, ForceNew)  Enterprise project ID. When creating a cluster,
-    associate the enterprise project ID with the cluster. 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the css cluster,
     Value 0 indicates the default enterprise project.
     Changing this parameter will create a new resource.
 

--- a/docs/resources/dis_stream.md
+++ b/docs/resources/dis_stream.md
@@ -61,8 +61,7 @@ The following arguments are supported:
 
 * `csv_delimiter` - (Optional, String, ForceNew) Field separator for CSV file.  Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew)  Enterprise project ID. When creating a cluster,
-    associate the enterprise project ID with the cluster. 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the dis stream,
     Value 0 indicates the default enterprise project.
     Changing this parameter will create a new resource.
 

--- a/docs/resources/dis_stream.md
+++ b/docs/resources/dis_stream.md
@@ -2,7 +2,7 @@
 subcategory: "Data Ingestion Service (DIS)"
 ---
 
-# huaweicloud\_dis\_stream
+# huaweicloud_dis_stream
 
 DIS Stream management
 This is an alternative to `huaweicloud_dis_stream_v2`
@@ -33,33 +33,38 @@ resource "huaweicloud_dis_stream" "stream" {
 
 The following arguments are supported:
 
+* `stream_name` - (Required, String) Name of the DIS stream to be created.
+
 * `partition_count` - (Required, Int) Number of the expect partitions. NOTE: Each stream can be scaled up
   and down a total of five times within one hour. After the stream is
   successfully scaled up or down, it cannot be scaled up or down again
   within the next one hour.
 
-* `stream_name` - (Required, String) Name of the DIS stream to be created.
+* `stream_type` - (Optional, String, ForceNew) Stream Type. The value is COMMON(means 1M bandwidth) or
+  ADVANCED(means 5M bandwidth).  Changing this parameter will create a new resource.
 
 * `region` - (Optional, String, ForceNew) The region in which to create the DIS stream resource. If omitted, the provider-level region will be used. Changing this creates a new DIS Stream resource.
+
+* `retention_period` - (Optional, Int, ForceNew) The number of hours for which data from the stream will be retained
+  in DIS. Value range: 24 to 72.Unit: hour. Changing this parameter will create a new resource.
+
+* `data_type` - (Optional, String, ForceNew) Data type of the data putting into the stream. The value is one of
+  BLOB, JSON and CSV.  Changing this parameter will create a new resource.
 
 * `auto_scale_max_partition_count` - (Optional, Int, ForceNew) Maximum number of partition for automatic scaling.  Changing this parameter will create a new resource.
 
 * `auto_scale_min_partition_count` - (Optional, Int, ForceNew) Minimum number of partition for automatic scaling.  Changing this parameter will create a new resource.
 
+* `data_schema` - (Optional, String, ForceNew) User's JOSN, CSV format data schema, described with Avro schema.  Changing this parameter will create a new resource.
+
 * `compression_format` - (Optional, String, ForceNew) Data compression type. The value is one of snappy, gzip and zip.  Changing this parameter will create a new resource.
 
 * `csv_delimiter` - (Optional, String, ForceNew) Field separator for CSV file.  Changing this parameter will create a new resource.
 
-* `data_schema` - (Optional, String, ForceNew) User's JOSN, CSV format data schema, described with Avro schema.  Changing this parameter will create a new resource.
-
-* `data_type` - (Optional, String, ForceNew) Data type of the data putting into the stream. The value is one of
-  BLOB, JSON and CSV.  Changing this parameter will create a new resource.
-
-* `retention_period` - (Optional, Int, ForceNew) The number of hours for which data from the stream will be retained
-  in DIS.  Changing this parameter will create a new resource.
-
-* `stream_type` - (Optional, String, ForceNew) Stream Type. The value is COMMON(means 1M bandwidth) or
-  ADVANCED(means 5M bandwidth).  Changing this parameter will create a new resource.
+* `enterprise_project_id` - (Optional, String, ForceNew)  Enterprise project ID. When creating a cluster,
+    associate the enterprise project ID with the cluster. 
+    Value 0 indicates the default enterprise project.
+    Changing this parameter will create a new resource.
 
 * `tags` - (Optional, List, ForceNew) List of tags for the newly created DIS stream. Structure is documented below. Changing this parameter will create a new resource.
 

--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -4,7 +4,7 @@ subcategory: "Data Warehouse Service (DWS)"
 
 # huaweicloud_dws_cluster
 
-cluster management
+Manages Cluster in the Data Warehouse Service.
 
 ## Example Usage
 
@@ -24,9 +24,8 @@ resource "huaweicloud_dws_cluster" "cluster" {
   security_group_id     = huaweicloud_networking_secgroup.secgroup.id
   availability_zone     = "{{ availability_zone }}"
   name                  = "terraform_dws_cluster_test"
-  user_name             = "userNmae"
-  user_pwd              = "password"
-  enterprise_project_id = "0"
+  user_name             = "test_cluster_admin"
+  user_pwd              = "cluster123@!"
   timeouts {
     create = "30m"
     delete = "30m"
@@ -66,8 +65,7 @@ The following arguments are supported:
   Lowercase letters  Uppercase letters  Digits  Special characters
   ~!@#%^&*()-_=+|[{}];:,<.>/?
 
-* `enterprise_project_id` - (Optional, String, ForceNew)  Enterprise project ID. When creating a cluster,
-    associate the enterprise project ID with the cluster. 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the dws cluster,
     Value 0 indicates the default enterprise project.
     Changing this parameter will create a new resource.
 

--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -2,7 +2,7 @@
 subcategory: "Data Warehouse Service (DWS)"
 ---
 
-# huaweicloud\_dws\_cluster
+# huaweicloud_dws_cluster
 
 cluster management
 
@@ -17,16 +17,16 @@ resource "huaweicloud_networking_secgroup" "secgroup" {
 }
 
 resource "huaweicloud_dws_cluster" "cluster" {
-  node_type         = "dws.m3.xlarge"
-  number_of_node    = 3
-  network_id        = "{{ network_id }}"
-  vpc_id            = "{{ vpc_id }}"
-  security_group_id = huaweicloud_networking_secgroup.secgroup.id
-  availability_zone = "{{ availability_zone }}"
-  name              = "terraform_dws_cluster_test"
-  user_name         = "test_cluster_admin"
-  user_pwd          = "cluster123@!"
-
+  node_type             = "dws.m3.xlarge"
+  number_of_node        = 3
+  network_id            = "{{ network_id }}"
+  vpc_id                = "{{ vpc_id }}"
+  security_group_id     = huaweicloud_networking_secgroup.secgroup.id
+  availability_zone     = "{{ availability_zone }}"
+  name                  = "terraform_dws_cluster_test"
+  user_name             = "userNmae"
+  user_pwd              = "password"
+  enterprise_project_id = "0"
   timeouts {
     create = "30m"
     delete = "30m"
@@ -65,6 +65,12 @@ The following arguments are supported:
   written in reverse order.  Contains three types of the following: 
   Lowercase letters  Uppercase letters  Digits  Special characters
   ~!@#%^&*()-_=+|[{}];:,<.>/?
+
+* `enterprise_project_id` - (Optional, String, ForceNew)  Enterprise project ID. When creating a cluster,
+    associate the enterprise project ID with the cluster. 
+    Value 0 indicates the default enterprise project.
+    Changing this parameter will create a new resource.
+
 
 - - -
 

--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -17,15 +17,16 @@ resource "huaweicloud_networking_secgroup" "secgroup" {
 }
 
 resource "huaweicloud_dws_cluster" "cluster" {
-  node_type             = "dws.m3.xlarge"
-  number_of_node        = 3
-  network_id            = "{{ network_id }}"
-  vpc_id                = "{{ vpc_id }}"
-  security_group_id     = huaweicloud_networking_secgroup.secgroup.id
-  availability_zone     = "{{ availability_zone }}"
-  name                  = "terraform_dws_cluster_test"
-  user_name             = "test_cluster_admin"
-  user_pwd              = "cluster123@!"
+  node_type         = "dws.m3.xlarge"
+  number_of_node    = 3
+  network_id        = "{{ network_id }}"
+  vpc_id            = "{{ vpc_id }}"
+  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+  availability_zone = "{{ availability_zone }}"
+  name              = "terraform_dws_cluster_test"
+  user_name         = "test_cluster_admin"
+  user_pwd          = "cluster123@!"
+
   timeouts {
     create = "30m"
     delete = "30m"

--- a/huaweicloud/resource_huaweicloud_css_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_css_cluster_v1.go
@@ -204,6 +204,12 @@ func ResourceCssClusterV1() *schema.Resource {
 					},
 				},
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -226,7 +232,6 @@ func resourceCssClusterV1Create(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return fmtp.Errorf("Error creating sdk client, err=%s", err)
 	}
-
 	opts := resourceCssClusterV1UserInputParams(d)
 	arrayIndex := map[string]int{
 		"node_config.network_info": 0,
@@ -234,7 +239,7 @@ func resourceCssClusterV1Create(d *schema.ResourceData, meta interface{}) error 
 		"node_config":              0,
 	}
 
-	params, err := buildCssClusterV1CreateParameters(opts, arrayIndex)
+	params, err := buildCssClusterV1CreateParameters(opts, arrayIndex, config)
 	if err != nil {
 		return fmtp.Errorf("Error building the request body of api(create), err=%s", err)
 	}
@@ -452,7 +457,7 @@ func resourceCssClusterV1Delete(d *schema.ResourceData, meta interface{}) error 
 	return err
 }
 
-func buildCssClusterV1CreateParameters(opts map[string]interface{}, arrayIndex map[string]int) (interface{}, error) {
+func buildCssClusterV1CreateParameters(opts map[string]interface{}, arrayIndex map[string]int, config *config.Config) (interface{}, error) {
 	params := make(map[string]interface{})
 
 	resourceData := opts["terraform_resource_data"].(*schema.ResourceData)
@@ -507,6 +512,11 @@ func buildCssClusterV1CreateParameters(opts map[string]interface{}, arrayIndex m
 
 	if len(params) == 0 {
 		return params, nil
+	}
+
+	enterpriseProjectID := config.GetEnterpriseProjectID(resourceData)
+	if enterpriseProjectID != "" {
+		params["enterprise_project_id"] = enterpriseProjectID
 	}
 
 	params = map[string]interface{}{"cluster": params}

--- a/huaweicloud/resource_huaweicloud_css_cluster_v1.go
+++ b/huaweicloud/resource_huaweicloud_css_cluster_v1.go
@@ -881,6 +881,12 @@ func fillCssClusterV1ReadRespBody(body interface{}) interface{} {
 		result["updated"] = nil
 	}
 
+	if v, ok := val["enterprise_project_id"]; ok {
+		result["enterprise_project_id"] = v
+	} else {
+		result["enterprise_project_id"] = nil
+	}
+
 	return result
 }
 
@@ -1018,6 +1024,13 @@ func setCssClusterV1Properties(d *schema.ResourceData, response map[string]inter
 	nodeNum := len(v.([]interface{}))
 	if err = d.Set("expect_node_num", nodeNum); err != nil {
 		return fmtp.Errorf("Error setting Cluster:expect_node_num, err: %s", err)
+	}
+
+	v, err = navigateValue(response, []string{"read", "enterprise_project_id"}, nil)
+	if err == nil {
+		if err = d.Set("enterprise_project_id", v); err != nil {
+			return fmtp.Errorf("Error setting Cluster:enterprise_project_id, err: %s", err)
+		}
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_dis_stream_v2.go
+++ b/huaweicloud/resource_huaweicloud_dis_stream_v2.go
@@ -157,7 +157,6 @@ func ResourceDisStreamV2() *schema.Resource {
 func resourceDisStreamV2UserInputParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"terraform_resource_data":        d,
-		"auto_scale_enabled":             d.Get("auto_scale_enabled"),
 		"auto_scale_max_partition_count": d.Get("auto_scale_max_partition_count"),
 		"auto_scale_min_partition_count": d.Get("auto_scale_min_partition_count"),
 		"compression_format":             d.Get("compression_format"),

--- a/huaweicloud/resource_huaweicloud_dis_stream_v2.go
+++ b/huaweicloud/resource_huaweicloud_dis_stream_v2.go
@@ -24,6 +24,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
+const DIS_SYS_TAG_KEY_ENTERPRISE_PROJECT_ID = "_sys_enterprise_project_id"
+
 func ResourceDisStreamV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDisStreamV2Create,
@@ -104,6 +106,13 @@ func ResourceDisStreamV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
 			"tags": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -148,6 +157,7 @@ func ResourceDisStreamV2() *schema.Resource {
 func resourceDisStreamV2UserInputParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"terraform_resource_data":        d,
+		"auto_scale_enabled":             d.Get("auto_scale_enabled"),
 		"auto_scale_max_partition_count": d.Get("auto_scale_max_partition_count"),
 		"auto_scale_min_partition_count": d.Get("auto_scale_min_partition_count"),
 		"compression_format":             d.Get("compression_format"),
@@ -171,7 +181,7 @@ func resourceDisStreamV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	opts := resourceDisStreamV2UserInputParams(d)
 
-	params, err := buildDisStreamV2CreateParameters(opts, nil)
+	params, err := buildDisStreamV2CreateParameters(opts, nil, config)
 	if err != nil {
 		return fmtp.Errorf("Error building the request body of api(create), err=%s", err)
 	}
@@ -254,7 +264,7 @@ func resourceDisStreamV2Delete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func buildDisStreamV2CreateParameters(opts map[string]interface{}, arrayIndex map[string]int) (interface{}, error) {
+func buildDisStreamV2CreateParameters(opts map[string]interface{}, arrayIndex map[string]int, config *config.Config) (interface{}, error) {
 	params := make(map[string]interface{})
 
 	v, err := expandDisStreamV2CreateAutoCaleEnable(opts, arrayIndex)
@@ -375,6 +385,19 @@ func buildDisStreamV2CreateParameters(opts map[string]interface{}, arrayIndex ma
 		return nil, err
 	} else if !e {
 		params["tags"] = v
+	}
+
+	resourceData := opts["terraform_resource_data"].(*schema.ResourceData)
+	if resourceData == nil {
+		return nil, fmtp.Errorf("failed to build parameters: Resource Data is null")
+	}
+
+	enterpriseProjectID := config.GetEnterpriseProjectID(resourceData)
+	if enterpriseProjectID != "" {
+		sysTag := make(map[string]string)
+		sysTag["key"] = DIS_SYS_TAG_KEY_ENTERPRISE_PROJECT_ID
+		sysTag["value"] = enterpriseProjectID
+		params["sys_tags"] = []map[string]string{sysTag}
 	}
 
 	return params, nil
@@ -607,6 +630,12 @@ func fillDisStreamV2ReadRespBody(body interface{}) interface{} {
 		result["writable_partition_count"] = nil
 	}
 
+	if v, ok := val["sys_tags"]; ok {
+		result["enterprise_project_id"] = parseDisStreamV2ReadRespSysTags(v)
+	} else {
+		result["enterprise_project_id"] = nil
+	}
+
 	return result
 }
 
@@ -628,6 +657,31 @@ func fillDisStreamV2ReadRespCsvProperties(value interface{}) interface{} {
 	}
 
 	return result
+}
+
+func parseDisStreamV2ReadRespSysTags(value interface{}) (r string) {
+	if value == nil {
+		return
+	}
+
+	value1, ok := value.([]interface{})
+	if !ok || len(value1) == 0 {
+		return
+	}
+
+	n := len(value1)
+	for i := 0; i < n; i++ {
+		item := value1[i].(map[string]interface{})
+
+		if k, ok := item["key"]; ok && k == DIS_SYS_TAG_KEY_ENTERPRISE_PROJECT_ID {
+			if v, ok := item["value"]; ok {
+				return v.(string)
+			}
+		}
+
+	}
+
+	return
 }
 
 func fillDisStreamV2ReadRespTags(value interface{}) interface{} {
@@ -755,7 +809,7 @@ func setDisStreamV2Properties(d *schema.ResourceData, response map[string]interf
 		return fmtp.Errorf("Error setting Stream:stream_type, err: %s", err)
 	}
 
-	v, _ = opts["tags"]
+	v = opts["tags"]
 	v, err = flattenDisStreamV2Tags(response, nil, v)
 	if err != nil {
 		return fmtp.Errorf("Error reading Stream:tags, err: %s", err)
@@ -770,6 +824,11 @@ func setDisStreamV2Properties(d *schema.ResourceData, response map[string]interf
 	}
 	if err = d.Set("writable_partition_count", v); err != nil {
 		return fmtp.Errorf("Error setting Stream:writable_partition_count, err: %s", err)
+	}
+
+	v, err = navigateValue(response, []string{"read", "enterprise_project_id"}, nil)
+	if err = d.Set("enterprise_project_id", v); err != nil {
+		return fmtp.Errorf("Error setting Stream:enterprise_project_id, err: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/resource_huaweicloud_dws_cluster.go
@@ -518,6 +518,12 @@ func resourceDwsClusterRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if v, ok := res["enterprise_project_id"]; ok {
+		if err := d.Set("enterprise_project_id", v); err != nil {
+			return fmtp.Errorf("Error reading Cluster:enterprise_project_id, err: %s", err)
+		}
+	}
+
 	return nil
 }
 

--- a/huaweicloud/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/resource_huaweicloud_dws_cluster.go
@@ -203,6 +203,13 @@ func ResourceDwsCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -315,6 +322,11 @@ func resourceDwsClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if !e {
 		opts["vpc_id"] = vpcIDProp
+	}
+
+	enterpriseProjectID := config.GetEnterpriseProjectID(d)
+	if enterpriseProjectID != "" {
+		opts["enterprise_project_id"] = enterpriseProjectID
 	}
 
 	url, err := replaceVars(d, "clusters", nil)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support enterprise_project_id in  CSS, DWS,DIS

**Which issue this PR fixes**:
fixes #1307 #1185

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccDisStreamV2_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccDisStreamV2_basic -timeout 360m -parallel 4
=== RUN   TestAccDisStreamV2_basic
=== PAUSE TestAccDisStreamV2_basic
=== CONT  TestAccDisStreamV2_basic
--- PASS: TestAccDisStreamV2_basic (9.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       9.957s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccDwsCluster_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccDwsCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsCluster_basic
=== PAUSE TestAccDwsCluster_basic
=== CONT  TestAccDwsCluster_basic
--- PASS: TestAccDwsCluster_basic (1095.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1096.163s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCssClusterV1_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCssClusterV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCssClusterV1_basic
=== PAUSE TestAccCssClusterV1_basic
=== CONT  TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (962.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       962.711s
```