### PR TITLE
Add ability to enable a bucket as a parallel file system

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -187,6 +187,9 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region where this bucket will be created.
   If not specified, used the region by the provider. Changing this will create a new bucket.
 
+* `parallel_fs` - (Optional, Bool, ForceNew) Whether enable a bucket as a parallel file system.
+  Changing this will create a new bucket.
+
 * `multi_az` - (Optional, Bool, ForceNew) Whether enable the multi-AZ mode for the bucket.
   When the multi-AZ mode is enabled, data in the bucket is duplicated and stored in multiple AZs.
 
@@ -285,6 +288,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the bucket.
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.obs.region.myhuaweicloud.com`.
+* `bucket_version` - The OBS version of the bucket.
 * `region` - The region where this bucket resides in.
 
 ## Import

--- a/huaweicloud/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_test.go
@@ -29,7 +29,9 @@ func TestAccObsBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az", "false"),
+					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "false"),
 					resource.TestCheckResourceAttr(resourceName, "region", HW_REGION_NAME),
+					resource.TestCheckResourceAttr(resourceName, "bucket_version", "3.0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -97,7 +99,35 @@ func TestAccObsBucket_multiAZ(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.multi_az", "3az"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_parallelFS(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "huaweicloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckOBS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigParallelFS(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket", testAccObsBucketName(rInt)),
+					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "multi_az", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.parallel_fs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.multi_az", "3az"),
+					resource.TestCheckNoResourceAttr(resourceName, "bucket_version"),
 				),
 			},
 		},
@@ -402,6 +432,22 @@ resource "huaweicloud_obs_bucket" "bucket" {
   tags = {
     key      = "value"
     multi_az = "3az"
+  }
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigParallelFS(randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket      = "tf-test-bucket-%d"
+  acl         = "private"
+  multi_az    = true
+  parallel_fs = true
+
+  tags = {
+    parallel_fs = "true"
+    multi_az    = "3az"
   }
 }
 `, randInt)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1312

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add "parallel_fs" argument;
2. Add "bucket_version" attribute;
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_basic -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (23.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       23.292s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_multiAZ'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_multiAZ -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_multiAZ
=== PAUSE TestAccObsBucket_multiAZ
=== CONT  TestAccObsBucket_multiAZ
--- PASS: TestAccObsBucket_multiAZ (10.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       10.817s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_parallelFS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_parallelFS -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== CONT  TestAccObsBucket_parallelFS
--- PASS: TestAccObsBucket_parallelFS (13.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       13.941s
```
