### PR TITLE
update test case for lb monitor

### DIFF
--- a/docs/resources/lb_monitor.md
+++ b/docs/resources/lb_monitor.md
@@ -2,20 +2,48 @@
 subcategory: "Elastic Load Balance (ELB)"
 ---
 
-# huaweicloud\_lb\_monitor
+# huaweicloud_lb_monitor
 
 Manages an ELB monitor resource within HuaweiCloud.
 This is an alternative to `huaweicloud_lb_monitor_v2`
 
 ## Example Usage
 
+### TCP Health Check
+
 ```hcl
-resource "huaweicloud_lb_monitor" "monitor_1" {
-  pool_id     = huaweicloud_lb_pool_v2.pool_1.id
-  type        = "PING"
-  delay       = 20
-  timeout     = 10
-  max_retries = 5
+resource "huaweicloud_lb_monitor" "monitor_tcp" {
+  pool_id     = var.pool_id
+  type        = "TCP"
+  delay       = 5
+  timeout     = 3
+  max_retries = 3
+}
+```
+
+### UDP Health Check
+
+```hcl
+resource "huaweicloud_lb_monitor" "monitor_udp" {
+  pool_id     = var.pool_id
+  type        = "UDP_CONNECT"
+  delay       = 5
+  timeout     = 3
+  max_retries = 3
+}
+```
+
+### HTTP Health Check
+
+```hcl
+resource "huaweicloud_lb_monitor" "monitor_http" {
+  pool_id        = var.pool_id
+  type           = "HTTP"
+  delay          = 5
+  timeout        = 3
+  max_retries    = 3
+  url_path       = "/test"
+  expected_codes = "200-202"
 }
 ```
 
@@ -27,45 +55,46 @@ The following arguments are supported:
     If omitted, the provider-level region will be used.
     Changing this creates a new monitor.
 
-* `pool_id` - (Required, String, ForceNew) The id of the pool that this monitor will be assigned to.
+* `pool_id` - (Required, String, ForceNew) Specifies the id of the pool that this monitor will be assigned to.
+    Changing this creates a new monitor.
 
-* `name` - (Optional, String) The Name of the Monitor.
+* `type` - (Required, String, ForceNew) Specifies the monitor protocol. The value can be *TCP*, *UDP_CONNECT*,
+    or *HTTP*. If the listener protocol is UDP, the monitor protocol must be *UDP_CONNECT*.
+    Changing this creates a new monitor.
 
-* `type` - (Required, String, ForceNew) The type of probe, which is PING, TCP, HTTP, or HTTPS,
-    that is sent by the load balancer to verify the member state. Changing this
-    creates a new monitor.
+* `delay` - (Required, Int) Specifies the maximum time between health checks in the unit of second.
+    The value ranges from 1 to 50.
 
-* `delay` - (Required, Int) The time, in seconds, between sending probes to members.
+* `timeout` - (Required, Int) Specifies the health check timeout duration in the unit of second.
+    The value ranges from 1 to 50 and must be less than the `delay` value.
 
-* `timeout` - (Required, Int) Maximum number of seconds for a monitor to wait for a
-    ping reply before it times out. The value must be less than the delay
-    value.
+* `max_retries` - (Required, Int) Specifies the maximum number of consecutive health checks after which
+    the backend servers are declared *healthy*. The value ranges from 1 to 10.
 
-* `max_retries` - (Required, Int) Number of permissible ping failures before
-    changing the member's status to INACTIVE. Must be a number between 1
-    and 10.
+    -> Backend servers can be declared *unhealthy* after **three** consecutive health checks that detect these
+    backend servers are unhealthy, regardless of the value set for `max_retries`. The health check time window is
+    determined by [Health Check Time Window](https://support.huaweicloud.com/intl/en-us/usermanual-elb/elb_ug_hc_0001.html#section4).
 
-* `port` - (Optional, Int) Specifies the health check port. The value ranges from 1 to 65535.
+* `name` - (Optional, String) Specifies the health check name. The value contains a maximum of 255 characters.
 
-* `url_path` - (Optional, String) Required for HTTP(S) types. URI path that will be
-    accessed if monitor type is HTTP or HTTPS.
+* `port` - (Optional, Int) Specifies the health check port. The port number ranges from 1 to 65535.
+    If not specified, the port of the backend server will be used as the health check port.
 
-*  `http_method` - (Optional, String) Required for HTTP(S) types. The HTTP method used
-    for requests by the monitor. If this attribute is not specified, it
-    defaults to "GET".
+* `url_path` - (Optional, String) Specifies the HTTP request path for the health check. Required for HTTP type.
+    The value starts with a slash (/) and contains a maximum of 255 characters.
 
-* `expected_codes` - (Optional, String) Required for HTTP(S) types. Expected HTTP codes
-    for a passing HTTP(S) monitor. You can either specify a single status like
-    "200", or a range like "200-202".
+* `http_method` - (Optional, String) Specifies the HTTP request method. Required for HTTP type.
+    The default value is *GET*.
 
-* `admin_state_up` - (Optional, Bool) The administrative state of the monitor.
-    A valid value is true (UP) or false (DOWN).
+* `expected_codes` - (Optional, String) Specifies the expected HTTP status code. Required for HTTP type.
+    You can either specify a single status like "200", or a range like "200-202".
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the monitor.
+* `admin_state_up` - The administrative state of the monitor.
 
 ## Timeouts
 This resource provides the following timeouts configuration options:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Monitor'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Monitor -timeout 360m -parallel 4
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== RUN   TestAccLBV2Monitor_udp
=== PAUSE TestAccLBV2Monitor_udp
=== RUN   TestAccLBV2Monitor_http
=== PAUSE TestAccLBV2Monitor_http
=== CONT  TestAccLBV2Monitor_basic
=== CONT  TestAccLBV2Monitor_http
=== CONT  TestAccLBV2Monitor_udp
--- PASS: TestAccLBV2Monitor_udp (107.46s)
--- PASS: TestAccLBV2Monitor_http (107.50s)
--- PASS: TestAccLBV2Monitor_basic (129.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       130.030s
```
