### PR TITLE
refactor: mark name and port as attributes for dcs_az data source

### DIFF
--- a/docs/data-sources/dcs_az.md
+++ b/docs/data-sources/dcs_az.md
@@ -2,37 +2,28 @@
 subcategory: "Distributed Cache Service"
 ---
 
-# huaweicloud\_dcs\_az
+# huaweicloud_dcs_az
 
 Use this data source to get the ID of an available Huaweicloud dcs az.
-This is an alternative to `huaweicloud_dcs_az_v1`
 
 ## Example Usage
 
 ```hcl
-
 data "huaweicloud_dcs_az" "az1" {
-  name = "AZ1"
-  port = "8004"
   code = "cn-north-1a"
 }
 ```
 
 ## Argument Reference
 
-For details, See [Querying AZ Information](https://support.huaweicloud.com/en-us/api-dcs/dcs-api-0312039.html).
-
 * `region` - (Optional, String) The region in which to obtain the dcs az. If omitted, the provider-level region will be used.
 
-* `name` - (Optional, String) Indicates the name of an AZ.
-
-* `code` - (Optional, String) Indicates the code of an AZ.
-
-* `port` - (Optional, String) Indicates the port number of an AZ.
-
+* `code` - (Required, String) Specifies the code of an AZ, e.g. "cn-north-1a".
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a data source ID in UUID format.
+* `id` - Indicates a data source ID in UUID format.
+* `name` - Indicates the name of an AZ.
+* `port` - Indicates the port number of an AZ.

--- a/huaweicloud/data_source_huaweicloud_availability_zones.go
+++ b/huaweicloud/data_source_huaweicloud_availability_zones.go
@@ -21,18 +21,18 @@ func DataSourceAvailabilityZones() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"state": {
+				Type:         schema.TypeString,
+				Default:      "available",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"available", "unavailable"}, false),
+			},
 			"names": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-			},
-			"state": {
-				Type:         schema.TypeString,
-				Default:      "available",
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"available", "unavailable"}, true),
 			},
 		},
 	}

--- a/huaweicloud/data_source_huaweicloud_dcs_az_v1.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_az_v1.go
@@ -1,12 +1,11 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dcs/v1/availablezones"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceDcsAZV1() *schema.Resource {
@@ -19,12 +18,12 @@ func DataSourceDcsAZV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"name": {
+			"code": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"code": {
+			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -40,9 +39,10 @@ func DataSourceDcsAZV1() *schema.Resource {
 
 func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	dcsV1Client, err := config.DcsV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating dcs key client: %s", err)
+		return fmtp.Errorf("Error creating DCS client: %s", err)
 	}
 
 	v, err := availablezones.Get(dcsV1Client).Extract()
@@ -50,12 +50,17 @@ func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	logp.Printf("[DEBUG] Dcs az : %+v", v)
+	logp.Printf("[DEBUG] fetching DCS available zones : %+v", v)
 	var filteredAZs []availablezones.AvailableZone
-	if v.RegionID == GetRegion(d, config) {
+	if v.RegionID == region {
 		AZs := v.AvailableZones
 		for _, newAZ := range AZs {
 			if newAZ.ResourceAvailability != "true" {
+				continue
+			}
+
+			code := d.Get("code").(string)
+			if code != "" && newAZ.Code != code {
 				continue
 			}
 
@@ -69,10 +74,6 @@ func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 				continue
 			}
 
-			code := d.Get("code").(string)
-			if code != "" && newAZ.Code != code {
-				continue
-			}
 			filteredAZs = append(filteredAZs, newAZ)
 		}
 	}
@@ -82,7 +83,7 @@ func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	az := filteredAZs[0]
-	logp.Printf("[DEBUG] Dcs az : %+v", az)
+	logp.Printf("[DEBUG] filter DCS available zone: %+v", az)
 
 	d.SetId(az.ID)
 	d.Set("code", az.Code)

--- a/huaweicloud/data_source_huaweicloud_dcs_az_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_dcs_az_v1_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDcsAZV1DataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_dcs_az.az1"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -18,9 +18,10 @@ func TestAccDcsAZV1DataSource_basic(t *testing.T) {
 			{
 				Config: testAccDcsAZV1DataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsAZV1DataSourceID("data.huaweicloud_dcs_az_v1.az1"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_dcs_az_v1.az1", "port", "8403"),
+					testAccCheckDcsAZV1DataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "code"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
 				),
 			},
 		},
@@ -31,11 +32,11 @@ func testAccCheckDcsAZV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find Dcs az data source: %s", n)
+			return fmt.Errorf("Can't find DCS az data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("Dcs az data source ID not set")
+			return fmt.Errorf("DCS az data source ID not set")
 		}
 
 		return nil
@@ -45,8 +46,7 @@ func testAccCheckDcsAZV1DataSourceID(n string) resource.TestCheckFunc {
 var testAccDcsAZV1DataSource_basic = fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_dcs_az_v1" "az1" {
+data "huaweicloud_dcs_az" "az1" {
   code = data.huaweicloud_availability_zones.test.names[0]
-  port = "8403"
 }
 `)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
users always can not how to set the value of `name` and `port`, so we can mark them as attributes.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDcsAZV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDcsAZV1DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsAZV1DataSource_basic
=== PAUSE TestAccDcsAZV1DataSource_basic
=== CONT  TestAccDcsAZV1DataSource_basic
--- PASS: TestAccDcsAZV1DataSource_basic (10.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       (10.396s)
```
