### PR TITLE
New MRS v2 job resource

### DIFF
--- a/docs/resources/mapreduce_job.md
+++ b/docs/resources/mapreduce_job.md
@@ -11,14 +11,16 @@ Manage a job resource within HuaweiCloud MRS.
 ```hcl
 variable "cluster_id" {}
 variable "job_name" {}
-variable "jar_path" {}
+variable "program_path" {}
+variable "access_key" {}
+variable "secret_key" {}
 
 resource "huaweicloud_mapreduce_job" "test" {
-  cluster_id = var.cluster_id
-  type       = "SparkSubmit"
-  name       = var.job_name
-  jar_path   = var.jar_path
-  parameters = "ACCESS_KEY SECRET_KEY 1 obs://obs-demo-analysis-tf/input obs://obs-demo-analysis-tf/output"
+  cluster_id   = var.cluster_id
+  type         = "SparkSubmit"
+  name         = var.job_name
+  program_path = var.program_path
+  parameters   = "${var.access_key} ${var.secret_key} 1 obs://obs-demo-analysis/input obs://obs-demo-analysis/output"
 
   program_parameters = {
     "--class" = "com.huawei.bigdata.spark.examples.DriverBehavior"
@@ -43,8 +45,6 @@ The following arguments are supported:
   underscores (_) and hyphens (-).
   Changing this will create a new MapReduce job resource.
 
-  -> **NOTE:** Identical job names are allowed but not recommended.
-
 * `type` - (Required, String, ForceNew) Specifies the job type.
   The valid values are as <span id="jump">follows</span>:
   - [Flink](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0527.html)
@@ -53,17 +53,19 @@ The following arguments are supported:
   - [MapReduce](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0052.html)
   - [SparkSubmit](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0524.html)
   - [SparkSql](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0526.html)
-  - [SparkScript](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0526.html).
+  - [SparkScript](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0526.html)
 
   Changing this will create a new MapReduce job resource.
 
   -> **NOTE:** Spark and Hive jobs can be added to only clusters including Spark and Hive components.
 
-* `jar_path` - (Optional, String, ForceNew) Specifies the .jar package path for program execution.
+* `program_path` - (Optional, String, ForceNew) Specifies the .jar package path or .py file path for program execution.
   The parameter must meet the following requirements:
   - Contains a maximum of 1023 characters, excluding special characters such as `;|&><'$`.
   - The address cannot be empty or full of spaces.
-  - Starts with (OBS:) obs:// and end with .jar or starts with (DHFS:) /user.
+  - The program support OBS or DHFS to storage program file or package:
+      - Starts with (OBS:) obs:// and end with .jar or .py
+      - Starts with (DHFS:) /user
 
   Required if `type` is __MapReduce__ or __SparkSubmit__.
   Changing this will create a new MapReduce job resource.
@@ -78,7 +80,7 @@ The following arguments are supported:
   thread, memory, and vCPUs, are used to optimize resource usage and improve job execution performance.
   This parameter can be set when `type` is __Flink__, __SparkSubmit__, __SparkSql__, __SparkScript__, __HiveSql__ or
   __HiveScript__.
-  Refer to the documents for each [type](#jump) of support value.
+  Refer to the documents for each [type](#jump) of support key-values.
   Changing this will create a new MapReduce job resource.
 
 * `service_parameters` - (Optional, Map, ForceNew) Specifies the key/value pairs used to modify service configuration.
@@ -100,13 +102,16 @@ In addition to all arguments above, the following attributes are exported:
 * `finish_time` - The completion time of the MapReduce job, in 13-bit timestamp format.
 
 ## Timeouts
+
 This resource provides the following timeouts configuration options:
+
 - `create` - Default is 20 minute.
 
 ## Import
 
 MapReduce jobs can be imported using their `id` and the IDs of the MapReduce cluster to which the job belongs,
 separated by a slash, e.g.
+
 ```
 $ terraform import huaweicloud_mapreduce_job.test <cluster_id>/<id>
 ```

--- a/docs/resources/mapreduce_job.md
+++ b/docs/resources/mapreduce_job.md
@@ -1,0 +1,112 @@
+---
+subcategory: "MapReduce Service (MRS)"
+---
+
+# huaweicloud_mapreduce_job
+
+Manage a job resource within HuaweiCloud MRS.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "job_name" {}
+variable "jar_path" {}
+
+resource "huaweicloud_mapreduce_job" "test" {
+  cluster_id = var.cluster_id
+  type       = "SparkSubmit"
+  name       = var.job_name
+  jar_path   = var.jar_path
+  parameters = "ACCESS_KEY SECRET_KEY 1 obs://obs-demo-analysis-tf/input obs://obs-demo-analysis-tf/output"
+
+  program_parameters = {
+    "--class" = "com.huawei.bigdata.spark.examples.DriverBehavior"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the MapReduce job resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new MapReduce job resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies an ID of the MapReduce cluster to which the
+  job belongs to.
+  Changing this will create a new MapReduce job resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the MapReduce job.
+  The name can contain 1 to 64 characters, which may consist of letters, digits,
+  underscores (_) and hyphens (-).
+  Changing this will create a new MapReduce job resource.
+
+  -> **NOTE:** Identical job names are allowed but not recommended.
+
+* `type` - (Required, String, ForceNew) Specifies the job type.
+  The valid values are as <span id="jump">follows</span>:
+  - [Flink](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0527.html)
+  - [HiveSql](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0525.html)
+  - [HiveScript](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0525.html)
+  - [MapReduce](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0052.html)
+  - [SparkSubmit](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0524.html)
+  - [SparkSql](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0526.html)
+  - [SparkScript](https://support.huaweicloud.com/intl/en-us/usermanual-mrs/mrs_01_0526.html).
+
+  Changing this will create a new MapReduce job resource.
+
+  -> **NOTE:** Spark and Hive jobs can be added to only clusters including Spark and Hive components.
+
+* `jar_path` - (Optional, String, ForceNew) Specifies the .jar package path for program execution.
+  The parameter must meet the following requirements:
+  - Contains a maximum of 1023 characters, excluding special characters such as `;|&><'$`.
+  - The address cannot be empty or full of spaces.
+  - Starts with (OBS:) obs:// and end with .jar or starts with (DHFS:) /user.
+
+  Required if `type` is __MapReduce__ or __SparkSubmit__.
+  Changing this will create a new MapReduce job resource.
+
+* `parameters` - (Optional, String, ForceNew) Specifies the parameters for the MapReduce job.
+  Add an at sign (@) before each parameter can prevent the parameters being saved in plaintext format.
+  Each parameters are separated with spaces.
+  This parameter can be set when `type` is __Flink__, __MapReduce__ or __SparkSubmit__.
+  Changing this will create a new MapReduce job resource.
+
+* `program_parameters` - (Optional, Map, ForceNew) Specifies the the key/value pairs of the program parameters, such as
+  thread, memory, and vCPUs, are used to optimize resource usage and improve job execution performance.
+  This parameter can be set when `type` is __Flink__, __SparkSubmit__, __SparkSql__, __SparkScript__, __HiveSql__ or
+  __HiveScript__.
+  Refer to the documents for each [type](#jump) of support value.
+  Changing this will create a new MapReduce job resource.
+
+* `service_parameters` - (Optional, Map, ForceNew) Specifies the key/value pairs used to modify service configuration.
+  Parameter configurations of services are available on the Service Configuration tab page of MapReduce Manager.
+  Changing this will create a new MapReduce job resource.
+
+* `sql` - (Optional, String, ForceNew) Specifies the SQL command or file path.
+  Only required if `type` is __HiveSql__ or __SparkSql__.
+  Changing this will create a new MapReduce job resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the MapReduce job in UUID format.
+* `status` - Status of the MapReduce job.
+* `start_time` - The creation time of the MapReduce job, in 13-bit timestamp format.
+* `submit_time` - The submission time of the MapReduce job, in 13-bit timestamp format.
+* `finish_time` - The completion time of the MapReduce job, in 13-bit timestamp format.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 20 minute.
+
+## Import
+
+MapReduce jobs can be imported using their `id` and the IDs of the MapReduce cluster to which the job belongs,
+separated by a slash, e.g.
+```
+$ terraform import huaweicloud_mapreduce_job.test <cluster_id>/<id>
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883
+	github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210729121530-85c6b7af2ad2 h1:nel1BOE/C
 github.com/huaweicloud/golangsdk v0.0.0-20210729121530-85c6b7af2ad2/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883 h1:4D/N05uptrcZuErPVCHeRJ89ND1RnZoVYjjCIfTflRs=
 github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a h1:yJda8qxR3mnJydpPlJ4MgYGZD8nO7eDwGSm52lbwSvw=
+github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -477,6 +477,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_oms_task":                        resourceMaasTaskV1(),
 			"huaweicloud_mls_instance":                    resourceMlsInstance(),
 			"huaweicloud_mapreduce_cluster":               mrs.ResourceMRSClusterV2(),
+			"huaweicloud_mapreduce_job":                   mrs.ResourceMRSJobV2(),
 			"huaweicloud_mrs_cluster":                     ResourceMRSClusterV1(),
 			"huaweicloud_mrs_job":                         ResourceMRSJobV1(),
 			"huaweicloud_nat_dnat_rule":                   ResourceNatDnatRuleV2(),

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_job_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_job_test.go
@@ -1,0 +1,163 @@
+package mrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccMrsMapReduceJob_basic(t *testing.T) {
+	var job jobs.Job
+	resourceName := "huaweicloud_mapreduce_job.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	pwd := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckMRSV2JobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceJobConfig_basic(rName, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2JobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "SparkSubmit"),
+					resource.TestCheckResourceAttr(resourceName, "jar_path",
+						"obs://obs-demo-analysis-tf/program/driver_behavior.jar"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccMRSClusterSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckMRSV2JobDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.MrsV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating huaweicloud mrs: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_mapreduce_job" {
+			continue
+		}
+
+		_, err := jobs.Get(client, rs.Primary.Attributes["cluster_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+			return fmt.Errorf("MRS cluster (%s) is still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMRSV2JobExists(n string, job *jobs.Job) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No MRS cluster ID")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.MrsV2Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating huaweicloud MRS client: %s ", err)
+		}
+
+		found, err := jobs.Get(client, rs.Primary.Attributes["cluster_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*job = *found
+		return nil
+	}
+}
+
+func testAccMRSClusterSubResourceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["cluster_id"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["cluster_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["cluster_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccMrsMapReduceJobConfig_base(rName, pwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_mapreduce_cluster" "test" {
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%s"
+  type               = "ANALYSIS"
+  version            = "MRS 1.9.2"
+  manager_admin_pass = "%s"
+  node_admin_pass    = "%s"
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = huaweicloud_vpc.test.id
+  component_list     = ["Hadoop", "Hive", "Tez"]
+
+  master_nodes {
+    flavor            = "c6.2xlarge.4.linux.bigdata"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_core_nodes {
+    flavor            = "c6.2xlarge.4.linux.bigdata"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd, pwd)
+}
+
+func testAccMrsMapReduceJobConfig_basic(rName, pwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_mapreduce_job" "test" {
+  cluster_id = huaweicloud_mapreduce_cluster.test.id
+  name       = "%s"
+  type       = "SparkSubmit"
+  jar_path   = "obs://obs-demo-analysis-tf/program/driver_behavior.jar"
+  parameters = "%s %s 1 obs://obs-demo-analysis-tf/input obs://obs-demo-analysis-tf/output"
+
+  program_parameters = {
+    "--class" = "com.huawei.bigdata.spark.examples.DriverBehavior"
+  }
+}`, testAccMrsMapReduceJobConfig_base(rName, pwd), rName, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_job_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_job_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	mrsRes "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mrs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
@@ -31,8 +32,8 @@ func TestAccMrsMapReduceJob_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMRSV2JobExists(resourceName, &job),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "type", "SparkSubmit"),
-					resource.TestCheckResourceAttr(resourceName, "jar_path",
+					resource.TestCheckResourceAttr(resourceName, "type", mrsRes.JobSparkSubmit),
+					resource.TestCheckResourceAttr(resourceName, "program_path",
 						"obs://obs-demo-analysis-tf/program/driver_behavior.jar"),
 				),
 			},
@@ -150,11 +151,11 @@ func testAccMrsMapReduceJobConfig_basic(rName, pwd string) string {
 %s
 
 resource "huaweicloud_mapreduce_job" "test" {
-  cluster_id = huaweicloud_mapreduce_cluster.test.id
-  name       = "%s"
-  type       = "SparkSubmit"
-  jar_path   = "obs://obs-demo-analysis-tf/program/driver_behavior.jar"
-  parameters = "%s %s 1 obs://obs-demo-analysis-tf/input obs://obs-demo-analysis-tf/output"
+  cluster_id   = huaweicloud_mapreduce_cluster.test.id
+  name         = "%s"
+  type         = "SparkSubmit"
+  program_path = "obs://obs-demo-analysis-tf/program/driver_behavior.jar"
+  parameters   = "%s %s 1 obs://obs-demo-analysis-tf/input obs://obs-demo-analysis-tf/output"
 
   program_parameters = {
     "--class" = "com.huawei.bigdata.spark.examples.DriverBehavior"

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_job.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_job.go
@@ -1,0 +1,525 @@
+package mrs
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func ResourceMRSJobV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMRSJobV2Create,
+		Read:   resourceMRSJobV2Read,
+		Delete: resourceMRSJobV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceMRSClusterSubResourceImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[A-Za-z0-9_-]{1,64}$"),
+					"The name consists of 1 to 64 characters, which only letters, digits, hyphens (-) and "+
+						"underscores (_) are allowed."),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Flink", "HiveSql", "HiveScript", "MapReduce", "SparkSubmit", "SparkSql", "SparkScript",
+				}, false),
+			},
+			"jar_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"parameters": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"program_parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"service_parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"sql": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"submit_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"finish_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildMRSJobProgramParameters(programs map[string]interface{}) []string {
+	result := make([]string, 0)
+	for k, v := range programs {
+		result = append(result, k)
+		result = append(result, v.(string))
+	}
+	logp.Printf("[DEBUG] The program parameters are: %+v", result)
+	return result
+}
+
+func buildMRSJobParameters(parameters string) []string {
+	return strings.Split(parameters, " ")
+}
+
+// The Request arguments of the flink job is: run -d <program parameters> -m yarn-cluster <jar path> <parameters>.
+func buildMRSFlinkJobRequestArguments(d *schema.ResourceData) []string {
+	programsMap := d.Get("program_parameters").(map[string]interface{})
+	programs := buildMRSJobProgramParameters(programsMap)
+	parameters := buildMRSJobParameters(d.Get("parameters").(string))
+	// The capacity of the result array is the sum of the respective lengths of 'run', '-d', '-m', 'yarn-cluster',
+	// jar path, program parameters and parameters.
+	result := make([]string, 0, 5+len(programs)+len(parameters))
+
+	result = append(result, "run")
+	result = append(result, "-d")
+	result = append(result, programs...)
+	result = append(result, "-m")
+	result = append(result, "yarn-cluster")
+	result = append(result, d.Get("jar_path").(string))
+	result = append(result, parameters...)
+
+	return result
+}
+
+// The request arguments of the SQL job is: <program parameters> <sql (file or path)>.
+func buildMRSSQLJobRequestArguments(d *schema.ResourceData) []string {
+	programsMap := d.Get("program_parameters").(map[string]interface{})
+	programs := buildMRSJobProgramParameters(programsMap)
+	// The capacity of the result array is the sum of the respective lengths of program parameters and sql parameter.
+	result := make([]string, 0, 1+len(programs))
+
+	result = append(result, programs...)
+	result = append(result, d.Get("sql").(string))
+
+	return result
+}
+
+// The request arguments of the MapReduce job is: <jar path> <parameters>.
+func buildMRSMapReduceJobRequestArguments(d *schema.ResourceData) []string {
+	parameters := buildMRSJobParameters(d.Get("parameters").(string))
+	// The capacity of the result array is the sum of the respective lengths of jar path and parameter.
+	result := make([]string, 0, 1+len(parameters))
+
+	result = append(result, d.Get("jar_path").(string))
+	result = append(result, parameters...)
+	return result
+}
+
+// The request arguments of the SparkSubmit job is: <program parameters> --master yarn-cluster <jar path> <parameters>.
+func buildMRSSparkSubmitJobRequestArguments(d *schema.ResourceData) []string {
+	programsMap := d.Get("program_parameters").(map[string]interface{})
+	programs := buildMRSJobProgramParameters(programsMap)
+	parameters := buildMRSJobParameters(d.Get("parameters").(string))
+
+	// The capacity of the result array is the sum of the respective lengths of '--master', 'yarn-cluster', jar path,
+	// program parameters and parameters.
+	result := make([]string, 3+len(programs)+len(parameters))
+
+	result = append(result, programs...)
+	result = append(result, "--master")
+	result = append(result, "yarn-cluster")
+	result = append(result, d.Get("jar_path").(string))
+	result = append(result, parameters...)
+
+	return result
+}
+
+func buildMRSJobProperties(d *schema.ResourceData) map[string]string {
+	result := make(map[string]string)
+	properties := d.Get("service_parameters").(map[string]interface{})
+	for k, v := range properties {
+		result[k] = v.(string)
+	}
+	logp.Printf("[DEBUG] The properties are: %+v", result)
+	return result
+}
+
+func buildMRSJobCreateParameters(d *schema.ResourceData) jobs.CreateOpts {
+	opts := jobs.CreateOpts{
+		JobType:    d.Get("type").(string),
+		JobName:    d.Get("name").(string),
+		Properties: buildMRSJobProperties(d),
+	}
+	switch d.Get("type").(string) {
+	case "Flink":
+		opts.Arguments = buildMRSFlinkJobRequestArguments(d)
+	case "HiveSql", "HiveScript", "SparkSql", "SparkScript":
+		opts.Arguments = buildMRSSQLJobRequestArguments(d)
+	case "MapReduce":
+		opts.Arguments = buildMRSMapReduceJobRequestArguments(d)
+	default:
+		opts.Arguments = buildMRSSparkSubmitJobRequestArguments(d)
+	}
+	return opts
+}
+
+func resourceMRSJobV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.MrsV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating Huaweicloud MRS V2 client: %s", err)
+	}
+
+	opts := buildMRSJobCreateParameters(d)
+	clusterId := d.Get("cluster_id").(string)
+	resp, err := jobs.Create(client, clusterId, opts).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error execution MapReduce job: %s", err)
+	}
+	d.SetId(resp.JobSubmitResult.JobId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"NEW", "NEW_SAVING", "ACCEPTED", "SUBMITTED", "RUNNING"},
+		Target:       []string{"FINISHED", "FAILED"},
+		Refresh:      mrsJobStateRefreshFunc(client, clusterId, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        30 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmtp.Errorf("Error waiting for job (%s) to become ready: %s ", d.Id(), err)
+	}
+
+	return resourceMRSJobV2Read(d, meta)
+}
+
+func mrsJobStateRefreshFunc(client *golangsdk.ServiceClient, clusterId, jobId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := jobs.Get(client, clusterId, jobId).Extract()
+		if err != nil {
+			if utils.IsResourceNotFound(err) {
+				return resp, "DELETED", nil
+			}
+			return nil, "", err
+		}
+		return resp, resp.JobState, nil
+	}
+}
+
+// The arguments (/program parameters) of the response is a list string.
+// For example: "["run", "-d", "-m", "yarn-cluster", "obs://obs-demo-analysis-tf/program/driver_behavior.jar"]".
+func makeMRSArgumentsByString(str string) []string {
+	regex := regexp.MustCompile(`^\[(.*)\]$`)
+	result := regex.FindAllStringSubmatch(str, -1)
+	if len(result) != 0 && len(result[0]) != 0 {
+		str := result[0][1]
+		// Separate all elements based on commas.
+		return strings.Split(str, ", ")
+	}
+	return []string{}
+}
+
+// The string arguments of the flink job is: 'run -d <program parameters> -m yarn-cluster <parameters>'.
+func makeMRSFlinkJobParameters(job *jobs.Job) (string, string, map[string]interface{}, error) {
+	programs := make(map[string]interface{})
+	arguments := makeMRSArgumentsByString(job.Arguments)
+	// The arguments must contain a head of 'run' and '-d'.
+	if len(arguments) < 2 {
+		return "", "", programs, fmtp.Errorf("Wrong flink arguments length of the API response")
+	}
+	arguments = arguments[2:] // remove 'run -d' program argument.
+	for arguments[0] != "-m" && len(arguments) > 1 {
+		programs[arguments[0]] = arguments[1]
+		arguments = arguments[2:]
+	}
+	// The remaining elements of arguments must contain '-m', 'yarn-cluster' and jar path.
+	if len(arguments) < 3 {
+		return "", "", programs, fmtp.Errorf("Wrong flink arguments length of the API response")
+	}
+	arguments = arguments[2:] // remove '-m yarn-cluster'.
+	// get jar path and remove it from argument list.
+	jarPath := arguments[0]
+	arguments = arguments[1:] // remove jar path.
+	parameters := strings.Join(arguments, " ")
+	return jarPath, parameters, programs, nil
+}
+
+// The string arguments of the flink job is: '<program parameters> <sql statement/file path>'.
+func makeMRSSQLJobParameters(job *jobs.Job) (string, map[string]interface{}, error) {
+	programs := make(map[string]interface{})
+	arguments := makeMRSArgumentsByString(job.Arguments)
+	for len(arguments) > 1 {
+		// The program parameters in the state is a map.
+		programs[arguments[0]] = arguments[1]
+		arguments = arguments[2:]
+	}
+	if len(arguments) < 1 {
+		return "", programs, fmtp.Errorf("The arguments of the API response has not contain statement of SQL file")
+	}
+	return arguments[0], programs, nil
+}
+
+// The string arguments of the flink job is: '<jar path> <parameters>'.
+func makeMRSMapReduceJobParameters(job *jobs.Job) (string, string, error) {
+	arguments := makeMRSArgumentsByString(job.Arguments)
+	// The arguments must contain jar path.
+	if len(arguments) < 1 {
+		return "", "", fmtp.Errorf("Wrong arguments length of the API response")
+	}
+	// get jar path and remove it from argument list.
+	jarPath := arguments[0]
+	arguments = arguments[1:]
+	// get parameters string.
+	parameters := strings.Join(arguments, " ")
+
+	return jarPath, parameters, nil
+}
+
+// The string arguments of the flink job is: '<program parameters> --master yarn-cluster <jar path> <parameters>'.
+func makeMRSSparkSubmitJobParameters(job *jobs.Job) (string, string, map[string]interface{}, error) {
+	programs := make(map[string]interface{})
+	arguments := makeMRSArgumentsByString(job.Arguments)
+
+	for arguments[0] != "--master" && len(arguments) > 1 {
+		// The program parameters in the state is a map.
+		programs[arguments[0]] = arguments[1]
+		arguments = arguments[2:]
+	}
+	// The remaining elements of arguments must contain '--master', 'yarn-cluster' and jar path.
+	if len(arguments) < 3 {
+		return "", "", programs, fmtp.Errorf("Wrong arguments length of the API response")
+	}
+	arguments = arguments[2:] // remove '--master' and 'yarn-clsuter' program arguments.
+	// get jar path and remove it from argument list.
+	jarPath := arguments[0]
+	arguments = arguments[1:]
+	// get parameters string.
+	parameters := strings.Join(arguments, " ")
+
+	return jarPath, parameters, programs, nil
+}
+
+func setMRSFlinkJob(d *schema.ResourceData, resp *jobs.Job) error {
+	jarPath, parameters, programs, err := makeMRSFlinkJobParameters(resp)
+	if err != nil {
+		return err
+	}
+
+	mErr := multierror.Append(
+		d.Set("jar_path", jarPath),
+		d.Set("parameters", parameters),
+		d.Set("program_parameters", programs),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.Errorf("Error setting job fields(: jar path, parameters or program parameters): %s", err)
+	}
+
+	return nil
+}
+
+func setMRSSQLJob(d *schema.ResourceData, resp *jobs.Job) error {
+	statement, programs, err := makeMRSSQLJobParameters(resp)
+	if err != nil {
+		return err
+	}
+
+	mErr := multierror.Append(
+		d.Set("sql", statement),
+		d.Set("program_parameters", programs),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.Errorf("Error setting job fields(: sql or program parameters): %s", err)
+	}
+
+	return nil
+}
+
+func setMRSMapReduceSubmitJob(d *schema.ResourceData, resp *jobs.Job) error {
+	jarPath, parameters, err := makeMRSMapReduceJobParameters(resp)
+	if err != nil {
+		return err
+	}
+
+	mErr := multierror.Append(
+		d.Set("jar_path", jarPath),
+		d.Set("parameters", parameters),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.Errorf("Error setting job fields (jar path or parameters): %s", err)
+	}
+
+	return nil
+}
+
+func setMRSSparkSubmitJob(d *schema.ResourceData, resp *jobs.Job) error {
+	jarPath, parameters, programs, err := makeMRSSparkSubmitJobParameters(resp)
+	if err != nil {
+		return err
+	}
+
+	mErr := multierror.Append(
+		d.Set("jar_path", jarPath),
+		d.Set("parameters", parameters),
+		d.Set("program_parameters", programs),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.Errorf("Error setting job fields(: jar path, parameters or program parameters): %s", err)
+	}
+
+	return nil
+}
+
+func setMRSJobParametersByArguments(d *schema.ResourceData, job *jobs.Job) error {
+	switch job.JobType {
+	case "HiveSql", "SparkSql", "HiveScript", "SparkScript":
+		return setMRSSQLJob(d, job)
+	case "MapReduce":
+		return setMRSMapReduceSubmitJob(d, job)
+	case "Flink":
+		return setMRSFlinkJob(d, job)
+	default:
+		return setMRSSparkSubmitJob(d, job)
+	}
+}
+
+// The properties of the response is a map string, and the separator between key and value is the equal sign (=).
+// For example: "{fs.obs.access.key=xxx, fs.obs.secret.key=xxx}".
+func setMRSJobProperties(d *schema.ResourceData, resp string) error {
+	properties := make(map[string]interface{})
+	// Remove the braces around the map string.
+	regex := regexp.MustCompile(`^{(.*)}$`)
+	result := regex.FindAllStringSubmatch(resp, -1)
+	if len(result) != 0 && len(result[0]) != 0 {
+		str := result[0][1]
+		if str == "" {
+			return nil
+		}
+		// Separate all key-value pairs based on commas.
+		elements := strings.Split(str, ", ")
+		for _, element := range elements {
+			property := strings.SplitN(element, "=", 2)
+			if len(property) == 2 {
+				properties[property[0]] = property[1]
+				continue
+			}
+			return fmtp.Errorf("The property (%s) of the MRS job is invalid", element)
+		}
+	}
+
+	return d.Set("service_parameters", properties)
+}
+
+func resourceMRSJobV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.MrsV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud MRS client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	resp, err := jobs.Get(client, clusterId, d.Id()).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error getting MRS job form server: %s", err)
+	}
+
+	logp.Printf("[DEBUG] Retrieved MRS job (%s): %+v", d.Id(), resp)
+	d.SetId(resp.JobId)
+	mErr := multierror.Append(
+		d.Set("region", config.GetRegion(d)),
+		d.Set("type", resp.JobType),
+		d.Set("name", resp.JobName),
+		d.Set("status", resp.JobState),
+		d.Set("start_time", resp.StartedTime),
+		d.Set("submit_time", resp.SubmittedTime),
+		d.Set("finish_time", resp.FinishedTime),
+		setMRSJobParametersByArguments(d, resp),
+		setMRSJobProperties(d, resp.Properties),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.Errorf("Error setting MRS job fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourceMRSJobV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.MrsV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud MRS client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	opts := jobs.DeleteOpts{
+		JobIds: []string{d.Id()},
+	}
+	err = jobs.Delete(client, clusterId, opts).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("Error deleting HuaweiCloud MRS job: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceMRSClusterSubResourceImportState(d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmtp.Errorf("Invalid format specified for import IDs, must be <cluster_id>/<id>")
+	}
+	d.SetId(parts[1])
+	d.Set("cluster_id", parts[0])
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs/requests.go
@@ -1,0 +1,177 @@
+package jobs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// CreateOpts is a structure representing information of the job creation.
+type CreateOpts struct {
+	// Type of a job, and the valid values are as follows:
+	//   MapReduce
+	//   SparkSubmit
+	//   HiveScript
+	//   HiveSql
+	//   DistCp, importing and exporting data
+	//   SparkScript
+	//   SparkSql
+	//   Flink
+	// NOTE:
+	//   Spark, Hive, and Flink jobs can be added to only clusters that include Spark, Hive, and Flink components.
+	JobType string `json:"job_type" required:"true"`
+	// Job name. It contains 1 to 64 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// NOTE:
+	// Identical job names are allowed but not recommended.
+	JobName string `json:"job_name" required:"true"`
+	// Key parameter for program execution.
+	// The parameter is specified by the function of the user's program.
+	// MRS is only responsible for loading the parameter.
+	// The parameter contains a maximum of 4,096 characters, excluding special characters such as ;|&>'<$,
+	// and can be left blank.
+	// NOTE:
+	//   If you enter a parameter with sensitive information (such as the login password), the parameter may be exposed
+	//   in the job details display and log printing. Exercise caution when performing this operation.
+	//   For MRS 1.9.2 or later, a file path on OBS can start with obs://. To use this format to submit HiveScript or
+	//   HiveSQL jobs, choose Components > Hive > Service Configuration on the cluster details page, set Type to All,
+	//   and search for core.site.customized.configs. Add the endpoint configuration item (fs.obs.endpoint) of OBS and
+	//   enter the endpoint corresponding to OBS in Value. Obtain the value from Regions and Endpoints.
+	//   For MRS 3.0.2 or later, a file path on OBS can start with obs://. To use this format to submit HiveScript or
+	//   HiveSQL jobs, choose Components > Hive > Service Configuration on Manager. Switch Basic to All, and search for
+	//   core.site.customized.configs. Add the endpoint configuration item (fs.obs.endpoint) of OBS and enter the
+	//   endpoint corresponding to OBS in Value. Obtain the value from Regions and Endpoints.
+	Arguments []string `json:"arguments,omitempty"`
+	// Program system parameter.
+	// The parameter contains a maximum of 2,048 characters, excluding special characters such as ><|'`&!\, and can be
+	// left blank.
+	Properties map[string]string `json:"properties,omitempty"`
+}
+
+// CreateOptsBuilder is an interface which to support request body build of the job creation.
+type CreateOptsBuilder interface {
+	ToJobCreateMap() (map[string]interface{}, error)
+}
+
+// ToJobCreateMap is a method which to build a request body by the CreateOpts.
+func (opts CreateOpts) ToJobCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method to create a new mapreduce job.
+func Create(client *golangsdk.ServiceClient, clusterId string, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToJobCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, clusterId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to get an existing mapreduce job by cluster ID and job ID.
+func Get(client *golangsdk.ServiceClient, clsuterId, jobId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, clsuterId, jobId), &r.Body, nil)
+	return
+}
+
+// ListOpts is a structure representing information of the job updation.
+type ListOpts struct {
+	// Job name. It contains 1 to 64 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	JobName string `q:"job_name"`
+	// Type of a job, and the valid values are as follows:
+	//   MapReduce
+	//   SparkSubmit
+	//   HiveScript
+	//   HiveSql
+	//   DistCp, importing and exporting data
+	//   SparkScript
+	//   SparkSql
+	//   Flink
+	JobType string `q:"job_type"`
+	// Execution status of a job.
+	//   FAILED: indicates that the job fails to be executed.
+	//   KILLED: indicates that the job is terminated.
+	//   New: indicates that the job is created.
+	//   NEW_SAVING: indicates that the job has been created and is being saved.
+	//   SUBMITTED: indicates that the job is submitted.
+	//   ACCEPTED: indicates that the job is accepted.
+	//   RUNNING: indicates that the job is running.
+	//   FINISHED: indicates that the job is completed.
+	JobState string `q:"job_state"`
+	// Execution result of a job.
+	//   FAILED: indicates that the job fails to be executed.
+	//   KILLED: indicates that the job is manually terminated during execution.
+	//   UNDEFINED: indicates that the job is being executed.
+	//   SUCCEEDED: indicates that the job has been successfully executed.
+	JobResult string `q:"job_result"`
+	// Number of records displayed on each page in the returned result. The default value is 10.
+	Limit int `q:"limit"`
+	// Offset.
+	// The default offset from which the job list starts to be queried is 1.
+	Offset int `q:"offset"`
+	// Ranking mode of returned results. The default value is desc.
+	//   asc: indicates that the returned results are ranked in ascending order.
+	//   desc: indicates that the returned results are ranked in descending order.
+	SortBy string `q:"sort_by"`
+	// UTC timestamp after which a job is submitted, in milliseconds. For example, 1562032041362.
+	SubmittedTimeBegin int `q:"submitted_time_begin"`
+	// UTC timestamp before which a job is submitted, in milliseconds. For example, 1562032041362.
+	SubmittedTimeEnd int `q:"submitted_time_end"`
+}
+
+// ListOptsBuilder is an interface which to support request query build of the job list operation.
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+// ToListQuery is a method which to build a request query by the ListOpts.
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more mapreduce jobs according to the query parameters.
+func List(client *golangsdk.ServiceClient, clusterId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, clusterId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return JobPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// DeleteOpts is a structure representing information of the job delete operation.
+type DeleteOpts struct {
+	JobIds []string `json:"job_id_list,omitempty"`
+}
+
+// DeleteOptsBuilder is an interface which to support request body build of the job delete operation.
+type DeleteOptsBuilder interface {
+	ToJobDeleteMap() (map[string]interface{}, error)
+}
+
+// ToJobDeleteMap is a method which to build a request body by the DeleteOpts.
+func (opts DeleteOpts) ToJobDeleteMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Delete is a method to delete an existing mapreduce job.
+func Delete(client *golangsdk.ServiceClient, clusterId string, opts DeleteOptsBuilder) (r DeleteResult) {
+	reqBody, err := opts.ToJobDeleteMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(deleteURL(client, clusterId), reqBody, nil, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs/results.go
@@ -1,0 +1,127 @@
+package jobs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// CreateResp is a struct that represents the result of Create methods.
+type CreateResp struct {
+	// Job execution result
+	JobSubmitResult JobResp `json:"job_submit_result"`
+	// Error message
+	ErrorMsg string `json:"error_msg"`
+	// Error code
+	ErrorCode string `json:"error_code"`
+}
+
+// JobResp is an object struct that represents the details of the submit result.
+type JobResp struct {
+	// Job ID
+	JobId string `json:"job_id"`
+	// Job submission status.
+	// COMPLETE: The job is submitted.
+	// JOBSTAT_SUBMIT_FAILED: Failed to submit the job.
+	State string `json:"state"`
+}
+
+// Extract is a method which to extract a creation response.
+func (r CreateResult) Extract() (*CreateResp, error) {
+	var s CreateResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// Job is a struct that represents the details of the mapreduce job.
+type Job struct {
+	// Job ID.
+	JobId string `json:"job_id"`
+	// Name of the user who submits a job.
+	User string `json:"user"`
+	// Job name. It contains 1 to 64 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	JobName string `json:"job_name"`
+	// Final result of a job.
+	//   FAILED: indicates that the job fails to be executed.
+	//   KILLED: indicates that the job is manually terminated during execution.
+	//   UNDEFINED: indicates that the job is being executed.
+	//   SUCCEEDED: indicates that the job has been successfully executed.
+	JobResult string `json:"job_result"`
+	// Execution status of a job.
+	//   FAILED: failed
+	//   KILLED: indicates that the job is terminated.
+	//   New: indicates that the job is created.
+	//   NEW_SAVING: indicates that the job has been created and is being saved.
+	//   SUBMITTED: indicates that the job is submitted.
+	//   ACCEPTED: indicates that the job is accepted.
+	//   RUNNING: indicates that the job is running.
+	//   FINISHED: indicates that the job is completed.
+	JobState string `json:"job_state"`
+	// Job execution progress.
+	JobProgress float32 `json:"job_progress"`
+	// Type of a job, which support:
+	//   MapReduce
+	//   SparkSubmit
+	//   HiveScript
+	//   HiveSql
+	//   DistCp, importing and exporting data
+	//   SparkScript
+	//   SparkSql
+	//   Flink
+	JobType string `json:"job_type"`
+	// Start time to run a job. Unit: ms.
+	StartedTime int `json:"started_time"`
+	// Time when a job is submitted. Unit: ms.
+	SubmittedTime int `json:"submitted_time"`
+	// End time to run a job. Unit: ms.
+	FinishedTime int `json:"finished_time"`
+	// Running duration of a job. Unit: ms.
+	ElapsedTime int `json:"elapsed_time"`
+	// Running parameter. The parameter contains a maximum of 4,096 characters,
+	// excluding special characters such as ;|&>'<$, and can be left blank.
+	Arguments string `json:"arguments"`
+	// Configuration parameter, which is used to configure -d parameters.
+	// The parameter contains a maximum of 2,048 characters, excluding special characters such as ><|'`&!\,
+	// and can be left blank.
+	Properties string `json:"properties"`
+	// Launcher job ID.
+	LauncherId string `json:"launcher_id"`
+	// Actual job ID.
+	AppId string `json:"app_id"`
+}
+
+// GetResult represents a result of the Get method.
+type GetResult struct {
+	commonResult
+}
+
+func (r commonResult) Extract() (*Job, error) {
+	var s Job
+	err := r.ExtractIntoStructPtr(&s, "job_detail")
+	return &s, err
+}
+
+// JobPage represents the response pages of the List operation.
+type JobPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractJobs is a method which to extract a job list by job pages.
+func ExtractJobs(r pagination.Page) ([]Job, error) {
+	var s []Job
+	err := r.(JobPage).Result.ExtractIntoSlicePtr(&s, "job_list")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs/urls.go
@@ -1,0 +1,23 @@
+package jobs
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+func buildRootPath(clusterId string) string {
+	return fmt.Sprintf("clusters/%s/job-executions", clusterId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, clusterId string) string {
+	return c.ServiceURL(buildRootPath(clusterId))
+}
+
+func resourceURL(c *golangsdk.ServiceClient, clusterId, jobId string) string {
+	return c.ServiceURL(buildRootPath(clusterId), jobId)
+}
+
+func deleteURL(c *golangsdk.ServiceClient, clusterId string) string {
+	return c.ServiceURL(buildRootPath(clusterId), "batch-delete")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883
+# github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -406,6 +406,7 @@ github.com/huaweicloud/golangsdk/openstack/maas/v1/task
 github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster
 github.com/huaweicloud/golangsdk/openstack/mrs/v1/job
 github.com/huaweicloud/golangsdk/openstack/mrs/v2/clusters
+github.com/huaweicloud/golangsdk/openstack/mrs/v2/jobs
 github.com/huaweicloud/golangsdk/openstack/networking/v1/bandwidths
 github.com/huaweicloud/golangsdk/openstack/networking/v1/eips
 github.com/huaweicloud/golangsdk/openstack/networking/v1/security/securitygroups


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Compared with the job of V1 version, the parameter design of V2 version refers to the console, which makes it more convenient for users to use job resources against the console and integrate old parameters such as jar path into a program parameters dictionary.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1324 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. New job resource support:
  Seven kinds job: Flink, MapReduce, SparkSubmit, HiveSql, HiveScript, SparkSql and SparkScript.
2. Related document and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run=TestAccMrsMapReduceJob_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run=TestAccMrsMapReduceJob_basic -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceJob_basic
=== PAUSE TestAccMrsMapReduceJob_basic
=== CONT  TestAccMrsMapReduceJob_basic
--- PASS: TestAccMrsMapReduceJob_basic (70.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       70.215s
```
