### PR TITLE
Add mrs v2 cluster endpoint test

### DIFF
--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -781,17 +781,29 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	var serviceClient *golangsdk.ServiceClient
 	config := testProvider.Meta().(*config.Config)
 
-	// test the endpoint of MRS service
+	// test the endpoint of MRS v1.1 service
 	serviceClient, err = config.MrsV1Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud MRS client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud MRS v1.1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://mrs.%s.%s/v1.1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
-		t.Fatalf("MRS endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+		t.Fatalf("MRS v1.1 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
-	t.Logf("MRS endpoint:\t %s", actualURL)
+	t.Logf("MRS v1.1 endpoint:\t %s", actualURL)
+
+	// test the endpoint of MRS v2 service
+	serviceClient, err = config.MrsV2Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud MRS v2 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://mrs.%s.%s/v2/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("MRS v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("MRS v2 endpoint:\t %s", actualURL)
 
 	// test the endpoint of SMN service
 	serviceClient, err = config.SmnV2Client(HW_REGION_NAME)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The endpoint test of mrs v2 cluster is missing.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add mrs v2 cluster endpoint test
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
go test -v -run TestAccServiceEndpoints_EnterpriseIntelligence
=== RUN   TestAccServiceEndpoints_EnterpriseIntelligence
--- PASS: TestAccServiceEndpoints_EnterpriseIntelligence (1.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1.974s
```
