### PR TITLE
Update ELB pool docs for listener_id and loadbalancer_id

### DIFF
--- a/docs/resources/elb_pool.md
+++ b/docs/resources/elb_pool.md
@@ -43,11 +43,11 @@ The following arguments are supported:
 
 * `loadbalancer_id` - (Optional, String, ForceNew) The load balancer on which to provision this
     pool. Changing this creates a new pool.
-    Note:  One of LoadbalancerID or ListenerID must be provided.
+    Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
 
 * `listener_id` - (Optional, String, ForceNew) The Listener on which the members of the pool
     will be associated with. Changing this creates a new pool.
-	Note:  One of LoadbalancerID or ListenerID must be provided.
+	Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
 
 * `lb_method` - (Required, String) The load balancing algorithm to
     distribute traffic to the pool's members. Must be one of

--- a/docs/resources/lb_pool.md
+++ b/docs/resources/lb_pool.md
@@ -44,11 +44,11 @@ The following arguments are supported:
 
 * `loadbalancer_id` - (Optional, String, ForceNew) The load balancer on which to provision this
     pool. Changing this creates a new pool.
-    Note:  One of LoadbalancerID or ListenerID must be provided.
+    Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
 
 * `listener_id` - (Optional, String, ForceNew) The Listener on which the members of the pool
     will be associated with. Changing this creates a new pool.
-	Note:  One of LoadbalancerID or ListenerID must be provided.
+	Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
 
 * `lb_method` - (Required, String) The load balancing algorithm to
     distribute traffic to the pool's members. Must be one of


### PR DESCRIPTION
Adds `Exactly` to make it more clear that one and only one of
listener_id and loadbalancer_id must be provided.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
