### PR TITLE
Update schema behavior of APIG authorizer resource

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -35,7 +35,9 @@ func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
 					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "FRONTEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "true"),
 					resource.TestCheckResourceAttr(resourceName, "cache_age", "60"),
+					resource.TestCheckResourceAttr(resourceName, "identity.#", "1"),
 				),
 			},
 			{
@@ -44,7 +46,9 @@ func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
 					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
 					resource.TestCheckResourceAttr(resourceName, "type", "FRONTEND"),
-					resource.TestCheckResourceAttr(resourceName, "cache_age", "45"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "0"),
+					resource.TestCheckResourceAttr(resourceName, "identity.#", "0"),
 				),
 			},
 			{
@@ -79,6 +83,7 @@ func TestAccApigCustomAuthorizerV2_backend(t *testing.T) {
 					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "BACKEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "false"),
 					resource.TestCheckResourceAttr(resourceName, "cache_age", "60"),
 				),
 			},
@@ -88,6 +93,7 @@ func TestAccApigCustomAuthorizerV2_backend(t *testing.T) {
 					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
 					resource.TestCheckResourceAttr(resourceName, "type", "BACKEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "false"),
 					resource.TestCheckResourceAttr(resourceName, "cache_age", "45"),
 				),
 			},
@@ -196,6 +202,7 @@ resource "huaweicloud_apig_custom_authorizer" "test" {
   name         = "%s"
   function_urn = huaweicloud_fgs_function.test.urn
   type         = "FRONTEND"
+  is_body_send = true
   cache_age    = 60
   
   identity {
@@ -215,12 +222,6 @@ resource "huaweicloud_apig_custom_authorizer" "test" {
   name         = "%s_update"
   function_urn = huaweicloud_fgs_function.test.urn
   type         = "FRONTEND"
-  cache_age    = 45
-  
-  identity {
-    name     = "user_name"
-    location = "HEADER"
-  }
 }
 `, testAccApigCustomAuthorizer_base(rName), rName)
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -66,12 +66,10 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 			"is_body_send": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 			"cache_age": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validation.IntBetween(0, 3600),
 			},
 			"user_data": {
@@ -82,7 +80,6 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 			"identity": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameters of the `identity`, `is_body_send` and `cache_age` can be set to nil value.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove computed behavior form identity, is_body_send and cache age.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigCustomAuthorizerV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigCustomAuthorizerV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigCustomAuthorizerV2_basic
=== PAUSE TestAccApigCustomAuthorizerV2_basic
=== CONT  TestAccApigCustomAuthorizerV2_basic
--- PASS: TestAccApigCustomAuthorizerV2_basic (466.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig    466.940s
```
