### PR TITLE
support hibernate/awake in cce cluster

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -194,6 +194,9 @@ The following arguments are supported:
 * `delete_all` - (Optional, String) Specified whether to delete all associated storage resources when deleting the CCE cluster.
   valid values are "true", "try" and "false". Default is false.
 
+* `hibernate` - (Optional, Bool) Specifies whether to hibernate the CCE cluster. Defaults to false.
+  After a cluster is hibernated, resources such as workloads cannot be created or managed in the cluster, and the cluster cannot be deleted.
+
 The `masters` block supports:
 
 * `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone of the master node. Changing this creates a new cluster.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a
+	github.com/huaweicloud/golangsdk v0.0.0-20210806094024-ee9e1498168a
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,12 +206,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210729121530-85c6b7af2ad2 h1:nel1BOE/C+vr/UMrrEZd+kDFZCwzj2tVZT665D0V81c=
-github.com/huaweicloud/golangsdk v0.0.0-20210729121530-85c6b7af2ad2/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883 h1:4D/N05uptrcZuErPVCHeRJ89ND1RnZoVYjjCIfTflRs=
-github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a h1:yJda8qxR3mnJydpPlJ4MgYGZD8nO7eDwGSm52lbwSvw=
-github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210806094024-ee9e1498168a h1:dSSB8Ws+u++5SPtytj36pwI45vq+l9e+Y7DCw7Knd8s=
+github.com/huaweicloud/golangsdk v0.0.0-20210806094024-ee9e1498168a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/vendor/github.com/huaweicloud/golangsdk/errors.go
+++ b/vendor/github.com/huaweicloud/golangsdk/errors.go
@@ -1,6 +1,9 @@
 package golangsdk
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // BaseError is an error type that all other error types embed.
 type BaseError struct {
@@ -118,9 +121,21 @@ func (e ErrDefault401) Error() string {
 	return "Authentication failed"
 }
 func (e ErrDefault403) Error() string {
+	var maxLength int = 200
+	var unAuthorized string = "Request not authorized"
+
+	messageBody := string(e.Body)
+	if len(messageBody) > maxLength {
+		if strings.Contains(messageBody, unAuthorized) {
+			messageBody = unAuthorized
+		} else {
+			messageBody = messageBody[:maxLength] + "\n..."
+		}
+	}
+
 	e.DefaultErrString = fmt.Sprintf(
 		"Action forbidden: [%s %s], error message: %s",
-		e.Method, e.URL, e.Body,
+		e.Method, e.URL, messageBody,
 	)
 	return e.choseErrString()
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -268,3 +268,11 @@ func UpdateMasterIp(c *golangsdk.ServiceClient, id string, opts UpdateIpOptsBuil
 	})
 	return
 }
+
+func Operation(c *golangsdk.ServiceClient, id, action string) (r OperationResult) {
+	_, r.Err = c.Post(operationURL(c, id, action), nil, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/results.go
@@ -311,3 +311,7 @@ func (r GetCertResult) Extract() (*Certificate, error) {
 type UpdateIpResult struct {
 	golangsdk.ErrResult
 }
+
+type OperationResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/urls.go
@@ -3,9 +3,10 @@ package clusters
 import "github.com/huaweicloud/golangsdk"
 
 const (
-	rootPath     = "clusters"
-	certPath     = "clustercert"
-	masterIpPath = "mastereip"
+	rootPath      = "clusters"
+	certPath      = "clustercert"
+	masterIpPath  = "mastereip"
+	operationPath = "operation"
 )
 
 func rootURL(client *golangsdk.ServiceClient) string {
@@ -22,4 +23,8 @@ func certificateURL(c *golangsdk.ServiceClient, id string) string {
 
 func masterIpURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(rootPath, id, masterIpPath)
+}
+
+func operationURL(c *golangsdk.ServiceClient, id, action string) string {
+	return c.ServiceURL(rootPath, id, operationPath, action)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a
+# github.com/huaweicloud/golangsdk v0.0.0-20210806094024-ee9e1498168a
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support hibernate/awake in cce cluster

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1344 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add a new bool type parameter `hibernate`, defaults to false.
If set to true, the cce cluster will be hibernated. If set to false, the cce cluster will be awake.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3_HibernateAndAwake'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3_HibernateAndAwake -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_HibernateAndAwake
=== PAUSE TestAccCCEClusterV3_HibernateAndAwake
=== CONT  TestAccCCEClusterV3_HibernateAndAwake
--- PASS: TestAccCCEClusterV3_HibernateAndAwake (673.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       673.662s
```
