### PR TITLE
Add new APIG example support

### DIFF
--- a/examples/apig/api-custom-authorizer/README.md
+++ b/examples/apig/api-custom-authorizer/README.md
@@ -1,0 +1,35 @@
+# Register an API with Custom Authorizer and FunctionGraph
+
+Configuration in this directory creates an API with custom authorizer and function back-end,
+The example includes a function graph, an ECS for Nginx server, an API Gateway instance, some VPC and APIG
+configurations. It also creates custom response, authorizer for the API and bind an EIP to ECS.
+
+To run, configure your Huaweicloud provider as described in the
+[document](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs).
+
+This example assumes that you have created a random password.
+If you want to use key-pair and do not have one, please visit the
+[document](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs/resources/compute_keypair)
+to create a key-pair.
+
+## Usage
+
+```
+terraform init
+terraform plan
+terraform apply
+terraform destroy
+```
+
+Wait a couple of minutes for the ECS to install nginx, and then you will see the nginx welcome page on your browser
+through the EIP address.
+
+For API, you need to configure your back-end database to bind the EIP address and port.
+After the connection is successful, you can debug or publish this API on the console.
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.12.0 |
+| huaweicloud | >= 1.27.1 |

--- a/examples/apig/api-custom-authorizer/main.tf
+++ b/examples/apig/api-custom-authorizer/main.tf
@@ -1,0 +1,217 @@
+data "huaweicloud_availability_zones" "default" {}
+
+resource "huaweicloud_vpc" "default" {
+  name = var.vpc_name
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "default" {
+  name       = var.subnet_name
+  cidr       = "192.168.0.0/20"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.default.id
+}
+
+resource "huaweicloud_networking_secgroup" "default" {
+  name = var.security_group_name
+}
+
+# HTTP access from anywhere
+resource "huaweicloud_networking_secgroup_rule" "http_rule" {
+  security_group_id = huaweicloud_networking_secgroup.default.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_max    = 80
+  port_range_min    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+data "huaweicloud_images_image" "default" {
+  name        = var.ecs_image
+  most_recent = true
+}
+
+data "huaweicloud_compute_flavors" "default" {
+  availability_zone = data.huaweicloud_availability_zones.default.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "random_password" "password" {
+  length           = 16
+  special          = true
+  override_special = "!@"
+  min_numeric      = 1
+  min_lower        = 1
+  min_special      = 1
+}
+
+resource "huaweicloud_compute_instance" "default" {
+  name               = var.ecs_name
+  image_id           = data.huaweicloud_images_image.default.id
+  flavor_id          = data.huaweicloud_compute_flavors.default.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.default.id]
+  availability_zone  = data.huaweicloud_availability_zones.default.names[0]
+  system_disk_type   = "SSD"
+  admin_pass         = random_password.password.result
+
+  network {
+    uuid = huaweicloud_vpc_subnet.default.id
+  }
+}
+
+resource "huaweicloud_vpc_eip" "default" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    share_type  = "PER"
+    name        = var.bandwidth_name
+    size        = 10
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_compute_eip_associate" "default" {
+  public_ip = huaweicloud_vpc_eip.default.address
+  instance_id = huaweicloud_compute_instance.default.id
+}
+
+resource "null_resource" "provision" {
+  depends_on = [
+    huaweicloud_compute_eip_associate.default
+  ]
+  provisioner "remote-exec" {
+    connection {
+      user     = "root"
+      password = random_password.password.result
+      host     = huaweicloud_vpc_eip.default.address
+      port     = 22
+    }
+    inline = [
+      "yum -y install nginx",
+      "systemctl enable nginx",
+      "systemctl start nginx",
+      "systemctl status nginx",
+    ]
+  }
+}
+
+resource "huaweicloud_fgs_function" "default" {
+  name        = var.function_name
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python3.6"
+  code_type   = "inline"
+
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler(event, context):
+    if event["headers"].get("x-user-auth")=='cXpsdzQyVW9Xa1NVTX==':
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                "status":"allow",
+                "context":{
+                    "user_name":"user1"
+                }
+            })
+        }
+    else:
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                "status":"deny",
+                "context":{
+                    "code":"1001",
+                    "message":"incorrect username or password"
+                }
+            })
+        }
+EOF
+}
+
+resource "huaweicloud_apig_instance" "default" {
+  name              = var.apig_instance_name
+  edition           = "BASIC"
+  vpc_id            = huaweicloud_vpc.default.id
+  subnet_id         = huaweicloud_vpc_subnet.default.id
+  security_group_id = huaweicloud_networking_secgroup.default.id
+
+  available_zones    = [
+    data.huaweicloud_availability_zones.default.names[0],
+  ]
+}
+
+resource "huaweicloud_apig_custom_authorizer" "default" {
+  instance_id  = huaweicloud_apig_instance.default.id
+  name         = var.apig_auth_name
+  function_urn = huaweicloud_fgs_function.default.urn
+  type         = "FRONTEND"
+}
+
+resource "huaweicloud_apig_response" "default" {
+  name        = var.apig_response_name
+  instance_id = huaweicloud_apig_instance.default.id
+  group_id    = huaweicloud_apig_group.default.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+
+resource "huaweicloud_apig_group" "default" {
+  name        = var.apig_group_name
+  instance_id = huaweicloud_apig_instance.default.id
+}
+
+resource "huaweicloud_apig_vpc_channel" "default" {
+  instance_id = huaweicloud_apig_instance.default.id
+  name        = var.apig_channel_name
+  port        = 80
+  member_type = "ECS"
+  protocol    = "HTTP"
+  path        = "/backend/users"
+  http_code   = "200,401"
+
+  members {
+    id = huaweicloud_compute_instance.default.id
+  }
+}
+
+resource "huaweicloud_apig_api" "default" {
+  instance_id             = huaweicloud_apig_instance.default.id
+  group_id                = huaweicloud_apig_group.default.id
+  type                    = "Public"
+  name                    = var.apig_api_name
+  request_protocol        = "BOTH"
+  request_method          = "GET"
+  request_path            = "/terraform/users"
+  security_authentication = "AUTHORIZER"
+  matching                = "Exact"
+  response_id             = huaweicloud_apig_response.default.id
+  authorizer_id           = huaweicloud_apig_custom_authorizer.default.id
+
+  backend_params {
+    type     = "SYSTEM"
+    name     = "X-User-Auth"
+    location = "HEADER"
+    value    = "user_name"
+  }
+
+  web {
+    # ensure the backend server include this path or API debug will fail
+    path             = "/backend/users"
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.default.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 5000
+  }
+}

--- a/examples/apig/api-custom-authorizer/variables.tf
+++ b/examples/apig/api-custom-authorizer/variables.tf
@@ -1,0 +1,65 @@
+variable "vpc_name" {
+  description = "The name of the Huaweicloud VPC"
+  default     = "tf_vpc_demo"
+}
+
+variable "subnet_name" {
+  description = "The name of the Huaweicloud Subnet"
+  default     = "tf_subnet_demo"
+}
+
+variable "security_group_name" {
+  description = "The name of the Huaweicloud Security Group"
+  default     = "tf_secgroup_demo"
+}
+
+# If you want to use other operation systems, please update the nginx install commands of the provisioner.
+variable "ecs_image" {
+  description = "The name of the Huaweicloud Image"
+  default     = "CentOS 7.3 64bit"
+}
+
+variable "ecs_name" {
+  description = "The instance name of the Huaweicloud ECS"
+  default     = "tf_ecs_demo"
+}
+
+variable "bandwidth_name" {
+  description = "The bandwidth name of the Huaweicloud EIP"
+  default     = "tf_bandwidth_demo"
+}
+
+variable "function_name" {
+  description = "The function name of the Huaweicloud FunctionGraph"
+  default     = "tf_function_demo"
+}
+
+variable "apig_instance_name" {
+  description = "The instance name of the Huaweicloud Dedicated APIG"
+  default     = "tf_apig_instance_demo"
+}
+
+variable "apig_auth_name" {
+  description = "The custom authorizer name of the Huaweicloud Dedicated APIG"
+  default     = "tf_apig_auth_demo"
+}
+
+variable "apig_response_name" {
+  description = "The response name of the Huaweicloud Dedicated APIG"
+  default     = "tf_apig_response_demo"
+}
+
+variable "apig_group_name" {
+  description = "The group name of the Huaweicloud Dedicated APIG"
+  default     = "tf_apig_group_demo"
+}
+
+variable "apig_channel_name" {
+  description = "The channel name of the Huaweicloud Dedicated APIG"
+  default     = "tf_vpc_channel_demo"
+}
+
+variable "apig_api_name" {
+  description = "The API name of the Huaweicloud Dedicated APIG"
+  default     = "tf_apig_api_demo"
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This example is according to the Huaweicloud best practice through custom authorizer and function graph development.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support api creation through custom authorizer
2. use function graph to api backend authorization
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
random_password.password: Creating...
random_password.password: Creation complete after 0s [id=none]
huaweicloud_vpc.test: Creating...
huaweicloud_fgs_function.test: Creating...
huaweicloud_networking_secgroup.test: Creating...
huaweicloud_vpc_eip.test: Creating...
huaweicloud_fgs_function.test: Creation complete after 1s [id=urn:fss:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:function:default:tf_acc_test_0809:latest]
huaweicloud_networking_secgroup.test: Creation complete after 4s [id=3c0a962c-81d7-4187-96bc-e50444fb7383]
huaweicloud_networking_secgroup_rule.rule_http_80: Creating...
huaweicloud_networking_secgroup_rule.rule_http_80: Creation complete after 1s [id=625542a1-98ff-4abf-a938-dbab8a576daa]
huaweicloud_vpc.test: Creation complete after 9s [id=292a8f4c-dd3d-42e0-bbf4-08e68d147334]
huaweicloud_vpc_subnet.test: Creating...
huaweicloud_vpc_eip.test: Creation complete after 10s [id=a7fc6b92-6a84-420c-bdcd-0d5cdee082fd]
huaweicloud_vpc_subnet.test: Creation complete after 10s [id=8997ff8a-cc50-4d1a-b470-d7e393dac8ea]
huaweicloud_apig_instance.test: Creating...
huaweicloud_compute_instance.test: Creating...
huaweicloud_compute_instance.test: Still creating... [10s elapsed]
huaweicloud_apig_instance.test: Still creating... [10s elapsed]
huaweicloud_apig_instance.test: Still creating... [20s elapsed]
huaweicloud_compute_instance.test: Still creating... [20s elapsed]
huaweicloud_compute_instance.test: Still creating... [30s elapsed]
huaweicloud_apig_instance.test: Still creating... [30s elapsed]
huaweicloud_apig_instance.test: Still creating... [40s elapsed]
huaweicloud_compute_instance.test: Still creating... [40s elapsed]
huaweicloud_apig_instance.test: Still creating... [50s elapsed]
huaweicloud_compute_instance.test: Still creating... [50s elapsed]
huaweicloud_compute_instance.test: Still creating... [1m0s elapsed]
huaweicloud_apig_instance.test: Still creating... [1m0s elapsed]
huaweicloud_compute_instance.test: Creation complete after 1m9s [id=8f0e998d-f9f8-487f-ae01-fac1ebe40d0b]
huaweicloud_compute_eip_associate.test: Creating...
huaweicloud_apig_instance.test: Still creating... [1m10s elapsed]
huaweicloud_compute_eip_associate.test: Still creating... [10s elapsed]
huaweicloud_apig_instance.test: Still creating... [1m20s elapsed]
huaweicloud_compute_eip_associate.test: Creation complete after 13s [id=124.71.232.37/8f0e998d-f9f8-487f-ae01-fac1ebe40d0b/]
null_resource.provision: Creating...
null_resource.provision: Provisioning with 'remote-exec'...
null_resource.provision (remote-exec): Connecting to remote host via SSH...
null_resource.provision (remote-exec):   Host: 124.71.232.37
null_resource.provision (remote-exec):   User: root
null_resource.provision (remote-exec):   Password: true
null_resource.provision (remote-exec):   Private key: false
null_resource.provision (remote-exec):   Certificate: false
null_resource.provision (remote-exec):   SSH Agent: false
null_resource.provision (remote-exec):   Checking Host Key: false
null_resource.provision (remote-exec):   Target Platform: unix
null_resource.provision (remote-exec): Connected!
null_resource.provision (remote-exec): Loaded plugins: fastestmirror
null_resource.provision (remote-exec): Determining fastest mirrors
null_resource.provision (remote-exec): base             | 3.6 kB     00:00
null_resource.provision (remote-exec): epel             | 4.7 kB     00:00
null_resource.provision (remote-exec): extras           | 2.9 kB     00:00
null_resource.provision (remote-exec): updates          | 2.9 kB     00:00
null_resource.provision (remote-exec): (1/7): epel/x86_64 | 1.0 MB   00:00
null_resource.provision (remote-exec): (2/7): base/7/x86_ | 153 kB   00:00
null_resource.provision (remote-exec): (3/7): epel/x86_64 |  96 kB   00:00
null_resource.provision (remote-exec): (5/7): epel/x86 5% | 1.3 MB   --:-- ETA
null_resource.provision (remote-exec): (5/7): epel/x86 7% | 1.7 MB   00:31 ETA
null_resource.provision (remote-exec): (5/7): epel/x8 31% | 7.4 MB   00:09 ETA
null_resource.provision (remote-exec): (5/7): epel/x8 31% | 7.5 MB   00:09 ETA
null_resource.provision (remote-exec): (4/7): extras/7/x8 | 242 kB   00:01
null_resource.provision (remote-exec): (7/7): updates 33% | 8.0 MB   00:09 ETA
null_resource.provision (remote-exec): (7/7): updates 34% | 8.2 MB   00:09 ETA
null_resource.provision (remote-exec): (7/7): updates 42% |  10 MB   00:07 ETA
null_resource.provision (remote-exec): (7/7): updates 46% |  11 MB   00:06 ETA
null_resource.provision (remote-exec): (5/7): base/7/ 46% |  11 MB   00:06 ETA
null_resource.provision (remote-exec): (5/7): base/7/ 46% |  11 MB   00:07 ETA
null_resource.provision (remote-exec): (5/7): base/7/ 47% |  11 MB   00:07 ETA
null_resource.provision (remote-exec): (5/7): base/7/ 47% |  11 MB   00:07 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 48% |  12 MB   00:08 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 54% |  13 MB   00:06 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 57% |  14 MB   00:05 ETA
null_resource.provision (remote-exec): (7/7): updates 57% |  14 MB   00:06 ETA
null_resource.provision (remote-exec): (7/7): updates 57% |  14 MB   00:06 ETA
null_resource.provision (remote-exec): (5/7): base/7/x86_ | 6.1 MB   00:05
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:07 ETA
huaweicloud_apig_instance.test: Still creating... [1m30s elapsed]
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:07 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:08 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:09 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:10 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:11 ETA
null_resource.provision: Still creating... [10s elapsed]
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:12 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:13 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:14 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:15 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:17 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:18 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:20 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:22 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:24 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:26 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:28 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:31 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:33 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:37 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:40 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   00:43 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:47 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:51 ETA
huaweicloud_apig_instance.test: Still creating... [1m40s elapsed]
null_resource.provision (remote-exec): (6/7): epel/x8 58% |  14 MB   00:55 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   01:00 ETA
null_resource.provision (remote-exec): (7/7): updates 58% |  14 MB   01:06 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   01:11 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   01:16 ETA
null_resource.provision: Still creating... [20s elapsed]
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   01:24 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   01:30 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   01:37 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   01:45 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   01:53 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   02:01 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   02:10 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   02:22 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   02:31 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   02:41 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   02:56 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   03:06 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   03:17 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   03:28 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   03:47 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   03:58 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   04:10 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   04:33 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   04:45 ETA
huaweicloud_apig_instance.test: Still creating... [1m50s elapsed]
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   04:56 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   05:23 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   05:34 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   05:44 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   05:55 ETA
null_resource.provision: Still creating... [30s elapsed]
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   06:27 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   06:36 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   06:44 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   07:22 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   07:27 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   08:02 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   08:04 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   08:06 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   08:17 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   08:31 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   08:54 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   08:52 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   09:42 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 59% |  14 MB   09:28 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   09:11 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   09:05 ETA
null_resource.provision (remote-exec): (7/7): updates 59% |  14 MB   08:59 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 60% |  14 MB   08:47 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 60% |  14 MB   08:37 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 60% |  14 MB   08:10 ETA
huaweicloud_apig_instance.test: Still creating... [2m0s elapsed]
null_resource.provision (remote-exec): (7/7): updates 60% |  14 MB   07:46 ETA
null_resource.provision (remote-exec): (7/7): updates 60% |  14 MB   07:08 ETA
null_resource.provision (remote-exec): (7/7): updates 60% |  14 MB   06:25 ETA
null_resource.provision (remote-exec): (7/7): updates 60% |  15 MB   05:41 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 60% |  15 MB   05:00 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 60% |  15 MB   03:39 ETA
null_resource.provision: Still creating... [40s elapsed]
null_resource.provision (remote-exec): (6/7): epel/x8 62% |  15 MB   01:25 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 73% |  18 MB   00:10 ETA
null_resource.provision (remote-exec): (7/7): updates 73% |  18 MB   00:10 ETA
null_resource.provision (remote-exec): (7/7): updates 73% |  18 MB   00:11 ETA
null_resource.provision (remote-exec): (7/7): updates 73% |  18 MB   00:11 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 78% |  19 MB   00:07 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 85% |  21 MB   00:03 ETA
null_resource.provision (remote-exec): (6/7): epel/x8 85% |  21 MB   00:03 ETA
null_resource.provision (remote-exec): (7/7): updates 86% |  21 MB   00:03 ETA
null_resource.provision (remote-exec): (7/7): updates 86% |  21 MB   00:04 ETA
null_resource.provision (remote-exec): (6/7): epel/x86_64 | 6.9 MB   00:41
null_resource.provision (remote-exec): (7/7): updates 90% |  22 MB   00:02 ETA
null_resource.provision (remote-exec): (7/7): updates 90% |  22 MB   00:02 ETA
null_resource.provision (remote-exec): (7/7): updates 91% |  22 MB   00:02 ETA
null_resource.provision (remote-exec): (7/7): updates 91% |  22 MB   00:02 ETA
null_resource.provision (remote-exec): (7/7): updates 93% |  22 MB   00:01 ETA
null_resource.provision (remote-exec): (7/7): updates 94% |  23 MB   00:01 ETA
null_resource.provision (remote-exec): (7/7): updates 96% |  23 MB   00:00 ETA
null_resource.provision (remote-exec): (7/7): updates 97% |  24 MB   00:00 ETA
null_resource.provision (remote-exec): (7/7): updates 98% |  24 MB   00:00 ETA
null_resource.provision (remote-exec): (7/7): updates 99% |  24 MB   00:00 ETA
null_resource.provision (remote-exec): (7/7): updates/7/x | 9.5 MB   00:44
huaweicloud_apig_instance.test: Still creating... [2m10s elapsed]
null_resource.provision: Still creating... [50s elapsed]
null_resource.provision (remote-exec): Resolving Dependencies
null_resource.provision (remote-exec): --> Running transaction check
null_resource.provision (remote-exec): ---> Package nginx.x86_64 1:1.20.1-2.el7 will be installed
null_resource.provision (remote-exec): --> Processing Dependency: nginx-filesystem = 1:1.20.1-2.el7 for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: libcrypto.so.1.1(OPENSSL_1_1_0)(64bit) for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: libssl.so.1.1(OPENSSL_1_1_0)(64bit) for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: libssl.so.1.1(OPENSSL_1_1_1)(64bit) for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: nginx-filesystem for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: redhat-indexhtml for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: libcrypto.so.1.1()(64bit) for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: libprofiler.so.0()(64bit) for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Processing Dependency: libssl.so.1.1()(64bit) for package: 1:nginx-1.20.1-2.el7.x86_64
null_resource.provision (remote-exec): --> Running transaction check
null_resource.provision (remote-exec): ---> Package centos-indexhtml.noarch 0:7-9.el7.centos will be installed
null_resource.provision (remote-exec): ---> Package gperftools-libs.x86_64 0:2.6.1-1.el7 will be installed
null_resource.provision (remote-exec): ---> Package nginx-filesystem.noarch 1:1.20.1-2.el7 will be installed
null_resource.provision (remote-exec): ---> Package openssl11-libs.x86_64 1:1.1.1g-3.el7 will be installed
null_resource.provision (remote-exec): --> Finished Dependency Resolution

null_resource.provision (remote-exec): Dependencies Resolved

null_resource.provision (remote-exec): ========================================
null_resource.provision (remote-exec):  Package
null_resource.provision (remote-exec):        Arch   Version        Repository
null_resource.provision (remote-exec):                                    Size
null_resource.provision (remote-exec): ========================================
null_resource.provision (remote-exec): Installing:
null_resource.provision (remote-exec):  nginx x86_64 1:1.20.1-2.el7 epel 586 k
null_resource.provision (remote-exec): Installing for dependencies:
null_resource.provision (remote-exec):  centos-indexhtml
null_resource.provision (remote-exec):        noarch 7-9.el7.centos base  92 k
null_resource.provision (remote-exec):  gperftools-libs
null_resource.provision (remote-exec):        x86_64 2.6.1-1.el7    base 272 k
null_resource.provision (remote-exec):  nginx-filesystem
null_resource.provision (remote-exec):        noarch 1:1.20.1-2.el7 epel  23 k
null_resource.provision (remote-exec):  openssl11-libs
null_resource.provision (remote-exec):        x86_64 1:1.1.1g-3.el7 epel 1.5 M

null_resource.provision (remote-exec): Transaction Summary
null_resource.provision (remote-exec): ========================================
null_resource.provision (remote-exec): Install  1 Package (+4 Dependent packages)

null_resource.provision (remote-exec): Total download size: 2.4 M
null_resource.provision (remote-exec): Installed size: 6.7 M
null_resource.provision (remote-exec): Downloading packages:
null_resource.provision (remote-exec): (1/5): centos-inde |  92 kB   00:00
null_resource.provision (remote-exec): (2/5): gperftools- | 272 kB   00:00
null_resource.provision (remote-exec): (3/5): nginx-files |  23 kB   00:00
null_resource.provision (remote-exec): (4/5): nginx-1.20. | 586 kB   00:00
null_resource.provision (remote-exec): (5/5): openssl11-l | 1.5 MB   00:00
null_resource.provision (remote-exec): ----------------------------------------
null_resource.provision (remote-exec): Total      7.5 MB/s | 2.4 MB  00:00
null_resource.provision (remote-exec): Running transaction check
null_resource.provision (remote-exec): Running transaction test
null_resource.provision (remote-exec): Transaction test succeeded
null_resource.provision (remote-exec): Running transaction
null_resource.provision (remote-exec):   Installing : 1:openss [         ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [#        ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [##       ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [###      ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [####     ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [#####    ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [######   ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [#######  ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openss [######## ] 1/5
null_resource.provision (remote-exec):   Installing : 1:openssl11-libs-1   1/5
null_resource.provision (remote-exec):   Installing : gperftoo [         ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [#        ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [##       ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [###      ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [####     ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [#####    ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [######   ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [#######  ] 2/5
null_resource.provision (remote-exec):   Installing : gperftoo [######## ] 2/5
null_resource.provision (remote-exec):   Installing : gperftools-libs-2.   2/5
null_resource.provision (remote-exec):   Installing : centos-i [         ] 3/5
null_resource.provision (remote-exec):   Installing : centos-i [######   ] 3/5
null_resource.provision (remote-exec):   Installing : centos-i [######## ] 3/5
null_resource.provision (remote-exec):   Installing : centos-indexhtml-7   3/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [         ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [##       ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [###      ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [####     ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [#####    ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [######   ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [#######  ] 4/5
null_resource.provision (remote-exec):   Installing : 1:nginx-filesystem   4/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [         ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [#        ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [##       ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [###      ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [####     ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [#####    ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [######   ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [#######  ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx- [######## ] 5/5
null_resource.provision (remote-exec):   Installing : 1:nginx-1.20.1-2.e   5/5
null_resource.provision (remote-exec):   Verifying  : 1:nginx-1.20.1-2.e   1/5
null_resource.provision (remote-exec):   Verifying  : 1:nginx-filesystem   2/5
null_resource.provision (remote-exec):   Verifying  : centos-indexhtml-7   3/5
null_resource.provision (remote-exec):   Verifying  : gperftools-libs-2.   4/5
null_resource.provision (remote-exec):   Verifying  : 1:openssl11-libs-1   5/5

null_resource.provision (remote-exec): Installed:
null_resource.provision (remote-exec):   nginx.x86_64 1:1.20.1-2.el7

null_resource.provision (remote-exec): Dependency Installed:
null_resource.provision (remote-exec):   centos-indexhtml.noarch 0:7-9.el7.centos
null_resource.provision (remote-exec):   gperftools-libs.x86_64 0:2.6.1-1.el7
null_resource.provision (remote-exec):   nginx-filesystem.noarch 1:1.20.1-2.el7
null_resource.provision (remote-exec):   openssl11-libs.x86_64 1:1.1.1g-3.el7

null_resource.provision (remote-exec): Complete!
null_resource.provision (remote-exec): Created symlink from /etc/systemd/system/multi-user.target.wants/nginx.service to /usr/lib/systemd/system/nginx.service.
null_resource.provision (remote-exec): ● nginx.service - The nginx HTTP and reverse proxy server
null_resource.provision (remote-exec):    Loaded: loaded (/usr/lib/systemd/system/nginx.service; enabled; vendor preset: disabled)
null_resource.provision (remote-exec):    Active: active (running) since Mon 2021-08-09 11:25:07 CST; 3ms ago
null_resource.provision (remote-exec):   Process: 7697 ExecStart=/usr/sbin/nginx (code=exited, status=0/SUCCESS)
null_resource.provision (remote-exec):   Process: 7693 ExecStartPre=/usr/sbin/nginx -t (code=exited, status=0/SUCCESS)
null_resource.provision (remote-exec):   Process: 7692 ExecStartPre=/usr/bin/rm -f /run/nginx.pid (code=exited, status=0/SUCCESS)
null_resource.provision (remote-exec):  Main PID: 7699 (nginx)
null_resource.provision (remote-exec):    CGroup: /system.slice/nginx.service
null_resource.provision (remote-exec):            ├─7699 nginx: master proce...
null_resource.provision (remote-exec):            ├─7700 nginx: worker proce...
null_resource.provision (remote-exec):            └─7701 nginx: worker proce...

null_resource.provision (remote-exec): Aug 09 11:25:07 tf-acc-test-0809 systemd[1]: ...
null_resource.provision (remote-exec): Aug 09 11:25:07 tf-acc-test-0809 nginx[7693]: ...
null_resource.provision (remote-exec): Aug 09 11:25:07 tf-acc-test-0809 nginx[7693]: ...
null_resource.provision (remote-exec): Aug 09 11:25:07 tf-acc-test-0809 systemd[1]: ...
null_resource.provision (remote-exec): Hint: Some lines were ellipsized, use -l to show in full.
null_resource.provision: Creation complete after 54s [id=8559788107385050553]
huaweicloud_apig_instance.test: Still creating... [2m20s elapsed]
huaweicloud_apig_instance.test: Still creating... [2m30s elapsed]
huaweicloud_apig_instance.test: Still creating... [2m40s elapsed]
huaweicloud_apig_instance.test: Still creating... [2m50s elapsed]
huaweicloud_apig_instance.test: Still creating... [3m0s elapsed]
huaweicloud_apig_instance.test: Still creating... [3m10s elapsed]
huaweicloud_apig_instance.test: Still creating... [3m20s elapsed]
huaweicloud_apig_instance.test: Still creating... [3m30s elapsed]
huaweicloud_apig_instance.test: Still creating... [3m40s elapsed]
huaweicloud_apig_instance.test: Still creating... [3m50s elapsed]
huaweicloud_apig_instance.test: Still creating... [4m0s elapsed]
huaweicloud_apig_instance.test: Still creating... [4m10s elapsed]
huaweicloud_apig_instance.test: Still creating... [4m20s elapsed]
huaweicloud_apig_instance.test: Still creating... [4m30s elapsed]
huaweicloud_apig_instance.test: Still creating... [4m40s elapsed]
huaweicloud_apig_instance.test: Creation complete after 4m43s [id=fd24fbabd3fd4a10a05103e3c89ee6ea]
huaweicloud_apig_group.test: Creating...
huaweicloud_apig_vpc_channel.test: Creating...
huaweicloud_apig_custom_authorizer.test: Creating...
huaweicloud_apig_group.test: Creation complete after 1s [id=6dc0c9ff9d914dc0be8183a5d3bfe062]
huaweicloud_apig_custom_authorizer.test: Creation complete after 1s [id=6325431a09c441e792af0d0d8d713ddc]
huaweicloud_apig_response.test: Creating...
huaweicloud_apig_response.test: Creation complete after 0s [id=f9a262e2bcbf43a4a8f1a8d79280fc20]
huaweicloud_apig_vpc_channel.test: Creation complete after 1s [id=625c2483f1c54065b41aa227c4fc98b4]
huaweicloud_apig_api.test: Creating...
huaweicloud_apig_api.test: Creation complete after 1s [id=2122bfc037524db793d43ff2ee14d7c1]

Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
```
