### PR TITLE
fix a spelling bug in identity user

### DIFF
--- a/docs/resources/identity_user.md
+++ b/docs/resources/identity_user.md
@@ -56,7 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
 
-* `password_stength` - Indicates the password strength. The value can be low, middle, high, or none.
+* `password_strength` - Indicates the password strength.
 
 * `create_time` - The time when the IAM user was created.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a
+	github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883 h1:4D/N05upt
 github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a h1:yJda8qxR3mnJydpPlJ4MgYGZD8nO7eDwGSm52lbwSvw=
 github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca h1:HorbTsfgeR6HvpuP09mYylN0K6RUg+0a0iWKSWlVoy8=
+github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/resource_huaweicloud_identity_user.go
+++ b/huaweicloud/resource_huaweicloud_identity_user.go
@@ -67,7 +67,7 @@ func ResourceIdentityUserV3() *schema.Resource {
 					"default", "programmatic", "console",
 				}, false),
 			},
-			"password_stength": {
+			"password_strength": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -140,7 +140,7 @@ func resourceIdentityUserV3Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("email", user.Email)
 	d.Set("country_code", user.AreaCode)
 	d.Set("access_type", user.AccessMode)
-	d.Set("password_stength", user.PasswordStength)
+	d.Set("password_strength", user.PasswordStrength)
 	d.Set("create_time", user.CreateAt)
 	d.Set("last_login", user.LastLogin)
 

--- a/huaweicloud/resource_huaweicloud_identity_user_test.go
+++ b/huaweicloud/resource_huaweicloud_identity_user_test.go
@@ -34,6 +34,8 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", userName),
 					resource.TestCheckResourceAttr(resourceName, "description", "tested by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "email", "user_1@abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "password_strength", "Strong"),
 				),
 			},
 			{
@@ -49,8 +51,9 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3UserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "name", userName),
-					resource.TestCheckResourceAttr(resourceName, "description", "tested by terraform update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "email", "user_1@abcd.com"),
 				),
 			},
 		},
@@ -116,6 +119,7 @@ resource "huaweicloud_identity_user" "user_1" {
   name        = "%s"
   password    = "password123@!"
   enabled     = true
+  email       = "user_1@abc.com"
   description = "tested by terraform"
 }
 `, userName)
@@ -127,7 +131,8 @@ resource "huaweicloud_identity_user" "user_1" {
   name        = "%s"
   password    = "password123@!"
   enabled     = false
-  description = "tested by terraform update"
+  email       = "user_1@abcd.com"
+  description = "updated by terraform"
 }
 `, userName)
 }

--- a/vendor/github.com/huaweicloud/golangsdk/errors.go
+++ b/vendor/github.com/huaweicloud/golangsdk/errors.go
@@ -1,6 +1,9 @@
 package golangsdk
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // BaseError is an error type that all other error types embed.
 type BaseError struct {
@@ -118,9 +121,21 @@ func (e ErrDefault401) Error() string {
 	return "Authentication failed"
 }
 func (e ErrDefault403) Error() string {
+	var maxLength int = 200
+	var unAuthorized string = "Request not authorized"
+
+	messageBody := string(e.Body)
+	if len(messageBody) > maxLength {
+		if strings.Contains(messageBody, unAuthorized) {
+			messageBody = unAuthorized
+		} else {
+			messageBody = messageBody[:maxLength] + "\n..."
+		}
+	}
+
 	e.DefaultErrString = fmt.Sprintf(
 		"Action forbidden: [%s %s], error message: %s",
-		e.Method, e.URL, e.Body,
+		e.Method, e.URL, messageBody,
 	)
 	return e.choseErrString()
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/users/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/users/results.go
@@ -6,20 +6,22 @@ import (
 
 // User represents a User in the OpenStack Identity Service.
 type User struct {
-	ID              string `json:"id"`
-	DomainID        string `json:"domain_id"`
-	Name            string `json:"name"`
-	Email           string `json:"email"`
-	AreaCode        string `json:"areacode"`
-	Phone           string `json:"phone"`
-	Description     string `json:"description"`
-	AccessMode      string `json:"access_mode"`
-	Enabled         bool   `json:"enabled"`
-	PasswordStatus  bool   `json:"pwd_status"`
-	PasswordStength string `json:"pwd_stength"`
-	CreateAt        string `json:"create_time"`
-	UpdateAt        string `json:"update_time"`
-	LastLogin       string `json:"last_login_time"`
+	ID               string `json:"id"`
+	DomainID         string `json:"domain_id"`
+	Name             string `json:"name"`
+	Email            string `json:"email"`
+	AreaCode         string `json:"areacode"`
+	Phone            string `json:"phone"`
+	Description      string `json:"description"`
+	AccessMode       string `json:"access_mode"`
+	Enabled          bool   `json:"enabled"`
+	PasswordStatus   bool   `json:"pwd_status"`
+	PasswordStrength string `json:"pwd_strength"`
+	CreateAt         string `json:"create_time"`
+	UpdateAt         string `json:"update_time"`
+	LastLogin        string `json:"last_login_time"`
+	XuserID          string `json:"xuser_id"`
+	XuserType        string `json:"xuser_type"`
 
 	// Links contains referencing links to the user.
 	Links map[string]interface{} `json:"links"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a
+# github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

update `password_stength` to `password_strength`.
It's an attribute field, we can rename it directly.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityV3User_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityV3User_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityV3User_basic
=== PAUSE TestAccIdentityV3User_basic
=== CONT  TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (15.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       15.894s
```
