### PR TITLE
New params support for rds instance updation

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -141,8 +141,7 @@ The following arguments are supported:
 * `subnet_id` - (Required, String, ForceNew) Specifies the network id of a subnet.
   Changing this parameter will create a new resource.
 
-* `security_group_id` - (Required, String, ForceNew) Specifies the security group which the RDS DB instance belongs to.
-  Changing this parameter will create a new resource.
+* `security_group_id` - (Required, String) Specifies the security group which the RDS DB instance belongs to.
 
 * `volume` - (Required, List) Specifies the volume information. Structure is documented below.
 
@@ -190,6 +189,8 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the RDS instance.
   Changing this parameter creates a new RDS instance.
 
+* `ssl_enable` - (Optional, Bool) Specifies whether to enable the SSL for MySQL database.
+
 * `tags` - (Optional, Map) A mapping of tags to assign to the RDS instance.
   Each tag is represented by one key-value pair.
 
@@ -209,7 +210,7 @@ The `db` block supports:
   password to improve security, preventing security risks such as
   brute force cracking. Changing this parameter will create a new resource.
 
-* `port` - (Optional, Int,  ForceNew) Specifies the database port. Changing this parameter will create a new resource.
+* `port` - (Optional, Int) Specifies the database port.
   - The MySQL database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are
     occupied by the RDS system and cannot be used). The default value is 3306.
   - The PostgreSQL database port ranges from 2100 to 9500. The default value is 5432.

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/requests.go
@@ -1,0 +1,110 @@
+package securities
+
+import "github.com/huaweicloud/golangsdk"
+
+// SSLOpts is a struct which will be used to config the SSL (Secure Sockets Layer).
+type SSLOpts struct {
+	// Specifies whether to enable SSL.
+	//   true: SSL is enabled.
+	//   false: SSL is disabled.
+	SSLEnable *bool `json:"ssl_option" required:"true"`
+}
+
+// SSLOptsBuilder is an interface which to support request body build of
+// the ssl configuration of the specifies database.
+type SSLOptsBuilder interface {
+	ToSSLOptsMap() (map[string]interface{}, error)
+}
+
+// ToSSLOptsMap is a method which to build a request body by the SSLOpts.
+func (opts SSLOpts) ToSSLOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateSSL is a method to enable or disable the SSL.
+func UpdateSSL(client *golangsdk.ServiceClient, instanceId string, opts SSLOptsBuilder) (r SSLUpdateResult) {
+	b, err := opts.ToSSLOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "ssl"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// PortOpts is a struct which will be used to config the secure sockets layer.
+type PortOpts struct {
+	// Specifies the port number.
+	// The MySQL port number ranges from 1024 to 65535, excluding 12017 and 33071.
+	Port int `json:"port" required:"true"`
+}
+
+// PortOptsBuilder is an interface which to support request body build of
+// the port configuration of the specifies database.
+type PortOptsBuilder interface {
+	ToPortOptsMap() (map[string]interface{}, error)
+}
+
+// ToPortOptsMap is a method which to build a request body by the DBPortOpts.
+func (opts PortOpts) ToPortOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdatePort is a method to update the port of the database.
+func UpdatePort(client *golangsdk.ServiceClient, instanceId string, opts PortOptsBuilder) (r commonResult) {
+	b, err := opts.ToPortOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "port"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// SecGroupOpts is a struct which will be used to update the specifies security group.
+type SecGroupOpts struct {
+	// Specifies the security group ID.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+}
+
+// SecGroupOptsBuilder is an interface which to support request body build of the security group updation.
+type SecGroupOptsBuilder interface {
+	ToSecGroupOptsMap() (map[string]interface{}, error)
+}
+
+// ToSecGroupOptsMap is a method which to build a request body by the SecGroupOpts.
+func (opts SecGroupOpts) ToSecGroupOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateSecGroup is a method to update the security group which the database belongs.
+func UpdateSecGroup(client *golangsdk.ServiceClient, instanceId string, opts SecGroupOptsBuilder) (r commonResult) {
+	b, err := opts.ToSecGroupOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "security-group"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/results.go
@@ -1,0 +1,34 @@
+package securities
+
+import "github.com/huaweicloud/golangsdk"
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// SSLUpdateResult represents a result of the ConfigureSSL method.
+type SSLUpdateResult struct {
+	golangsdk.ErrResult
+}
+
+// DBPortUpdateResult represents a result of the UpdateDBPort method.
+type DBPortUpdateResult struct {
+	commonResult
+}
+
+// SecGroupUpdateResult represents a result of the UpdateSecGroup method.
+type SecGroupUpdateResult struct {
+	commonResult
+}
+
+// WorkFlow is a struct that represents the result of database updation.
+type WorkFlow struct {
+	// Indicates the workflow ID.
+	WorkflowId string `json:"workflowId"`
+}
+
+func (r commonResult) Extract() (*WorkFlow, error) {
+	var s WorkFlow
+	err := r.ExtractInto(&s)
+	return &s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/urls.go
@@ -1,0 +1,7 @@
+package securities
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId, path string) string {
+	return c.ServiceURL("instances", instanceId, path)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -448,6 +448,7 @@ github.com/huaweicloud/golangsdk/openstack/opengauss/v3/instances
 github.com/huaweicloud/golangsdk/openstack/rds/v3/backups
 github.com/huaweicloud/golangsdk/openstack/rds/v3/configurations
 github.com/huaweicloud/golangsdk/openstack/rds/v3/instances
+github.com/huaweicloud/golangsdk/openstack/rds/v3/securities
 github.com/huaweicloud/golangsdk/openstack/rts/v1/softwareconfig
 github.com/huaweicloud/golangsdk/openstack/rts/v1/stackresources
 github.com/huaweicloud/golangsdk/openstack/rts/v1/stacks


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The RDS instance supports updating the security group ID and database port.
For MySQL, we can configure SSL. now

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1317 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support ssl enable and disable
2. database port and securtiy group can be updated now
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsInstanceV3_mysql'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_mysql -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_mysql
=== PAUSE TestAccRdsInstanceV3_mysql
=== CONT  TestAccRdsInstanceV3_mysql
--- PASS: TestAccRdsInstanceV3_mysql (646.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       646.982s
```
