### PR TITLE
Add new API support for APIG service

### DIFF
--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -1,0 +1,389 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_api
+
+Manages an APIG API resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+variable "api_name" {}
+variable "custom_response_id" {}
+variable "custom_auth_id" {}
+variable "vpc_channel_id" {}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = var.instance_id
+  group_id                = var.group_id
+  type                    = "Public"
+  name                    = var.api_name
+  request_protocol        = "HTTP"
+  request_method          = "POST"
+  request_path            = "/terraform/users"
+  security_authentication = "AUTHORIZER"
+  matching                = "Exact"
+  success_response        = "Successful"
+  response_id             = var.custom_response_id
+  authorizer_id           = var.custom_auth_id
+
+  backend_params {
+    type     = "SYSTEM"
+    name     = "X-User-Auth"
+    location = "HEADER"
+    value    = "user_name"
+  }
+
+  web {
+    path             = "/backend/users"
+    vpc_channel_id   = var.vpc_channel_id
+    request_method   = "POST"
+    request_protocol = "HTTP"
+    timeout          = 5000
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new API resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API
+  belongs to.
+  Changing this will create a new API resource.
+
+* `group_id` - (Required, String) Specifies an ID of the APIG group to which the API belongs to.
+
+* `type` - (Required, String) Specifies the API type. The valid values are __Public__ and __Private__.
+
+* `name` - (Required, String) Specifies the API name, which can consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `request_method` - (Required, String) Specifies the request method of the API.
+  The valid values are __GET__, __POST__, __PUT__, __DELETE__, __HEAD__, __PATCH__, __OPTIONS__ and __ANY__.
+
+* `request_path` - (Required, String) Specifies the request address, which can contain a maximum of 512 characters
+  request parameters enclosed with brackets ({}).
+  - The address can contain special characters, such as asterisks (), percent signs (%), hyphens (-), and
+    underscores (_) and must comply with URI specifications.
+  - The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+    Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+
+* `request_protocol` - (Required, String) Specifies the request protocol of the API.
+  The valid value are __HTTP__, __HTTPS__ and __BOTH__.
+
+* `request_params` - (Optional, List) Specifies an array of one or more request parameters of the front-end.
+  The maximum of request parameters is 50.
+  The [object](#request_params) structure is documented below.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters.
+  The [object](#backend_params) structure is documented below.
+  The maximum of request parameters is 50.
+
+* `security_authentication` - (Optional, String) Specifies the security authentication mode.
+  The valid values are __NONE__, __APP__ and __IAM__, default to __NONE__.
+
+* `simple_authentication` - (Optional, Bool) Specifies whether AppCode authentication is enabled.
+  The applicaiton code must located in the header when `simple_authentication` is true.
+
+* `authorizer_id` - (Optional, Bool) Specifies ID of the front-end custom authorizer.
+
+* `body_description` - (Optional, String) Specifies the description of the API request body, which can be an example request body,
+  media type or parameters.
+  The request body does not exceed 20,480 characters.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `cors` - (Optional, Bool) Specifies whether CORS is supported, default to false.
+
+* `description` - (Optional, String) Specifies the API description, which can contain a maximum of 255 characters.
+  The Chinese characters must be in UTF-8 or Unicode format.
+
+* `matching` - (Optional, String) Specifies the route matching mode.
+  The valid value are __Exact__ and __Prefix__, default to __Exact__.
+
+* `response_id` - (Optional, String) Specifies the APIG group response ID.
+
+* `success_response` - (Optional, String) Specifies the example response for a successful request.
+  Ensure that the response does not exceed 20,480 characters.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `failure_response` - (Optional, String) Specifies the example response for a successful request.
+  Ensure that the response does not exceed 20,480 characters.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `mock` - (Optional, List, ForceNew) Specifies the mock backend details.
+  The [object](#mock) structure is documented below.
+  Changing this will create a new API resource.
+
+* `func_graph` - (Optional, List, ForceNew) Specifies the function graph backend details.
+  The [object](#func_graph) structure is documented below.
+  Changing this will create a new API resource.
+
+* `web` - (Optional, List, ForceNew) Specifies the web backend details.
+  The [object](#web) structure is documented below.
+  Changing this will create a new API resource.
+
+* `mock_policy` - (Optional, List) Specifies the Mock policy backends.
+  The maximum of the policy is 5.
+  The [object](#mock_policy) structure is documented below.
+
+* `func_graph_policy` - (Optional, List) Specifies the Mock policy backends.
+  The maximum of the policy is 5.
+  The [object](#func_graph_policy) structure is documented below.
+
+* `web_policy` - (Optional, List) Specifies the example response for a failed request.
+  The maximum of the policy is 5.
+  The [object](#web_policy) structure is documented below.
+
+The <span id="request_params">`request_params`</span> block supports:
+
+* `name` - (Required, String) Specifies the request parameter name, which contain of 1 to 32 characters and start with
+  a letter. Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed.
+  If Location is specified as __HEADER__ and `security_authentication` is specified as __APP__, the parameter name is
+  not 'Authorization' (case-insensitive) and cannot contain underscores.
+
+* `required` - (Required, Bool) Specifies whether the request parameter is required.
+
+* `location` - (Optional, String) Specifies the location of the request parameter.
+  The valid values are __PATH__, __QUERY__ and __HEADER__, default to __PATH__.
+
+* `type` - (Optional, String) Specifies the request parameter type.
+  The valid values are __STRING__ and __NUMBER__, default to __STRING__.
+
+* `maximum` - (Optional, Int) Specifies the maximum value or size of the request parameter.
+
+* `minimum` - (Optional, Int) Specifies the minimum value or size of the request parameter.
+  For string type, The `maximum` and `minimum` means size.
+  For number type, they means value.
+
+* `example` - (Optional, String) Specifies the example value of the request parameter, which contain a maximum of
+  255 characters, and the angle brackets (< and >) are not allowed.
+
+* `default` - (Optional, String) Specifies the default value of the request parameter, which contain a maximum of
+  255 characters, and the angle brackets (< and >) are not allowed.
+
+* `description` - (Optional, String) Specifies the description of the request parameter, which contain a maximum of
+  255 characters, and the angle brackets (< and >) are not allowed.
+
+The <span id="backend_params">`backend_params`</span> block supports:
+
+* `type` - (Required, String) Specifies the backend parameter type.
+  The valid values are __REQUEST__, __CONSTANT__ and __SYSTEM__.
+
+* `name` - (Required, String) Specifies the backend parameter name, which contain of 1 to 32 characters and start with
+  a letter. Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed.
+  The parameter name is not case-sensitive.
+  It cannot start with 'x-apig-' or 'x-sdk-' and cannot be 'x-stage'.
+  If the location is specified as __HEADER__,  the name cannot contain underscores.
+
+* `location` - (Required, String) Specifies the location of the backend parameter.
+  The valid values are __PATH__, __QUERY__ and __HEADER__.
+
+* `value` - (Required, String) Specifies the request parameter name corresponding to the request parameter name of
+  the back-end parameter.
+
+* `description` - (Optional, String) Specifies the description of the constant or system parameter, which contain a
+  maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+
+The <span id="mock">`mock`</span> block supports:
+
+* `response` - (Required, String) Specifies the response of the backend policy, which contain a maximum of 2,048
+  characters, and the angle brackets (< and >) are not allowed.
+
+  -> **NOTE:**  Mock enables APIG to return a response without sending the request to the backend.
+  This is useful for testing APIs when the backend is not available.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+The <span id="func_graph">`func_graph`</span> block supports:
+
+* `function_urn` - (Required, String) Specifies the function graph URN.
+
+* `version` - (Required, String) Specifies the version of the function graph.
+
+* `timeout` - (Optional, Int) Specifies the location of the backend parameter.
+  The valid value is range form 1 to 600,000, default to 5,000.
+
+* `invocation_type` - (Optional, String) Specifies the invocation mode.
+  The valid values are __async__ and __sync__, default to __sync__.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+The <span id="web">`web`</span> block supports:
+
+* `path` - (Required, String) Specifies the backend request address, which can contain a maximum of 512 characters and
+  must comply with URI specifications.
+  - The request address can contain request parameters enclosed with brackets ({}).
+  - The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-) and
+    underscores (_) and must comply with URI specifications.
+  - The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+    Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+
+* `host_header` - (Optional, String) Specifies the proxy host header.
+  The host header can be customized for requests to be forwarded to cloud servers through the VPC channel.
+  By default, the original host header of the request is used.
+
+* `vpc_channel_id` - (Optional, String) Specifies the VPC channel ID.
+  This parameter and `backend_address` are alternative.
+
+* `backend_address` - (Optional, String) Specifies the backend service address, which consists of a domain name or
+  IP address, and a port number, with not more than 255 characters.
+  The backend service address must be in the format "Host name:Port number", for example, apig.example.com:7443.
+  If the port number is not specified, the default HTTPS port 443, or the default HTTP port 80 is used.
+  The backend service address can contain environment variables, each starting with a letter and consisting of
+  3 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+
+* `request_method` - (Optional, String) Specifies the backend request method of the API.
+  The valid types are __GET__, __POST__, __PUT__, __DELETE__, __HEAD__, __PATCH__, __OPTIONS__ and __ANY__.
+
+* `request_protocol` - (Optional, String) Specifies the backend request protocol.
+  The valid values are __HTTP__ and __HTTPS__, default to __HTTPS__.
+
+* `timeout` - (Optional, Int) Specifies the timeout, in ms, which allowed for APIG to request the backend service.
+  The valid value is range from 1 to 600,000, default to 5,000.
+
+* `ssl_enable` - (Optional, Bool) Specifies the indicates whether to enable two-way authentication, default to false.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+The <span id="mock_policy">`mock_policy`</span> block supports:
+
+* `name` - (Required, String) Specifies the backend policy name, which can contains of 3 to 64 characters and start
+  with a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `conditions` - (Required, List) Specifies an array of one or more policy conditions.
+  Up to five conditions can be set.
+  The [object](#conditions) structure is documented below.
+
+* `response` - (Optional, String) Specifies the response of the backend policy, which contain a maximum of 2,048
+  characters, and the angle brackets (< and >) are not allowed.
+
+* `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy.
+  The valid values are __ALL__ and __ANY__, default to __ANY__.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters.
+  The maximum of request parameters is 50.
+  The [object](#backend_params) structure is documented above.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+The <span id="func_graph_policy">`func_graph_policy`</span> block supports:
+
+* `name` - (Required, String) Specifies the backend policy name, which can contains of 3 to 64 characters and start
+  with a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `function_urn` - (Required, String) Specifies the URN of the function graph.
+
+* `conditions` - (Required, List) Specifies an array of one or more policy conditions.
+  Up to five conditions can be set.
+  The [object](#conditions) structure is documented below.
+
+* `invocation_mode` - (Optional, String) Specifies the invocation mode of the function graph.
+  The valid values are __async__ and __sync__, default to __sync__.
+
+* `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy.
+  The valid values are __ALL__ and __ANY__, default to __ANY__.
+
+* `timeout` - (Optional, Int) Specifies the timeout, in ms, which allowed for APIG to request the backend service.
+  The valid value is range from 1 to 600,000, default to 5,000.
+
+* `version` - (Optional, String) Specifies the version of the function graph.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters.
+  The maximum of request parameters is 50.
+  The [object](#backend_params) structure is documented above.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+The <span id="web_policy">`web_policy`</span> block supports:
+
+* `name` - (Required, String) Specifies the backend policy name, which can contains of 3 to 64 characters and start
+  with a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `path` - (Required, String) Specifies the backend request address, which can contain a maximum of 512 characters and
+  must comply with URI specifications.
+  - The request address can contain request parameters enclosed with brackets ({}).
+  - The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-) and
+    underscores (_) and must comply with URI specifications.
+  - The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+    Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+
+* `request_method` - (Required, String) Specifies the backend request method of the API.
+  The valid types are __GET__, __POST__, __PUT__, __DELETE__, __HEAD__, __PATCH__, __OPTIONS__ and __ANY__.
+
+* `conditions` - (Required, List) Specifies an array of one or more policy conditions.
+  Up to five conditions can be set.
+  The [object](#conditions) structure is documented below.
+
+* `host_header` - (Optional, String) Specifies the proxy host header.
+  The host header can be customized for requests to be forwarded to cloud servers through the VPC channel.
+  By default, the original host header of the request is used.
+
+* `vpc_channel_id` - (Optional, String) Specifies the VPC channel ID.
+  This parameter and `backend_address` are alternative.
+
+* `backend_address` - (Optional, String) Specifies the backend service address, which consists of a domain name or
+  IP address, and a port number, with not more than 255 characters.
+  The backend service address must be in the format "Host name:Port number", for example, apig.example.com:7443.
+  If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+  The backend service address can contain environment variables, each starting with a letter and consisting of
+  3 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+
+* `request_protocol` - (Optional, String) Specifies the backend request protocol.
+  The valid values are __HTTP__ and __HTTPS__, default to __HTTPS__.
+
+* `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy.
+  The valid values are __ALL__ and __ANY__, default to __ANY__.
+
+* `timeout` - (Optional, Int) Specifies the timeout, in ms, which allowed for APIG to request the backend service.
+  The valid value is range from 1 to 600,000, default to 5,000.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters.
+  The maximum of request parameters is 50.
+  The [object](#backend_params) structure is documented above.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+The <span id="conditions">`conditions`</span> block supports:
+
+* `value` - (Required, String) Specifies the condition type.
+  For a condition with the input parameter source:
+  - If the condition type is __Enumerated__, separate condition values with commas.
+  - If the condition type is __Matching__, enter a regular expression compatible with PERL.
+
+  For a condition with the Source IP address source, enter IPv4 addresses and separate them with commas.
+  The CIDR address format is supported.
+
+* `param_name` - (Optional, String) Specifies the request parameter name.
+  This parameter is required if the policy type is param.
+
+* `source` - (Optional, String) Specifies the policy type.
+  The valid values are __param__ and __source__, default to __source__.
+
+* `type` - (Optional, String) Specifies the condition type of the backend policy.
+  The valid values are __Equal__, __Enumerated__ and __Matching__, default to __Equal__.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG API.
+* `register_time` - Time when the API is registered, in UTC format.
+* `update_time` - Time when the API was last modified, in UTC format.
+
+## Import
+
+APIs can be imported using their `name` and ID of the APIG dedicated instance to which the API
+belongs, separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_apig_api.test <instance_id>/<name>
+```

--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -94,7 +94,7 @@ The following arguments are supported:
 * `simple_authentication` - (Optional, Bool) Specifies whether AppCode authentication is enabled.
   The applicaiton code must located in the header when `simple_authentication` is true.
 
-* `authorizer_id` - (Optional, Bool) Specifies ID of the front-end custom authorizer.
+* `authorizer_id` - (Optional, String) Specifies ID of the front-end custom authorizer.
 
 * `body_description` - (Optional, String) Specifies the description of the API request body, which can be an example request body,
   media type or parameters.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca
+	github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883 h1:4D/N05upt
 github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a h1:yJda8qxR3mnJydpPlJ4MgYGZD8nO7eDwGSm52lbwSvw=
 github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca h1:HorbTsfgeR6HvpuP09mYylN0K6RUg+0a0iWKSWlVoy8=
-github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6 h1:bBWGvYquVhlmsOVU3AY8XMAjUuMg/s36fPOBTjVwCgQ=
+github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -373,6 +373,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"huaweicloud_api_gateway_api":                 ResourceAPIGatewayAPI(),
 			"huaweicloud_api_gateway_group":               ResourceAPIGatewayGroup(),
+			"huaweicloud_apig_api":                        apig.ResourceApigAPIV2(),
 			"huaweicloud_apig_instance":                   apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_application":                apig.ResourceApigApplicationV2(),
 			"huaweicloud_apig_custom_authorizer":          apig.ResourceApigCustomAuthorizerV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -1,0 +1,314 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigAPIV2_basic(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "huaweicloud_apig_api.test"
+		api          apis.APIResp
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckApigAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigAPI_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigAPIExists(resourceName, &api),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "Public"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "request_path", "/user_info/{user_age}"),
+					resource.TestCheckResourceAttr(resourceName, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(resourceName, "matching", "Exact"),
+					resource.TestCheckResourceAttr(resourceName, "success_response", "Success response"),
+					resource.TestCheckResourceAttr(resourceName, "failure_response", "Failed response"),
+					resource.TestCheckResourceAttr(resourceName, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.path", "/getUserAge/{userAge}"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.timeout", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "web_policy.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock_policy"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph_policy"),
+				),
+			},
+			{
+				Config: testAccApigAPI_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigAPIExists(resourceName, &api),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Public"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "request_path", "/user_info/{user_name}"),
+					resource.TestCheckResourceAttr(resourceName, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(resourceName, "matching", "Exact"),
+					resource.TestCheckResourceAttr(resourceName, "success_response", "Updated Success response"),
+					resource.TestCheckResourceAttr(resourceName, "failure_response", "Updated Failed response"),
+					resource.TestCheckResourceAttr(resourceName, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.path", "/getUserName/{userName}"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.timeout", "60000"),
+					resource.TestCheckResourceAttr(resourceName, "web_policy.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock_policy"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph_policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigAPIResourceImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigAPIDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_apig_api" {
+			continue
+		}
+		_, err := apis.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigAPIExists(n string, app *apis.APIResp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Unable to find API ID")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		}
+		found, err := apis.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigAPIResourceImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["name"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
+	}
+}
+
+func testAccApigAPI_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+}
+
+resource "huaweicloud_apig_vpc_channel" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  port        = 80
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    id = huaweicloud_compute_instance.test.id
+  }
+}
+`, testAccApigVpcChannel_base(rName), rName, rName)
+}
+
+func testAccApigAPI_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+  
+  backend_params {
+	type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = "%s_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+}
+`, testAccApigAPI_base(rName), rName, rName)
+}
+
+func testAccApigAPI_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%s_update"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_name}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Updated Success response"
+  failure_response        = "Updated Failed response"
+  description             = "Updated by script"
+
+  request_params {
+    name     = "user_name"
+    type     = "STRING"
+    location = "PATH"
+    required = true
+    maximum  = 64
+    minimum  = 3
+  }
+  
+  backend_params {
+    type     = "REQUEST"
+    name     = "userName"
+    location = "PATH"
+    value    = "user_name"
+  }
+
+  web {
+    path             = "/getUserName/{userName}"
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 60000
+  }
+
+  web_policy {
+    name             = "%s_update_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getAdminName/{adminName}"
+    timeout          = 60000
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "adminName"
+      location = "PATH"
+      value    = "user_name"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_name"
+      type       = "Equal"
+      value      = "Administrator"
+    }
+  }
+}
+`, testAccApigAPI_base(rName), rName, rName)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
@@ -1,0 +1,1389 @@
+package apig
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+const (
+	protocolHTTP  = "HTTP"
+	protocolHTTPS = "HTTPS"
+	protocolBOTH  = "BOTH"
+
+	methodGET     = "GET"
+	methodPOST    = "POST"
+	methodPUT     = "PUT"
+	methodDELETE  = "DELETE"
+	methodHEAD    = "HEAD"
+	methodPATCH   = "PATCH"
+	methodOPTIONS = "OPTIONS"
+	methodANY     = "ANY"
+)
+
+var (
+	matching = map[string]string{
+		"Prefix": "SWA",
+		"Exact":  "NORMAL",
+	}
+	conditionType = map[string]string{
+		"Equal":      "exact",
+		"Enumerated": "enum",
+		"Matching":   "pattern",
+	}
+)
+
+func ResourceApigAPIV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApigAPIV2Create,
+		Read:   resourceApigAPIV2Read,
+		Update: resourceApigAPIV2Update,
+		Delete: resourceApigAPIV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceApigAPIResourceImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(40 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Public", "Private",
+				}, false),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([\u4e00-\u9fa5A-Za-z][\u4e00-\u9fa5A-Za-z_0-9]{2,63})$"),
+					"The name contains of 3 to 64 characters, starting with a letter. Only letters, digits, "+
+						"hyphens (-) and underscore (_) are allowed."),
+			},
+			"request_method": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					methodGET, methodPOST, methodPUT, methodDELETE, methodHEAD, methodPATCH, methodOPTIONS, methodANY,
+				}, false),
+			},
+			"request_path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"request_protocol": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					protocolHTTP, protocolHTTPS, protocolBOTH,
+				}, false),
+			},
+			"request_params": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 50,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^([A-Za-z][A-Za-z0-9-_\\.]{0,31})$"),
+								"The name can contains of 1 to 32 characters and start with a letter."+
+									"Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed."),
+						},
+						"required": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "PATH",
+							ValidateFunc: validation.StringInSlice([]string{
+								"PATH", "HEADER", "QUERY",
+							}, false),
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "STRING",
+							ValidateFunc: validation.StringInSlice([]string{
+								"STRING", "NUMBER",
+							}, false),
+						},
+						"maximum": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"minimum": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"example": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+								"The example value contain a maximum of 255 characters, "+
+									"and the angle brackets (< and >) are not allowed."),
+						},
+						"default": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+								"The default value contain a maximum of 255 characters, "+
+									"and the angle brackets (< and >) are not allowed."),
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+								"The description contain a maximum of 255 characters, "+
+									"and the angle brackets (< and >) are not allowed."),
+						},
+					},
+				},
+			},
+			"backend_params": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     backendParamSchemaResource(),
+				Set:      resourceBackendParamtersHash,
+			},
+			"security_authentication": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "NONE",
+				ValidateFunc: validation.StringInSlice([]string{
+					"NONE", "APP", "IAM", "AUTHORIZER",
+				}, false),
+			},
+			"simple_authentication": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"authorizer_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"body_description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 20480),
+			},
+			"cors": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+					"The description contain a maximum of 255 characters, "+
+						"and the angle brackets (< and >) are not allowed."),
+			},
+			"matching": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Exact",
+				ValidateFunc: validation.StringInSlice([]string{
+					"Exact", "Prefix",
+				}, false),
+			},
+			"response_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"success_response": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 20480),
+			},
+			"failure_response": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 20480),
+			},
+			"mock": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				MaxItems:     1,
+				ExactlyOneOf: []string{"func_graph", "web"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"response": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 2048),
+						},
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"func_graph": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"function_urn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      5000,
+							ValidateFunc: validation.IntBetween(1, 600000),
+						},
+						"invocation_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "sync",
+							ValidateFunc: validation.StringInSlice([]string{
+								"async", "sync",
+							}, false),
+						},
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"web": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"host_header": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"web.0.backend_address"},
+						},
+						"vpc_channel_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: []string{"web.0.backend_address"},
+						},
+						"backend_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"request_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								methodGET, methodPOST, methodPUT, methodDELETE, methodHEAD, methodPATCH, methodOPTIONS, methodANY,
+							}, false),
+						},
+						"request_protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  protocolHTTPS,
+							ValidateFunc: validation.StringInSlice([]string{
+								protocolHTTP, protocolHTTPS,
+							}, false),
+						},
+						"timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      5000,
+							ValidateFunc: validation.IntBetween(1, 600000),
+						},
+						"ssl_enable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"mock_policy": {
+				Type:          schema.TypeSet,
+				MaxItems:      5,
+				Optional:      true,
+				ConflictsWith: []string{"func_graph", "web", "func_graph_policy", "web_policy"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^([A-Za-z][A-Za-z0-9_]{2,63})$"),
+								"The name can contains of 3 to 64 characters and start with a letter."+
+									"Only letters, digits and underscores (_) are allowed."),
+						},
+						"conditions": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 5,
+							Elem:     policyConditionSchemaResource(),
+						},
+						"response": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(8, 2048),
+						},
+						"effective_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ANY",
+							ValidateFunc: validation.StringInSlice([]string{
+								"ALL", "ANY",
+							}, false),
+						},
+						"backend_params": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     backendParamSchemaResource(),
+							Set:      resourceBackendParamtersHash,
+						},
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"func_graph_policy": {
+				Type:          schema.TypeSet,
+				MaxItems:      5,
+				Optional:      true,
+				ConflictsWith: []string{"mock", "web", "mock_policy", "web_policy"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^([A-Za-z][A-Za-z0-9_]{2,63})$"),
+								"The name can contains of 3 to 64 characters and start with a letter."+
+									"Only letters, digits and underscores (_) are allowed."),
+						},
+						"function_urn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"conditions": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 5,
+							Elem:     policyConditionSchemaResource(),
+						},
+						"invocation_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "sync",
+							ValidateFunc: validation.StringInSlice([]string{
+								"async", "sync",
+							}, false),
+						},
+						"effective_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ANY",
+							ValidateFunc: validation.StringInSlice([]string{
+								"ALL", "ANY",
+							}, false),
+						},
+						"timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      5000,
+							ValidateFunc: validation.IntBetween(1, 600000),
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"backend_params": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     backendParamSchemaResource(),
+							Set:      resourceBackendParamtersHash,
+						},
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"web_policy": {
+				Type:          schema.TypeSet,
+				MaxItems:      5,
+				Optional:      true,
+				ConflictsWith: []string{"mock", "func_graph", "mock_policy", "func_graph_policy"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile("^([A-Za-z][A-Za-z0-9_]{2,63})$"),
+								"The name can contains of 3 to 64 characters and start with a letter."+
+									"Only letters, digits and underscores (_) are allowed."),
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"request_method": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								methodGET, methodPOST, methodPUT, methodDELETE, methodHEAD, methodPATCH, methodOPTIONS, methodANY,
+							}, false),
+						},
+						"conditions": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 5,
+							Elem:     policyConditionSchemaResource(),
+						},
+						"host_header": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"vpc_channel_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"backend_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"request_protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								protocolHTTP, protocolHTTPS,
+							}, false),
+						},
+						"effective_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ANY",
+							ValidateFunc: validation.StringInSlice([]string{
+								"ALL", "ANY",
+							}, false),
+						},
+						"timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      5000,
+							ValidateFunc: validation.IntBetween(1, 600000),
+						},
+						"backend_params": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     backendParamSchemaResource(),
+							Set:      resourceBackendParamtersHash,
+						},
+						"authorizer_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"register_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func policyConditionSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"param_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "param",
+				ValidateFunc: validation.StringInSlice([]string{
+					"param", "source",
+				}, false),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Equal",
+				ValidateFunc: validation.StringInSlice([]string{
+					"Equal", "Enumerated", "Matching",
+				}, false),
+			},
+		},
+	}
+}
+
+func backendParamSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"REQUEST", "CONSTANT", "SYSTEM",
+				}, false),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([A-Za-z][A-Za-z0-9-_\\.]{0,31})$"),
+					"The name can contains of 1 to 32 characters and start with a letter."+
+						"Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed."),
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"PATH", "QUERY", "HEADER",
+				}, false),
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+					"The value contain a maximum of 255 characters, "+
+						"and the angle brackets (< and >) are not allowed."),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^<>]{1,255}$"),
+					"The description contain a maximum of 255 characters, "+
+						"and the angle brackets (< and >) are not allowed."),
+			},
+		},
+	}
+}
+
+func buildAPIType(t string) (int, error) {
+	apiType := map[string]int{
+		"Public":  1,
+		"Private": 2,
+	}
+	if v, ok := apiType[t]; ok {
+		return v, nil
+	}
+	return -1, fmtp.Errorf("The API type (%s) is invalid", t)
+}
+
+func buildAPIMock(mock []interface{}) *apis.Mock {
+	mockMap := mock[0].(map[string]interface{})
+	cont := mockMap["response"].(string)
+	authId := mockMap["authorizer_id"].(string)
+
+	return &apis.Mock{
+		ResultContent: &cont,
+		AuthorizerId:  &authId,
+	}
+}
+
+func buildAPIFuncGraph(funcGraph []interface{}) *apis.FuncGraph {
+	funcMap := funcGraph[0].(map[string]interface{})
+	authId := funcMap["authorizer_id"].(string)
+
+	return &apis.FuncGraph{
+		Timeout:        funcMap["timeout"].(int),
+		InvocationType: funcMap["invocation_type"].(string),
+		FunctionUrn:    funcMap["function_urn"].(string),
+		Version:        funcMap["version"].(string),
+		AuthorizerId:   &authId,
+	}
+}
+
+func buildApigAPIWeb(web []interface{}) *apis.Web {
+	webMap := web[0].(map[string]interface{})
+	sslEnable := webMap["ssl_enable"].(bool)
+	authId := webMap["authorizer_id"].(string)
+
+	result := apis.Web{
+		ReqURI:          webMap["path"].(string),
+		ReqMethod:       webMap["request_method"].(string),
+		ReqProtocol:     webMap["request_protocol"].(string),
+		Timeout:         webMap["timeout"].(int),
+		ClientSslEnable: &sslEnable,
+		AuthorizerId:    &authId,
+	}
+	// If vpc_channel_id is empty, the backend address is used.
+	if chanId, ok := webMap["vpc_channel_id"]; ok && chanId != "" {
+		result.VpcChannelStatus = 1
+		result.VpcChannelInfo = &apis.VpcChannel{
+			VpcChannelId:        chanId.(string),
+			VpcChannelProxyHost: webMap["host_header"].(string),
+		}
+	} else {
+		result.VpcChannelStatus = 2
+		result.DomainURL = webMap["backend_address"].(string)
+	}
+
+	return &result
+}
+
+func buildAPIRequestParameters(requests *schema.Set) []apis.ReqParamBase {
+	result := make([]apis.ReqParamBase, requests.Len())
+	for i, v := range requests.List() {
+		paramMap := v.(map[string]interface{})
+		paramType := paramMap["type"].(string)
+		desc := paramMap["description"].(string)
+		param := apis.ReqParamBase{
+			Name:        paramMap["name"].(string),
+			Location:    paramMap["location"].(string),
+			Description: &desc,
+		}
+		if paramType == "NUMBER" {
+			param.MaxNum = golangsdk.IntToPointer(paramMap["maximum"].(int))
+			param.MinNum = golangsdk.IntToPointer(paramMap["minimum"].(int))
+		} else if paramType == "STRING" {
+			param.MaxSize = golangsdk.IntToPointer(paramMap["maximum"].(int))
+			param.MinSize = golangsdk.IntToPointer(paramMap["minimum"].(int))
+		}
+		param.Type = paramType
+
+		if paramMap["required"].(bool) {
+			param.Required = 1
+		} else {
+			param.Required = 2
+		}
+		result[i] = param
+	}
+	return result
+}
+
+func buildAPIBackendParameterValue(origin, value string) string {
+	// The internal parameters of the system parameters include as below:
+	internalParams := []string{
+		"sourceIp", "stage", "apiId", "requestId", "serverAddr", "serverName", "handleTime", "providerAppId",
+	}
+	if origin == "SYSTEM" {
+		// If the system parameters are configured as internal parameters, the internal format is used to construct.
+		if utils.StrSliceContains(internalParams, value) {
+			return fmt.Sprintf("$context.%s", value)
+		}
+		// The fornt-end format is used to construct.
+		return fmt.Sprintf("$context.authorizer.frontend.%s", value)
+	}
+	return value
+}
+
+// For backend API, the parameters contains request parameters and constant parameters.
+func buildAPIBackendParameters(backends *schema.Set) []apis.BackendParamBase {
+	result := make([]apis.BackendParamBase, backends.Len())
+	for i, v := range backends.List() {
+		paramMap := v.(map[string]interface{})
+		origin := paramMap["type"].(string)
+		param := apis.BackendParamBase{
+			Origin:   origin,
+			Name:     paramMap["name"].(string),
+			Location: paramMap["location"].(string),
+			Value:    buildAPIBackendParameterValue(origin, paramMap["value"].(string)),
+		}
+		if origin != "REQUEST" {
+			param.Description = golangsdk.MaybeString(paramMap["description"].(string))
+		}
+		result[i] = param
+	}
+
+	return result
+}
+
+func buildAPIPolicyConditions(conditions *schema.Set) ([]apis.APIConditionBase, error) {
+	result := make([]apis.APIConditionBase, conditions.Len())
+	for i, v := range conditions.List() {
+		conditionMap := v.(map[string]interface{})
+		condition := apis.APIConditionBase{
+			ReqParamName:    conditionMap["param_name"].(string),
+			ConditionOrigin: conditionMap["source"].(string),
+			ConditionValue:  conditionMap["value"].(string),
+		}
+		conType := conditionMap["type"].(string)
+		if v, ok := conditionType[conType]; ok {
+			condition.ConditionType = v
+		} else {
+			return result, fmtp.Errorf("The condition type is invalid")
+		}
+		result[i] = condition
+	}
+	return result, nil
+}
+
+func buildAPIMockPolicy(mocks *schema.Set) ([]apis.PolicyMock, error) {
+	result := make([]apis.PolicyMock, mocks.Len())
+	for i, policy := range mocks.List() {
+		pm := policy.(map[string]interface{})
+		condition, err := buildAPIPolicyConditions(pm["conditions"].(*schema.Set))
+		if err != nil {
+			return result, err
+		}
+		result[i] = apis.PolicyMock{
+			Name:          pm["name"].(string),
+			ResultContent: pm["response"].(string),
+			EffectMode:    pm["effective_mode"].(string),
+			Conditions:    condition,
+			BackendParams: buildAPIBackendParameters(pm["backend_params"].(*schema.Set)),
+		}
+	}
+	return result, nil
+}
+
+func buildAPIFuncGraphPolicy(policies *schema.Set) ([]apis.PolicyFuncGraph, error) {
+	result := make([]apis.PolicyFuncGraph, policies.Len())
+	for i, policy := range policies.List() {
+		pm := policy.(map[string]interface{})
+		condition, err := buildAPIPolicyConditions(pm["conditions"].(*schema.Set))
+		if err != nil {
+			return result, err
+		}
+		result[i] = apis.PolicyFuncGraph{
+			Name:           pm["name"].(string),
+			FunctionUrn:    pm["function_urn"].(string),
+			InvocationType: pm["invocation_mode"].(string),
+			EffectMode:     pm["effective_mode"].(string),
+			Timeout:        pm["timeout"].(int),
+			Conditions:     condition,
+			BackendParams:  buildAPIBackendParameters(pm["backend_params"].(*schema.Set)),
+		}
+	}
+	return result, nil
+}
+
+func buildApigAPIWebPolicy(policies *schema.Set) ([]apis.PolicyWeb, error) {
+	result := make([]apis.PolicyWeb, policies.Len())
+	for i, policy := range policies.List() {
+		pm := policy.(map[string]interface{})
+		condition, err := buildAPIPolicyConditions(pm["conditions"].(*schema.Set))
+		if err != nil {
+			return result, err
+		}
+		wp := apis.PolicyWeb{
+			Name:          pm["name"].(string),
+			ReqProtocol:   pm["request_protocol"].(string),
+			ReqMethod:     pm["request_method"].(string),
+			ReqURI:        pm["path"].(string),
+			EffectMode:    pm["effective_mode"].(string),
+			Timeout:       pm["timeout"].(int),
+			DomainURL:     pm["host_header"].(string),
+			Conditions:    condition,
+			BackendParams: buildAPIBackendParameters(pm["backend_params"].(*schema.Set)),
+		}
+		if chanId, ok := pm["vpc_channel_id"]; ok {
+			if chanId != "" {
+				wp.VpcChannelInfo = &apis.VpcChannel{
+					VpcChannelId:        pm["vpc_channel_id"].(string),
+					VpcChannelProxyHost: pm["host_header"].(string),
+				}
+				wp.VpcChannelStatus = 1
+			} else {
+				wp.VpcChannelStatus = 2
+			}
+		}
+		result[i] = wp
+	}
+	return result, nil
+}
+
+func buildApigAPIParameters(d *schema.ResourceData) (apis.APIOpts, error) {
+	apiType, err := buildAPIType(d.Get("type").(string))
+	if err != nil {
+		return apis.APIOpts{}, err
+	}
+	cors := d.Get("cors").(bool)
+	desc := d.Get("description").(string)
+	bodyDesc := d.Get("body_description").(string)
+	successResp := d.Get("success_response").(string)
+	failureResp := d.Get("failure_response").(string)
+	authType := d.Get("security_authentication").(string)
+	opt := apis.APIOpts{
+		Type:                apiType,
+		AuthorizerId:        d.Get("authorizer_id").(string),
+		GroupId:             d.Get("group_id").(string),
+		Name:                d.Get("name").(string),
+		ReqProtocol:         d.Get("request_protocol").(string),
+		ReqMethod:           d.Get("request_method").(string),
+		ReqURI:              d.Get("request_path").(string),
+		Cors:                &cors,
+		AuthType:            authType,
+		MatchMode:           d.Get("matching").(string),
+		Description:         &desc,
+		BodyDescription:     &bodyDesc,
+		ResultNormalSample:  &successResp,
+		ResultFailureSample: &failureResp,
+		ResponseId:          d.Get("response_id").(string),
+	}
+	// build match mode
+	v, ok := matching[d.Get("matching").(string)]
+	if !ok {
+		return opt, fmtp.Errorf("Unable to extract match mode")
+	}
+	opt.MatchMode = v
+
+	isSimpleAuthEnabled := d.Get("simple_authentication").(bool)
+	if authType == "APP" {
+		if isSimpleAuthEnabled {
+			opt.AuthOpt = &apis.AuthOpt{
+				AppCodeAuthType: "HEADER",
+			}
+		} else {
+			opt.AuthOpt = &apis.AuthOpt{
+				AppCodeAuthType: "DISABLE",
+			}
+		}
+	} else if isSimpleAuthEnabled {
+		return opt, fmtp.Errorf("The security authentication must be 'APP' if simple authentication is true")
+	}
+
+	opt.ReqParams = buildAPIRequestParameters(d.Get("request_params").(*schema.Set))
+	opt.BackendParams = buildAPIBackendParameters(d.Get("backend_params").(*schema.Set))
+
+	// build backend (one of the mock, function graph and web) server and related policies.
+	if m, ok := d.GetOk("mock"); ok {
+		opt.BackendType = "MOCK"
+		opt.MockInfo = buildAPIMock(m.([]interface{}))
+		mp := d.Get("mock_policy").(*schema.Set)
+		policy, err := buildAPIMockPolicy(mp)
+		if err != nil {
+			return opt, err
+		}
+		opt.PolicyMocks = policy
+	} else if fg, ok := d.GetOk("func_graph"); ok {
+		opt.BackendType = "FUNCTION"
+		opt.FuncInfo = buildAPIFuncGraph(fg.([]interface{}))
+		fgp := d.Get("func_graph_policy").(*schema.Set)
+		policy, err := buildAPIFuncGraphPolicy(fgp)
+		if err != nil {
+			return opt, err
+		}
+		opt.PolicyFunctions = policy
+	} else {
+		opt.BackendType = protocolHTTP
+		web := d.Get("web").([]interface{})
+		opt.WebInfo = buildApigAPIWeb(web)
+		wp := d.Get("web_policy").(*schema.Set)
+		policy, err := buildApigAPIWebPolicy(wp)
+		if err != nil {
+			return opt, err
+		}
+		opt.PolicyWebs = policy
+	}
+
+	logp.Printf("[DEBUG] The API Opts is : %+v", opt)
+	return opt, nil
+}
+
+func resourceApigAPIV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	opt, err := buildApigAPIParameters(d)
+	if err != nil {
+		return fmtp.Errorf("Unable to build the Api parameter: %s", err)
+	}
+
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+	instanceId := d.Get("instance_id").(string)
+	resp, err := apis.Create(client, instanceId, opt).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error creating APIG v2 API: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	return resourceApigAPIV2Read(d, meta)
+}
+
+func getAPIBackendParameterValue(origin, value string) (string, error) {
+	if origin == "SYSTEM" {
+		// The system parameters include gateway parameters and front-end parameters.
+		if ok, err := regexp.MatchString(`\$context\.authorizer\.frontend\.`, value); ok && err == nil {
+			regex, err := regexp.Compile(`\$context\.authorizer\.frontend\.(.*)`)
+			if err != nil {
+				return "", err
+			}
+			result := regex.FindStringSubmatch(value)
+			fmt.Println(result)
+			if len(result) < 2 {
+				return "", fmtp.Errorf("Wrong front-end parameter format: %s", value)
+			}
+			return result[1], nil
+		}
+		if ok, err := regexp.MatchString(`\$context\.`, value); ok && err == nil {
+			regex, err := regexp.Compile(`\$context\.(.*)`)
+			if err != nil {
+				return "", err
+			}
+			result := regex.FindStringSubmatch(value)
+			fmt.Println(result)
+			if len(result) < 2 {
+				return "", fmtp.Errorf("Wrong gateway parameter format: %s", value)
+			}
+			return result[1], nil
+		}
+		return "", fmtp.Errorf("[ERROR] The parameter %s is not in the format of a gateway or front-end", value)
+	}
+	return value, nil
+}
+
+func getAPIBackendParameters(backendParams []apis.BackendParamResp) ([]map[string]interface{}, error) {
+	result := make([]map[string]interface{}, len(backendParams))
+	for i, v := range backendParams {
+		origin := v.Origin
+		value, err := getAPIBackendParameterValue(v.Origin, v.Value)
+		if err != nil {
+			return result, err
+		}
+		param := map[string]interface{}{
+			"type":     origin,
+			"name":     v.Name,
+			"location": v.Location,
+			"value":    value,
+		}
+		if origin != "REQUEST" {
+			param["description"] = v.Description
+		}
+		result[i] = param
+	}
+	return result, nil
+}
+
+func getAPIPolicyConditions(conditions []apis.APIConditionBase) ([]map[string]interface{}, error) {
+	result := make([]map[string]interface{}, len(conditions))
+	for i, v := range conditions {
+		conType, err := analysisConditionType(v.ConditionType)
+		if err != nil {
+			return result, err
+		}
+		result[i] = map[string]interface{}{
+			"source":     v.ConditionOrigin,
+			"param_name": v.ReqParamName,
+			"type":       conType,
+			"value":      v.ConditionValue,
+		}
+	}
+	return result, nil
+}
+
+func analysisConditionType(conType string) (string, error) {
+	for k, v := range conditionType {
+		if v == conType {
+			return k, nil
+		}
+	}
+	return "", fmtp.Errorf("The condition type (%s) is invalid", conType)
+}
+
+func setApigAPIType(d *schema.ResourceData, t int) error {
+	apiType := map[int]string{
+		1: "Public",
+		2: "Private",
+	}
+	if v, ok := apiType[t]; ok {
+		return d.Set("type", v)
+	}
+	return fmtp.Errorf("The API type (%d) is invalid", t)
+}
+
+func setApigAPIMatchMode(d *schema.ResourceData, mode string) error {
+	for k, v := range matching {
+		if v == mode {
+			return d.Set("matching", k)
+		}
+	}
+	return fmtp.Errorf("The API matching mode is invalid", mode)
+}
+
+func setApigAPIAppSimpleAuth(d *schema.ResourceData, opt apis.AuthOpt) error {
+	// HEADER: AppCode authentication is enabled and the AppCode is located in the header.
+	if opt.AppCodeAuthType == "HEADER" {
+		return d.Set("simple_authentication", true)
+	}
+	return d.Set("simple_authentication", false)
+}
+
+func setApigAPIReqParams(d *schema.ResourceData, reqParams []apis.ReqParamResp) error {
+	result := make([]map[string]interface{}, len(reqParams))
+	for i, v := range reqParams {
+		param := map[string]interface{}{
+			"name":        v.Name,
+			"location":    v.Location,
+			"type":        v.Type,
+			"example":     v.SampleValue,
+			"default":     v.DefaultValue,
+			"description": v.Description,
+		}
+		if v.Type == "NUMBER" {
+			param["maximum"] = v.MaxNum
+			param["minimum"] = v.MinNum
+		} else if v.Type == "STRING" {
+			param["maximum"] = v.MaxSize
+			param["minimum"] = v.MinSize
+		}
+		if v.Required == 1 {
+			param["required"] = true
+		} else if v.Required == 2 {
+			param["required"] = false
+		} else {
+			return fmtp.Errorf("Invalid value of 'required'")
+		}
+		result[i] = param
+	}
+	return d.Set("request_params", result)
+}
+
+func setApigAPIMock(d *schema.ResourceData, mockResp apis.Mock) error {
+	if mockResp == (apis.Mock{}) {
+		return d.Set("mock", nil)
+	}
+	result := []map[string]interface{}{
+		{
+			"response":      mockResp.ResultContent,
+			"authorizer_id": mockResp.AuthorizerId,
+		},
+	}
+	return d.Set("mock", result)
+}
+
+func setApigAPIFuncGraph(d *schema.ResourceData, funcResp apis.FuncGraph) error {
+	if funcResp == (apis.FuncGraph{}) {
+		return d.Set("func_graph", nil)
+	}
+	result := []map[string]interface{}{
+		{
+			"function_urn":    funcResp.FunctionUrn,
+			"timeout":         funcResp.Timeout,
+			"invocation_type": funcResp.InvocationType,
+			"version":         funcResp.Version,
+			"authorizer_id":   funcResp.AuthorizerId,
+		},
+	}
+	return d.Set("func_graph", result)
+}
+
+func setApigAPIWeb(d *schema.ResourceData, webResp apis.Web) error {
+	if webResp == (apis.Web{}) {
+		return d.Set("web", nil)
+	}
+	result := make([]map[string]interface{}, 1)
+	web := map[string]interface{}{
+		"path":             webResp.ReqURI,
+		"request_method":   webResp.ReqMethod,
+		"request_protocol": webResp.ReqProtocol,
+		"timeout":          webResp.Timeout,
+		"ssl_enable":       d.Get("web.0.ssl_enable"),
+		"authorizer_id":    webResp.AuthorizerId,
+	}
+	if webResp.VpcChannelInfo.VpcChannelId != "" {
+		web["vpc_channel_id"] = webResp.VpcChannelInfo.VpcChannelId
+		web["host_header"] = webResp.VpcChannelInfo.VpcChannelProxyHost
+	} else {
+		web["backend_address"] = webResp.DomainURL
+	}
+	result[0] = web
+
+	return d.Set("web", result)
+}
+
+func setApigAPIMockPolicy(d *schema.ResourceData, policies []apis.PolicyMockResp) error {
+	result := make([]map[string]interface{}, len(policies))
+	for i, policy := range policies {
+		mp := map[string]interface{}{
+			"name":           policy.Name,
+			"response":       policy.ResultContent,
+			"effective_mode": policy.EffectMode,
+			"authorizer_id":  policy.AuthorizerId,
+		}
+		backendParams, err := getAPIBackendParameters(policy.BackendParams)
+		if err != nil {
+			return err
+		}
+		mp["backend_params"] = backendParams
+		condition, err := getAPIPolicyConditions(policy.Conditions)
+		if err != nil {
+			return fmtp.Errorf("Error setting policy (%s): %s", policy.Name, err)
+		}
+		mp["conditions"] = condition
+
+		result[i] = mp
+	}
+
+	return d.Set("mock_policy", result)
+}
+
+func setApigAPIFuncGraphPolicy(d *schema.ResourceData, policies []apis.PolicyFuncGraphResp) error {
+	result := make([]map[string]interface{}, len(policies))
+	for i, policy := range policies {
+		fgp := map[string]interface{}{
+			"name":            policy.Name,
+			"function_urn":    policy.FunctionUrn,
+			"version":         policy.Version,
+			"invocation_mode": policy.InvocationType,
+			"effective_mode":  policy.EffectMode,
+			"timeout":         policy.Timeout,
+			"authorizer_id":   policy.AuthorizerId,
+		}
+		backendParams, err := getAPIBackendParameters(policy.BackendParams)
+		if err != nil {
+			return err
+		}
+		fgp["backend_params"] = backendParams
+		condition, err := getAPIPolicyConditions(policy.Conditions)
+		if err != nil {
+			return fmtp.Errorf("Error setting policy (%s): %s", policy.Name, err)
+		}
+		fgp["conditions"] = condition
+
+		result[i] = fgp
+	}
+
+	return d.Set("func_graph_policy", result)
+}
+
+func setApigAPIWebPolicy(d *schema.ResourceData, policies []apis.PolicyWebResp) error {
+	result := make([]map[string]interface{}, len(policies))
+	for i, policy := range policies {
+		wp := map[string]interface{}{
+			"name":             policy.Name,
+			"request_protocol": policy.ReqProtocol,
+			"request_method":   policy.ReqMethod,
+			"effective_mode":   policy.EffectMode,
+			"path":             policy.ReqURI,
+			"timeout":          policy.Timeout,
+			"authorizer_id":    policy.AuthorizerId,
+		}
+		// which policy use backend address or vpc channel.
+		if policy.VpcChannelInfo.VpcChannelId != "" {
+			wp["vpc_channel_id"] = policy.VpcChannelInfo.VpcChannelId
+			wp["host_header"] = policy.VpcChannelInfo.VpcChannelProxyHost
+		} else {
+			wp["backend_address"] = policy.DomainURL
+		}
+		backendParams, err := getAPIBackendParameters(policy.BackendParams)
+		if err != nil {
+			return err
+		}
+		wp["backend_params"] = backendParams
+		condition, err := getAPIPolicyConditions(policy.Conditions)
+		if err != nil {
+			return fmtp.Errorf("Error setting policy (%s): %s", policy.Name, err)
+		}
+		wp["conditions"] = condition
+
+		result[i] = wp
+	}
+
+	return d.Set("web_policy", result)
+}
+
+func setApigAPIParameters(d *schema.ResourceData, config *config.Config, resp *apis.APIResp) error {
+	backendParams, err := getAPIBackendParameters(resp.BackendParams)
+	if err != nil {
+		return err
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("group_id", resp.GroupId),
+		d.Set("name", resp.Name),
+		d.Set("authorizer_id", resp.AuthorizerId),
+		d.Set("request_protocol", resp.ReqProtocol),
+		d.Set("request_method", resp.ReqMethod),
+		d.Set("request_path", resp.ReqURI),
+		d.Set("security_authentication", resp.AuthType),
+		d.Set("cors", resp.Cors),
+		d.Set("description", resp.Description),
+		d.Set("body_description", resp.BodyDescription),
+		d.Set("success_response", resp.ResultNormalSample),
+		d.Set("failure_response", resp.ResultFailureSample),
+		d.Set("response_id", resp.ResponseId),
+		d.Set("backend_params", backendParams),
+		setApigAPIType(d, resp.Type),
+		setApigAPIReqParams(d, resp.ReqParams),
+		setApigAPIMatchMode(d, resp.MatchMode),
+		setApigAPIAppSimpleAuth(d, resp.AuthOpt),
+		setApigAPIMock(d, resp.MockInfo),
+		setApigAPIMockPolicy(d, resp.PolicyMocks),
+		setApigAPIFuncGraph(d, resp.FuncInfo),
+		setApigAPIFuncGraphPolicy(d, resp.PolicyFunctions),
+		setApigAPIWeb(d, resp.WebInfo),
+		setApigAPIWebPolicy(d, resp.PolicyWebs),
+		d.Set("register_time", resp.RegisterTime),
+		d.Set("update_time", resp.UpdateTime),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+
+	return nil
+}
+
+func resourceApigAPIV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	resp, err := apis.Get(client, instanceId, d.Id()).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error getting api information from server: %s", err)
+	}
+
+	return setApigAPIParameters(d, config, resp)
+}
+
+func resourceApigAPIV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	opt, err := buildApigAPIParameters(d)
+	if err != nil {
+		return fmtp.Errorf("Unable to build the Api parameter: %s", err)
+	}
+	_, err = apis.Update(client, instanceId, d.Id(), opt).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error updating APIG v2 API: %s", err)
+	}
+
+	return resourceApigAPIV2Read(d, meta)
+}
+
+func resourceApigAPIV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	if err = apis.Delete(client, instanceId, d.Id()).ExtractErr(); err != nil {
+		return fmtp.Errorf("Unable to delete the APIG v2 dedicated instance (%s): %s", d.Id(), err)
+	}
+	d.SetId("")
+
+	return nil
+}
+
+func resourceBackendParamtersHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if m["type"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
+	}
+	if m["name"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+// GetApigAPIIdByName is a method to get a specifies API ID from a APIG instance by name.
+func GetApigAPIIdByName(client *golangsdk.ServiceClient, instanceId, name string) (string, error) {
+	opt := apis.ListOpts{
+		Name: name,
+	}
+	pages, err := apis.List(client, instanceId, opt).AllPages()
+	if err != nil {
+		return "", fmtp.Errorf("Error retrieving APIs: %s", err)
+	}
+	resp, err := apis.ExtractApis(pages)
+	if len(resp) < 1 {
+		return "", fmtp.Errorf("Unable to find the API (%s) form server: %s", name, err)
+	}
+	return resp[0].ID, nil
+}
+
+func resourceApigAPIResourceImportState(d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*config.Config)
+	client, err := config.ApigV2Client(config.GetRegion(d))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmtp.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmtp.Errorf("Invalid format specified for import id, must be <instance_id>/<name>")
+	}
+	name := parts[1]
+	instanceId := parts[0]
+	id, err := GetApigAPIIdByName(client, instanceId, name)
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+	d.SetId(id)
+	d.Set("instance_id", instanceId)
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/requests.go
@@ -1,0 +1,477 @@
+package apis
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// APIOpts is a struct which will be used to create a new API or update an existing API.
+type APIOpts struct {
+	// ID of the API group to which the API belongs.
+	GroupId string `json:"group_id" required:"true"`
+	// API name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// API type. The valid types are as following:
+	//   1: public API
+	//   2: private API
+	Type int `json:"type" required:"true"`
+	// Request protocol. The valid protocols are as following:
+	//   HTTP.
+	//   HTTPS (default).
+	//   BOTH: The API can be accessed through both HTTP and HTTPS.
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request method. The valid values are GET,  POST,  PUT,  DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request address, which can contain a maximum of 512 characters request parameters enclosed with brackets ({}).
+	// For example, /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (), percent signs (%), hyphens (-), and
+	// underscores (_) and must comply with URI specifications.
+	// The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Security authentication mode. The valid modes are as following:
+	//   NONE
+	//   APP
+	//   IAM
+	//   AUTHORIZER
+	AuthType string `json:"auth_type" required:"true"`
+	// Backend type. The valid types are as following:
+	//   HTTP: web backend.
+	//   FUNCTION: FunctionGraph backend.
+	//   MOCK: Mock backend.
+	BackendType string `json:"backend_type" required:"true"`
+	// API version. The maximum length of version string is 16.
+	Version *string `json:"version,omitempty"`
+	// Security authentication parameter.
+	AuthOpt *AuthOpt `json:"auth_opt,omitempty"`
+	// Indicates whether CORS is supported. The valid values are as following:
+	//   TRUE: supported.
+	//   FALSE: not supported (default).
+	Cors *bool `json:"cors,omitempty"`
+	// Route matching mode.  The valid modes are as following:
+	//   SWA: prefix match
+	//   NORMAL: exact match (default).
+	MatchMode string `json:"match_mode,omitempty"`
+	// Description of the API, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// API request body, which can be an example request body, media type, or parameters.
+	// Ensure that the request body does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	BodyDescription *string `json:"body_remark,omitempty"`
+	// Example response for a successful request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultNormalSample *string `json:"result_normal_sample,omitempty"`
+	// Example response for a failed request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultFailureSample *string `json:"result_failure_sample,omitempty"`
+	// ID of the frontend custom authorizer.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// List of tags. The length of the tags list is range from 1 to 128.
+	// The value can contain only letters, digits, and underscores (_), and must start with a letter.
+	Tags []string `json:"tags,omitempty"`
+	// Group response ID.
+	ResponseId string `json:"response_id,omitempty"`
+	// Request parameters.
+	ReqParams []ReqParamBase `json:"req_params,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Mock backend details.
+	MockInfo *Mock `json:"mock_info,omitempty"`
+	// FunctionGraph backend details.
+	FuncInfo *FuncGraph `json:"func_info,omitempty"`
+	// Web backend details.
+	WebInfo *Web `json:"backend_api,omitempty"`
+	// Mock policy backends.
+	PolicyMocks []PolicyMock `json:"policy_mocks,omitempty"`
+	// FunctionGraph policy backends.
+	PolicyFunctions []PolicyFuncGraph `json:"policy_functions,omitempty"`
+	// Web policy backends.
+	PolicyWebs []PolicyWeb `json:"policy_https,omitempty"`
+}
+
+// AuthOpt is an object which will be build up an APIG application authorization.
+type AuthOpt struct {
+	// Indicates whether AppCode authentication is enabled. The valid types are as following:
+	//   DISABLE: AppCode authentication is disabled (default).
+	//   HEADER: AppCode authentication is enabled and the AppCode is located in the header.
+	// This parameter is valid only if auth_type is set to App.
+	AppCodeAuthType string `json:"app_code_auth_type,omitempty"`
+}
+
+// Mock is an object which will be build up a mock backend.
+type Mock struct {
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Response.
+	ResultContent *string `json:"result_content,omitempty"`
+	// Function version Ensure that the version does not exceed 64 characters.
+	Version string `json:"version,omitempty"`
+	// Backend custom authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+}
+
+// FuncGraph is an object which will be build up a function graph backend.
+type FuncGraph struct {
+	// Function URN.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// Invocation mode. The valid modes are as following:
+	//   async: asynchronous
+	//   sync: synchronous
+	InvocationType string `json:"invocation_type" required:"true"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout" required:"true"`
+	// Backend custom authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Function version.
+	// Maximum: 64
+	Version string `json:"version,omitempty"`
+}
+
+// Web is an object which will be build up a http backend.
+type Web struct {
+	// Request method. The valid methods are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request protocol. The valid protocols are HTTP and HTTPS
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request address, which can contain a maximum of 512 characters request parameters enclosed with brackets ({}).
+	// For example, /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-), and
+	// underscores (_) and must comply with URI specifications.
+	// The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout" required:"true"`
+	// Backend custom authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Backend service address which consists of a domain name or IP address and a port number, with not more than 255
+	// characters. It must be in the format "Host name:Port number", for example, apig.example.com:7443.
+	// If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+	// The backend service address can contain environment variables, each starting with a letter and consisting of
+	// 3 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	DomainURL string `json:"url_domain,omitempty"`
+	// Description, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Web backend version, which can contain a maximum of 16 characters.
+	Version *string `json:"version,omitempty"`
+	// Indicates whether to enable two-way authentication.
+	ClientSslEnable *bool `json:"enable_client_ssl,omitempty"`
+	// VPC channel details. This parameter is required if vpc_channel_status is set to 1.
+	VpcChannelInfo *VpcChannel `json:"vpc_channel_info,omitempty"`
+	// Indicates whether to use a VPC channel. The valid values are as following:
+	//   1: (A VPC channel is used).
+	//   2: (No VPC channel is used).
+	VpcChannelStatus int `json:"vpc_channel_status,omitempty"`
+}
+
+// VpcChannel is an object which will be build up a vpc channel.
+type VpcChannel struct {
+	// VPC channel ID.
+	VpcChannelId string `json:"vpc_channel_id" required:"true"`
+	// Proxy host.
+	VpcChannelProxyHost string `json:"vpc_channel_proxy_host,omitempty"`
+}
+
+// ReqParamBase is an object which will be build up a front-end request parameter.
+type ReqParamBase struct {
+	// The parameter name, which contain of 1 to 32 characters and start with a letter.
+	// Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
+	Name string `json:"name" required:"true"`
+	// Parameter type. The valid types are as following:
+	//   STRING
+	//   NUMBER
+	Type string `json:"type" required:"true"`
+	// Parameter location. The valid modes are as following:
+	//   PATH
+	//   QUERY
+	//   HEADER
+	Location string `json:"location" required:"true"`
+	// Default value.
+	DefaultValue *string `json:"default_value,omitempty"`
+	// Example value.
+	SampleValue string `json:"sample_value,omitempty"`
+	// Indicates whether the parameter is required. The valid values are 1 (yes) and 2 (no).
+	// The value of this parameter is 1 if Location is set to PATH, and 2 if Location is set to another value.
+	Required int `json:"required,omitempty"`
+	// Indicates whether validity check is enabled. The valid modes are as following:
+	//   1: enabled.
+	//   2: disabled (default).
+	ValidEnable int `json:"valid_enable,omitempty"`
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Enumerated value.
+	Enumerations *string `json:"enumerations,omitempty"`
+	// Minimum value.
+	// This parameter is valid when type is set to NUMBER.
+	MinNum *int `json:"min_num,omitempty"`
+	// Maximum value.
+	// This parameter is valid when type is set to NUMBER.
+	MaxNum *int `json:"max_num,omitempty"`
+	// Minimum length.
+	// This parameter is valid when type is set to STRING.
+	MinSize *int `json:"min_size,omitempty"`
+	// Maximum length.
+	// This parameter is valid when type is set to STRING.
+	MaxSize *int `json:"max_size,omitempty"`
+	// Indicates whether to transparently transfer the parameter. The valid values are 1 (yes) and 2 (no).
+	PassThrough string `json:"pass_through,omitempty"`
+}
+
+// PolicyMock is an object which will be build up a backend policy of the mock.
+type PolicyMock struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which consists of 3 to 64 characters and must start with a letter and can contain letters, digits,
+	// and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Response.
+	ResultContent string `json:"result_content,omitempty"`
+}
+
+// PolicyFuncGraph is an object which will be build up a backend policy of the function graph.
+type PolicyFuncGraph struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy.
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Function URN.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// Invocation mode. The valid modes are as following:
+	//   async: asynchronous
+	//   sync: synchronous
+	InvocationType string `json:"invocation_type" required:"true"`
+	// The backend name consists of 3 to 64 characters, which must start with a letter and can contain letters, digits,
+	// and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+	// Function version Ensure that the version does not exceed 64 characters.
+	Version string `json:"version,omitempty"`
+}
+
+// PolicyWeb is an object which will be build up a backend policy of the http.
+type PolicyWeb struct {
+	// Request protocol. The value can be HTTP or HTTPS.
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request method. The valid methods are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request address, which can contain request parameters enclosed with brackets ({}).
+	// For example, /getUserInfo/{userId}. The request address can contain special characters, such as asterisks (),
+	// percent signs (%), hyphens (-), and underscores (_). It can contain a maximum of 512 characters and must comply
+	// with URI specifications.
+	// The request address can contain environment variables, each starting with a letter and consisting of 3 to 32
+	// characters. Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	// The request address must comply with URI specifications.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which contains of 3 to 64, must start with a letter and can contain letters, digits, and
+	// underscores (_).
+	Name string `json:"name" required:"true"`
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// VPC channel details. This parameter is required if vpc_channel_status is set to 1.
+	VpcChannelInfo *VpcChannel `json:"vpc_channel_info,omitempty"`
+	// Indicates whether to use a VPC channel. The valid value are as following:
+	//   1: A VPC channel is used.
+	//   2: No VPC channel is used.
+	VpcChannelStatus int `json:"vpc_channel_status,omitempty"`
+	// Endpoint of the policy backend.
+	// An endpoint consists of a domain name or IP address and a port number, with not more than 255 characters.
+	// It must be in the format "Domain name:Port number", for example, apig.example.com:7443.
+	// If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+	// The endpoint can contain environment variables, each starting with letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	DomainURL string `json:"url_domain,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+}
+
+// BackendParamBase is an object which will be build up a back-end parameter.
+type BackendParamBase struct {
+	// Parameter type. The valid types are as following:
+	//   REQUEST: Backend parameter.
+	//   CONSTANT: Constant parameter.
+	//   SYSTEM: System parameter.
+	Origin string `json:"origin" required:"true"`
+	// Parameter name, which can contains 1 to 32 characters, must start with a letter and can only contain letters,
+	// digits, hyphens (-), underscores (_) and periods (.).
+	Name string `json:"name" required:"true"`
+	// Parameter location. The valid values are PATH, QUERY and HEADER.
+	Location string `json:"location" required:"true"`
+	// Parameter value, which can contain a maximum of 255 characters. If the origin type is REQUEST, the value of this parameter is the parameter name in req_params.
+	// If the origin type is CONSTANT, the value is a constant.
+	// If the origin type is SYSTEM, the value is a system parameter name. System parameters include gateway parameters, frontend authentication parameters, and backend authentication parameters. You can set the frontend or backend authentication parameters after enabling custom frontend or backend authentication.
+	// The gateway parameters are as follows:
+	//   $context.sourceIp: source IP address of the API caller.
+	//   $context.stage: deployment environment in which the API is called.
+	//   $context.apiId: API ID.
+	//   $context.appId: ID of the app used by the API caller.
+	//   $context.requestId: request ID generated when the API is called.
+	//   $context.serverAddr: address of the gateway server.
+	//   $context.serverName: name of the gateway server.
+	//   $context.handleTime: time when the API request is processed.
+	//   $context.providerAppId: ID of the app used by the API owner. This parameter is currently not supported.
+	// Frontend authentication parameter: prefixed with "$context.authorizer.frontend.". For example, to return "aaa" upon successful custom authentication, set this parameter to "$context.authorizer.frontend.aaa".
+	// Backend authentication parameter: prefixed with "$context.authorizer.backend.". For example, to return "aaa" upon successful custom authentication, set this parameter to "$context.authorizer.backend.aaa".
+	Value string `json:"value" required:"true"`
+	// Description, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+}
+
+// APIConditionBase is an object which will be build up a policy condition.
+type APIConditionBase struct {
+	// Policy type. The valid types are as following:
+	//   param: input parameter
+	//   source: source IP address
+	ConditionOrigin string `json:"condition_origin" required:"true"`
+	// Condition value.
+	ConditionValue string `json:"condition_value" required:"true"`
+	// Input parameter name. This parameter is required if the policy type is param.
+	ReqParamName string `json:"req_param_name,omitempty"`
+	// Policy condition. The valid values are as following:
+	//   exact: exact match
+	//   enum: enumeration
+	//   pattern: regular expression
+	// This parameter is required if the policy type is param.
+	ConditionType string `json:"condition_type,omitempty"`
+}
+
+// APIOptsBuilder is an interface which to support request body build of the API creation and updation.
+type APIOptsBuilder interface {
+	ToAPIOptsMap() (map[string]interface{}, error)
+}
+
+// ToAPIOptsMap is a method which to build a request body by the APIOpts.
+func (opts APIOpts) ToAPIOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new custom API.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts APIOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToAPIOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method to update an existing custom API.
+func Update(client *golangsdk.ServiceClient, instanceId, appId string, opts APIOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToAPIOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, appId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain the specified API according to the instanceId and API ID.
+func Get(client *golangsdk.ServiceClient, instanceId, apiId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, apiId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// API ID.
+	ID string `q:"id"`
+	// API name.
+	Name string `q:"name"`
+	// API group ID.
+	GroupId string `q:"group_id"`
+	// Request protocol.
+	ReqProtocol string `q:"req_protocol"`
+	// Request method.
+	ReqMethod string `q:"req_method"`
+	// Request path.
+	ReqURI string `q:"req_uri"`
+	// Security authentication mode.
+	AuthType string `q:"auth_type"`
+	// ID of the environment in which the API has been published.
+	EnvId string `q:"env_id"`
+	// API type.
+	Type int `q:"type"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The range of number is form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name (name or req_uri) for exact matching.
+	PreciseSearch string `q:"precise_search"`
+}
+
+// ListOptsBuilder is an interface which to support request query build of the API search.
+type ListOptsBuilder interface {
+	ToListOptsQuery() (string, error)
+}
+
+// ToListOptsQuery is a method which to build a request query by the ListOpts.
+func (opts ListOpts) ToListOptsQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more APIs according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListOptsQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return APIPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing custom API.
+func Delete(client *golangsdk.ServiceClient, instanceId, apiId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, apiId), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/results.go
@@ -1,0 +1,354 @@
+package apis
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get method.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+// APIResp is a struct that represents the result of Create, Update, Get and List methods.
+type APIResp struct {
+	// API name which can contains of 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name"`
+	// API type. The valid types are as following:
+	//   1: public API
+	//   2: private API
+	Type int `json:"type"`
+	// API version which can contains maximum of 16 characters.
+	Version string `json:"version"`
+	// Request protocol.
+	//   HTTP
+	//   HTTPS (default)
+	//   BOTH: The API can be accessed through both HTTP and HTTPS.
+	ReqProtocol string `json:"req_protocol"`
+	// Request method. The valid values are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method"`
+	// Request address, which can contain request parameters enclosed with brackets ({}). For example,
+	//   /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-), and underscores (_). It can contain a maximum of 512 characters and must comply with URI specifications.
+	// The request address must comply with URI specifications.
+	ReqURI string `json:"req_uri"`
+	// Security authentication mode. The valid values are as following:
+	//   NONE
+	//   APP
+	//   IAM
+	//   AUTHORIZER
+	AuthType string `json:"auth_type"`
+	// Security authentication parameter.
+	AuthOpt AuthOpt `json:"auth_opt"`
+	// Indicates whether CORS is supported.
+	// TRUE: supported
+	// FALSE: not supported (default).
+	Cors bool `json:"cors"`
+	// Route matching mode.
+	//   SWA: prefix match
+	//   NORMAL: exact match (default).
+	MatchMode string `json:"match_mode"`
+	// Backend type. The valid types are as following:
+	//   HTTP: web backend
+	//   FUNCTION: FunctionGraph backend
+	//   MOCK: Mock backend
+	BackendType string `json:"backend_type"`
+	// Description of the API, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark"`
+	// ID of the API group to which the API belongs.
+	GroupId string `json:"group_id"`
+	// API request body, which can be an example request body, media type, or parameters.
+	// Ensure that the request body does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	BodyDescription string `json:"body_remark"`
+	// Example response for a successful request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultNormalSample string `json:"result_normal_sample"`
+	// Example response for a failed request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultFailureSample string `json:"result_failure_sample"`
+	// ID of the frontend custom authorizer.
+	AuthorizerId string `json:"authorizer_id"`
+	// Tags.
+	Tags []string `json:"tags"`
+	// Group response ID.
+	ResponseId string `json:"response_id"`
+	// API ID.
+	ID string `json:"id"`
+	// API status. 1: valid
+	Status int `json:"status"`
+	// Indicates whether to enable orchestration.
+	ArrangeNecessary int `json:"arrange_necessary"`
+	// Time when the API is registered.
+	RegisterTime string `json:"register_time"`
+	// Time when the API was last modified.
+	UpdateTime string `json:"update_time"`
+	// Name of the API group to which the API belongs.
+	GroupName string `json:"group_name"`
+	// Version of the API group to which the API belongs.
+	// The default value is V1. Other versions are not supported.
+	GroupVersion string `json:"group_version"`
+	// ID of the environment in which the API has been published.
+	// If there are multiple publication records, separate the environment IDs with vertical bars (|).
+	RunEnvId string `json:"run_env_id"`
+	// Name of the environment in which the API has been published.
+	// If there are multiple publication records, separate the environment names with vertical bars (|).
+	RunEnvName string `json:"run_env_name"`
+	// Publication record ID.
+	// You can separate multiple publication record IDs with vertical bars (|).
+	PublishId string `json:"publish_id"`
+	// FunctionGraph backend details.
+	FuncInfo FuncGraph `json:"func_info"`
+	// Mock backend details.
+	MockInfo Mock `json:"mock_info"`
+	// Web backend details.
+	WebInfo Web `json:"backend_api"`
+	// Request parameters.
+	ReqParams []ReqParamResp `json:"req_params"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params"`
+	// Mock policy backends.
+	PolicyMocks []PolicyMockResp `json:"policy_mocks"`
+	// FunctionGraph policy backends.
+	PolicyFunctions []PolicyFuncGraphResp `json:"policy_functions"`
+	// Web policy backends.
+	PolicyWebs []PolicyWebResp `json:"policy_https"`
+	// The following four parameters are only provided by the response of the API Versions.
+	//   SlDomain
+	//   SlDomains
+	//   VersionId
+	//   PublishTime.
+	// Subdomain name that API Gateway automatically allocates to the API group.
+	SlDomain string `json:"sl_domain"`
+	// Subdomain names that API Gateway automatically allocates to the API group.
+	SlDomains []string `json:"sl_domains"`
+	// API version ID.
+	VersionId string `json:"version_id"`
+	//Time when the API version is published.
+	PublishTime string `json:"publish_time"`
+}
+
+// ReqParamResp is an object struct that represents the elements of the front-end request parameter.
+type ReqParamResp struct {
+	// The parameter name, which contain of 1 to 32 characters and start with a letter.
+	// Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
+	Name string `json:"name"`
+	// Parameter type. The valid types are as following:
+	//   STRING
+	//   NUMBER
+	Type string `json:"type"`
+	// Parameter location. The valid modes are as following:
+	//   PATH
+	//   QUERY
+	//   HEADER
+	Location string `json:"location"`
+	// Default value.
+	DefaultValue string `json:"default_value"`
+	// Example value.
+	SampleValue string `json:"sample_value"`
+	// Indicates whether the parameter is required. The valid values are 1 (yes) and 2 (no).
+	// The value of this parameter is 1 if Location is set to PATH, and 2 if Location is set to another value.
+	Required int `json:"required"`
+	// Indicates whether validity check is enabled. The valid modes are as following:
+	// 1: enabled.
+	// 2: disabled (default).
+	ValidEnable int `json:"valid_enable"`
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark"`
+	// Enumerated value.
+	Enumerations string `json:"enumerations"`
+	// Minimum value.
+	// This parameter is valid when type is set to NUMBER.
+	MinNum int `json:"min_num"`
+	// Maximum value.
+	// This parameter is valid when type is set to NUMBER.
+	MaxNum int `json:"max_num"`
+	// Minimum length.
+	// This parameter is valid when type is set to STRING.
+	MinSize int `json:"min_size"`
+	// Maximum length.
+	// This parameter is valid when type is set to STRING.
+	MaxSize int `json:"max_size"`
+	// Indicates whether to transparently transfer the parameter. The valid values are 1 (yes) and 2 (no).
+	PassThrough int `json:"pass_through"`
+	// Parameter ID.
+	// Notes: This parameter is used for response.
+	ID string `json:"id"`
+}
+
+// BackendParamResp is an object struct that represents the elements of the back-end parameter.
+type BackendParamResp struct {
+	// Parameter type. The valid types are as following:
+	//   REQUEST: Backend parameter.
+	//   CONSTANT: Constant parameter.
+	//   SYSTEM: System parameter.
+	Origin string `json:"origin"`
+	// Parameter name, which can contains 1 to 32 characters, must start with a letter and can only contain letters, digits, hyphens (-), underscores (_),
+	// and periods (.).
+	Name string `json:"name"`
+	// Description, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark"`
+	// Parameter location. The valid values are PATH, QUERY and HEADER.
+	Location string `json:"location"`
+	// Parameter value, which can contain a maximum of 255 characters.
+	// If the origin type is REQUEST, the value of this parameter is the parameter name in req_params.
+	// If the origin type is CONSTANT, the value is a constant.
+	// If the origin type is SYSTEM, the value is a system parameter name.
+	// System parameters include gateway parameters, front-end authentication parameters, and back-end authentication
+	// parameters. You can set the frontend or backend authentication parameters after enabling custom frontend or
+	// backend authentication.
+	// The gateway parameters are as follows:
+	//   $context.sourceIp: source IP address of the API caller.
+	//   $context.stage: deployment environment in which the API is called.
+	//   $context.apiId: API ID.
+	//   $context.appId: ID of the app used by the API caller.
+	//   $context.requestId: request ID generated when the API is called.
+	//   $context.serverAddr: address of the gateway server.
+	//   $context.serverName: name of the gateway server.
+	//   $context.handleTime: time when the API request is processed.
+	//   $context.providerAppId: ID of the app used by the API owner. This parameter is currently not supported.
+	// Frontend authentication parameter: prefixed with "$context.authorizer.frontend.".
+	// For example, to return "aaa" upon successful custom authentication, set this parameter to
+	// "$context.authorizer.frontend.aaa".
+	// Backend authentication parameter: prefixed with "$context.authorizer.backend.".
+	// For example, to return "aaa" upon successful custom authentication, set this parameter to
+	// "$context.authorizer.backend.aaa".
+	Value string `json:"value"`
+	// ID of the the specifies request parameter.
+	ReqParamId string `json:"req_param_id"`
+}
+
+// PolicyMockResp is an object struct that represents the back-end policy of mock.
+type PolicyMockResp struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which consists of 3 to 64 characters and must start with a letter and can contain letters, digits,
+	// and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params,omitempty"`
+	// Response.
+	ResultContent string `json:"result_content,omitempty"`
+}
+
+// PolicyFuncGraphResp is an object struct that represents the back-end policy of function graph.
+type PolicyFuncGraphResp struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy.
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Function URN.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// Invocation mode. The valid modes are as following:
+	//   async: asynchronous
+	//   sync: synchronous
+	InvocationType string `json:"invocation_type" required:"true"`
+	// The backend name, which can consists of 3 to 64 characters and must start with a letter and can contain letters,
+	// digits, and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+	// Function version Ensure that the version does not exceed 64 characters.
+	Version string `json:"version,omitempty"`
+}
+
+// PolicyWebResp is an object struct that represents the back-end policy of http and https.
+type PolicyWebResp struct {
+	// Request protocol. The value can be HTTP or HTTPS.
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request method. The valid methods are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request address, which can contain request parameters enclosed with brackets ({}). For example,
+	//   /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (), percent signs (%), hyphens (-), and
+	// underscores (_). It can contain a maximum of 512 characters and must comply with URI specifications.
+	// The request address can contain environment variables, each starting with a letter and consisting of 3 to 32
+	// characters. Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	// The request address must comply with URI specifications.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Endpoint of the policy backend.
+	// An endpoint consists of a domain name or IP address and a port number, with not more than 255 characters.
+	// It must be in the format "Domain name:Port number", for example, apig.example.com:7443.
+	// If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+	// The endpoint can contain environment variables, each starting with letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	DomainURL string `json:"url_domain,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which contains of 3 to 64 and must start with a letter and can contain letters, digits, and
+	// underscores (_).
+	Name string `json:"name" required:"true"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params,omitempty"`
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Authorizer ID.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// VPC channel details. This parameter is required if vpc_channel_status is set to 1.
+	VpcChannelInfo VpcChannel `json:"vpc_channel_info,omitempty"`
+	// Indicates whether to use a VPC channel. The valid value are as following:
+	//   1: A VPC channel is used.
+	//   2: No VPC channel is used.
+	VpcChannelEnable int `json:"vpc_channel_status,omitempty"`
+}
+
+// Extract is a method to extract an response struct.
+func (r commonResult) Extract() (*APIResp, error) {
+	var s APIResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// APIPage represents the api pages of the List operation.
+type APIPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractApis is a method to extract an response struct list.
+func ExtractApis(r pagination.Page) ([]APIResp, error) {
+	var s []APIResp
+	err := r.(APIPage).Result.ExtractIntoSlicePtr(&s, "apis")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/urls.go
@@ -1,0 +1,21 @@
+package apis
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+const rootPath = "instances"
+
+func buildRootPath(instanceId string) string {
+	return fmt.Sprintf("instances/%s/apis", instanceId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId))
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, apiId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), apiId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca
+# github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -277,6 +277,7 @@ github.com/huaweicloud/golangsdk/openstack/aom/v1/icagents
 github.com/huaweicloud/golangsdk/openstack/apigw/apis
 github.com/huaweicloud/golangsdk/openstack/apigw/groups
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/apigroups
+github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/applications
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers
 github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
API resource support as follows:
- support to create a public API or private API.
- API support IAM, APP and custom authorization currently
- front-end configuration
  - request parameters: HEADER, QUERY and PATH
- back-end configuration
  - back-end parameters: REQUEST, CONSTANT and SYSTEM.
  - web and related policies configuration
  - function graph and related policies configuration
  - mock and related policies configuration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1330
reference #1353 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new api resource support
2. add related document and acc test
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigAPIV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigAPIV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigAPIV2_basic
=== PAUSE TestAccApigAPIV2_basic
=== CONT  TestAccApigAPIV2_basic
--- PASS: TestAccApigAPIV2_basic (602.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      604.112s
```
