### PR TITLE
[WAF] Add a data source for querying a list of policies.

### DIFF
--- a/docs/data-sources/waf_policies.md
+++ b/docs/data-sources/waf_policies.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_policies
+
+Use this data source to get a list of WAF policies.
+
+## Example Usage
+
+```hcl
+variable "policy_name" {}
+data "huaweicloud_waf_policies" "policies" {
+  name = var.policy_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the WAF policies. If omitted, the provider-level region
+  will be used.
+
+* `name` - (Optional, String) Policy name used for matching. The value is case sensitive and supports fuzzy matching.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `policies` - A list of WAF policies.
+
+The `policies` block supports:
+
+* `id` - The WAF Policy ID.
+
+* `name` - The WAF policy name.
+
+* `protection_mode` - Specifies the protective action after a rule is matched. Valid values are:
+  * `block`: WAF blocks and logs detected attacks.
+  * `log`: WAF logs detected attacks only.
+
+* `level` - Specifies the protection level. Valid values are:
+  * `1`: low
+  * `2`: medium
+  * `3`: high
+
+* `full_detection` - The detection mode in Precise Protection.
+  * `true`: full detection. Full detection finishes all threat detections before blocking requests that meet Precise
+    Protection specified conditions.
+  * `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that
+    meets Precise Protection specified conditions.
+
+* `options` - The protection switches. The options object structure is documented below.
+
+The `options` block supports:
+
+* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
+
+* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
+
+* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+
+* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
+
+* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
+
+* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
+
+* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
+
+* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
+
+* `cc_attack_protection` - Indicates whether CC Attack Protection is enabled.
+
+* `precise_protection` - Indicates whether Precise Protection is enabled.
+
+* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
+
+* `data_masking` - Indicates whether Data Masking is enabled.
+
+* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
+
+* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6
+	github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -206,14 +206,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/golangsdk v0.0.0-20210729121530-85c6b7af2ad2 h1:nel1BOE/C+vr/UMrrEZd+kDFZCwzj2tVZT665D0V81c=
-github.com/huaweicloud/golangsdk v0.0.0-20210729121530-85c6b7af2ad2/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883 h1:4D/N05uptrcZuErPVCHeRJ89ND1RnZoVYjjCIfTflRs=
-github.com/huaweicloud/golangsdk v0.0.0-20210730025156-e4c4c50d1883/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a h1:yJda8qxR3mnJydpPlJ4MgYGZD8nO7eDwGSm52lbwSvw=
-github.com/huaweicloud/golangsdk v0.0.0-20210802032346-3c4a88adf03a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6 h1:bBWGvYquVhlmsOVU3AY8XMAjUuMg/s36fPOBTjVwCgQ=
-github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd h1:BHIBmqat49BfJAWRhnWvq9D2tlqfhrZkDpy8ADTCiP4=
+github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -327,6 +327,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_vpc_subnet_ids":              DataSourceVpcSubnetIdsV1(),
 			"huaweicloud_vpcep_public_services":       DataSourceVPCEPPublicServices(),
 			"huaweicloud_waf_certificate":             waf.DataSourceWafCertificateV1(),
+			"huaweicloud_waf_policies":                waf.DataSourceWafPoliciesV1(),
 
 			// Legacy
 			"huaweicloud_images_image_v2":           DataSourceImagesImageV2(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
@@ -1,0 +1,56 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccDataSourceWafPoliciesV1_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_waf_policies.policies_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPoliciesV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPoliciesID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.0.name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.options.0.blacklist"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWafPoliciesID(r string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmtp.Errorf("Can't find WAF policies data source: %s.", r)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("The WAF policies data source ID does not set.")
+		}
+		return nil
+	}
+}
+
+func testAccWafPoliciesV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_policies" "policies_1" {
+  name = huaweicloud_waf_policy.policy_1.name
+}
+`, testAccWafPolicyV1_basic(name))
+}

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
@@ -29,7 +29,7 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 				Config: testAccWafPolicyV1_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWafPolicyV1Exists(resourceName, &policy),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("policy-%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "level", "1"),
 					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
 				),
@@ -38,7 +38,7 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 				Config: testAccWafPolicyV1_update(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWafPolicyV1Exists(resourceName, &policy),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("policy_%s_updated", randName)),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"_updated"),
 					resource.TestCheckResourceAttr(resourceName, "protection_mode", "block"),
 					resource.TestCheckResourceAttr(resourceName, "level", "3"),
 				),
@@ -105,7 +105,7 @@ func testAccCheckWafPolicyV1Exists(n string, policy *policies.Policy) resource.T
 func testAccWafPolicyV1_basic(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_waf_policy" "policy_1" {
-  name  = "policy-%s"
+  name  = "%s"
   level = 1
 }
 `, name)
@@ -114,7 +114,7 @@ resource "huaweicloud_waf_policy" "policy_1" {
 func testAccWafPolicyV1_update(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_waf_policy" "policy_1" {
-  name            = "policy_%s_updated"
+  name            = "%s_updated"
   protection_mode = "block"
   level           = 3
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
@@ -1,0 +1,185 @@
+package waf
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+// DataSourceWafPoliciesV1 the function is used for data source 'huaweicloud_waf_policies'.
+func DataSourceWafPoliciesV1() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceWafPoliciesV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protection_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"level": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"basic_web_protection": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"general_check": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"crawler": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"crawler_engine": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"crawler_scanner": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"crawler_script": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"crawler_other": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"webshell": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"cc_attack_protection": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"precise_protection": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"blacklist": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"data_masking": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"false_alarm_masking": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"web_tamper_protection": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"full_detection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceWafPoliciesV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud WAF client: %s", err)
+	}
+
+	listOpts := policies.ListPolicyOpts{
+		Name: d.Get("name").(string),
+	}
+	rst, err := policies.ListPolicy(wafClient, listOpts)
+	if err != nil {
+		return fmtp.Errorf("Unable to retrieve waf policies: %s", err)
+	}
+	logp.Printf("[DEBUG] Get a list of policies: %#v.", rst)
+
+	if len(rst.Items) == 0 {
+		return fmtp.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	// The IDs of all policies in the list, and get it hashcode set to the value of schema id.
+	ids := make([]string, 0, len(rst.Items))
+	policies := make([]map[string]interface{}, 0, len(rst.Items))
+
+	for _, p := range rst.Items {
+		options := []map[string]interface{}{
+			{
+				"basic_web_protection":  p.Options.Webattack,
+				"general_check":         p.Options.Common,
+				"crawler":               p.Options.Crawler,
+				"crawler_engine":        p.Options.CrawlerEngine,
+				"crawler_scanner":       p.Options.CrawlerScanner,
+				"crawler_script":        p.Options.CrawlerScript,
+				"crawler_other":         p.Options.CrawlerOther,
+				"webshell":              p.Options.Webshell,
+				"cc_attack_protection":  p.Options.Cc,
+				"precise_protection":    p.Options.Custom,
+				"blacklist":             p.Options.Whiteblackip,
+				"false_alarm_masking":   p.Options.Ignore,
+				"data_masking":          p.Options.Privacy,
+				"web_tamper_protection": p.Options.Antitamper,
+			},
+		}
+		plc := map[string]interface{}{
+			"id":              p.Id,
+			"name":            p.Name,
+			"protection_mode": p.Action.Category,
+			"level":           p.Level,
+			"options":         options,
+			"full_detection":  p.FullDetection,
+		}
+		policies = append(policies, plc)
+		ids = append(ids, p.Id)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	if err = d.Set("policies", policies); err != nil {
+		return fmtp.Errorf("error setting WAF policy fields: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf_hw/v1/policies/requests.go
@@ -133,11 +133,11 @@ func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
 }
 
 // ListPolicy retrieve waf policy by ListPolicyOpts
-func ListPolicy(c *golangsdk.ServiceClient, opts ListPolicyOpts) (r ListPolicyRst, err error) {
+func ListPolicy(c *golangsdk.ServiceClient, opts ListPolicyOpts) (*ListPolicyRst, error) {
 	url := rootURL(c)
 	query, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
-		return r, err
+		return nil, err
 	}
 	url += query.String()
 
@@ -145,8 +145,11 @@ func ListPolicy(c *golangsdk.ServiceClient, opts ListPolicyOpts) (r ListPolicyRs
 	_, err = c.Get(url, &rst.Body, &golangsdk.RequestOpts{
 		MoreHeaders: RequestOpts.MoreHeaders,
 	})
-	if err != nil {
+
+	if err == nil {
+		var r ListPolicyRst
 		rst.ExtractInto(&r)
+		return &r, nil
 	}
-	return
+	return nil, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210811015908-f7ad77891df6
+# github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

#1355
- Add the data source to query WAF policies, source name is `huaweicloud_waf_policies`.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Please do not close the issue.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafPoliciesV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafPoliciesV1_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafPoliciesV1_basic
--- PASS: TestAccDataSourceWafPoliciesV1_basic (10.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       10.564s

```
