### PR TITLE
feat: add the ability to manage DMS kafka topics

### DIFF
--- a/docs/resources/dms_kafka_topic.md
+++ b/docs/resources/dms_kafka_topic.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_topic
+
+Manages a DMS kafka topic resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "kafka_instance_id" {}
+
+resource "huaweicloud_dms_kafka_topic" "topic" {
+  instance_id = var.kafka_instance_id
+  name        = "topic_1"
+  partitions  = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS kafka topic resource.
+    If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DMS kafka instance to which the topic belongs.
+    Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the topic. The name starts with a letter,
+    consists of 4 to 64 characters, and supports only letters, digits, hyphens (-) and underscores (_).
+    Changing this creates a new resource.
+
+* `partitions` - (Required, Int) Specifies the partition number. The value ranges from 1 to 100.
+
+* `replicas` - (Optional, Int, ForceNew) Specifies the replica number. The value ranges from 1 to 3 and defaults to 3.
+    Changing this creates a new resource.
+
+* `aging_time` - (Optional, Int) Specifies the aging time in hours.
+    The value ranges from 1 to 168 and defaults to 72.
+
+* `sync_replication` - (Optional, Bool) Whether or not to enable synchronous replication.
+
+* `sync_flushing` - (Optional, Bool) Whether or not to enable synchronous flushing.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals to the topic name.
+
+## Import
+
+DMS kafka topics can be imported using the kafka instance ID and topic name separated by a slash, e.g.:
+
+```sh
+terraform import huaweicloud_dms_kafka_topic.topic c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/topic_1
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd
+	github.com/huaweicloud/golangsdk v0.0.0-20210817085035-914d19567b2a
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd h1:BHIBmqat49BfJAWRhnWvq9D2tlqfhrZkDpy8ADTCiP4=
 github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210817085035-914d19567b2a h1:poC75XKNAt3dkdnu/frC4n7xCjkFkA4vgoDKV4qsvk4=
+github.com/huaweicloud/golangsdk v0.0.0-20210817085035-914d19567b2a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -423,6 +423,7 @@ func Provider() terraform.ResourceProvider {
 			"huaweicloud_dms_instance":                    ResourceDmsInstancesV1(),
 			"huaweicloud_dms_queue":                       ResourceDmsQueuesV1(),
 			"huaweicloud_dms_kafka_instance":              ResourceDmsKafkaInstance(),
+			"huaweicloud_dms_kafka_topic":                 ResourceDmsKafkaTopic(),
 			"huaweicloud_dms_rabbitmq_instance":           ResourceDmsRabbitmqInstance(),
 			"huaweicloud_dns_ptrrecord":                   ResourceDNSPtrRecordV2(),
 			"huaweicloud_dns_recordset":                   ResourceDNSRecordSetV2(),

--- a/huaweicloud/resource_huaweicloud_dms_kafka_topic.go
+++ b/huaweicloud/resource_huaweicloud_dms_kafka_topic.go
@@ -1,0 +1,224 @@
+package huaweicloud
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+// ResourceDmsKafkaTopic implements the resource of "huaweicloud_dms_kafka_topic"
+func ResourceDmsKafkaTopic() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDmsKafkaTopicCreate,
+		Read:   resourceDmsKafkaTopicRead,
+		Update: resourceDmsKafkaTopicUpdate,
+		Delete: resourceDmsKafkaTopicDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceDmsKafkaTopicImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"partitions": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"replicas": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"aging_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"sync_replication": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"sync_flushing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaTopicCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	dmsV2Client, err := config.DmsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud DMS client: %s", err)
+	}
+
+	createOpts := &topics.CreateOps{
+		Name:             d.Get("name").(string),
+		Partition:        d.Get("partitions").(int),
+		Replication:      d.Get("replicas").(int),
+		RetentionTime:    d.Get("aging_time").(int),
+		SyncReplication:  d.Get("sync_replication").(bool),
+		SyncMessageFlush: d.Get("sync_flushing").(bool),
+	}
+
+	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	instanceID := d.Get("instance_id").(string)
+	v, err := topics.Create(dmsV2Client, instanceID, createOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud DMS kafka topic: %s", err)
+	}
+
+	// use topic name as the resource ID
+	d.SetId(v.Name)
+	return resourceDmsKafkaTopicRead(d, meta)
+}
+
+func resourceDmsKafkaTopicRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	dmsV2Client, err := config.DmsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud DMS client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	allTopics, err := topics.List(dmsV2Client, instanceID).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "DMS kafka topic")
+	}
+
+	topicID := d.Id()
+	var found *topics.Topic
+	for _, item := range allTopics {
+		if item.Name == topicID {
+			found = &item
+			break
+		}
+	}
+
+	if found == nil {
+		d.SetId("")
+		return nil
+	}
+
+	logp.Printf("[DEBUG] DMS kafka topic %s: %+v", d.Id(), found)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", GetRegion(d, config)),
+		d.Set("name", found.Name),
+		d.Set("partitions", found.Partition),
+		d.Set("replicas", found.Replication),
+		d.Set("aging_time", found.RetentionTime),
+		d.Set("sync_replication", found.SyncReplication),
+		d.Set("sync_flushing", found.SyncMessageFlush),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+
+	return nil
+}
+
+func resourceDmsKafkaTopicUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	dmsV2Client, err := config.DmsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud DMS client: %s", err)
+	}
+
+	newPartition := d.Get("partitions").(int)
+	retentionTime := d.Get("aging_time").(int)
+	syncReplication := d.Get("sync_replication").(bool)
+	syncMessageFlush := d.Get("sync_flushing").(bool)
+
+	updateOpts := topics.UpdateOpts{
+		Topics: []topics.UpdateItem{
+			{
+				Name:             d.Get("name").(string),
+				Partition:        &newPartition,
+				RetentionTime:    &retentionTime,
+				SyncMessageFlush: &syncMessageFlush,
+				SyncReplication:  &syncReplication,
+			},
+		},
+	}
+
+	logp.Printf("[DEBUG] Update Options: %#v", updateOpts)
+	instanceID := d.Get("instance_id").(string)
+	err = topics.Update(dmsV2Client, instanceID, updateOpts).Err
+	if err != nil {
+		return fmtp.Errorf("error updating HuaweiCloud DMS kafka topic: %s", err)
+	}
+
+	return resourceDmsKafkaTopicRead(d, meta)
+}
+
+func resourceDmsKafkaTopicDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	dmsV2Client, err := config.DmsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("error creating HuaweiCloud DMS client: %s", err)
+	}
+
+	topicID := d.Id()
+	instanceID := d.Get("instance_id").(string)
+	response, err := topics.Delete(dmsV2Client, instanceID, []string{topicID}).Extract()
+	if err != nil {
+		return fmtp.Errorf("error deleting DMS kafka topic: %s", err)
+	}
+
+	var success bool
+	for _, item := range response {
+		if item.Name == topicID {
+			success = item.Success
+			break
+		}
+	}
+	if !success {
+		return fmtp.Errorf("error deleting DMS kafka topic")
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// resourceDmsKafkaTopicImport query the rules from HuaweiCloud and imports them to Terraform.
+// It is a common function in waf and is also called by other rule resources.
+func resourceDmsKafkaTopicImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmtp.Errorf("Invalid format specified for DMS kafka topic. Format must be <instance id>/<topic name>")
+		return nil, err
+	}
+
+	instanceID := parts[0]
+	topicID := parts[1]
+
+	d.SetId(topicID)
+	d.Set("instance_id", instanceID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/resource_huaweicloud_dms_kafka_topic_test.go
+++ b/huaweicloud/resource_huaweicloud_dms_kafka_topic_test.go
@@ -1,0 +1,166 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccDmsKafkaTopic_basic(t *testing.T) {
+	var kafkaTopic topics.Topic
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_dms_kafka_topic.topic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDmsKafkaTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaTopic_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDmsKafkaTopicExists(resourceName, &kafkaTopic),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "partitions", "10"),
+					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
+					resource.TestCheckResourceAttr(resourceName, "aging_time", "36"),
+					resource.TestCheckResourceAttr(resourceName, "sync_replication", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sync_flushing", "false"),
+				),
+			},
+			{
+				Config: testAccDmsKafkaTopic_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDmsKafkaTopicExists(resourceName, &kafkaTopic),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "partitions", "20"),
+					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
+					resource.TestCheckResourceAttr(resourceName, "aging_time", "72"),
+					resource.TestCheckResourceAttr(resourceName, "sync_replication", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sync_flushing", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccKafkaTopicImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckDmsKafkaTopicDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	dmsClient, err := config.DmsV2Client(HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating HuaweiCloud DMS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_dms_kafka_topic" {
+			continue
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		allTopics, err := topics.List(dmsClient, instanceID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+			return fmt.Errorf("Error listing DMS kafka topics in %s, err: %s", instanceID, err)
+		}
+
+		topicID := rs.Primary.ID
+		for _, item := range allTopics {
+			if item.Name == topicID {
+				return fmt.Errorf("The DMS kafka topic %s still exists", topicID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckDmsKafkaTopicExists(n string, topic *topics.Topic) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		dmsClient, err := config.DmsV2Client(HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating HuaweiCloud DMS client: %s", err)
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		allTopics, err := topics.List(dmsClient, instanceID).Extract()
+		if err != nil {
+			return fmt.Errorf("Error listing DMS kafka topics in %s, err: %s", instanceID, err)
+		}
+
+		topicID := rs.Primary.ID
+		for _, item := range allTopics {
+			if item.Name == topicID {
+				*topic = item
+				return nil
+			}
+		}
+
+		return fmt.Errorf("The DMS kafka topic %s not found", topicID)
+	}
+}
+
+// testAccKafkaTopicImportStateFunc is used to import the resource
+func testAccKafkaTopicImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		instance, ok := s.RootModule().Resources["huaweicloud_dms_kafka_instance.test"]
+		if !ok {
+			return "", fmt.Errorf("DMS kafka instance not found")
+		}
+		topic, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("DMS kafka topic not found")
+		}
+
+		return fmt.Sprintf("%s/%s", instance.Primary.ID, topic.Primary.ID), nil
+	}
+}
+
+func testAccDmsKafkaTopic_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_topic" "topic" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%s"
+  partitions  = 10
+  aging_time  = 36
+}
+`, testAccDmsKafkaInstance_basic(rName), rName)
+}
+
+func testAccDmsKafkaTopic_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_topic" "topic" {
+  instance_id   = huaweicloud_dms_kafka_instance.test.id
+  name          = "%s"
+  partitions    = 20
+  aging_time    = 72
+  sync_flushing = true
+}
+`, testAccDmsKafkaInstance_basic(rName), rName)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics/requests.go
@@ -1,0 +1,115 @@
+package topics
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// CreateOpsBuilder is an interface which is used for creating a kafka topic
+type CreateOpsBuilder interface {
+	ToTopicCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOps is a struct that contains all the parameters of create function
+type CreateOps struct {
+	// the name/ID of a topic
+	Name string `json:"id" required:"true"`
+	// topic partitions, value range: 1-100
+	Partition int `json:"partition,omitempty"`
+	// topic replications, value range: 1-3
+	Replication int `json:"replication,omitempty"`
+	// aging time in hours, value range: 1-168, defaults to 72
+	RetentionTime int `json:"retention_time,omitempty"`
+
+	SyncMessageFlush bool `json:"sync_message_flush,omitempty"`
+	SyncReplication  bool `json:"sync_replication,omitempty"`
+}
+
+// ToTopicCreateMap is used for type convert
+func (ops CreateOps) ToTopicCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(ops, "")
+}
+
+// Create a kafka topic with given parameters
+func Create(client *golangsdk.ServiceClient, instanceID string, ops CreateOpsBuilder) (r CreateResult) {
+	b, err := ops.ToTopicCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(rootURL(client, instanceID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// UpdateOptsBuilder is an interface which can build the map paramter of update function
+type UpdateOptsBuilder interface {
+	ToTopicUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is a struct which represents the parameters of update function
+type UpdateOpts struct {
+	Topics []UpdateItem `json:"topics" required:"true"`
+}
+
+// UpdateItem represents the object of one topic in update function
+type UpdateItem struct {
+	// Name can not be updated
+	Name             string `json:"id" required:"true"`
+	Partition        *int   `json:"new_partition_numbers,omitempty"`
+	RetentionTime    *int   `json:"retention_time,omitempty"`
+	SyncMessageFlush *bool  `json:"sync_message_flush,omitempty"`
+	SyncReplication  *bool  `json:"sync_replication,omitempty"`
+}
+
+// ToTopicUpdateMap is used for type convert
+func (opts UpdateOpts) ToTopicUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method which can be able to update topics
+func Update(client *golangsdk.ServiceClient, instanceID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	body, err := opts.ToTopicUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(rootURL(client, instanceID), body, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Get an topic with detailed information by instance id and topic name
+func Get(client *golangsdk.ServiceClient, instanceID, topicName string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, instanceID, topicName), &r.Body, nil)
+	return
+}
+
+// List all topics belong to the instance id
+func List(client *golangsdk.ServiceClient, instanceID string) (r ListResult) {
+	_, r.Err = client.Get(rootURL(client, instanceID), &r.Body, nil)
+	return
+}
+
+// Delete given topics belong to the instance id
+func Delete(client *golangsdk.ServiceClient, instanceID string, topics []string) (r DeleteResult) {
+	var delOpts = struct {
+		Topics []string `json:"topics" required:"true"`
+	}{Topics: topics}
+
+	b, err := golangsdk.BuildRequestBody(delOpts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(deleteURL(client, instanceID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics/results.go
@@ -1,0 +1,125 @@
+package topics
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// CreateResponse is a struct that contains the create response
+type CreateResponse struct {
+	Name string `json:"name"`
+}
+
+// Topic includes the parameters of an topic
+type Topic struct {
+	Name             string      `json:"name"`
+	Partition        int         `json:"partition"`
+	Replication      int         `json:"replication"`
+	RetentionTime    int         `json:"retention_time"`
+	SyncReplication  bool        `json:"sync_replication"`
+	SyncMessageFlush bool        `json:"sync_message_flush"`
+	TopicType        int         `json:"topic_type"`
+	PoliciesOnly     bool        `json:"policiesOnly"`
+	ExternalConfigs  interface{} `json:"external_configs"`
+}
+
+// ListResponse is a struct that contains the list response
+type ListResponse struct {
+	Total            int     `json:"total"`
+	Size             int     `json:"size"`
+	RemainPartitions int     `json:"remain_partitions"`
+	MaxPartitions    int     `json:"max_partitions"`
+	Topics           []Topic `json:"topics"`
+}
+
+// TopicDetail includes the detail parameters of an topic
+type TopicDetail struct {
+	Name            string      `json:"topic"`
+	Partitions      []Partition `json:"partitions"`
+	GroupSubscribed []string    `json:"group_subscribed"`
+}
+
+// Partition represents the details of a partition
+type Partition struct {
+	Partition int       `json:"partition"`
+	Replicas  []Replica `json:"replicas"`
+	// Node ID
+	Leader int `json:"leader"`
+	// Log End Offset
+	Leo int `json:"leo"`
+	// High Watermark
+	Hw int `json:"hw"`
+	// Log Start Offset
+	Lso int `json:"lso"`
+	// time stamp
+	UpdateTimestamp int64 `json:"last_update_timestamp"`
+}
+
+// Replica represents the details of a replica
+type Replica struct {
+	Broker int  `json:"broker"`
+	Leader bool `json:"leader"`
+	InSync bool `json:"in_sync"`
+	Size   int  `json:"size"`
+	Lag    int  `json:"lag"`
+}
+
+// CreateResult is a struct that contains all the return parameters of creation
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// Extract from CreateResult
+func (r CreateResult) Extract() (*CreateResponse, error) {
+	var s CreateResponse
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+// GetResult is a struct which contains the result of query
+type GetResult struct {
+	golangsdk.Result
+}
+
+// Extract from GetResult
+func (r GetResult) Extract() (*TopicDetail, error) {
+	var s TopicDetail
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+// ListResult contains the body of getting detailed
+type ListResult struct {
+	golangsdk.Result
+}
+
+// Extract from ListResult
+func (r ListResult) Extract() ([]Topic, error) {
+	var s ListResponse
+	err := r.Result.ExtractInto(&s)
+	return s.Topics, err
+}
+
+// UpdateResult is a struct from which can get the result of update method
+type UpdateResult struct {
+	golangsdk.ErrResult
+}
+
+// DeleteResult is a struct which contains the result of deletion
+type DeleteResult struct {
+	golangsdk.Result
+}
+
+// DeleteResponse is a struct that contains the deletion response
+type DeleteResponse struct {
+	Name    string `json:"id"`
+	Success bool   `json:"success"`
+}
+
+// Extract from DeleteResult
+func (r DeleteResult) Extract() ([]DeleteResponse, error) {
+	var s struct {
+		Topics []DeleteResponse `json:"topics"`
+	}
+	err := r.Result.ExtractInto(&s)
+	return s.Topics, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics/urls.go
@@ -1,0 +1,25 @@
+package topics
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+const (
+	resourcePath = "instances"
+	topicPath    = "topics"
+)
+
+// rootURL will build the url of create, update and list
+func rootURL(client *golangsdk.ServiceClient, instanceID string) string {
+	return client.ServiceURL(resourcePath, instanceID, topicPath)
+}
+
+// getURL will build the url of get
+func getURL(client *golangsdk.ServiceClient, instanceID, topic string) string {
+	return client.ServiceURL(resourcePath, instanceID, "management", topicPath, topic)
+}
+
+// deleteURL will build the url of delete
+func deleteURL(client *golangsdk.ServiceClient, instanceID string) string {
+	return client.ServiceURL(resourcePath, instanceID, topicPath, "delete")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/clusters/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v2/clusters/requests.go
@@ -50,9 +50,9 @@ type CreateOpts struct {
 	// KEYPAIR: specifies the key pair used for login. If this value is selected, node_keypair_name cannot be left blank.
 	LoginMode string `json:"login_mode" required:"true"`
 	// Password of the MRS Manager administrator.
-	// The password can contain 8 to 32 charactors.
-	// The password must contain at least three types of lowercase letters, uppercase letters, digits, spaces and the
-	// special characters: `~!@#$%^&*()-_=+\|[{}];:'",<>./?`.
+	// The password can contain 8 to 26 charactors.
+	// The password must contain lowercase letters, uppercase letters, digits, spaces
+	// and the special characters: !?,.:-_{}[]@$^+=/.
 	// the password cannot be the username or the username spelled backwards.
 	ManagerAdminPassword string `json:"manager_admin_password" required:"true"`
 	// Information about the node groups in the cluster. For details about the parameters, see Table 5.
@@ -93,8 +93,8 @@ type CreateOpts struct {
 	MrsEcsDefaultAgency string `json:"mrs_ecs_default_agency,omitempty"`
 	// Password of user root for logging in to a cluster node.
 	// The password can contain 8 to 26 charactors.
-	// The password at least three of the following: uppercase letters, lowercase letters, digits, and special
-	// characters (!@$%^-_=+[{}]:,./?), but must not contain spaces.
+	// The password must contain lowercase letters, uppercase letters, digits, spaces
+	// and the special characters: !?,.:-_{}[]@$^+=/.
 	// the password cannot be the username or the username spelled backwards.
 	NodeRootPassword string `json:"node_root_password,omitempty"`
 	// Name of a key pair You can use a key pair to log in to the Master node in the cluster.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210816020648-b3598389f8fd
+# github.com/huaweicloud/golangsdk v0.0.0-20210817085035-914d19567b2a
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -341,6 +341,7 @@ github.com/huaweicloud/golangsdk/openstack/dms/v1/maintainwindows
 github.com/huaweicloud/golangsdk/openstack/dms/v1/products
 github.com/huaweicloud/golangsdk/openstack/dms/v1/queues
 github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/instances
+github.com/huaweicloud/golangsdk/openstack/dms/v2/kafka/topics
 github.com/huaweicloud/golangsdk/openstack/dms/v2/rabbitmq/instances
 github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords
 github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1363 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resoruce huaweicloud_dms_kafka_topic
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccDmsKafkaTopic_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDmsKafkaTopic_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaTopic_basic
=== PAUSE TestAccDmsKafkaTopic_basic
=== CONT  TestAccDmsKafkaTopic_basic
--- PASS: TestAccDmsKafkaTopic_basic (569.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       569.715s
```
