### PR TITLE
support updating labels and taints in cce node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -100,16 +100,18 @@ The following arguments are supported:
 
 * `priority` - (Optional, Int) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
 
-* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format. Changing this parameter will create a new resource.
+* `labels` - (Optional, Map) Tags of a Kubernetes node, key/value pair format.
 
 * `tags` - (Optional, Map) Tags of a VM node, key/value pair format.
 
-* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration.
+  The structure is described below. Changing this parameter will create a new resource.
 
-* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
+* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created.
+  The structure is described below. Changing this parameter will create a new resource.
 
-* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
-
+* `taints` - (Optional, List) You can add taints to created nodes to configure anti-affinity.
+  The structure is described below.
 
 The `root_volume` block supports:
 

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -66,7 +66,6 @@ func ResourceCCENodePool() *schema.Resource {
 			"labels": { //(k8s_tags)
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"root_volume": {
@@ -157,7 +156,6 @@ func ResourceCCENodePool() *schema.Resource {
 			"taints": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
@@ -513,6 +511,8 @@ func resourceCCENodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 				DataVolumes: resourceCCEDataVolume(d),
 				Count:       1,
 				UserTags:    resourceCCENodePoolTags(d),
+				K8sTags:     resourceCCENodeK8sTags(d),
+				Taints:      resourceCCETaint(d),
 			},
 			Type: d.Get("type").(string),
 		},

--- a/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
@@ -67,7 +67,7 @@ func TestAccCCENodePool_basic(t *testing.T) {
 	})
 }
 
-func TestAccCCENodePool_tags(t *testing.T) {
+func TestAccCCENodePool_tagsLabelsTaints(t *testing.T) {
 	var nodePool nodepools.NodePool
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -81,21 +81,34 @@ func TestAccCCENodePool_tags(t *testing.T) {
 		CheckDestroy: testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCENodePool_tags(rName),
+				Config: testAccCCENodePool_tagsLabelsTaints(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.test1", "val1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.test2", "val2"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test1", "val1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test2", "val2"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
 				),
 			},
 			{
-				Config: testAccCCENodePool_tags_update(rName),
+				Config: testAccCCENodePool_tagsLabelsTaints_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.test1", "val1_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.test2_update", "val2_update"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test1", "val1_update"),
+					resource.TestCheckResourceAttr(resourceName, "labels.test2_update", "val2_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "taints.1.key", "test_key_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.1.value", "test_value_update"),
+					resource.TestCheckResourceAttr(resourceName, "taints.1.effect", "NoSchedule"),
 				),
 			},
 		},
@@ -320,7 +333,7 @@ resource "huaweicloud_cce_node_pool" "test" {
 `, testAccCCENodePool_Base(rName), rName)
 }
 
-func testAccCCENodePool_tags(rName string) string {
+func testAccCCENodePool_tagsLabelsTaints(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -352,11 +365,23 @@ resource "huaweicloud_cce_node_pool" "test" {
 	test1 = "val1"
 	test2 = "val2"
   }
+
+  labels = {
+	test1 = "val1"
+	test2 = "val2"
+  }
+
+  taints {
+	key    = "test_key"
+	value  = "test_value"
+	effect = "NoSchedule"
+  }
+
 }
 `, testAccCCENodePool_Base(rName), rName)
 }
 
-func testAccCCENodePool_tags_update(rName string) string {
+func testAccCCENodePool_tagsLabelsTaints_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -387,6 +412,23 @@ resource "huaweicloud_cce_node_pool" "test" {
   tags = {
 	test1        = "val1_update"
 	test2_update = "val2_update"
+  }
+
+  labels = {
+	test1        = "val1_update"
+	test2_update = "val2_update"
+  }
+
+  taints {
+	key    = "test_key"
+	value  = "test_value_update"
+	effect = "NoSchedule"
+  }
+
+  taints {
+	key    = "test_key_update"
+	value  = "test_value_update"
+	effect = "NoSchedule"
   }
 }
 `, testAccCCENodePool_Base(rName), rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support updating labels and taints in cce node pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1384 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePool_tagsLabelsTaints'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePool_tagsLabelsTaints -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_tagsLabelsTaints
=== PAUSE TestAccCCENodePool_tagsLabelsTaints
=== CONT  TestAccCCENodePool_tagsLabelsTaints
--- PASS: TestAccCCENodePool_tagsLabelsTaints (910.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       910.460s
```
