### PR TITLE
bugfix: add missing description attribute in security group data source

### DIFF
--- a/docs/data-sources/networking_secgroup.md
+++ b/docs/data-sources/networking_secgroup.md
@@ -2,10 +2,9 @@
 subcategory: "Virtual Private Cloud (VPC)"
 ---
 
-# huaweicloud\_networking\_secgroup
+# huaweicloud_networking_secgroup
 
 Use this data source to get the ID of an available HuaweiCloud security group.
-This is an alternative to `huaweicloud_networking_secgroup_v2`
 
 ## Example Usage
 
@@ -17,18 +16,17 @@ data "huaweicloud_networking_secgroup" "secgroup" {
 
 ## Argument Reference
 
-* `region` - (Optional, String) The region in which to obtain the V2 Neutron client.
-  A Neutron client is needed to retrieve security groups ids. If omitted, the
-  `region` argument of the provider is used.
+* `region` - (Optional, String) Specifies the region in which to obtain the security group.
+  If omitted, the provider-level region will be used.
 
-* `secgroup_id` - (Optional, String) The ID of the security group.
+* `secgroup_id` - (Optional, String) Specifiest he ID of the security group.
 
-* `name` - (Optional, String) The name of the security group.
+* `name` - (Optional, String) Specifies the name of the security group.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a data source ID in UUID format.
+* `id` - The data source ID in UUID format.
 
 * `description`- The description of the security group.

--- a/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
@@ -28,10 +28,14 @@ func DataSourceNetworkingSecGroupV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"tenant_id": {
+			"description": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
+			},
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}
@@ -75,7 +79,6 @@ func dataSourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}
 
 	d.Set("name", secGroup.Name)
 	d.Set("description", secGroup.Description)
-	d.Set("tenant_id", secGroup.TenantID)
 	d.Set("region", GetRegion(d, config))
 
 	return nil

--- a/huaweicloud/data_source_huaweicloud_networking_secgroup_v2_test.go
+++ b/huaweicloud/data_source_huaweicloud_networking_secgroup_v2_test.go
@@ -4,51 +4,49 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccHuaweiCloudNetworkingSecGroupV2DataSource_basic(t *testing.T) {
+func TestAccNetworkingSecGroupV2DataSource_basic(t *testing.T) {
 	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.huaweicloud_networking_secgroup.secgroup_1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHuaweiCloudNetworkingSecGroupV2DataSource_group(rName),
+				Config: testAccNetworkingSecGroupV2DataSource_group(rName),
 			},
 			{
-				Config: testAccHuaweiCloudNetworkingSecGroupV2DataSource_basic(rName),
+				Config: testAccNetworkingSecGroupV2DataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSecGroupV2DataSourceID("data.huaweicloud_networking_secgroup_v2.secgroup_1"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_networking_secgroup_v2.secgroup_1", "name", rName),
+					testAccCheckNetworkingSecGroupV2DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 		},
 	})
 }
 
-func TestAccHuaweiCloudNetworkingSecGroupV2DataSource_secGroupID(t *testing.T) {
+func TestAccNetworkingSecGroupV2DataSource_byID(t *testing.T) {
 	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.huaweicloud_networking_secgroup.secgroup_1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHuaweiCloudNetworkingSecGroupV2DataSource_group(rName),
+				Config: testAccNetworkingSecGroupV2DataSource_group(rName),
 			},
 			{
-				Config: testAccHuaweiCloudNetworkingSecGroupV2DataSource_secGroupID(rName),
+				Config: testAccNetworkingSecGroupV2DataSource_secGroupID(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSecGroupV2DataSourceID("data.huaweicloud_networking_secgroup_v2.secgroup_1"),
-					resource.TestCheckResourceAttr(
-						"data.huaweicloud_networking_secgroup_v2.secgroup_1", "name", rName),
+					testAccCheckNetworkingSecGroupV2DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 		},
@@ -59,42 +57,42 @@ func testAccCheckNetworkingSecGroupV2DataSourceID(n string) resource.TestCheckFu
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find security group data source: %s", n)
+			return fmt.Errorf("Can't find security group data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("Security group data source ID not set")
+			return fmt.Errorf("Security group data source ID not set")
 		}
 
 		return nil
 	}
 }
 
-func testAccHuaweiCloudNetworkingSecGroupV2DataSource_group(rName string) string {
+func testAccNetworkingSecGroupV2DataSource_group(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
+resource "huaweicloud_networking_secgroup" "secgroup_1" {
   name        = "%s"
   description = "My neutron security group"
 }
 `, rName)
 }
 
-func testAccHuaweiCloudNetworkingSecGroupV2DataSource_basic(rName string) string {
+func testAccNetworkingSecGroupV2DataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-  name = "${huaweicloud_networking_secgroup_v2.secgroup_1.name}"
+data "huaweicloud_networking_secgroup" "secgroup_1" {
+  name = huaweicloud_networking_secgroup.secgroup_1.name
 }
-`, testAccHuaweiCloudNetworkingSecGroupV2DataSource_group(rName))
+`, testAccNetworkingSecGroupV2DataSource_group(rName))
 }
 
-func testAccHuaweiCloudNetworkingSecGroupV2DataSource_secGroupID(rName string) string {
+func testAccNetworkingSecGroupV2DataSource_secGroupID(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-  name = "${huaweicloud_networking_secgroup_v2.secgroup_1.name}"
+data "huaweicloud_networking_secgroup" "secgroup_1" {
+  secgroup_id = huaweicloud_networking_secgroup.secgroup_1.id
 }
-`, testAccHuaweiCloudNetworkingSecGroupV2DataSource_group(rName))
+`, testAccNetworkingSecGroupV2DataSource_group(rName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingSecGroupV2DataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingSecGroupV2DataSource -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupV2DataSource_basic
=== PAUSE TestAccNetworkingSecGroupV2DataSource_basic
=== RUN   TestAccNetworkingSecGroupV2DataSource_byID
=== PAUSE TestAccNetworkingSecGroupV2DataSource_byID
=== CONT  TestAccNetworkingSecGroupV2DataSource_basic
=== CONT  TestAccNetworkingSecGroupV2DataSource_byID
--- PASS: TestAccNetworkingSecGroupV2DataSource_basic (82.30s)
--- PASS: TestAccNetworkingSecGroupV2DataSource_byID (82.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       82.957s
```
