### PR TITLE
fix: make sure all values in the extendParam map are string

### DIFF
--- a/huaweicloud/data_source_huaweicloud_cce_node_pool_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_pool_v3.go
@@ -180,6 +180,7 @@ func dataSourceCceNodePoolsV3Read(d *schema.ResourceData, meta interface{}) erro
 
 	logp.Printf("[DEBUG] Retrieved Node Pools using given filter %s: %+v", NodePool.Metadata.Id, NodePool)
 	d.SetId(NodePool.Metadata.Id)
+
 	d.Set("node_pool_id", NodePool.Metadata.Id)
 	d.Set("name", NodePool.Metadata.Name)
 	d.Set("type", NodePool.Spec.Type)
@@ -195,10 +196,16 @@ func dataSourceCceNodePoolsV3Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("scale_down_cooldown_time", NodePool.Spec.Autoscaling.ScaleDownCooldownTime)
 	d.Set("priority", NodePool.Spec.Autoscaling.Priority)
 	d.Set("subnet_id", NodePool.Spec.NodeTemplate.NodeNicSpec.PrimaryNic.SubnetId)
-	d.Set("max_pods", NodePool.Spec.NodeTemplate.ExtendParam["maxPods"])
-	d.Set("extend_param", NodePool.Spec.NodeTemplate.ExtendParam)
 	d.Set("status", NodePool.Status.Phase)
 	d.Set("region", GetRegion(d, config))
+
+	// set extend_param
+	var extendParam = NodePool.Spec.NodeTemplate.ExtendParam
+	d.Set("max_pods", extendParam["maxPods"])
+	delete(extendParam, "maxPods")
+	if len(extendParam) > 0 {
+		d.Set("extend_param", extendParam)
+	}
 
 	labels := map[string]string{}
 	for key, val := range NodePool.Spec.NodeTemplate.K8sTags {

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -411,10 +411,10 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("type", s.Spec.Type)
 
 	// set extend_param
-	var extend_param = s.Spec.NodeTemplate.ExtendParam
-	d.Set("max_pods", extend_param["maxPods"].(float64))
-	delete(extend_param, "maxPods")
-	d.Set("extend_param", extend_param)
+	var extendParam = s.Spec.NodeTemplate.ExtendParam
+	d.Set("max_pods", extendParam["maxPods"])
+	delete(extendParam, "maxPods")
+	d.Set("extend_param", extendParam)
 
 	if s.Spec.NodeTemplate.RunTime != nil {
 		d.Set("runtime", s.Spec.NodeTemplate.RunTime.Name)


### PR DESCRIPTION
calling d.Set("extend_param", extendParam) will raising the following error:
Error: extend_param.maxPods: '' expected type 'string', got unconvertible type 'float64'

we should make sure all values in the map are string

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePoolV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePoolV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (874.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       874.971s
```
