### PR TITLE
Add eps pre-check for APIG test

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
@@ -22,7 +22,10 @@ func TestAccApigApplicationV2_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckApigApplicationDestroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
@@ -22,7 +22,10 @@ func TestAccApigVpcChannelV2_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckApigVpcChannelDestroy,
 		Steps: []resource.TestStep{
@@ -71,7 +74,10 @@ func TestAccApigVpcChannelV2_withEipMembers(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // Method testAccApigApplication_base needs HW_ENTERPRISE_PROJECT_ID.
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckApigVpcChannelDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The enterprise project ID pre-check is missing where acc test of APIG service.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add eps pre-check to APIG application test and vpc channel test.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
