### PR TITLE
Add app key and app secret attributes

### DIFF
--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -61,6 +61,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - ID of the APIG application.
 * `registraion_time` - Registration time, in RFC-3339 format.
 * `update_time` - Time when the API group was last modified, in RFC-3339 format.
+* `app_key` - App key.
+* `app_secret` - App secret.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
@@ -32,6 +32,8 @@ func TestAccApigApplicationV2_basic(t *testing.T) {
 					testAccCheckApigApplicationExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_secret"),
 				),
 			},
 			{
@@ -41,6 +43,8 @@ func TestAccApigApplicationV2_basic(t *testing.T) {
 					testAccCheckApigApplicationExists(resourceName, &application),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_secret"),
 				),
 			},
 			{

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -76,6 +76,14 @@ func ResourceApigApplicationV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"app_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_secret": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"update_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -171,6 +179,8 @@ func setApigApplicationParamters(d *schema.ResourceData, config *config.Config, 
 		d.Set("description", resp.Description),
 		d.Set("registraion_time", resp.RegistraionTime),
 		d.Set("update_time", resp.UpdateTime),
+		d.Set("app_key", resp.AppKey),
+		d.Set("app_secret", resp.AppSecret),
 		setApigApplicationCodes(d, config, resp),
 	)
 	if mErr.ErrorOrNil() != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add two attributes support for `huaweicloud_apig_application` resource:
  1. app_key
  2. app_secret

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add app key and app secret attributes
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigApplicationV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigApplicationV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigApplicationV2_basic
=== PAUSE TestAccApigApplicationV2_basic
=== CONT  TestAccApigApplicationV2_basic
--- PASS: TestAccApigApplicationV2_basic (507.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      507.869s
```
