### PR TITLE
test: fix wrong address or type in Set method

### DIFF
--- a/huaweicloud/data_source_huaweicloud_images_image.go
+++ b/huaweicloud/data_source_huaweicloud_images_image.go
@@ -206,7 +206,6 @@ func dataSourceImagesImageV2Attributes(d *schema.ResourceData, image *images.Ima
 
 	d.SetId(image.ID)
 	d.Set("name", image.Name)
-	d.Set("tags", image.Tags)
 	d.Set("container_format", image.ContainerFormat)
 	d.Set("disk_format", image.DiskFormat)
 	d.Set("min_disk_gb", image.MinDiskGigabytes)

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -177,7 +177,7 @@ func testAccPreCheckDestProject(t *testing.T) {
 
 func testAccPreCheckEpsID(t *testing.T) {
 	if HW_ENTERPRISE_PROJECT_ID_TEST == "" {
-		t.Skip("This environment does not support EPS_ID tests")
+		t.Skip("This environment does not support Enterprise Project ID tests")
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -659,7 +659,6 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_pair", s.Spec.Login.SshKey)
 	d.Set("subnet_id", s.Spec.NodeNicSpec.PrimaryNic.SubnetId)
 	d.Set("ecs_group_id", s.Spec.EcsGroupID)
-	d.Set("billing_mode", s.Spec.BillingMode)
 	if s.Spec.BillingMode != 0 {
 		d.Set("charging_mode", "prePaid")
 	}

--- a/huaweicloud/resource_huaweicloud_iec_security_group.go
+++ b/huaweicloud/resource_huaweicloud_iec_security_group.go
@@ -106,7 +106,6 @@ func resourceIecSecurityGroupV1Read(d *schema.ResourceData, meta interface{}) er
 		return CheckDeleted(d, err, "HuaweiCloud IEC Security group")
 	}
 
-	d.Set("id", group.ID)
 	d.Set("name", group.Name)
 	d.Set("description", group.Description)
 

--- a/huaweicloud/resource_huaweicloud_iec_vip.go
+++ b/huaweicloud/resource_huaweicloud_iec_vip.go
@@ -120,7 +120,6 @@ func resourceIecVIPV1Read(d *schema.ResourceData, meta interface{}) error {
 		return CheckDeleted(d, err, "Error retrieving Huaweicloud IEC VPC")
 	}
 
-	d.Set("name", vip.Name)
 	d.Set("subnet_id", vip.NetworkID)
 	d.Set("mac_address", vip.MacAddress)
 

--- a/huaweicloud/resource_huaweicloud_networking_eip_associate.go
+++ b/huaweicloud/resource_huaweicloud_networking_eip_associate.go
@@ -70,7 +70,7 @@ func resourceNetworkingFloatingIPAssociateV2Create(d *schema.ResourceData, meta 
 
 	d.SetId(floatingIPID)
 
-	return resourceNetworkFloatingIPV2Read(d, meta)
+	return resourceNetworkingFloatingIPAssociateV2Read(d, meta)
 }
 
 func resourceNetworkingFloatingIPAssociateV2Read(d *schema.ResourceData, meta interface{}) error {

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -69,7 +69,7 @@ func TestAccPreCheckDeprecated(t *testing.T) {
 //lintignore:AT003
 func TestAccPreCheckEpsID(t *testing.T) {
 	if HW_ENTERPRISE_PROJECT_ID == "" {
-		t.Fatal("HW_ENTERPRISE_PROJECT_ID must be set for acceptance tests")
+		t.Skip("This environment does not support Enterprise Project ID tests")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
in sdkv2, if the address is not exist or the type is wrong, an panic will arised in acceptance testing.
so, fix it.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecVipResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecVipResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecVipResource_basic
=== PAUSE TestAccIecVipResource_basic
=== CONT  TestAccIecVipResource_basic
--- PASS: TestAccIecVipResource_basic (69.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       69.505s

$ make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run TestAccApigApplicationV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccApigApplicationV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigApplicationV2_basic
=== PAUSE TestAccApigApplicationV2_basic
=== CONT  TestAccApigApplicationV2_basic
    acceptance.go:72: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccApigApplicationV2_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      0.051s
```
