### PR TITLE
fix: update rds refresh check and port check

### DIFF
--- a/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3_test.go
@@ -50,7 +50,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_updated"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8636"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Between status 'BUILD' and 'BACK UP', the instance has a few time at 'ACTIVE' status. In order to fix it, add a `ContinuousTargetOccurence` configuration to refresh check.
The instance provider have some invalid schema setting (port, type and disk_encryption_id), remove them.
The database port test of update check should be 8636, not 8635.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
- remove active state from pending list
- add continuous target occurence check
- replace min timeout with poll interval
- remove invalid params set from read method
- update database port check
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsInstanceV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (1172.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1172.776s
```
