### PR TITLE
Add dedicated_resource_id support to gaussdb cassandra

### DIFF
--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -87,6 +87,8 @@ The following arguments are supported:
 
 * `configuration_id` - (Optional, String) Specifies the Parameter Template ID.
 
+* `dedicated_resource_id` - (Optional, String, ForceNew) Specifies the dedicated resource ID.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id, Only valid for users who
   have enabled the enterprise multi-project service.
   Changing this parameter will create a new resource.

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -95,6 +95,11 @@ func resourceGeminiDBInstanceV3() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"dedicated_resource_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"datastore": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -344,6 +349,7 @@ func resourceGeminiDBInstanceV3Create(d *schema.ResourceData, meta interface{}) 
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		ConfigurationId:     d.Get("configuration_id").(string),
 		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
+		DedicatedResourceId: d.Get("dedicated_resource_id").(string),
 		Mode:                "Cluster",
 		Flavor:              resourceGeminiDBFlavor(d),
 		DataStore:           resourceGeminiDBDataStore(d),
@@ -436,6 +442,7 @@ func resourceGeminiDBInstanceV3Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("vpc_id", instance.VpcId)
 	d.Set("subnet_id", instance.SubnetId)
 	d.Set("security_group_id", instance.SecurityGroupId)
+	d.Set("dedicated_resource_id", instance.DedicatedResourceId)
 	d.Set("mode", instance.Mode)
 	d.Set("db_user_name", instance.DbUserName)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccGeminiDBInstance_basic'
...
=== RUN   TestAccGeminiDBInstance_basic
--- PASS: TestAccGeminiDBInstance_basic (1130.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1130.625s
```
