### PR TITLE
Add dedicated_resource_id support to gaussdb mysql

### DIFF
--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -88,6 +88,7 @@ The following arguments are supported:
 * `configuration_id` - (Optional, String) Specifies the Parameter Template ID.
 
 * `dedicated_resource_id` - (Optional, String, ForceNew) Specifies the dedicated resource ID.
+  Changing this parameter will create a new resource.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id, Only valid for users who
   have enabled the enterprise multi-project service.

--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -70,6 +70,9 @@ The following arguments are supported:
 * `configuration_id` - (Optional, String, ForceNew) Specifies the configuration ID.
   Changing this parameter will create a new resource.
 
+* `dedicated_resource_id` - (Optional, String, ForceNew) Specifies the dedicated resource ID.
+  Changing this parameter will create a new resource.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id. Required if EPS enabled.
   Changing this parameter will create a new resource.
 

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -88,6 +88,11 @@ func resourceGaussDBInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"dedicated_resource_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"table_name_case_sensitivity": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -343,6 +348,7 @@ func resourceGaussDBInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		ConfigurationId:     d.Get("configuration_id").(string),
 		EnterpriseProjectId: GetEnterpriseProjectID(d, config),
+		DedicatedResourceId: d.Get("dedicated_resource_id").(string),
 		TimeZone:            d.Get("time_zone").(string),
 		SlaveCount:          d.Get("read_replicas").(int),
 		Mode:                "Cluster",
@@ -502,6 +508,7 @@ func resourceGaussDBInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("subnet_id", instance.SubnetId)
 	d.Set("security_group_id", instance.SecurityGroupId)
 	d.Set("configuration_id", instance.ConfigurationId)
+	d.Set("dedicated_resource_id", instance.DedicatedResourceId)
 	d.Set("db_user_name", instance.DbUserName)
 	d.Set("time_zone", instance.TimeZone)
 	d.Set("availability_zone_mode", instance.AZMode)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1364 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
