### PR TITLE
Add dependencies data-source support for FGS service

### DIFF
--- a/docs/data-sources/fgs_dependencies.md
+++ b/docs/data-sources/fgs_dependencies.md
@@ -1,0 +1,70 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# huaweicloud_fgs_dependencies
+
+Use this data source to filter dependent packages of FGS from HuaweiCloud.
+
+## Example Usage
+
+### Obtain all public dependent packages
+
+```hcl
+data "huaweicloud_fgs_dependencies" "test" {}
+```
+
+### Obtain specific public dependent package by name
+
+```hcl
+data "huaweicloud_fgs_dependencies" "test" {
+  type = "public"
+  name = "obssdk-3.0.2"
+}
+```
+
+### Obtain all public Python2.7 dependent packages
+
+```hcl
+data "huaweicloud_fgs_dependencies" "test" {
+  type    = "public"
+  runtime = "Python2.7"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the dependent packages.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the dependent package type to match. Valid values: **public** and **private**.
+
+* `runtime` - (Optional, String) Specifies the dependent package runtime to match. Valid values: **Java8**,
+  **Node.js6.10**, **Node.js8.10**, **Node.js10.16**, **Node.js12.13**, **Python2.7**, **Python3.6**, **Go1.8**,
+  **Go1.x**, **C#(.NET Core 2.0)**, **C#(.NET Core 2.1)**, **C#(.NET Core 3.1)** and **PHP7.3**.
+
+* `name` - (Optional, String) Specifies the dependent package runtime to match.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A data source ID.
+
+* `packages` - All dependent packages that match.
+
+  * `id` - Dependent package ID.
+
+  * `name` - Dependent package name.
+
+  * `owner` - Dependent package owner.
+
+  * `link` - URL of the dependent package in the OBS console.
+
+  * `etag` - Unique ID of the dependent package.
+
+  * `size` - Dependent package size.
+
+  * `file_name` - File name of the Dependent package.
+
+  * `runtime` - Dependent package runtime.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mrs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
@@ -282,6 +283,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_maintainwindow":                   DataSourceDmsMaintainWindowV1(),
 			"huaweicloud_elb_flavors":                          dataSourceElbFlavorsV3(),
 			"huaweicloud_enterprise_project":                   DataSourceEnterpriseProject(),
+			"huaweicloud_fgs_dependencies":                     fgs.DataSourceFunctionGraphDependencies(),
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": dataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_instance":           dataSourceGeminiDBInstance(),
 			"huaweicloud_gaussdb_cassandra_instances":          dataSourceGeminiDBInstances(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
@@ -1,0 +1,89 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFunctionGraphDependencies_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDependencies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphDependencies_name(t *testing.T) {
+	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDependencies_name(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "obssdk-3.0.2"),
+					resource.TestCheckResourceAttr(dataSourceName, "packages.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
+	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDependencies_runtime(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "runtime", "Python2.7"),
+					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccFunctionGraphDependencies_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_fgs_dependencies" "test" {}
+`)
+}
+
+func testAccFunctionGraphDependencies_name() string {
+	return fmt.Sprintf(`
+data "huaweicloud_fgs_dependencies" "test" {
+  type = "public"
+  name = "obssdk-3.0.2"
+}
+`)
+}
+
+func testAccFunctionGraphDependencies_runtime() string {
+	return fmt.Sprintf(`
+data "huaweicloud_fgs_dependencies" "test" {
+  type    = "public"
+  runtime = "Python2.7"
+}
+`)
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependencies.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependencies.go
@@ -1,0 +1,130 @@
+package fgs
+
+import (
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+)
+
+// DataSourceFunctionGraphDependencies provides some parameters to filter dependent packages on the server.
+func DataSourceFunctionGraphDependencies() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFunctionGraphDependenciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"public", "private",
+				}, false),
+			},
+			"runtime": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"packages": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"link": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"etag": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"file_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"runtime": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceFunctionGraphDependenciesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.FgsV2Client(region)
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud compute client: %s", err)
+	}
+	// Limit and Marker use default values.
+	listOpts := dependencies.ListOpts{
+		Name:           d.Get("name").(string),
+		Runtime:        d.Get("runtime").(string),
+		DependencyType: d.Get("type").(string),
+	}
+
+	allPages, err := dependencies.List(client, listOpts).AllPages()
+	if err != nil {
+		return fmtp.Errorf("Error retrieving dependent packages: %s", err)
+	}
+	resp, err := dependencies.ExtractDependencies(allPages)
+	if len(resp.Dependencies) < 1 {
+		return fmtp.Errorf("No dependent package found, please check your parameters.")
+	}
+
+	return setFunctionGraphDependencies(d, resp.Dependencies)
+}
+
+func setFunctionGraphDependencies(d *schema.ResourceData, pkgs []dependencies.Dependency) error {
+	packages := make([]map[string]interface{}, len(pkgs))
+
+	names := schema.NewSet(schema.HashString, nil)
+	for i, pkg := range pkgs {
+		names.Add(pkg.Name)
+		packages[i] = map[string]interface{}{
+			"id":        pkg.ID,
+			"name":      pkg.Name,
+			"owner":     pkg.Owner,
+			"link":      pkg.Link,
+			"etag":      pkg.Etag,
+			"size":      pkg.Size,
+			"file_name": pkg.FileName,
+			"runtime":   pkg.Runtime,
+		}
+	}
+	d.SetId(hashcode.Strings(utils.ExpandToStringList(names.List())))
+
+	return d.Set("packages", packages)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies/requests.go
@@ -1,0 +1,53 @@
+package dependencies
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Dependency type, which support public, private, and all, default to all.
+	//   public
+	//   private
+	//   all
+	DependencyType string `q:"dependency_type"`
+	// Runtime of function.
+	Runtime string `q:"runtime"`
+	// Name of the dependency.
+	Name string `q:"name"`
+	// Final record queried last time. Default value: 0.
+	Marker string `q:"marker"`
+	// Maximum number of dependencies that can be obtained in a query, default to 400.
+	Limit string `q:"limit"`
+}
+
+// ListOptsBuilder is an interface which to support request query build of
+// the dependent package search.
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+// ToListQuery is a method which to build a request query by the ListOpts.
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more dependent packages according to the query parameters.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := DependencyPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies/results.go
@@ -1,0 +1,89 @@
+package dependencies
+
+import (
+	"strconv"
+
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// Dependency is an object struct that represents the elements of the dependencies parameter.
+type Dependency struct {
+	// Dependency ID.
+	ID string `json:"id"`
+	// Dependency owner.
+	Owner string `json:"owner"`
+	// URL of the dependency in the OBS console.
+	Link string `json:"link"`
+	// Runtime.
+	Runtime string `json:"runtime"`
+	// Unique ID of the dependency.
+	Etag string `json:"etag"`
+	// Size of the dependency.
+	Size int `json:"size"`
+	// Name of the dependency.
+	Name string `json:"name"`
+	// Description of the dependency.
+	Description string `json:"description"`
+	// File name of the dependency.
+	FileName string `json:"file_name"`
+}
+
+// ListResp is an object struct that represents the result of each page.
+type ListResp struct {
+	// Next read location.
+	Next int `json:"next_marker"`
+	// Total number of dependencies.
+	Count int `json:"count"`
+	// Dependency list.
+	Dependencies []Dependency `json:"dependencies"`
+}
+
+// DependencyPage represents the response pages of the List method.
+type DependencyPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no dependent package.
+func (r DependencyPage) IsEmpty() (bool, error) {
+	resp, err := ExtractDependencies(r)
+	return len(resp.Dependencies) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r DependencyPage) LastMarker() (string, error) {
+	resp, err := ExtractDependencies(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.Next >= resp.Count {
+		return "", nil
+	}
+	return strconv.Itoa(resp.Next), nil
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r DependencyPage) NextPageURL() (string, error) {
+	currentURL := r.URL
+
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == "" {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// ExtractDependencies is a method which to extract the response to a dependent package list, next marker index and
+// count number.
+func ExtractDependencies(r pagination.Page) (ListResp, error) {
+	var s ListResp
+	err := r.(DependencyPage).Result.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies/urls.go
@@ -1,0 +1,7 @@
+package dependencies
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("fgs", "dependencies")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,6 +250,7 @@ github.com/huaweicloud/golangsdk/openstack/eps/v1/enterpriseprojects
 github.com/huaweicloud/golangsdk/openstack/evs/v2/snapshots
 github.com/huaweicloud/golangsdk/openstack/evs/v2/tags
 github.com/huaweicloud/golangsdk/openstack/evs/v3/volumes
+github.com/huaweicloud/golangsdk/openstack/fgs/v2/dependencies
 github.com/huaweicloud/golangsdk/openstack/fgs/v2/function
 github.com/huaweicloud/golangsdk/openstack/geminidb/v3/backups
 github.com/huaweicloud/golangsdk/openstack/geminidb/v3/configurations


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is currently no method to obtain the ID of a dependent package, and it is difficult to create a function using a dependent package.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. provide a data-source to filter dependent packages.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionGraphDependencies_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionGraphDependencies_ -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphDependencies_basic
=== PAUSE TestAccFunctionGraphDependencies_basic
=== RUN   TestAccFunctionGraphDependencies_name
=== PAUSE TestAccFunctionGraphDependencies_name
=== RUN   TestAccFunctionGraphDependencies_runtime
=== PAUSE TestAccFunctionGraphDependencies_runtime
=== CONT  TestAccFunctionGraphDependencies_basic
=== CONT  TestAccFunctionGraphDependencies_runtime
=== CONT  TestAccFunctionGraphDependencies_name
--- PASS: TestAccFunctionGraphDependencies_runtime (54.04s)
--- PASS: TestAccFunctionGraphDependencies_basic (55.04s)
--- PASS: TestAccFunctionGraphDependencies_name (56.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       56.147s
```
