### PR TITLE
[MD026] Remove trailing punctuation from heading

### DIFF
--- a/docs/data-sources/enterprise_project.md
+++ b/docs/data-sources/enterprise_project.md
@@ -14,7 +14,7 @@ data "huaweicloud_enterprise_project" "test" {
 }
 ```
 
-## Resources Supported Currently:
+## Resources Supported Currently
 Service Name | Resource Name | Sub Resource Name
 ---- | --- | ---
 AS  | huaweicloud_as_group |

--- a/docs/resources/scm_certificate.md
+++ b/docs/resources/scm_certificate.md
@@ -10,7 +10,7 @@ centrally manage all your SSL certificates in one place.
 
 ## Example Usage
 
-### Load the certificate contents from the local files.
+### Load the certificate contents from the local files
 ```hcl
 resource "huaweicloud_scm_certificate" "certificate_1" {
   name              = "certificate_1"
@@ -19,7 +19,7 @@ resource "huaweicloud_scm_certificate" "certificate_1" {
   private_key       = file("/usr/local/data/certificate/cert_xxx/xxx_server.key")
 }
 ```
-### Write the contents of the certificate into the Terrafrom script.
+### Write the contents of the certificate into the Terrafrom script
 ```hcl
 resource "huaweicloud_scm_certificate" "certificate_2" {
   name              ="certificate_2"
@@ -47,7 +47,7 @@ EOT
 }
 ```
 
-### Push the SSL certificate to another HUAWEI CLOUD service.
+### Push the SSL certificate to another HUAWEI CLOUD service
 
 ```hcl
 # Load the certificate contents from the local files.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MD026 rule is triggered on any heading that has one of the specified normal or full-width punctuation characters as the last character in the line.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove trailing punctuation from heading.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
