### PR TITLE
[MD046] Format sublist marker and context

### DIFF
--- a/docs/resources/sfs_access_rule.md
+++ b/docs/resources/sfs_access_rule.md
@@ -70,13 +70,12 @@ The following arguments are supported:
 * `access_to` - (Required, String, ForceNew) Specifies the value that defines the access rule. The value contains 1 to
   255 characters. Changing this will create a new access rule. The value varies according to the scenario:
   + Set the VPC ID in VPC authorization scenarios.
-  + Set this parameter in IP address authorization scenario.
+  + Set this parameter in IP address authorization scenario:
+      - For an NFS shared file system, the value in the format of  *VPC_ID#IP_address#priority#user_permission*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
 
-          For an NFS shared file system, the value in the format of *VPC_ID#IP_address#priority#user_permission*.
-          For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
-
-          For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
-          For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
+      - For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
 
 ## Attributes Reference
 

--- a/docs/resources/sfs_file_system.md
+++ b/docs/resources/sfs_file_system.md
@@ -99,13 +99,11 @@ The following arguments are supported:
 * `access_to` - (Optional, String) Specifies the value that defines the access rule. The value contains 1 to 255
   characters. Changing this will create a new access rule. The value varies according to the scenario:
   + Set the VPC ID in VPC authorization scenarios.
-  + Set this parameter in IP address authorization scenario.
-
-          - For an NFS shared file system, the value in the format of *VPC_ID#IP_address#priority#user_permission*.
-          For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
-
-          - For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
-          For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
+  + Set this parameter in IP address authorization scenario:
+      - For an NFS shared file system, the value in the format of *VPC_ID#IP_address#priority#user_permission*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
+      - For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*.
+        For example, 0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
 
 -> **NOTE:** If you want to create more access rules, please
 using [huaweicloud_sfs_access_rule](https://www.terraform.io/docs/providers/huaweicloud/r/sfs_access_rule.html).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The rule 46 of the markdownlint is triggered when unwanted or different code block styles are used in the same document.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. format sublist marker and context.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
