### PR TITLE
[WAF]: add dependencies for unit tests to ensure that they can automatically run successfully

### DIFF
--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF certificate resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The certificate resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a dedicated mode domain resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The dedicated mode domain name resource can be used in Dedicated Mode and ELB Mode.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF domain resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The domain name resource can be used in Cloud Mode.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF policy resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The policy resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_reference_table.md
+++ b/docs/resources/waf_reference_table.md
@@ -7,7 +7,7 @@ subcategory: "Web Application Firewall (WAF)"
 Manages a WAF reference table resource within HuaweiCloud.
 
 -> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
-used. The reference table can be used in Cloud Mode (professional version), Dedicated Mode and ELB Mode.
+used. The reference table resource can be used in Cloud Mode (professional version), Dedicated Mode and ELB Mode.
 
 ## Example Usage
 

--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF blacklist and whitelist rule resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The blacklist and whitelist rule resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF Data Masking Rule resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The data masking rule resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF web tamper protection rule resource within HuaweiCloud.
 
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The web tamper protection rule resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+
 ## Example Usage
 
 ```hcl

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -31,6 +31,8 @@ var (
 	HW_MAPREDUCE_CUSTOM      = os.Getenv("HW_MAPREDUCE_CUSTOM")
 
 	HW_DEPRECATED_ENVIRONMENT = os.Getenv("HW_DEPRECATED_ENVIRONMENT")
+
+	HW_WAF_ENABLE_FLAG = os.Getenv("HW_WAF_ENABLE_FLAG")
 )
 
 var TestAccProviders map[string]*schema.Provider
@@ -91,4 +93,11 @@ func TestAccPreCheckMrsCustom(t *testing.T) {
 
 func RandomAccResourceName() string {
 	return fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+}
+
+//lintignore:AT003
+func TestAccPrecheckWafInstance(t *testing.T) {
+	if HW_WAF_ENABLE_FLAG == "" {
+		t.Skip("Jump the WAF acceptance tests.")
+	}
 }

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -12,11 +11,14 @@ import (
 )
 
 func TestAccDataSourceWafCertificateV1_basic(t *testing.T) {
-	name := fmt.Sprintf("cert-%s", acctest.RandString(5))
+	name := acceptance.RandomAccResourceName()
 	dataSourceName := "data.huaweicloud_waf_certificate.cert_1"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers: acceptance.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -51,6 +53,10 @@ func testAccWafCertificateListV1_conf(name string) string {
 
 data "huaweicloud_waf_certificate" "cert_1" {
   name = huaweicloud_waf_certificate.certificate_1.name
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
 }
 `, testAccWafCertificateV1_conf(name))
 }

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_instances_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_instances_test.go
@@ -15,8 +15,11 @@ func TestAccDataSourceWafDedicatedInstancesV1_basic(t *testing.T) {
 	resourceName1 := "data.huaweicloud_waf_dedicated_instances.instance_1"
 	resourceName2 := "data.huaweicloud_waf_dedicated_instances.instance_2"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers: acceptance.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
@@ -14,8 +14,11 @@ func TestAccDataSourceWafPoliciesV1_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	dataSourceName := "data.huaweicloud_waf_policies.policies_1"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers: acceptance.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -51,6 +54,10 @@ func testAccWafPoliciesV1_conf(name string) string {
 
 data "huaweicloud_waf_policies" "policies_1" {
   name = huaweicloud_waf_policy.policy_1.name
+
+  depends_on = [
+    huaweicloud_waf_policy.policy_1
+  ]
 }
 `, testAccWafPolicyV1_basic(name))
 }

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
@@ -15,7 +15,10 @@ func TestAccDataSourceReferenceTablesV1_basic(t *testing.T) {
 	dataSourceName := "data.huaweicloud_waf_reference_tables.ref_table"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers: acceptance.TestAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates"
@@ -15,11 +14,14 @@ import (
 func TestAccWafCertificateV1_basic(t *testing.T) {
 	var certificate certificates.Certificate
 	resourceName := "huaweicloud_waf_certificate.certificate_1"
-	name := fmt.Sprintf("cert-%s", acctest.RandString(5))
+	name := acceptance.RandomAccResourceName()
 	updateName := name + "_update"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafCertificateV1Destroy,
 		Steps: []resource.TestStep{
@@ -102,6 +104,8 @@ func testAccCheckWafCertificateV1Exists(n string, certificate *certificates.Cert
 
 func testAccWafCertificateV1_conf(name string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "huaweicloud_waf_certificate" "certificate_1" {
   name = "%s"
 
@@ -159,6 +163,10 @@ x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
 X7ioLbTeWGBqFM+C80PkdBNp
 -----END PRIVATE KEY-----
 EOT
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
 }
-`, name)
+`, testAccWafDedicatedInstanceV1_conf(name), name)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -18,7 +18,10 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafDedicatedDomainV1Destroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
@@ -19,7 +19,10 @@ func TestAccWafDedicatedInstanceV1_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafDedicatedInstanceV1Destroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -16,11 +15,14 @@ import (
 func TestAccWafDomainV1_basic(t *testing.T) {
 	var domain domains.Domain
 	resourceName := "huaweicloud_waf_domain.domain_1"
-	randName := acctest.RandString(8)
-	certificateName := acctest.RandString(8)
+	randName := acceptance.RandomAccResourceName()
+	certificateName := acceptance.RandomAccResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafDomainV1Destroy,
 		Steps: []resource.TestStep{
@@ -58,11 +60,14 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 func TestAccWafDomainV1_policy(t *testing.T) {
 	var domain domains.Domain
 	resourceName := "huaweicloud_waf_domain.domain_1"
-	randName := acctest.RandString(8)
-	certificateName := acctest.RandString(8)
+	randName := acceptance.RandomAccResourceName()
+	certificateName := acceptance.RandomAccResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafDomainV1Destroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -17,11 +16,14 @@ import (
 
 func TestAccWafPolicyV1_basic(t *testing.T) {
 	var policy policies.Policy
-	randName := acctest.RandString(5)
+	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_waf_policy.policy_1"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafPolicyV1Destroy,
 		Steps: []resource.TestStep{
@@ -104,19 +106,31 @@ func testAccCheckWafPolicyV1Exists(n string, policy *policies.Policy) resource.T
 
 func testAccWafPolicyV1_basic(name string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "huaweicloud_waf_policy" "policy_1" {
   name  = "%s"
   level = 1
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
 }
-`, name)
+`, testAccWafDedicatedInstanceV1_conf(name), name)
 }
 
 func testAccWafPolicyV1_update(name string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "huaweicloud_waf_policy" "policy_1" {
   name            = "%s_updated"
   protection_mode = "block"
   level           = 3
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
 }
-`, name)
+`, testAccWafDedicatedInstanceV1_conf(name), name)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
@@ -18,7 +18,10 @@ func TestAccWafReferenceTableV1_basic(t *testing.T) {
 	updateName := name + "_update"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafReferenceTableV1Destroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -16,12 +15,15 @@ import (
 
 func TestAccWafRuleBlackList_basic(t *testing.T) {
 	var rule rules.WhiteBlackIP
-	randName := acctest.RandString(5)
+	randName := acceptance.RandomAccResourceName()
 	rName1 := "huaweicloud_waf_rule_blacklist.rule_1"
 	rName2 := "huaweicloud_waf_rule_blacklist.rule_2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafRuleBlackListDestroy,
 		Steps: []resource.TestStep{
@@ -136,9 +138,7 @@ func testAccWafRuleImportStateIdFunc(name string) resource.ImportStateIdFunc {
 
 func testAccWafRuleBlackList_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_%s"
-}
+%s
 
 resource "huaweicloud_waf_rule_blacklist" "rule_1" {
   policy_id  = huaweicloud_waf_policy.policy_1.id
@@ -150,15 +150,12 @@ resource "huaweicloud_waf_rule_blacklist" "rule_2" {
   ip_address = "192.165.0.0/24"
   action     = 1
 }
-
-`, name)
+`, testAccWafPolicyV1_basic(name))
 }
 
 func testAccWafRuleBlackList_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_%s"
-}
+%s
 
 resource "huaweicloud_waf_rule_blacklist" "rule_1" {
   policy_id  = huaweicloud_waf_policy.policy_1.id
@@ -171,6 +168,5 @@ resource "huaweicloud_waf_rule_blacklist" "rule_2" {
   ip_address = "192.150.0.0/24"
   action     = 0
 }
-
-`, name)
+`, testAccWafPolicyV1_basic(name))
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -20,14 +19,17 @@ import (
 
 func TestAccWafRuleDataMasking_basic(t *testing.T) {
 	var rule rules.DataMasking
-	policyName := "policy-" + acctest.RandString(5)
+	policyName := acceptance.RandomAccResourceName()
 	resourceName1 := "huaweicloud_waf_rule_data_masking.rule_1"
 	resourceName2 := "huaweicloud_waf_rule_data_masking.rule_2"
 	resourceName3 := "huaweicloud_waf_rule_data_masking.rule_3"
 	resourceName4 := "huaweicloud_waf_rule_data_masking.rule_4"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafRuleDataMaskingDestroy,
 		Steps: []resource.TestStep{
@@ -121,9 +123,7 @@ func testAccCheckWafRuleDataMaskingExists(n string, rule *rules.DataMasking) res
 
 func testAccWafRuleDataMasking_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "%s"
-}
+%s
 
 resource "huaweicloud_waf_rule_data_masking" "rule_1" {
   policy_id = huaweicloud_waf_policy.policy_1.id
@@ -149,14 +149,12 @@ resource "huaweicloud_waf_rule_data_masking" "rule_4" {
   field     = "cookie"
   subfield  = "password"
 }
-`, name)
+`, testAccWafPolicyV1_basic(name))
 }
 
 func testAccWafRuleDataMasking_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "%s"
-}
+%s
 
 resource "huaweicloud_waf_rule_data_masking" "rule_1" {
   policy_id = huaweicloud_waf_policy.policy_1.id
@@ -182,5 +180,5 @@ resource "huaweicloud_waf_rule_data_masking" "rule_4" {
   field     = "cookie"
   subfield  = "secret"
 }
-`, name)
+`, testAccWafPolicyV1_basic(name))
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -20,16 +19,19 @@ import (
 
 func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 	var rule rules.WebTamper
-	randName := acctest.RandString(5)
+	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
 		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckWafWafRuleWebTamperProtectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafWafRuleWebTamperProtection_basic(randName),
+				Config: testAccWafRuleWebTamperProtection_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
@@ -101,16 +103,14 @@ func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTampe
 	}
 }
 
-func testAccWafWafRuleWebTamperProtection_basic(name string) string {
+func testAccWafRuleWebTamperProtection_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_%s"
-}
+%s
 
 resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
   policy_id = huaweicloud_waf_policy.policy_1.id
   domain    = "www.abc.com"
   path      = "/a"
 }
-`, name)
+`, testAccWafPolicyV1_basic(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

1. Add dependencies for unit tests to ensure that they can automatically run successfully.
2. Add resource subscription reminders in the document for WAF.
3. Through the environment variable, close the test case of the WAF domain.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAcc -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafCertificateV1_basic
=== PAUSE TestAccDataSourceWafCertificateV1_basic
=== RUN   TestAccDataSourceWafDedicatedInstancesV1_basic
=== PAUSE TestAccDataSourceWafDedicatedInstancesV1_basic
=== RUN   TestAccDataSourceWafPoliciesV1_basic
=== PAUSE TestAccDataSourceWafPoliciesV1_basic
=== RUN   TestAccWafCertificateV1_basic
=== PAUSE TestAccWafCertificateV1_basic
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== RUN   TestAccWafDedicatedInstanceV1_basic
=== PAUSE TestAccWafDedicatedInstanceV1_basic
=== RUN   TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (0.00s)
=== RUN   TestAccWafDomainV1_policy
--- PASS: TestAccWafDomainV1_policy (0.00s)
=== RUN   TestAccWafPolicyV1_basic
=== PAUSE TestAccWafPolicyV1_basic
=== RUN   TestAccWafReferenceTableV1_basic
=== PAUSE TestAccWafReferenceTableV1_basic
=== RUN   TestAccWafRuleBlackList_basic
=== PAUSE TestAccWafRuleBlackList_basic
=== RUN   TestAccWafRuleDataMasking_basic
=== PAUSE TestAccWafRuleDataMasking_basic
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccDataSourceWafCertificateV1_basic
=== CONT  TestAccWafPolicyV1_basic
=== CONT  TestAccWafCertificateV1_basic
=== CONT  TestAccWafRuleDataMasking_basic
--- PASS: TestAccDataSourceWafCertificateV1_basic (433.42s)
=== CONT  TestAccWafRuleBlackList_basic
--- PASS: TestAccWafPolicyV1_basic (471.16s)
=== CONT  TestAccWafReferenceTableV1_basic
--- PASS: TestAccWafCertificateV1_basic (496.53s)
=== CONT  TestAccWafDedicatedInstanceV1_basic
--- PASS: TestAccWafRuleDataMasking_basic (516.62s)
=== CONT  TestAccWafDedicateDomainV1_basic
--- PASS: TestAccWafRuleBlackList_basic (604.92s)
=== CONT  TestAccDataSourceWafPoliciesV1_basic
=== CONT  TestAccWafRuleWebTamperProtection_basic
--- PASS: TestAccWafDedicatedInstanceV1_basic (612.10s)
--- PASS: TestAccWafReferenceTableV1_basic (658.61s)
=== CONT  TestAccDataSourceWafDedicatedInstancesV1_basic
--- PASS: TestAccWafDedicateDomainV1_basic (738.70s)
--- PASS: TestAccDataSourceWafPoliciesV1_basic (451.82s)
--- PASS: TestAccDataSourceWafDedicatedInstancesV1_basic (376.68s)
--- PASS: TestAccWafRuleWebTamperProtection_basic (406.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       1515.515s

```
