### PR TITLE
fix: set the eip status to BOUND after binding to a port

### DIFF
--- a/huaweicloud/data_source_huaweicloud_iec_eips.go
+++ b/huaweicloud/data_source_huaweicloud_iec_eips.go
@@ -113,17 +113,12 @@ func dataSourceIECNetworkEipsRead(d *schema.ResourceData, meta interface{}) erro
 			"public_ip":            item.PublicIpAddress,
 			"private_ip":           item.PrivateIpAddress,
 			"port_id":              item.PortID,
+			"status":               normalizeEIPStatus(item.Status),
 			"ip_version":           item.IPVersion,
 			"bandwidth_id":         item.BandwidthID,
 			"bandwidth_name":       item.BandwidthName,
 			"bandwidth_size":       item.BandwidthSize,
 			"bandwidth_share_type": item.BandwidthShareType,
-		}
-		// "DOWN" means the publicips is active but unbound
-		if item.Status == "DOWN" {
-			val["status"] = "UNBOUND"
-		} else {
-			val["status"] = item.Status
 		}
 
 		iecEips = append(iecEips, val)

--- a/huaweicloud/resource_huaweicloud_iec_eip.go
+++ b/huaweicloud/resource_huaweicloud_iec_eip.go
@@ -175,13 +175,7 @@ func resourceIecEipV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bandwidth_size", n.BandwidthSize)
 	d.Set("bandwidth_share_type", n.BandwidthShareType)
 	d.Set("site_info", n.SiteInfo)
-
-	// "DOWN" means the publicips is active but unbound
-	if n.Status == "DOWN" {
-		d.Set("status", "UNBOUND")
-	} else {
-		d.Set("status", n.Status)
-	}
+	d.Set("status", normalizeEIPStatus(n.Status))
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1410 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcV1EIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcV1EIP_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (93.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       93.943s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecEIPResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecEIPResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecEIPResource_basic
=== PAUSE TestAccIecEIPResource_basic
=== CONT  TestAccIecEIPResource_basic
--- PASS: TestAccIecEIPResource_basic (63.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       63.750s
```
