### PR TITLE
chore(lint-config): enable markdownlint rule 33

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,6 +14,10 @@
     "MD024": {
         "siblings_only": true
     },
-    "MD033": false,
+    "MD033": {
+        "allowed_elements": [
+            "a"
+        ]
+    },
     "MD040": false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**
Now, the lint rule rejects inline html, so documents that have realized in-page/between-page jumps cannot pass the markdownlint check.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. enable markdownlint rule 33.
2. allow label a for html inline.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
