### PR TITLE
chore(sdkv2): use context aware CRUD operations for vpc resources

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -12,6 +12,8 @@ package common
 import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/bss/v2/orders"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -48,6 +50,17 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 	}
 
 	return fmtp.Errorf("%s: %s", msg, err)
+}
+
+// CheckDeletedDiag checks the error to see if it's a 404 (Not Found) and, if so,
+// sets the resource ID to the empty string instead of throwing an error.
+func CheckDeletedDiag(d *schema.ResourceData, err error, msg string) diag.Diagnostics {
+	if _, ok := err.(golangsdk.ErrDefault404); ok {
+		d.SetId("")
+		return nil
+	}
+
+	return diag.Errorf("%s: %s", msg, err)
 }
 
 // UnsubscribePrePaidResource impl the action of unsubscribe resource

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -35,13 +35,31 @@ var (
 	HW_WAF_ENABLE_FLAG = os.Getenv("HW_WAF_ENABLE_FLAG")
 )
 
+// TestAccProviders is a static map containing only the main provider instance.
+//
+// Deprecated: Terraform Plugin SDK version 2 uses TestCase.ProviderFactories
+// but supports this value in TestCase.Providers for backwards compatibility.
+// In the future Providers: TestAccProviders will be changed to
+// ProviderFactories: TestAccProviderFactories
 var TestAccProviders map[string]*schema.Provider
+
+// TestAccProviderFactories is a static map containing only the main provider instance
+var TestAccProviderFactories map[string]func() (*schema.Provider, error)
+
+// TestAccProvider is the "main" provider instance
 var TestAccProvider *schema.Provider
 
 func init() {
 	TestAccProvider = huaweicloud.Provider()
+
 	TestAccProviders = map[string]*schema.Provider{
 		"huaweicloud": TestAccProvider,
+	}
+
+	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"huaweicloud": func() (*schema.Provider, error) {
+			return TestAccProvider, nil
+		},
 	}
 }
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
@@ -23,9 +23,9 @@ func TestAccVpcSubnetV1_basic(t *testing.T) {
 	rNameUpdate := rName + "-updated"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckVpcSubnetV1Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetV1_basic(rName),
@@ -64,9 +64,9 @@ func TestAccVpcSubnetV1_ipv6(t *testing.T) {
 	resourceName := "huaweicloud_vpc_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckVpcSubnetV1Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetV1_basic(rName),

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -22,9 +22,9 @@ func TestAccVpcV1_basic(t *testing.T) {
 	resourceName := "huaweicloud_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckVpcV1Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckVpcV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV1_basic(rName),
@@ -62,9 +62,9 @@ func TestAccVpcV1_WithEpsId(t *testing.T) {
 	resourceName := "huaweicloud_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckEpsID(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckVpcV1Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckVpcV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV1_epsId(rName),
@@ -93,9 +93,9 @@ func TestAccVpcV1_WithCustomRegion(t *testing.T) {
 	var vpc1, vpc2 vpcs.Vpc
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPrecheckCustomRegion(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckVpcV1Destroy,
+		PreCheck:          func() { acceptance.TestAccPrecheckCustomRegion(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckVpcV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV1_WithCustomRegion(vpcName1, vpcName2, acceptance.HW_CUSTOM_REGION_NAME),

--- a/huaweicloud/utils/fmtp/errors.go
+++ b/huaweicloud/utils/fmtp/errors.go
@@ -3,10 +3,16 @@ package fmtp
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func Errorf(format string, a ...interface{}) error {
 	newFormat := utils.BuildNewFormatByConfig(format)
 	return fmt.Errorf(newFormat, a...)
+}
+
+// DiagErrorf wraps fmtp.Errorf into diag.Diagnostics
+func DiagErrorf(format string, a ...interface{}) diag.Diagnostics {
+	return diag.FromErr(Errorf(format, a...))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
use context aware CRUD operations for vpc resources
use resource.TestCase.ProviderFactories for acceptance test
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcSubnetV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1 -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== CONT  TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_ipv6 (129.37s)
--- PASS: TestAccVpcSubnetV1_basic (129.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       129.599s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1 -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_WithEpsId
--- PASS: TestAccVpcV1_WithCustomRegion (56.09s)
--- PASS: TestAccVpcV1_WithEpsId (60.45s)
--- PASS: TestAccVpcV1_basic (110.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       110.300s
```
