### PR TITLE
refactor(tags): ignore system tags when transferring tags to map

### DIFF
--- a/huaweicloud/data_source_huaweicloud_cce_node_pool_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_pool_v3.go
@@ -240,8 +240,6 @@ func dataSourceCceNodePoolsV3Read(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	tagmap := utils.TagsToMap(NodePool.Spec.NodeTemplate.UserTags)
-	// ignore "CCE-Dynamic-Provisioning-Node"
-	delete(tagmap, "CCE-Dynamic-Provisioning-Node")
 	if err := d.Set("tags", tagmap); err != nil {
 		return fmtp.Errorf("error saving tags to state for CCE Node Pool(%s): %s", d.Id(), err)
 	}

--- a/huaweicloud/data_source_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/data_source_huaweicloud_cce_node_v3.go
@@ -234,8 +234,6 @@ func dataSourceCceNodesV3Read(d *schema.ResourceData, meta interface{}) error {
 
 	if resourceTags, err := tags.Get(computeClient, "cloudservers", serverId).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
-		// ignore "CCE-Dynamic-Provisioning-Node"
-		delete(tagmap, "CCE-Dynamic-Provisioning-Node")
 		if err := d.Set("tags", tagmap); err != nil {
 			return fmtp.Errorf("Error saving tags to state for CCE Node (%s): %s", serverId, err)
 		}

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -457,8 +457,6 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tagmap := utils.TagsToMap(s.Spec.NodeTemplate.UserTags)
-	// ignore "CCE-Dynamic-Provisioning-Node"
-	delete(tagmap, "CCE-Dynamic-Provisioning-Node")
 	if err := d.Set("tags", tagmap); err != nil {
 		return fmtp.Errorf("Error saving tags to state for CCE Node Pool(%s): %s", d.Id(), err)
 	}

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -708,8 +708,6 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 
 	if resourceTags, err := tags.Get(computeClient, "cloudservers", serverId).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
-		// ignore "CCE-Dynamic-Provisioning-Node"
-		delete(tagmap, "CCE-Dynamic-Provisioning-Node")
 		if err := d.Set("tags", tagmap); err != nil {
 			return fmtp.Errorf("Error saving tags to state for CCE Node (%s): %s", serverId, err)
 		}

--- a/huaweicloud/utils/tags.go
+++ b/huaweicloud/utils/tags.go
@@ -45,6 +45,9 @@ func TagsToMap(tags []tags.ResourceTag) map[string]string {
 		result[val.Key] = val.Value
 	}
 
+	// ignore system tags to keep the tags consistent with what the user set
+	delete(result, "CCE-Dynamic-Provisioning-Node")
+
 	return result
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1461 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. move ignoring tag CCE-Dynamic-Provisioning-Node to utils.TagsToMap since it is used in several parts of the code
2. fix unexpected update for tags of eip cause by tag CCE-Dynamic-Provisioning-Node
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcV1EIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcV1EIP_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (79.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       79.592s
```
