### PR TITLE
docs(fgs_function): Update description of the vpc access configuration

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -195,7 +195,9 @@ The following arguments are supported:
 
 * `vpc_id`  - (Optional, String) Specifies the ID of VPC.
 
-* `network_id`  - (Optional, String) Specifies the ID of subnet.
+* `network_id`  - (Optional, String) Specifies the network ID of subnet.
+
+-> **NOTE:** An agency with VPC management permissions must be specified for the function.
 
 * `mount_user_id` - (Optional, String) Specifies the user ID, a non-0 integer from –1 to 65534. Default to -1.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The description of the subnet id is confused with the netwerk id.
An agency with VPC management permissions must be specified for the function. If the VPC proxy is not configured, the function will not be able to query subnet resources through the subnet id.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add argument note of vpc access configuration
2. update description of the subnet id
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
