### PR TITLE
fix: use Summary rather than Detail field in Diagnostic struct

### DIFF
--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -43,7 +43,7 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -119,7 +119,7 @@ func TestAccServiceEndpoints_Management(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -171,7 +171,7 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -259,7 +259,7 @@ func TestAccServiceEndpoints_Security(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -335,7 +335,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -360,7 +360,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud API-GW v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://apig.%s.%s/v2/apigw/", HW_REGION_NAME, config.Cloud)
+	expectedURL = fmt.Sprintf("https://apig.%s.%s/v2/%s/apigw/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("API-GW v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
@@ -439,7 +439,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	config := testProvider.Meta().(*config.Config)
@@ -578,7 +578,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	config := testProvider.Meta().(*config.Config)
@@ -666,7 +666,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	config := testProvider.Meta().(*config.Config)
@@ -806,7 +806,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -883,6 +883,10 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	}
 	t.Logf("cloudtable endpoint:\t %s", actualURL)
 
+	serviceClient, err = config.CloudStreamV1Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud cloudStream client: %s", err)
+	}
 	expectedURL = fmt.Sprintf("https://cs.%s.%s/v1.0/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
@@ -953,7 +957,7 @@ func TestAccServiceEndpoints_Edge(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -981,7 +985,7 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -236,7 +236,7 @@ func TestAccProvider_caCertFile(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying HuaweiCloud CA by file: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying HuaweiCloud CA by file: %s", diags[0].Summary)
 	}
 }
 
@@ -260,7 +260,7 @@ func TestAccProvider_caCertString(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying HuaweiCloud CA by string: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying HuaweiCloud CA by string: %s", diags[0].Summary)
 	}
 }
 
@@ -292,7 +292,7 @@ func TestAccProvider_clientCertFile(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying HuaweiCloud Client keypair by file: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying HuaweiCloud Client keypair by file: %s", diags[0].Summary)
 	}
 }
 
@@ -322,7 +322,7 @@ func TestAccProvider_clientCertString(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying HuaweiCloud Client keypair by contents: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying HuaweiCloud Client keypair by contents: %s", diags[0].Summary)
 	}
 }
 


### PR DESCRIPTION
Both diag.FromErr and diag.Errorf does not use `Detail` field,
we should use `Summary` instead of it.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
