### PR TITLE
feat: make domain_name optional for IAM resources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -102,10 +102,6 @@ The following arguments are supported:
 * `region` - (Required) This is the Huawei Cloud region. It must be provided, but it can also be sourced from
   the `HW_REGION_NAME` environment variables.
 
-* `domain_name` - (Optional, Required for IAM resources) The
-  [Account name](https://support.huaweicloud.com/en-us/usermanual-iam/iam_01_0552.html)
-  of IAM to scope to. If omitted, the `HW_DOMAIN_NAME` environment variable is used.
-
 * `access_key` - (Optional) The access key of the HuaweiCloud to use. If omitted, the `HW_ACCESS_KEY` environment
   variable is used.
 
@@ -114,6 +110,9 @@ The following arguments are supported:
 
 * `project_name` - (Optional) The Name of the project to login with. If omitted, the `HW_PROJECT_NAME` environment
   variable or `region` is used.
+
+* `domain_name` - (Optional) The [Account name](https://support.huaweicloud.com/en-us/usermanual-iam/iam_01_0552.html)
+  of IAM to scope to. If omitted, the `HW_DOMAIN_NAME` environment variable is used.
 
 * `security_token` - (Optional) The security token to authenticate with a
   [temporary security credential](https://support.huaweicloud.com/intl/en-us/iam_faq/iam_01_0620.html). If omitted,

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -101,6 +101,11 @@ func (c *Config) LoadAndValidate() error {
 	if c.DomainID == "" {
 		if domainID, err := c.getDomainID(); err == nil {
 			c.DomainID = domainID
+
+			// update DomainClient.AKSKAuthOptions
+			if c.DomainClient.AKSKAuthOptions.AccessKey != "" {
+				c.DomainClient.AKSKAuthOptions.DomainID = c.DomainID
+			}
 		} else {
 			log.Printf("[WARN] get domain id failed: %s", err)
 		}

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -96,11 +96,7 @@ func testAccPreCheckDeprecated(t *testing.T) {
 
 func testAccPreCheckAdminOnly(t *testing.T) {
 	if HW_ADMIN == "" {
-		t.Skip("Skipping test because it requires the admin user group")
-	}
-
-	if HW_DOMAIN_ID == "" && HW_DOMAIN_NAME == "" {
-		t.Fatal("HW_DOMAIN_ID or HW_DOMAIN_NAME must be set for acceptance tests with admin privileges")
+		t.Skip("Skipping test because it requires the admin privileges")
 	}
 }
 


### PR DESCRIPTION
we can get the domain_name for API, then it's unnecessary to
set `domain_name` for IAN resources

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityV3User_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityV3User_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityV3User_basic
=== PAUSE TestAccIdentityV3User_basic
=== CONT  TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (54.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       54.175s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIdentityCustomRoleDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIdentityCustomRoleDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityCustomRoleDataSource_basic
=== PAUSE TestAccIdentityCustomRoleDataSource_basic
=== CONT  TestAccIdentityCustomRoleDataSource_basic
--- PASS: TestAccIdentityCustomRoleDataSource_basic (27.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       27.552s
```
