### PR TITLE
add a function to check routetable message

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -693,6 +693,10 @@ func (c *Config) VPCEPClient(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("vpcep", region)
 }
 
+func (c *Config) RouteTablesV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("routetables", region)
+}
+
 func (c *Config) NatGatewayClient(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("nat", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -191,6 +191,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "vpcep",
 		Version: "v1",
 	},
+	"routetables": {
+		Name:    "vpc",
+		Version: "v1",
+	},
 	"dns": {
 		Name:             "dns",
 		Version:          "v2",

--- a/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
@@ -1,6 +1,7 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -36,6 +37,54 @@ func DataSourceNetworkingSecGroupV2() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				Deprecated: "tenant_id is deprecated",
+			},
+			"security_group_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"direction": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ethertype": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_range_max": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_range_min": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_ip_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -80,6 +129,23 @@ func dataSourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}
 	d.Set("name", secGroup.Name)
 	d.Set("description", secGroup.Description)
 	d.Set("region", GetRegion(d, config))
+	security_group_rules := make([]map[string]string, 0, len(secGroup.Rules))
+	for _, v := range secGroup.Rules {
+		logp.Printf("[DEBUG] Retrieved Security Group %s", v)
+		rule := make(map[string]string)
+		rule["id"] = v.ID
+		rule["security_group_id"] = v.SecGroupID
+		rule["direction"] = v.Direction
+		rule["protocol"] = v.Protocol
+		rule["description"] = v.Description
+		rule["ethertype"] = v.EtherType
+		rule["port_range_max"] = fmt.Sprintf("%d", v.PortRangeMax)
+		rule["port_range_min"] = fmt.Sprintf("%d", v.PortRangeMin)
+		rule["remote_group_id"] = v.RemoteGroupID
+		rule["remote_ip_prefix"] = v.RemoteIPPrefix
+		security_group_rules = append(security_group_rules, rule)
+	}
+	d.Set("security_group_rules", security_group_rules)
 
 	return nil
 }

--- a/huaweicloud/data_source_huaweicloud_vpc_routetable.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_routetable.go
@@ -1,0 +1,125 @@
+package huaweicloud
+
+import (
+	"github.com/chnsz/golangsdk/openstack/networking/v1/routetables"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceVPCRouteTableV1() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVpcRouteTableV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"routes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nexthop": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"system": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"subnets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"destination": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceVpcRouteTableV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	vpcRouteTableClient, err := config.RouteTablesV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+	}
+
+	logp.Printf("[INFO] Retrieved Vpc Route using given filter %s ", vpcRouteTableClient)
+
+	routetables_id := d.Get("id").(string)
+
+	RouteTables, err := routetables.Get(vpcRouteTableClient, routetables_id).Extract()
+	if err != nil {
+		return err
+	}
+	logp.Printf("[DEBUG] Retrieved huaweicloud_vpc_routetable %s: %+v", RouteTables.RouteID, RouteTables)
+	d.SetId(RouteTables.RouteID)
+
+	d.Set("name", RouteTables.Name)
+	d.Set("destination", RouteTables.Destination)
+	d.Set("vpc_id", RouteTables.VPC_ID)
+	d.Set("tenant_id", RouteTables.Tenant_Id)
+	d.Set("region", GetRegion(d, config))
+
+	routes := make([]map[string]string, 0, len(RouteTables.Routes))
+	for _, v := range RouteTables.Routes {
+		route := make(map[string]string)
+		route["type"] = v.Type
+		route["destination"] = v.Destination
+		route["nexthop"] = v.Nexthop
+		route["system"] = v.System
+		routes = append(routes, route)
+	}
+	d.Set("routes", routes)
+
+	subnets := make([]map[string]string, 0, len(RouteTables.Subnets))
+	for _, v := range RouteTables.Subnets {
+		subnet := make(map[string]string)
+		subnet["id"] = v.Id
+		subnets = append(subnets, subnet)
+	}
+	d.Set("subnets", subnets)
+
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_vpc_routetable_list.go
+++ b/huaweicloud/data_source_huaweicloud_vpc_routetable_list.go
@@ -1,0 +1,117 @@
+package huaweicloud
+
+import (
+	"github.com/chnsz/golangsdk/openstack/networking/v1/routetables"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceVPCRouteTableListV1() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVpcRouteTableListV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"routes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				//Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nexthop": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"system": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"subnets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				//Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"destination": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceVpcRouteTableListV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	vpcRouteTableListClient, err := config.RouteTablesV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+	}
+
+	listOpts := routetables.ListOpts{}
+
+	if v, ok := d.GetOk("vpc_id"); ok {
+		listOpts.VPC_ID = v.(string)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		listOpts.SubnetID = v.(string)
+	}
+
+	pages, err := routetables.List(vpcRouteTableListClient, listOpts).AllPages()
+
+	RouteTableLists, err := routetables.ExtractRouteTables(pages)
+	if err != nil {
+		return fmtp.Errorf("Unable to list huaweicloud_vpc_routetable_list: %s", err)
+	}
+
+	RouteTableList := RouteTableLists[0]
+	logp.Printf("[DEBUG] Retrieved huaweicloud_vpc_routetable_list %s: %+v", RouteTableList.RouteID, RouteTableList)
+	d.SetId(RouteTableList.RouteID)
+
+	d.Set("name", RouteTableList.Name)
+	d.Set("destination", RouteTableList.Destination)
+	d.Set("vpc_id", RouteTableList.VPC_ID)
+	d.Set("tenant_id", RouteTableList.Tenant_Id)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -331,6 +331,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_route_ids":                        dataSourceVPCRouteIdsV2(),
 			"huaweicloud_vpc_subnet":                           DataSourceVpcSubnetV1(),
 			"huaweicloud_vpc_subnet_ids":                       DataSourceVpcSubnetIdsV1(),
+			"huaweicloud_vpc_routetable_list":                  DataSourceVPCRouteTableListV1(),
+			"huaweicloud_vpc_routetable":                       DataSourceVPCRouteTableV1(),
 			"huaweicloud_vpcep_public_services":                DataSourceVPCEPPublicServices(),
 			"huaweicloud_waf_certificate":                      waf.DataSourceWafCertificateV1(),
 			"huaweicloud_waf_policies":                         waf.DataSourceWafPoliciesV1(),

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routetables/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routetables/requests.go
@@ -1,0 +1,108 @@
+package routetables
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the attributes you want to see returned.
+type ListOpts struct {
+	// Specifies the route name.
+	Name string `q:"name"`
+
+	//Specifies the destination route.
+	Destination string `q:"destination"`
+
+	// Specifies the VPC.
+	VPC_ID string `q:"vpc_id"`
+
+	//Specifies the tenant ID. Only the administrator can specify the tenant ID of other tenants.
+	Tenant_Id string `q:"tenant_id"`
+
+	//Specifies the route ID.
+	RouteTableID string `q:"id"`
+
+	//Specifies the subnet ID.
+	SubnetID string `q:"subnet_id"`
+}
+
+type ListOptsBuilder interface {
+	ToRouteTableListQuery() (string, error)
+}
+
+// ToRouteListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToRouteTableListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// vpc routes  resources. It accepts a ListOpts struct, which allows you to
+// filter  the returned collection for greater efficiency.
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+
+	if opts != nil {
+		query, err := opts.ToRouteTableListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return RouteTablePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToRouteTablesCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new routes. There are
+// no required values.
+type CreateOpts struct {
+	Name        string `json:"name,omitempty" required:"true"`
+	Destination string `json:"destination,omitempty" required:"true"`
+	Tenant_Id   string `json:"tenant_id,omitempty"`
+	VPC_ID      string `json:"vpc_id,omitempty" required:"true"`
+}
+
+// ToRouteCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToRouteTablesCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "route")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// logical routes. When it is created, the routes does not have an internal
+// interface - it is not associated to any routes.
+//
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRouteTablesCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{201}}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular route based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// Delete will permanently delete a particular route based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routetables/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routetables/results.go
@@ -1,0 +1,108 @@
+package routetables
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+type Route struct {
+	Type  string `json:"type"`
+	Destination string `json:"destination,omitempty"`
+	Nexthop string `json:"nexthop"`
+	System string `json:"system,omitempty"`
+}
+
+type Subnet struct {
+	Id  string `json:"id"`
+}
+
+type RouteTable struct {
+	// Specifies the route name.
+	Name string `json:"name"`
+
+	// Specifies the routes. 
+	Routes []Route `json:"routes"`
+
+	// Specifies the subnets. 
+	Subnets []Subnet `json:"subnets"`
+
+	//Specifies the destination .
+	Destination string `json:"destination"`
+
+	// Specifies the VPC .
+	VPC_ID string `json:"vpc_id"`
+
+	//Specifies the tenant ID. Only the administrator can specify the tenant ID of other tenants.
+	Tenant_Id string `json:"tenant_id"`
+
+	//Specifies the route ID.
+	RouteID string `json:"id"`
+}
+
+// RoutePage is the page returned by a pager when traversing over a
+// collection of routes.
+type RouteTablePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of routes has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r RouteTablePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"routetables_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a RoutePage struct is empty.
+func (r RouteTablePage) IsEmpty() (bool, error) {
+	is, err := ExtractRouteTables(r)
+	return len(is) == 0, err
+}
+
+// ExtractRoutes accepts a Page struct, specifically a RoutePage struct,
+// and extracts the elements into a slice of Roue structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractRouteTables(r pagination.Page) ([]RouteTable, error) {
+	var s struct {
+		RouteTables []RouteTable `json:"routetables"`
+	}
+	err := (r.(RouteTablePage)).ExtractInto(&s)
+	return s.RouteTables, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a Route.
+func (r commonResult) Extract() (*RouteTable, error) {
+	var s struct {
+		RouteTable *RouteTable `json:"routetable"`
+	}
+	err := r.ExtractInto(&s)
+	return s.RouteTable, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Route.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Route.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routetables/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routetables/urls.go
@@ -1,0 +1,15 @@
+package routetables
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "routetables"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}
+
+
+


### PR DESCRIPTION
add a function to check routetable message and add some return params from port and secgroup
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
