### PR TITLE
feat: add rules attribute into networking secgroup resource and data source

### DIFF
--- a/docs/data-sources/networking_secgroup.md
+++ b/docs/data-sources/networking_secgroup.md
@@ -30,3 +30,19 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The data source ID in UUID format.
 
 * `description`- The description of the security group.
+
+* `rules` - The array of security group rules associating with the security group.
+  The [rule object](#security_group_rule) is documented below.
+
+<a name="security_group_rule"></a>
+The `rules` block supports:
+
+* `id` - The security group rule ID.
+* `description` - The supplementary information about the security group rule.
+* `direction` - The direction of the rule. The value can be *egress* or *ingress*.
+* `ethertype` - The IP protocol version. The value can be *IPv4* or *IPv6*.
+* `protocol` - The protocol type.
+* `port_range_min` - The lower part of the allowed port range.
+* `port_range_max` - The higher part of the allowed port range.
+* `remote_ip_prefix` - The remote IP address. The value can be in the CIDR format or IP addresses.
+* `remote_group_id` - The ID of the peer security group.

--- a/docs/resources/networking_secgroup.md
+++ b/docs/resources/networking_secgroup.md
@@ -73,6 +73,22 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
 
+* `rules` - The array of security group rules associating with the security group.
+  The [rule object](#security_group_rule) is documented below.
+
+<a name="security_group_rule"></a>
+The `rules` block supports:
+
+* `id` - The security group rule ID.
+* `description` - The supplementary information about the security group rule.
+* `direction` - The direction of the rule. The value can be *egress* or *ingress*.
+* `ethertype` - The IP protocol version. The value can be *IPv4* or *IPv6*.
+* `protocol` - The protocol type.
+* `port_range_min` - The lower part of the allowed port range.
+* `port_range_max` - The higher part of the allowed port range.
+* `remote_ip_prefix` - The remote IP address. The value can be in the CIDR format or IP addresses.
+* `remote_group_id` - The ID of the peer security group.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
@@ -1,14 +1,13 @@
 package huaweicloud
 
 import (
-	"fmt"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/security/groups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceNetworkingSecGroupV2() *schema.Resource {
@@ -33,58 +32,12 @@ func DataSourceNetworkingSecGroupV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"rules": sgRuleComputedSchema,
+
 			"tenant_id": {
 				Type:       schema.TypeString,
 				Optional:   true,
 				Deprecated: "tenant_id is deprecated",
-			},
-			"security_group_rules": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"direction": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"protocol": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ethertype": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"port_range_max": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"port_range_min": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"remote_ip_prefix": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"remote_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
 			},
 		},
 	}
@@ -126,26 +79,34 @@ func dataSourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}
 	logp.Printf("[DEBUG] Retrieved Security Group %s: %+v", secGroup.ID, secGroup)
 	d.SetId(secGroup.ID)
 
-	d.Set("name", secGroup.Name)
-	d.Set("description", secGroup.Description)
-	d.Set("region", GetRegion(d, config))
-	security_group_rules := make([]map[string]string, 0, len(secGroup.Rules))
-	for _, v := range secGroup.Rules {
-		logp.Printf("[DEBUG] Retrieved Security Group %s", v)
-		rule := make(map[string]string)
-		rule["id"] = v.ID
-		rule["security_group_id"] = v.SecGroupID
-		rule["direction"] = v.Direction
-		rule["protocol"] = v.Protocol
-		rule["description"] = v.Description
-		rule["ethertype"] = v.EtherType
-		rule["port_range_max"] = fmt.Sprintf("%d", v.PortRangeMax)
-		rule["port_range_min"] = fmt.Sprintf("%d", v.PortRangeMin)
-		rule["remote_group_id"] = v.RemoteGroupID
-		rule["remote_ip_prefix"] = v.RemoteIPPrefix
-		security_group_rules = append(security_group_rules, rule)
+	mErr := multierror.Append(nil,
+		d.Set("region", GetRegion(d, config)),
+		d.Set("name", secGroup.Name),
+		d.Set("description", secGroup.Description),
+		d.Set("rules", flattenSecurityGroupDataRules(&secGroup)),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
 	}
-	d.Set("security_group_rules", security_group_rules)
 
 	return nil
+}
+
+func flattenSecurityGroupDataRules(secGroup *groups.SecGroup) []map[string]interface{} {
+	sgRules := make([]map[string]interface{}, len(secGroup.Rules))
+	for i, rule := range secGroup.Rules {
+		sgRules[i] = map[string]interface{}{
+			"id":               rule.ID,
+			"direction":        rule.Direction,
+			"protocol":         rule.Protocol,
+			"ethertype":        rule.EtherType,
+			"port_range_max":   rule.PortRangeMax,
+			"port_range_min":   rule.PortRangeMin,
+			"remote_ip_prefix": rule.RemoteIPPrefix,
+			"remote_group_id":  rule.RemoteGroupID,
+			"description":      rule.Description,
+		}
+	}
+
+	return sgRules
 }

--- a/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/data_source_huaweicloud_networking_secgroup_v2.go
@@ -1,6 +1,7 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -36,6 +37,54 @@ func DataSourceNetworkingSecGroupV2() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				Deprecated: "tenant_id is deprecated",
+			},
+			"security_group_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"direction": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ethertype": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_range_max": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_range_min": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_ip_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -80,6 +129,23 @@ func dataSourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}
 	d.Set("name", secGroup.Name)
 	d.Set("description", secGroup.Description)
 	d.Set("region", GetRegion(d, config))
+	security_group_rules := make([]map[string]string, 0, len(secGroup.Rules))
+	for _, v := range secGroup.Rules {
+		logp.Printf("[DEBUG] Retrieved Security Group %s", v)
+		rule := make(map[string]string)
+		rule["id"] = v.ID
+		rule["security_group_id"] = v.SecGroupID
+		rule["direction"] = v.Direction
+		rule["protocol"] = v.Protocol
+		rule["description"] = v.Description
+		rule["ethertype"] = v.EtherType
+		rule["port_range_max"] = fmt.Sprintf("%d", v.PortRangeMax)
+		rule["port_range_min"] = fmt.Sprintf("%d", v.PortRangeMin)
+		rule["remote_group_id"] = v.RemoteGroupID
+		rule["remote_ip_prefix"] = v.RemoteIPPrefix
+		security_group_rules = append(security_group_rules, rule)
+	}
+	d.Set("security_group_rules", security_group_rules)
 
 	return nil
 }

--- a/huaweicloud/data_source_huaweicloud_networking_secgroup_v2_test.go
+++ b/huaweicloud/data_source_huaweicloud_networking_secgroup_v2_test.go
@@ -25,6 +25,7 @@ func TestAccNetworkingSecGroupV2DataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingSecGroupV2DataSourceID(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "rules.#"),
 				),
 			},
 		},
@@ -47,6 +48,7 @@ func TestAccNetworkingSecGroupV2DataSource_byID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingSecGroupV2DataSourceID(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "rules.#"),
 				),
 			},
 		},

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_v2.go
@@ -1,9 +1,9 @@
 package huaweicloud
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -15,6 +15,51 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
+
+var sgRuleComputedSchema = &schema.Schema{
+	Type:     schema.TypeList,
+	Computed: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"direction": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ethertype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port_range_min": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"port_range_max": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"remote_ip_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"remote_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	},
+}
 
 func ResourceNetworkingSecGroupV2() *schema.Resource {
 	return &schema.Resource{
@@ -57,6 +102,7 @@ func ResourceNetworkingSecGroupV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"rules": sgRuleComputedSchema,
 
 			"tenant_id": {
 				Type:       schema.TypeString,
@@ -64,54 +110,6 @@ func ResourceNetworkingSecGroupV2() *schema.Resource {
 				ForceNew:   true,
 				Computed:   true,
 				Deprecated: "tenant_id is deprecated",
-			},
-			"security_group_rules": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"direction": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"protocol": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ethertype": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"port_range_max": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"port_range_min": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"remote_ip_prefix": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"remote_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
 			},
 		},
 	}
@@ -175,35 +173,44 @@ func resourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}) 
 	}
 
 	logp.Printf("[DEBUG] Retrieve information about security group: %s", d.Id())
-	securityGroup, err := securitygroups.Get(segClient, d.Id()).Extract()
-
+	secGroup, err := securitygroups.Get(segClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "HuaweiCloud Security group")
 	}
 
-	d.Set("region", GetRegion(d, config))
-	d.Set("name", securityGroup.Name)
-	d.Set("description", securityGroup.Description)
-	d.Set("enterprise_project_id", securityGroup.EnterpriseProjectId)
-	security_group_rules := make([]map[string]string, 0, len(securityGroup.SecurityGroupRules))
-	for _, v := range securityGroup.SecurityGroupRules {
-		logp.Printf("[DEBUG] Retrieved Security Group %s", v)
-		rule := make(map[string]string)
-		rule["id"] = v.ID
-		rule["security_group_id"] = v.ID
-		rule["direction"] = v.Direction
-		rule["protocol"] = v.Protocol
-		rule["description"] = v.Description
-		rule["ethertype"] = v.Ethertype
-		rule["port_range_max"] = fmt.Sprintf("%d", v.PortRangeMax)
-		rule["port_range_min"] = fmt.Sprintf("%d", v.PortRangeMin)
-		rule["remote_group_id"] = v.RemoteGroupId
-		rule["remote_ip_prefix"] = v.RemoteIpPrefix
-		security_group_rules = append(security_group_rules, rule)
+	logp.Printf("[DEBUG] Retrieved Security Group %s: %+v", d.Id(), secGroup)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", GetRegion(d, config)),
+		d.Set("name", secGroup.Name),
+		d.Set("description", secGroup.Description),
+		d.Set("enterprise_project_id", secGroup.EnterpriseProjectId),
+		d.Set("rules", flattenSecurityGroupRules(secGroup)),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
 	}
-	d.Set("security_group_rules", security_group_rules)
 
 	return nil
+}
+
+func flattenSecurityGroupRules(secGroup *securitygroups.SecurityGroup) []map[string]interface{} {
+	sgRules := make([]map[string]interface{}, len(secGroup.SecurityGroupRules))
+	for i, rule := range secGroup.SecurityGroupRules {
+		sgRules[i] = map[string]interface{}{
+			"id":               rule.ID,
+			"direction":        rule.Direction,
+			"protocol":         rule.Protocol,
+			"ethertype":        rule.Ethertype,
+			"port_range_max":   rule.PortRangeMax,
+			"port_range_min":   rule.PortRangeMin,
+			"remote_ip_prefix": rule.RemoteIpPrefix,
+			"remote_group_id":  rule.RemoteGroupId,
+			"description":      rule.Description,
+		}
+	}
+
+	return sgRules
 }
 
 func resourceNetworkingSecGroupV2Update(d *schema.ResourceData, meta interface{}) error {
@@ -282,8 +289,7 @@ func waitForSecGroupDelete(segClient *golangsdk.ServiceClient, secGroupId string
 			return r, "ACTIVE", err
 		}
 
-		logp.Printf("[DEBUG] HuaweiCloud Security Group %s still active.\n", secGroupId)
+		logp.Printf("[DEBUG] HuaweiCloud Security Group %s still active", secGroupId)
 		return r, "ACTIVE", nil
 	}
 }
-

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_v2.go
@@ -1,6 +1,7 @@
 package huaweicloud
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -63,6 +64,54 @@ func ResourceNetworkingSecGroupV2() *schema.Resource {
 				ForceNew:   true,
 				Computed:   true,
 				Deprecated: "tenant_id is deprecated",
+			},
+			"security_group_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"direction": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ethertype": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_range_max": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_range_min": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_ip_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -136,6 +185,23 @@ func resourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("name", securityGroup.Name)
 	d.Set("description", securityGroup.Description)
 	d.Set("enterprise_project_id", securityGroup.EnterpriseProjectId)
+	security_group_rules := make([]map[string]string, 0, len(securityGroup.SecurityGroupRules))
+	for _, v := range securityGroup.SecurityGroupRules {
+		logp.Printf("[DEBUG] Retrieved Security Group %s", v)
+		rule := make(map[string]string)
+		rule["id"] = v.ID
+		rule["security_group_id"] = v.ID
+		rule["direction"] = v.Direction
+		rule["protocol"] = v.Protocol
+		rule["description"] = v.Description
+		rule["ethertype"] = v.Ethertype
+		rule["port_range_max"] = fmt.Sprintf("%d", v.PortRangeMax)
+		rule["port_range_min"] = fmt.Sprintf("%d", v.PortRangeMin)
+		rule["remote_group_id"] = v.RemoteGroupId
+		rule["remote_ip_prefix"] = v.RemoteIpPrefix
+		security_group_rules = append(security_group_rules, rule)
+	}
+	d.Set("security_group_rules", security_group_rules)
 
 	return nil
 }
@@ -220,3 +286,4 @@ func waitForSecGroupDelete(segClient *golangsdk.ServiceClient, secGroupId string
 		return r, "ACTIVE", nil
 	}
 }
+

--- a/huaweicloud/resource_huaweicloud_networking_secgroup_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_v2_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
-	var security_group groups.SecGroup
+	var secGroup groups.SecGroup
 	name := fmt.Sprintf("seg-acc-test-%s", acctest.RandString(5))
 	updatedName := fmt.Sprintf("%s-updated", name)
 	resourceName := "huaweicloud_networking_secgroup.secgroup_1"
@@ -27,9 +27,10 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 			{
 				Config: testAccSecGroup_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(resourceName, &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 6),
+					testAccCheckNetworkingV2SecGroupExists(resourceName, &secGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&secGroup, 6),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "6"),
 				),
 			},
 			{
@@ -40,7 +41,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 			{
 				Config: testAccSecGroup_update(updatedName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPtr(resourceName, "id", &security_group.ID),
+					resource.TestCheckResourceAttrPtr(resourceName, "id", &secGroup.ID),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 				),
 			},
@@ -49,7 +50,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroup_withEpsId(t *testing.T) {
-	var security_group groups.SecGroup
+	var secGroup groups.SecGroup
 	name := fmt.Sprintf("seg-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_networking_secgroup.secgroup_1"
 
@@ -61,7 +62,7 @@ func TestAccNetworkingV2SecGroup_withEpsId(t *testing.T) {
 			{
 				Config: testAccSecGroup_epsId(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(resourceName, &security_group),
+					testAccCheckNetworkingV2SecGroupExists(resourceName, &secGroup),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -71,7 +72,7 @@ func TestAccNetworkingV2SecGroup_withEpsId(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
-	var security_group groups.SecGroup
+	var secGroup groups.SecGroup
 	name := fmt.Sprintf("seg-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_networking_secgroup.secgroup_1"
 
@@ -83,9 +84,10 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 			{
 				Config: testAccSecGroup_noDefaultRules(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(resourceName, &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
+					testAccCheckNetworkingV2SecGroupExists(resourceName, &secGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&secGroup, 0),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "rules.#", "0"),
 				),
 			},
 		},
@@ -113,7 +115,7 @@ func testAccCheckNetworkingV2SecGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckNetworkingV2SecGroupExists(n string, security_group *groups.SecGroup) resource.TestCheckFunc {
+func testAccCheckNetworkingV2SecGroupExists(n string, secGroup *groups.SecGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -139,7 +141,7 @@ func testAccCheckNetworkingV2SecGroupExists(n string, security_group *groups.Sec
 			return fmtp.Errorf("Security group not found")
 		}
 
-		*security_group = *found
+		*secGroup = *found
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2SecGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2SecGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroup_basic
=== PAUSE TestAccNetworkingV2SecGroup_basic
=== CONT  TestAccNetworkingV2SecGroup_basic
--- PASS: TestAccNetworkingV2SecGroup_basic (82.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       82.458s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2SecGroup_noDefaultRules'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2SecGroup_noDefaultRules -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroup_noDefaultRules
=== PAUSE TestAccNetworkingV2SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV2SecGroup_noDefaultRules
--- PASS: TestAccNetworkingV2SecGroup_noDefaultRules (47.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       47.660s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingSecGroupV2DataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingSecGroupV2DataSource -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupV2DataSource_basic
=== PAUSE TestAccNetworkingSecGroupV2DataSource_basic
=== RUN   TestAccNetworkingSecGroupV2DataSource_byID
=== PAUSE TestAccNetworkingSecGroupV2DataSource_byID
=== CONT  TestAccNetworkingSecGroupV2DataSource_basic
=== CONT  TestAccNetworkingSecGroupV2DataSource_byID
--- PASS: TestAccNetworkingSecGroupV2DataSource_basic (70.31s)
--- PASS: TestAccNetworkingSecGroupV2DataSource_byID (70.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.990s
```
