### PR TITLE
feat(CSS): Add CSS Thesaurus resource support

### DIFF
--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# huaweicloud_css_thesaurus
+
+Manages CSS thesaurus resource within HuaweiCloud
+
+## Example Usage
+
+### create a thesaurus
+
+```hcl
+
+resource "huaweicloud_css_thesaurus" "test" {
+  cluster_id  = {{ css_cluster_id }}
+  bucket_name = {{ bucket_name }}
+  main_object = {{ bucket_obj_key }}
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the thesaurus resource. If omitted, the
+  provider-level region will be used. Changing this creates a new thesaurus resource.
+
+* `cluster_id` - (Required, String, ForceNew) Cluster Id. Specify the cluster ID for configuring the thesaurus
+  Changing this parameter will create a new resource.
+
+* `bucket_name` - (Optional, String) Specifies the OBS bucket where the thesaurus files are stored (the bucket type
+   must be standard storage or low-frequency storage, and archive storage is not supported).
+
+* `main_object` - (Optional, String) Specifies the path of the main thesaurus file object.
+
+* `stop_object` - (Optional, String) Specifies the path of the stop word library file object.
+
+* `synonym_object` - (Optional, String) Specifies the path of the synonyms thesaurus file object.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a resource ID in UUID format.
+
+* `status` - Indicates the status of the thesaurus loading
+
+* `update_time` - Specifies the time (UTC) when the thesaurus was modified. Example: 1631241332000
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+CSS thesaurus can be imported by  `id`. For example,
+
+```
+terraform import huaweicloud_css_thesaurus.example  e9ee3f48-f097-406a-aa74-cfece0af3e31
+```

--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - Indicates the status of the thesaurus loading
 
-* `update_time` - Specifies the time (UTC) when the thesaurus was modified. Example: 1631241332000
+* `update_time` - Specifies the time (UTC) when the thesaurus was modified. The format is ISO8601:YYYY-MM-DDThh:mm:ssZ
 
 ## Timeouts
 
@@ -59,8 +59,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-CSS thesaurus can be imported by  `id`. For example,
+CSS thesaurus can be imported by `id`. For example,
 
 ```
-terraform import huaweicloud_css_thesaurus.example  e9ee3f48-f097-406a-aa74-cfece0af3e31
+terraform import huaweicloud_css_thesaurus.example e9ee3f48-f097-406a-aa74-cfece0af3e31
 ```

--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -8,7 +8,7 @@ Manages CSS thesaurus resource within HuaweiCloud
 
 ## Example Usage
 
-### create a thesaurus
+### Create a thesaurus
 
 ```hcl
 

--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -6,18 +6,18 @@ subcategory: "Cloud Search Service (CSS)"
 
 Manages CSS thesaurus resource within HuaweiCloud
 
+-> Only one thesaurus resource can be created for the specified cluster
+
 ## Example Usage
 
 ### Create a thesaurus
 
 ```hcl
-
 resource "huaweicloud_css_thesaurus" "test" {
   cluster_id  = {{ css_cluster_id }}
   bucket_name = {{ bucket_name }}
   main_object = {{ bucket_obj_key }}
 }
-
 ```
 
 ## Argument Reference
@@ -27,17 +27,19 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the thesaurus resource. If omitted, the
   provider-level region will be used. Changing this creates a new thesaurus resource.
 
-* `cluster_id` - (Required, String, ForceNew) Cluster Id. Specify the cluster ID for configuring the thesaurus
+* `cluster_id` - (Required, String, ForceNew) Specifies the CSS cluster ID for configuring the thesaurus.
   Changing this parameter will create a new resource.
 
-* `bucket_name` - (Optional, String) Specifies the OBS bucket where the thesaurus files are stored (the bucket type
-   must be standard storage or low-frequency storage, and archive storage is not supported).
+* `bucket_name` - (Required, String, ForceNew) Specifies the OBS bucket where the thesaurus files are stored
+ (the bucket type must be standard storage or low-frequency storage, and archive storage is not supported).
 
 * `main_object` - (Optional, String) Specifies the path of the main thesaurus file object.
 
 * `stop_object` - (Optional, String) Specifies the path of the stop word library file object.
 
 * `synonym_object` - (Optional, String) Specifies the path of the synonyms thesaurus file object.
+
+-> Specifies at least one of `main_object`,`stop_object`,`synonym_object`
 
 ## Attributes Reference
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -430,6 +430,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_csbs_backup_policy":              resourceCSBSBackupPolicyV1(),
 			"huaweicloud_css_cluster":                     css.ResourceCssCluster(),
 			"huaweicloud_css_snapshot":                    ResourceCssSnapshot(),
+			"huaweicloud_css_thesaurus":                   css.ResourceCssthesaurus(),
 			"huaweicloud_dcs_instance":                    ResourceDcsInstanceV1(),
 			"huaweicloud_dds_instance":                    ResourceDdsInstanceV3(),
 			"huaweicloud_dis_stream":                      ResourceDisStreamV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -308,6 +308,10 @@ func RandomAccResourceName() string {
 	return fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
 }
 
+func RandomAccResourceNameWithDash() string {
+	return fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+}
+
 //lintignore:AT003
 func TestAccPrecheckWafInstance(t *testing.T) {
 	if HW_WAF_ENABLE_FLAG == "" {
@@ -326,5 +330,12 @@ func TestAccPreCheckAdminOnly(t *testing.T) {
 func TestAccPreCheckReplication(t *testing.T) {
 	if HW_DEST_REGION == "" || HW_DEST_PROJECT_ID == "" {
 		t.Skip("Jump the replication policy acceptance tests.")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckOBS(t *testing.T) {
+	if HW_ACCESS_KEY == "" || HW_SECRET_KEY == "" {
+		t.Skip("HW_ACCESS_KEY and HW_SECRET_KEY must be set for OBS acceptance tests")
 	}
 }

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
@@ -1,0 +1,129 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/css/v1/thesaurus"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccCssThesaurus_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_css_thesaurus.test"
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: testAccCheckCssThesaurusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssThesaurus_basic(rName, bucketName, "main.txt"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssThesaurusExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "main_object", "main.txt"),
+				),
+			},
+			{
+				Config: testAccCssThesaurus_basic(rName, bucketName, "main2.txt"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssThesaurusExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "main_object", "main2.txt"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCssThesaurus_basic(rName string, bucketName string, obsObjectKey string) string {
+	cssClusterBasic := testAccCssCluster_basic(rName, 1, 1, "value")
+
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket = "%s"
+  acl    = "private"
+}
+
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%s"
+  content      = "123"
+  content_type = "text/plain"
+}
+
+resource "huaweicloud_css_thesaurus" "test" {
+  cluster_id  = huaweicloud_css_cluster.test.id
+  bucket_name = huaweicloud_obs_bucket.test.bucket
+  main_object = huaweicloud_obs_bucket_object.test.key
+}
+
+`, cssClusterBasic, bucketName, obsObjectKey)
+}
+
+func testAccCheckCssThesaurusDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.CssV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("error creating CSS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_css_thesaurus" {
+			continue
+		}
+
+		resp, getErr := thesaurus.Get(client, rs.Primary.ID)
+		if getErr != nil {
+			if _, ok := getErr.(golangsdk.ErrDefault404); !ok {
+				return fmtp.Errorf("Get CSS thesaurus failed.error=%s", getErr)
+			}
+		} else {
+			if resp.Bucket != "" {
+				return fmtp.Errorf("CSS thesaurus still exists, cluster_id:%s", rs.Primary.ID)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckCssThesaurusExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.CssV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("error creating CSS client: %s", err)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmtp.Errorf("Error checking huaweicloud_css_thesaurus exist, err=not found this resource")
+		}
+
+		resp, errQueryDetail := thesaurus.Get(client, rs.Primary.ID)
+		if errQueryDetail != nil {
+			return fmtp.Errorf("error checking huaweicloud_css_thesaurus exist,err=send request failed:%s", errQueryDetail)
+		}
+
+		if resp == nil || resp.Bucket == "" {
+			return fmtp.Errorf("CSS thesaurus don't exists, cluster_id:%s", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
@@ -42,6 +42,11 @@ func TestAccCssThesaurus_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "main_object", "main2.txt"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
@@ -23,8 +23,8 @@ func TestAccCssThesaurus_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckOBS(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckCssThesaurusDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssThesaurusDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCssThesaurus_basic(rName, bucketName, "main.txt"),

--- a/huaweicloud/services/css/resource_huaweicloud_css_thesaurus.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_thesaurus.go
@@ -44,11 +44,13 @@ func ResourceCssthesaurus() *schema.Resource {
 			},
 			"bucket_name": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
+				ForceNew: true,
 			},
 			"main_object": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"main_object", "stop_object", "synonym_object"},
 			},
 			"stop_object": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/css/resource_huaweicloud_css_thesaurus.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_thesaurus.go
@@ -1,0 +1,225 @@
+package css
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/css/v1/thesaurus"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceCssthesaurus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceCssthesaurusCreate,
+		ReadContext:   ResourceCssthesaurusRead,
+		UpdateContext: ResourceCssthesaurusCreate,
+		DeleteContext: ResourceCssthesaurusDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"main_object": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"stop_object": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"synonym_object": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceCssthesaurusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	cssV1Client, err := config.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("Error creating CSS V1 client: %s", err)
+	}
+	opts := buildThesaurusCreateParameters(d)
+	clusterId := d.Get("cluster_id").(string)
+
+	loadErr := thesaurus.Load(cssV1Client, clusterId, *opts)
+	if loadErr.Err != nil {
+		return diag.Errorf("load thesaurus to css cluster failed. cluster_id=%s,error=%s", clusterId, loadErr.Err)
+	}
+
+	d.SetId(clusterId)
+
+	createResultErr := checkThesaurusLoadResult(ctx, cssV1Client, clusterId, d.Timeout(schema.TimeoutCreate))
+	if createResultErr != nil {
+		return diag.FromErr(createResultErr)
+	}
+
+	return ResourceCssthesaurusRead(ctx, d, meta)
+}
+
+func buildThesaurusCreateParameters(d *schema.ResourceData) *thesaurus.LoadThesaurusReq {
+	opts := thesaurus.LoadThesaurusReq{
+		BucketName: d.Get("bucket_name").(string),
+	}
+
+	if obj, ok := d.GetOk("main_object"); ok {
+		opts.MainObject = obj.(string)
+	}
+	if obj, ok := d.GetOk("stop_object"); ok {
+		opts.StopObject = obj.(string)
+	}
+	if obj, ok := d.GetOk("synonym_object"); ok {
+		opts.SynonymObject = obj.(string)
+	}
+
+	return &opts
+}
+
+func ResourceCssthesaurusRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	cssV1Client, err := config.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("Error creating CSS V1 client: %s", err)
+	}
+
+	detail, err := thesaurus.Get(cssV1Client, d.Id())
+	if err != nil {
+		return diag.Errorf("Query cluster thesaurus failed,cluster_id=%s,err=%s", d.Id(), err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("cluster_id", detail.ClusterId),
+		d.Set("bucket_name", detail.Bucket),
+		d.Set("main_object", detail.MainObj),
+		d.Set("stop_object", detail.StopObj),
+		d.Set("stop_object", detail.StopObj),
+		d.Set("synonym_object", detail.SynonymObj),
+		d.Set("status", detail.Status),
+		d.Set("update_time", detail.UpdateTime),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("Error setting vault fields: %s", err)
+	}
+
+	return nil
+}
+
+func ResourceCssthesaurusDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	cssV1Client, err := config.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("Error creating CSS V1 client: %s", err)
+	}
+
+	clusterId := d.Id()
+
+	errResult := thesaurus.Delete(cssV1Client, clusterId)
+	if errResult.Err != nil {
+		return diag.Errorf("Delete CSS Cluster thesaurus failed. %s", errResult.Err)
+	}
+
+	errCheckRt := checkThesaurusDeleteResult(ctx, cssV1Client, clusterId, d.Timeout(schema.TimeoutDelete))
+	if errCheckRt != nil {
+		return diag.Errorf("Failed to check the result of deletion %s", errCheckRt)
+	}
+	d.SetId("")
+	return nil
+}
+
+func checkThesaurusLoadResult(ctx context.Context, client *golangsdk.ServiceClient, clusterId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Loading"},
+		Target:  []string{"Loaded"},
+		Refresh: func() (interface{}, string, error) {
+			resp, err := thesaurus.Get(client, clusterId)
+			if err != nil {
+				return nil, "failed", err
+			}
+			if resp.Status == "Failed" {
+				return nil, "failed", fmtp.Errorf("load thesaurus failed in cluster_id=%s", clusterId)
+			}
+			return resp, resp.Status, err
+		},
+		Timeout:      timeout,
+		PollInterval: 10 * timeout,
+		Delay:        10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for CSS (%s) to load thesaurus: %s", clusterId, err)
+	}
+	return nil
+}
+
+func checkThesaurusDeleteResult(ctx context.Context, client *golangsdk.ServiceClient, clusterId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Pending"},
+		Target:  []string{"Done"},
+		Refresh: func() (interface{}, string, error) {
+			resp, err := thesaurus.Get(client, clusterId)
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					return nil, "Done", nil
+				}
+				return nil, "failed", err
+			}
+			if resp != nil && resp.MainObj == "" && resp.StopObj == "" && resp.SynonymObj == "" {
+				return resp, "Done", nil
+			}
+			return resp, "Pending", nil
+		},
+		Timeout:      timeout,
+		PollInterval: 10 * timeout,
+		Delay:        10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for CSS thesaurus (%s) to be delete: %s", clusterId, err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource:  huaweicloud_css_thesaurus 

**Which issue this PR fixes**:
fixes #1497 

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssThesaurus_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccCssThesaurus_basic -timeout 360m -parallel 4
=== RUN   TestAccCssThesaurus_basic
=== PAUSE TestAccCssThesaurus_basic
=== CONT  TestAccCssThesaurus_basic
--- PASS: TestAccCssThesaurus_basic (1038.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1038.580s
```
