### PR TITLE
refactor(cbr/policy): move cbr policy to services directory

### DIFF
--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -59,40 +59,41 @@ The following arguments are supported:
   characters, which may consist of chinese charactors, letters, digits, underscores(_) and hyphens (-).
 
 * `type` - (Required, String, ForceNew) Specifies the protection type of the CBR policy.
-  Valid values are *backup* and *replication*.
+  Valid values are **backup** and **replication**.
   Changing this will create a new policy.
 
-* `backup_cycle` - (Required, List) Specifies the scheduling rule for the CBR policy backup execution. The backup_cycle
-  structure is documented below.
+* `backup_cycle` - (Required, List) Specifies the scheduling rule for the CBR policy backup execution.
+  The [object](#cbr_policy_backup_cycle) structure is documented below.
 
-* `enabled` - (Optional, Bool) Specifies whether to enable the CBR policy. Default to true.
+* `enabled` - (Optional, Bool) Specifies whether to enable the CBR policy. Default to **true**.
 
 * `destination_region` - (Optional, String) Specifies the name of the replication destination region, which is mandatory
-  for cross-region replication. Required if `protection_type` is *replication*.
+  for cross-region replication. Required if `protection_type` is **replication**.
 
 * `destination_project_id` - (Optional, String) Specifies the ID of the replication destination project, which is
-  mandatory for cross-region replication. Required if `protection_type` is *replication*.
+  mandatory for cross-region replication. Required if `protection_type` is **replication**.
 
-* `backup_quantity` - (Optional, Int) Specifies the maximum number of retained backups. The value ranges from 2 to
-  99999. This parameter and `time_period` are alternative.
+* `backup_quantity` - (Optional, Int) Specifies the maximum number of retained backups. The value ranges from `2` to
+  `99,999`. This parameter and `time_period` are alternative.
 
-* `time_period` - (Optional, Int) Specifies the duration (in days) for retained backups. The value ranges from 2 to
-  99999.
+* `time_period` - (Optional, Int) Specifies the duration (in days) for retained backups. The value ranges from `2` to
+  `99,999`.
 
 -> **NOTE:** If this `backup_quantity` and `time_period` are both left blank, the backups will be retained permanently.
 
+<a name="cbr_policy_backup_cycle"></a>
 The `backup_cycle` block supports:
 
 * `days` - (Optional, String) Specifies the weekly backup day of backup schedule. It supports seven days a week (MO, TU,
   WE, TH, FR, SA, SU) and this parameter is separated by a comma (,) without spaces, between date and date during the
   configuration.
 
-* `interval` - (Optional, Int) Specifies the interval (in days) of backup schedule. The value ranges from 1 to 30. This
+* `interval` - (Optional, Int) Specifies the interval (in days) of backup schedule. The value range is `1` to `30`. This
   parameter and `days` are alternative.
 
 * `execution_times` - (Required, List) Specifies the backup time. Automated backups will be triggered at the backup
-  time. The current time is in the UTC format (HH:MM). The minutes in the list must be set to *00* and the hours cannot
-  be repeated. In the replication policy, you are advised to set one time point for one day.
+  time. The current time is in the UTC format (HH:MM). The minutes in the list must be set to **00** and the hours
+  cannot be repeated. In the replication policy, you are advised to set one time point for one day.
 
 ## Attributes Reference
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
@@ -401,7 +402,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_as_policy":                       ResourceASPolicy(),
 			"huaweicloud_bms_instance":                    ResourceBmsInstance(),
 			"huaweicloud_bcs_instance":                    resourceBCSInstanceV2(),
-			"huaweicloud_cbr_policy":                      resourceCBRPolicyV3(),
+			"huaweicloud_cbr_policy":                      cbr.ResourceCBRPolicyV3(),
 			"huaweicloud_cbr_vault":                       resourceCBRVaultV3(),
 			"huaweicloud_cce_cluster":                     ResourceCCEClusterV3(),
 			"huaweicloud_cce_node":                        ResourceCCENodeV3(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -41,6 +41,9 @@ var (
 	HW_DEPRECATED_ENVIRONMENT = os.Getenv("HW_DEPRECATED_ENVIRONMENT")
 
 	HW_WAF_ENABLE_FLAG = os.Getenv("HW_WAF_ENABLE_FLAG")
+
+	HW_DEST_REGION     = os.Getenv("HW_DEST_REGION")
+	HW_DEST_PROJECT_ID = os.Getenv("HW_DEST_PROJECT_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -316,5 +319,12 @@ func TestAccPrecheckWafInstance(t *testing.T) {
 func TestAccPreCheckAdminOnly(t *testing.T) {
 	if HW_ADMIN == "" {
 		t.Skip("Skipping test because it requires the admin privileges")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckReplication(t *testing.T) {
+	if HW_DEST_REGION == "" || HW_DEST_PROJECT_ID == "" {
+		t.Skip("Jump the replication policy acceptance tests.")
 	}
 }

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
@@ -1,35 +1,45 @@
-package huaweicloud
+package cbr
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
+
+func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CbrV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HuaweiCloud CBR client: %s", err)
+	}
+	return policies.Get(c, state.Primary.ID).Extract()
+}
 
 func TestAccCBRV3Policy_basic(t *testing.T) {
 	var asPolicy policies.Policy
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_policy.test"
 
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asPolicy,
+		getResourceFunc,
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCBRV3PolicyDestroy,
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRV3Policy_basic(rName),
+				Config: testCBRV3Policy_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRV3PolicyExists(resourceName, &asPolicy),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
@@ -39,10 +49,10 @@ func TestAccCBRV3Policy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testCBRV3Policy_update(rName),
+				Config: testCBRV3Policy_update(randName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRV3PolicyExists(resourceName, &asPolicy),
-					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "5"),
@@ -62,26 +72,32 @@ func TestAccCBRV3Policy_basic(t *testing.T) {
 
 func TestAccCBRV3Policy_replication(t *testing.T) {
 	var asPolicy policies.Policy
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asPolicy,
+		getResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckDestProject(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckReplication(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCBRV3PolicyDestroy,
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRV3Policy_replication(rName),
+				Config: testCBRV3Policy_replication(randName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRV3PolicyExists(resourceName, &asPolicy),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "type", "replication"),
-					resource.TestCheckResourceAttr(resourceName, "destination_region", HW_DEST_REGION),
-					resource.TestCheckResourceAttr(resourceName, "destination_project_id", HW_DEST_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "destination_region", acceptance.HW_DEST_REGION),
+					resource.TestCheckResourceAttr(resourceName, "destination_project_id", acceptance.HW_DEST_PROJECT_ID),
 					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
 					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "06:00"),
@@ -95,55 +111,6 @@ func TestAccCBRV3Policy_replication(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckCBRV3PolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	client, err := config.CbrV3Client(HW_REGION_NAME)
-	if err != nil {
-		return fmtp.Errorf("error creating Huaweicloud CBR client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_cbr_policy" {
-			continue
-		}
-
-		_, err := policies.Get(client, rs.Primary.ID).Extract()
-		if err == nil {
-			return fmtp.Errorf("policy still exists")
-		}
-	}
-	return nil
-}
-
-func testAccCheckCBRV3PolicyExists(n string, policy *policies.Policy) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*config.Config)
-		client, err := config.CbrV3Client(HW_REGION_NAME)
-		if err != nil {
-			return fmtp.Errorf("error creating Huaweicloud CBR client: %s", err)
-		}
-
-		found, err := policies.Get(client, rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-
-		logp.Printf("[DEBUG] test found is: %#v", found)
-		policy = found
-
-		return nil
-	}
 }
 
 func testCBRV3Policy_basic(rName string) string {
@@ -190,5 +157,5 @@ resource "huaweicloud_cbr_policy" "test" {
     execution_times = ["06:00", "18:00"]
   }
 }
-`, rName, HW_DEST_REGION, HW_DEST_PROJECT_ID)
+`, rName, acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
 }

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cbr
 
 import (
 	"fmt"
@@ -10,12 +10,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
-func resourceCBRPolicyV3() *schema.Resource {
+func ResourceCBRPolicyV3() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCBRPolicyV3Create,
 		Read:   resourceCBRPolicyV3Read,
@@ -113,7 +114,7 @@ func resourceCBRPolicyV3() *schema.Resource {
 
 func resourceCBRPolicyV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(GetRegion(d, config))
+	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
 	}
@@ -148,20 +149,20 @@ func resourceCBRPolicyV3Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceCBRPolicyV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(GetRegion(d, config))
+	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
 	}
 
 	cbrPolicy, err := policies.Get(client, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving CBRv3 policy")
+		return common.CheckDeleted(d, err, "Error retrieving CBRv3 policy")
 	}
 
 	logp.Printf("[DEBUG] Retrieved policy %s: %+v", d.Id(), cbrPolicy)
 	operationDefinition := cbrPolicy.OperationDefinition
 	mErr := multierror.Append(nil,
-		d.Set("region", GetRegion(d, config)),
+		d.Set("region", config.GetRegion(d)),
 		d.Set("enabled", cbrPolicy.Enabled),
 		d.Set("name", cbrPolicy.Name),
 		d.Set("type", cbrPolicy.OperationType),
@@ -184,7 +185,7 @@ func resourceCBRPolicyV3Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceCBRPolicyV3Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(GetRegion(d, config))
+	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
 	}
@@ -225,7 +226,7 @@ func resourceCBRPolicyV3Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceCBRPolicyV3Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(GetRegion(d, config))
+	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Apply new acc test format for cbr policy.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. move policy resource and test to services directory.
2. refactor policy test.
3. update document description.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
Basic policy test
```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCBRV3Policy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCBRV3Policy_basic -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== CONT  TestAccCBRV3Policy_basic
--- PASS: TestAccCBRV3Policy_basic (61.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       61.429s
```
replication policy test
```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCBRV3Policy_replication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCBRV3Policy_replication -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Policy_replication
=== PAUSE TestAccCBRV3Policy_replication
=== CONT  TestAccCBRV3Policy_replication
--- PASS: TestAccCBRV3Policy_replication (39.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       39.404s
```
