### PR TITLE
feat(obs): support default encryption for a bucket

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -201,6 +201,10 @@ The following arguments are supported:
   bucket, but the name of a deleted bucket can be reused for another bucket at least 30 minutes after the deletion.
   Exercise caution when changing this field.
 
+* `encryption` - (Optional, Bool) Whether enable default server-side encryption of the bucket in SSE-KMS mode.
+
+* `kms_key_id` - (Optional, String) Specifies the ID of a kms key. If omitted, the default master key will be used.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the OBS bucket. Changing
   this will create a new bucket.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20210902090116-d665e804e20b
+	github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20210902090116-d665e804e20b h1:WGZFkbf05sJhYXSZY4igU7f1m0NjLbVtLuspx51R59M=
 github.com/chnsz/golangsdk v0.0.0-20210902090116-d665e804e20b/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984 h1:fmhHRkpEwQQ0YiJ9eVOuhzERHz93pnOJIDVRUMdZNjY=
+github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/CHANGELOG
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/CHANGELOG
@@ -1,3 +1,22 @@
+Version 3.21.8
+
+New Features:
+1. Added bucket encryption-related APIs, including SetBucketEncryption, GetBucketEncryption, and DeleteBucketEncryption.
+2. Added the AppendObject API.
+3. Added the ModifyObject API.
+4. Allowed you to specify a type in the ListBuckets API to list the buckets of this type.
+
+Documentation & Demo:
+1. Added descriptions about bucket encryption APIs.
+2. Added descriptions about the AppendObject API.
+3. Added descriptions about the ModifyObject API.
+4. Added descriptions about the new parameter for specifying a bucket type in the ListBuckets API.
+
+Resolved Issues:
+1. Use proxy URL from environment variables by default.
+
+-----------------------------------------------------------------------------------
+
 Version 3.21.1
 
 New Features:

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/README.MD
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/README.MD
@@ -1,4 +1,12 @@
-Version:3.21.1
+# README
 
-You can get the latest source code from [here](https://obssdk.obs.cn-north-1.myhuaweicloud.com/current/go/go.zip),
-then unzip the file.
+## Version
+
+3.21.8
+
+You can get the latest source code from [huaweicloud-sdk-go-obs](https://github.com/huaweicloud/huaweicloud-sdk-go-obs).
+
+## Backporting
+
+Please backport [GH-11](https://github.com/chnsz/golangsdk/pull/11) after updating the sdk from
+huaweicloud-sdk-go-obs.

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/conf.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/conf.go
@@ -341,6 +341,8 @@ func (conf *config) getTransport() error {
 				return err
 			}
 			conf.transport.Proxy = http.ProxyURL(proxyURL)
+		} else {
+			conf.transport.Proxy = http.ProxyFromEnvironment
 		}
 
 		tlsConfig := &tls.Config{InsecureSkipVerify: !conf.sslVerify}

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/const.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/const.go
@@ -13,7 +13,7 @@
 package obs
 
 const (
-	obsSdkVersion          = "3.21.1"
+	obsSdkVersion          = "3.21.8"
 	USER_AGENT             = "obs-sdk-go/" + obsSdkVersion
 	HEADER_PREFIX          = "x-amz-"
 	HEADER_PREFIX_META     = "x-amz-meta-"
@@ -72,6 +72,7 @@ const (
 	HEADER_CONTENT_DISPOSITION              = "content-disposition"
 	HEADER_CONTENT_ENCODING                 = "content-encoding"
 	HEADER_AZ_REDUNDANCY                    = "az-redundancy"
+	HEADER_BUCKET_TYPE                      = "bucket-type"
 	headerOefMarker                         = "oef-marker"
 
 	HEADER_ETAG         = "etag"
@@ -258,6 +259,7 @@ var (
 		"encryption":                   true,
 		"tagging":                      true,
 		"append":                       true,
+		"modify":                       true,
 		"position":                     true,
 		"replication":                  true,
 		"response-content-type":        true,
@@ -731,6 +733,12 @@ const (
 
 	// SubResourceRequestPayment subResource value: requestPayment
 	SubResourceRequestPayment SubResourceType = "requestPayment"
+
+	// SubResourceAppend subResource value: append
+	SubResourceAppend SubResourceType = "append"
+
+	// SubResourceModify subResource value: modify
+	SubResourceModify SubResourceType = "modify"
 )
 
 // objectKeyType defines the objectKey value
@@ -949,4 +957,12 @@ type FSStatusType string
 const (
 	FSStatusEnabled  FSStatusType = "Enabled"
 	FSStatusDisabled FSStatusType = "Disabled"
+)
+
+// BucketType defines type of bucket
+type BucketType string
+
+const (
+	OBJECT BucketType = "OBJECT"
+	POSIX  BucketType = "POSIX"
 )

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/convert.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/convert.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -731,7 +732,7 @@ func ParseGetBucketMetadataOutput(output *GetBucketMetadataOutput) {
 		output.Epid = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_AZ_REDUNDANCY]; ok {
-		output.AvailableZone = ret[0]
+		output.AZRedundancy = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[headerFSFileInterface]; ok {
 		output.FSStatus = parseStringToFSStatusType(ret[0])
@@ -1085,4 +1086,29 @@ func decodeInitiateMultipartUploadOutput(output *InitiateMultipartUploadOutput) 
 func decodeCompleteMultipartUploadOutput(output *CompleteMultipartUploadOutput) (err error) {
 	output.Key, err = url.QueryUnescape(output.Key)
 	return
+}
+
+// ParseAppendObjectOutput sets AppendObjectOutput field values with response headers
+func ParseAppendObjectOutput(output *AppendObjectOutput) (err error) {
+	if ret, ok := output.ResponseHeaders[HEADER_VERSION_ID]; ok {
+		output.VersionId = ret[0]
+	}
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
+		output.ETag = ret[0]
+	}
+	if ret, ok := output.ResponseHeaders[HEADER_NEXT_APPEND_POSITION]; ok {
+		output.NextAppendPosition, err = strconv.ParseInt(ret[0], 10, 64)
+		if err != nil {
+			err = fmt.Errorf("failed to parse next append position with error [%v]", err)
+		}
+	}
+	return
+}
+
+// ParseModifyObjectOutput sets ModifyObjectOutput field values with response headers
+func ParseModifyObjectOutput(output *ModifyObjectOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
+		output.ETag = ret[0]
+	}
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/model.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/model.go
@@ -52,6 +52,7 @@ type Initiator struct {
 // ListBucketsInput is the input parameter of ListBuckets function
 type ListBucketsInput struct {
 	QueryLocation bool
+	BucketType    BucketType
 }
 
 // ListBucketsOutput is the result of ListBuckets function
@@ -531,7 +532,7 @@ type GetBucketMetadataOutput struct {
 	MaxAgeSeconds int
 	ExposeHeader  string
 	Epid          string
-	AvailableZone string
+	AZRedundancy  string
 	FSStatus      FSStatusType
 }
 
@@ -1270,4 +1271,31 @@ type JobResponse struct {
 	CallBackHost     string `json:"callbackhost"`
 	FileType         string `json:"file_type"`
 	IgnoreSameKey    bool   `json:"ignore_same_key"`
+}
+
+type AppendObjectInput struct {
+	PutObjectBasicInput
+	Body     io.Reader
+	Position int64
+}
+
+type AppendObjectOutput struct {
+	BaseModel
+	VersionId          string
+	SseHeader          ISseHeader
+	NextAppendPosition int64
+	ETag               string
+}
+
+type ModifyObjectInput struct {
+	Bucket        string
+	Key           string
+	Position      int64
+	Body          io.Reader
+	ContentLength int64
+}
+
+type ModifyObjectOutput struct {
+	BaseModel
+	ETag string
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/temporary.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/temporary.go
@@ -834,3 +834,59 @@ func (obsClient ObsClient) GetBucketRequestPaymentWithSignedUrl(signedUrl string
 	}
 	return
 }
+
+// SetBucketEncryptionWithSignedURL sets bucket encryption setting for a bucket with the specified signed url and signed request headers and data
+func (obsClient ObsClient) SetBucketEncryptionWithSignedURL(signedURL string, actualSignedRequestHeaders http.Header, data io.Reader) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHTTPWithSignedURL("SetBucketEncryption", HTTP_PUT, signedURL, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketEncryptionWithSignedURL gets bucket encryption setting of a bucket with the specified signed url and signed request headers
+func (obsClient ObsClient) GetBucketEncryptionWithSignedURL(signedURL string, actualSignedRequestHeaders http.Header) (output *GetBucketEncryptionOutput, err error) {
+	output = &GetBucketEncryptionOutput{}
+	err = obsClient.doHTTPWithSignedURL("GetBucketEncryption", HTTP_GET, signedURL, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// DeleteBucketEncryptionWithSignedURL deletes bucket encryption setting of a bucket with the specified signed url and signed request headers
+func (obsClient ObsClient) DeleteBucketEncryptionWithSignedURL(signedURL string, actualSignedRequestHeaders http.Header) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doHTTPWithSignedURL("DeleteBucketEncryption", HTTP_DELETE, signedURL, actualSignedRequestHeaders, nil, output, true)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// AppendObjectWithSignedUrl uploads an object to the specified bucket with the specified signed url and signed request headers and data
+func (obsClient ObsClient) AppendObjectWithSignedURL(signedURL string, actualSignedRequestHeaders http.Header, data io.Reader) (output *AppendObjectOutput, err error) {
+	output = &AppendObjectOutput{}
+	err = obsClient.doHTTPWithSignedURL("AppendObject", HTTP_POST, signedURL, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		if err = ParseAppendObjectOutput(output); err != nil {
+			output = nil
+		}
+	}
+	return
+}
+
+// ModifyObjectWithSignedUrl uploads an object to the specified bucket with the specified signed url and signed request headers and data
+func (obsClient ObsClient) ModifyObjectWithSignedURL(signedURL string, actualSignedRequestHeaders http.Header, data io.Reader) (output *ModifyObjectOutput, err error) {
+	output = &ModifyObjectOutput{}
+	err = obsClient.doHTTPWithSignedURL("ModifyObject", HTTP_PUT, signedURL, actualSignedRequestHeaders, data, output, true)
+	if err != nil {
+		output = nil
+	} else {
+		ParseModifyObjectOutput(output)
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20210902090116-d665e804e20b
+# github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support default encryption for a bucket
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_basic -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (111.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       111.320s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_encryption -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (84.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       84.495s
```
