### PR TITLE
refactor:docs:Add key_file parameter and update the behavior of public_key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ modules-dev/
 .vscode
 *.iml
 *.test
+*.pem
 
 
 # Test exclusions

--- a/docs/resources/compute_keypair.md
+++ b/docs/resources/compute_keypair.md
@@ -8,6 +8,17 @@ Manages a keypair resource within HuaweiCloud. This is an alternative to `huawei
 
 ## Example Usage
 
+### Create a new keypair and export private key to current folder
+
+```hcl
+resource "huaweicloud_compute_keypair" "test-keypair" {
+  name     = "my-keypair"
+  key_file = "private_key.pem"
+}
+```
+
+### Import an exist keypair
+
 ```hcl
 resource "huaweicloud_compute_keypair" "test-keypair" {
   name       = "my-keypair"
@@ -20,12 +31,21 @@ resource "huaweicloud_compute_keypair" "test-keypair" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the keypair resource. If omitted, the
-  provider-level region will be used. Changing this creates a new keypair resource.
+  provider-level region will be used. Changing this creates a new keypair.
 
 * `name` - (Required, String, ForceNew) Specifies a unique name for the keypair. Changing this creates a new keypair.
 
-* `public_key` - (Required, String, ForceNew) Specifies the imported OpenSSH-formatted public key. Changing this creates
+* `public_key` - (Optional, String, ForceNew) Specifies the imported OpenSSH-formatted public key. Changing this creates
   a new keypair.
+  This parameter and `key_file` are alternative.
+
+* `key_file` - (Optional, String, ForceNew) Specifies the path of the created private key.
+  The private key file (**.pem**) is created only after the resource is created.
+  By default, the private key file will be created in the same folder as the current script file.
+  If you need to create it in another folder, please specify the path for `key_file`.
+  Changing this creates a new keypair.
+
+  ~>**NOTE:** If the private key file already exists, it will be overwritten after a new keypair is created.
 
 ## Attributes Reference
 

--- a/huaweicloud/resource_huaweicloud_compute_keypair_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_keypair_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccComputeV2Keypair_basic(t *testing.T) {
 	var keypair keypairs.KeyPair
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "huaweicloud_compute_keypair.kp_1"
+	resourceName := "huaweicloud_compute_keypair.test"
 	publicKey, _, _ := acctest.RandSSHKeyPair("Generated-by-AccTest")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,6 +35,27 @@ func TestAccComputeV2Keypair_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeV2Keypair_privateKey(t *testing.T) {
+	var keypair keypairs.KeyPair
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_compute_keypair.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2KeypairDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Keypair_privateKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2KeypairExists(resourceName, &keypair),
+					resource.TestCheckResourceAttrSet(resourceName, "key_file"),
+				),
 			},
 		},
 	})
@@ -95,9 +116,17 @@ func testAccCheckComputeV2KeypairExists(n string, kp *keypairs.KeyPair) resource
 
 func testAccComputeV2Keypair_basic(rName, keypair string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_compute_keypair" "kp_1" {
+resource "huaweicloud_compute_keypair" "test" {
   name       = "%s"
   public_key = "%s"
 }
 `, rName, keypair)
+}
+
+func testAccComputeV2Keypair_privateKey(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_compute_keypair" "test" {
+  name = "%s"
+}
+`, rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Add `key_file` parameter to specify the path of the created private key.
- Add `Computed` behavior to the parameter of the `public_key`.
- Mark conflict for `key_file` and `public_key`.
- Update the wrong schema type of the `public_key`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add key file parameter of the private key creation path: the private key file is read-only.
2. Add computed behavior to the parameter of public key.
3. Update schema type of the public key.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeV2Keypair_privateKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeV2Keypair_privateKey -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Keypair_privateKey
=== PAUSE TestAccComputeV2Keypair_privateKey
=== CONT  TestAccComputeV2Keypair_privateKey
--- PASS: TestAccComputeV2Keypair_privateKey (29.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       30.027s
```
