### PR TITLE
feat: add huaweicloud_vpc_route_table resource and docs

### DIFF
--- a/docs/resources/vpc_route_table.md
+++ b/docs/resources/vpc_route_table.md
@@ -1,0 +1,126 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# huaweicloud_vpc_route_table
+
+Manages a VPC custom route table resource within HuaweiCloud.
+
+-> **NOTE:** To use a custom route table, you need to submit a service ticket to increase quota.
+
+## Example Usage
+
+### Basic Custom Route Table
+
+```hcl
+variable "vpc_id" {}
+variable "vpc_peering_id" {}
+
+resource "huaweicloud_vpc_route_table" "demo" {
+  name        = "demo"
+  vpc_id      = var.vpc_id
+  description = "a custom route table demo"
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = var.vpc_peering_id
+  }
+}
+```
+
+### Associating Subnets with a Route Table
+
+```hcl
+variable "vpc_id" {}
+variable "vpc_peering_id" {}
+
+data "huaweicloud_vpc_subnet_ids" "subnet_ids" {
+  vpc_id = var.vpc_id
+}
+
+resource "huaweicloud_vpc_route_table" "demo" {
+  name    = "demo"
+  vpc_id  = var.vpc_id
+  subnets = data.huaweicloud_vpc_subnet_ids.subnet_ids.ids
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = var.vpc_peering_id
+  }
+  route {
+    destination = "192.168.100.0/24"
+    type        = "vip"
+    nexthop     = "192.168.10.200"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the vpc route table.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `vpc_id` (Required, String, ForceNew) - Specifies the VPC ID for which a route table is to be added.
+  Changing this creates a new resource.
+
+* `name` (Required, String) - Specifies the route table name. The value is a string of no more than
+  64 characters that can contain letters, digits, underscores (_), hyphens (-), and periods (.).
+
+* `description` (Optional, String) - Specifies the supplementary information about the route table.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `subnets` (Optional, List) - Specifies an array of one or more subnets associating with the route table.
+
+  -> **NOTE:** The custom route table associated with a subnet affects only the outbound traffic.
+  The default route table determines the inbound traffic.
+
+* `route` (Optional, List) - Specifies the route object list. The [route object](#route_object)
+  is documented below.
+
+<a name="route_object"></a>
+The `route` block supports:
+
+* `destination` (Required, String) - Specifies the destination address in the CIDR notation format,
+  for example, 192.168.200.0/24. The destination of each route must be unique and cannot overlap
+  with any subnet in the VPC.
+
+* `type` (Required, String) - Specifies the route type. Currently, the value can be:
+  **ecs**, **eni**, **vip**, **nat**, **peering**, **vpn**, **dc** and **cc**.
+
+* `nexthop` (Required, String) - Specifies the next hop.
+  + If the route type is **ecs**, the value is an ECS instance ID in the VPC.
+  + If the route type is **eni**, the value is the extension NIC of an ECS in the VPC.
+  + If the route type is **vip**, the value is a virtual IP address.
+  + If the route type is **nat**, the value is a VPN gateway ID.
+  + If the route type is **peering**, the value is a VPC peering connection ID.
+  + If the route type is **vpn**, the value is a VPN gateway ID.
+  + If the route type is **dc**, the value is a Direct Connect gateway ID.
+  + If the route type is **cc**, the value is a Cloud Connection ID.
+
+* `description` (Optional, String) - Specifies the supplementary information about the route.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+vpc route tables can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_vpc_route_table.demo e1b3208a-544b-42a7-84e6-5d70371dd982
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984
+	github.com/chnsz/golangsdk v0.0.0-20210913091218-db72ff026f6c
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/chnsz/golangsdk v0.0.0-20210902090116-d665e804e20b h1:WGZFkbf05sJhYXS
 github.com/chnsz/golangsdk v0.0.0-20210902090116-d665e804e20b/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984 h1:fmhHRkpEwQQ0YiJ9eVOuhzERHz93pnOJIDVRUMdZNjY=
 github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20210913091218-db72ff026f6c h1:GyzczyT01SFV5PluCRRKP1K/hL8E4nvOhpMaGi/POLg=
+github.com/chnsz/golangsdk v0.0.0-20210913091218-db72ff026f6c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -526,6 +526,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eip":                         ResourceVpcEIPV1(),
 			"huaweicloud_vpc_peering_connection":          ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": resourceVpcPeeringConnectionAccepterV2(),
+			"huaweicloud_vpc_route_table":                 ResourceVPCRouteTable(),
 			"huaweicloud_vpc_route":                       ResourceVPCRouteV2(),
 			"huaweicloud_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
 			"huaweicloud_vpcep_approval":                  ResourceVPCEndpointApproval(),

--- a/huaweicloud/resource_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/resource_huaweicloud_vpc_route_table.go
@@ -1,0 +1,339 @@
+package huaweicloud
+
+import (
+	"context"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/routables"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func ResourceVPCRouteTable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVpcRouteTableCreate,
+		ReadContext:   resourceVpcRouteTableRead,
+		UpdateContext: resourceVpcRouteTableUpdate,
+		DeleteContext: resourceVpcRouteTableDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{ //request and response parameters
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnets": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"route": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				MaxItems: 200,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: utils.ValidateCIDR,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"nexthop": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+	}
+
+	allRouteOpts := buildVpcRTRoutes(d)
+	createOpts := routables.CreateOpts{
+		VpcID:       d.Get("vpc_id").(string),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Routes:      allRouteOpts,
+	}
+
+	logp.Printf("[DEBUG] VPC route table create options: %#v", createOpts)
+	routeTable, err := routables.Create(vpcClient, createOpts).Extract()
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating VPC route table: %s", err)
+	}
+
+	d.SetId(routeTable.ID)
+
+	if v, ok := d.GetOk("subnets"); ok {
+		subnets := utils.ExpandToStringList(v.(*schema.Set).List())
+		err = associateRouteTableSubnets(vpcClient, d.Id(), subnets)
+		if err != nil {
+			return fmtp.DiagErrorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceVpcRouteTableRead(ctx, d, meta)
+
+}
+
+func resourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+	}
+
+	routeTable, err := routables.Get(vpcClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "VPC route table")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", GetRegion(d, config)),
+		d.Set("vpc_id", routeTable.VpcID),
+		d.Set("name", routeTable.Name),
+		d.Set("description", routeTable.Description),
+		d.Set("route", expandVpcRTRoutes(routeTable.Routes)),
+		d.Set("subnets", expandVpcRTSubnets(routeTable.Subnets)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.DiagErrorf("Error saving VPC route table: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+	}
+
+	var changed bool
+	var updateOpts routables.UpdateOpts
+	if d.HasChanges("name", "description") {
+		changed = true
+		desc := d.Get("description").(string)
+		updateOpts.Description = &desc
+		updateOpts.Name = d.Get("name").(string)
+	}
+
+	if d.HasChange("route") {
+		changed = true
+		routesOpts := map[string][]routables.RouteOpts{}
+
+		old, new := d.GetChange("route")
+		addRaws := new.(*schema.Set).Difference(old.(*schema.Set))
+		delRaws := old.(*schema.Set).Difference(new.(*schema.Set))
+
+		if delLen := delRaws.Len(); delLen > 0 {
+			delRouteOpts := make([]routables.RouteOpts, delLen)
+			for i, item := range delRaws.List() {
+				opts := item.(map[string]interface{})
+				delRouteOpts[i] = routables.RouteOpts{
+					Type:        opts["type"].(string),
+					NextHop:     opts["nexthop"].(string),
+					Destination: opts["destination"].(string),
+				}
+			}
+			routesOpts["del"] = delRouteOpts
+		}
+
+		if addLen := addRaws.Len(); addLen > 0 {
+			addRouteOpts := make([]routables.RouteOpts, addLen)
+			for i, item := range addRaws.List() {
+				opts := item.(map[string]interface{})
+				desc := opts["description"].(string)
+				addRouteOpts[i] = routables.RouteOpts{
+					Type:        opts["type"].(string),
+					NextHop:     opts["nexthop"].(string),
+					Destination: opts["destination"].(string),
+					Description: &desc,
+				}
+			}
+			routesOpts["add"] = addRouteOpts
+		}
+		updateOpts.Routes = routesOpts
+	}
+
+	if changed {
+		logp.Printf("[DEBUG] VPC route table update options: %#v", updateOpts)
+		if _, err := routables.Update(vpcClient, d.Id(), updateOpts).Extract(); err != nil {
+			return fmtp.DiagErrorf("Error updating VPC route table: %s", err)
+		}
+	}
+
+	if d.HasChange("subnets") {
+		old, new := d.GetChange("subnets")
+		associateRaws := new.(*schema.Set).Difference(old.(*schema.Set))
+		disassociateRaws := old.(*schema.Set).Difference(new.(*schema.Set))
+
+		disassociateSubnets := utils.ExpandToStringList(disassociateRaws.List())
+		if len(disassociateSubnets) > 0 {
+			err = disassociateRouteTableSubnets(vpcClient, d.Id(), disassociateSubnets)
+			if err != nil {
+				return fmtp.DiagErrorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
+			}
+		}
+
+		associateSubnets := utils.ExpandToStringList(associateRaws.List())
+		if len(associateSubnets) > 0 {
+			err = associateRouteTableSubnets(vpcClient, d.Id(), associateSubnets)
+			if err != nil {
+				return fmtp.DiagErrorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
+			}
+		}
+	}
+
+	return resourceVpcRouteTableRead(ctx, d, meta)
+}
+
+func resourceVpcRouteTableDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+	}
+
+	if v, ok := d.GetOk("subnets"); ok {
+		subnets := utils.ExpandToStringList(v.(*schema.Set).List())
+		err = disassociateRouteTableSubnets(vpcClient, d.Id(), subnets)
+		if err != nil {
+			return fmtp.DiagErrorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
+		}
+	}
+
+	err = routables.Delete(vpcClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.DiagErrorf("Error deleting VPC route table: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func associateRouteTableSubnets(client *golangsdk.ServiceClient, id string, subnets []string) error {
+	return ipmlVpcRTSubnetsAction(client, id, "associate", subnets)
+}
+
+func disassociateRouteTableSubnets(client *golangsdk.ServiceClient, id string, subnets []string) error {
+	return ipmlVpcRTSubnetsAction(client, id, "disassociate", subnets)
+}
+
+func ipmlVpcRTSubnetsAction(client *golangsdk.ServiceClient, id, action string, subnets []string) error {
+	var opts routables.ActionSubnetsOpts
+	switch action {
+	case "associate":
+		opts.Associate = subnets
+	case "disassociate":
+		opts.Disassociate = subnets
+	default:
+		return fmtp.Errorf("action should be associate or disassociate, but got %s", action)
+	}
+
+	actionOpts := routables.ActionOpts{
+		Subnets: opts,
+	}
+
+	logp.Printf("[DEBUG] %s subnets %v with VPC route table %s", action, subnets, id)
+	_, err := routables.Action(client, id, actionOpts).Extract()
+	return err
+}
+
+func buildVpcRTRoutes(d *schema.ResourceData) []routables.RouteOpts {
+	rawRoutes := d.Get("route").(*schema.Set).List()
+	routeOpts := make([]routables.RouteOpts, len(rawRoutes))
+
+	for i, raw := range rawRoutes {
+		opts := raw.(map[string]interface{})
+		routeDesc := opts["description"].(string)
+		routeOpts[i] = routables.RouteOpts{
+			Type:        opts["type"].(string),
+			NextHop:     opts["nexthop"].(string),
+			Destination: opts["destination"].(string),
+			Description: &routeDesc,
+		}
+	}
+
+	return routeOpts
+}
+
+func expandVpcRTRoutes(routes []routables.Route) []map[string]interface{} {
+	rtRules := make([]map[string]interface{}, 0, len(routes))
+
+	for _, item := range routes {
+		// ignore local rule as it can not be modified
+		if item.Type == "local" {
+			continue
+		}
+
+		acessRule := map[string]interface{}{
+			"destination": item.DestinationCIDR,
+			"type":        item.Type,
+			"nexthop":     item.NextHop,
+			"description": item.Description,
+		}
+		rtRules = append(rtRules, acessRule)
+	}
+
+	return rtRules
+}
+
+func expandVpcRTSubnets(subnets []routables.Subnet) []string {
+	rtSubnets := make([]string, len(subnets))
+
+	for i, item := range subnets {
+		rtSubnets[i] = item.ID
+	}
+
+	return rtSubnets
+}

--- a/huaweicloud/resource_huaweicloud_vpc_route_table_test.go
+++ b/huaweicloud/resource_huaweicloud_vpc_route_table_test.go
@@ -1,0 +1,219 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/routables"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccVpcRouteTable_basic(t *testing.T) {
+	var route routables.RouteTable
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_vpc_route_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTable_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcRouteTableExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "0"),
+				),
+			},
+			{
+				Config: testAccVpcRouteTable_route(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform with routes"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.type", "peering"),
+				),
+			},
+			{
+				Config: testAccVpcRouteTable_associate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform with subnets"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.type", "peering"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVpcRouteTableDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(HW_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating huaweicloud VPC client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_vpc_route_table" {
+			continue
+		}
+
+		_, err := routables.Get(vpcClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("Route table still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVpcRouteTableExists(n string, routeTable *routables.RouteTable) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		vpcClient, err := config.NetworkingV1Client(HW_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating huaweicloud VPC client: %s", err)
+		}
+
+		found, err := routables.Get(vpcClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmtp.Errorf("route table not found")
+		}
+
+		*routeTable = *found
+
+		return nil
+	}
+}
+
+func testAccVpcRouteTable_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test1" {
+  name = "%s-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test1-1" {
+  name       = "%s-1-1"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test1.id
+}
+
+resource "huaweicloud_vpc_subnet" "test1-2" {
+  name       = "%s-1-2"
+  cidr       = "192.168.10.0/24"
+  gateway_ip = "192.168.10.1"
+  vpc_id     = huaweicloud_vpc.test1.id
+}
+
+resource "huaweicloud_vpc" "test2" {
+  name = "%s-2"
+  cidr = "172.16.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test2-1" {
+  name       = "%s-2-1"
+  cidr       = "172.16.10.0/24"
+  gateway_ip = "172.16.10.1"
+  vpc_id     = huaweicloud_vpc.test2.id
+}
+`, rName, rName, rName, rName, rName)
+}
+
+func testAccVpcRouteTable_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  description = "created by terraform"
+}
+`, testAccVpcRouteTable_base(rName), rName)
+}
+
+func testAccVpcRouteTable_route(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_peering_connection" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  peer_vpc_id = huaweicloud_vpc.test2.id
+}
+
+resource "huaweicloud_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  description = "created by terraform with routes"
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering rule"
+  }
+}
+`, testAccVpcRouteTable_base(rName), rName, rName)
+}
+
+func testAccVpcRouteTable_associate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_peering_connection" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  peer_vpc_id = huaweicloud_vpc.test2.id
+}
+
+resource "huaweicloud_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  description = "created by terraform with subnets"
+
+  subnets     = [
+    huaweicloud_vpc_subnet.test1-1.id,
+    huaweicloud_vpc_subnet.test1-2.id,
+  ]
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering rule"
+  }
+}
+`, testAccVpcRouteTable_base(rName), rName, rName)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routables/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routables/requests.go
@@ -1,0 +1,188 @@
+package routables
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOptsBuilder is an interface by which can build the request body of listing route tables
+type ListOptsBuilder interface {
+	ToRouteTableListQuery() (string, error)
+}
+
+// ListOpts allows to query all route tables or filter collections by parameters
+// Marker and Limit are used for pagination.
+type ListOpts struct {
+	// ID is the unique identifier for the route table
+	ID string `q:"id"`
+	// VpcID is the unique identifier for the vpc
+	VpcID string `q:"vpc_id"`
+	// SubnetID the unique identifier for the subnet
+	SubnetID string `q:"subnet_id"`
+	// Limit is the number of records returned for each page query, the value range is 0~intmax
+	Limit int `q:"limit"`
+	// Marker is the starting resource ID of the paging query,
+	// which means that the query starts from the next record of the specified resource
+	Marker string `q:"marker"`
+}
+
+// ToRouteTableListQuery formats a ListOpts into a query string
+func (opts ListOpts) ToRouteTableListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// vpc route tables. It accepts a ListOpts struct, which allows you to
+// filter  the returned collection for greater efficiency.
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+
+	if opts != nil {
+		query, err := opts.ToRouteTableListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := RouteTablePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToRouteTableCreateMap() (map[string]interface{}, error)
+}
+
+// RouteOpts contains all the values needed to manage a vpc route
+type RouteOpts struct {
+	// The destination CIDR block. The destination of each route must be unique.
+	// The destination cannot overlap with any subnet CIDR block in the VPC.
+	Destination string `json:"destination" required:"true"`
+	// the type of the next hop. value range:
+	// ecs, eni, vip, nat, peering, vpn, dc, cc, egw
+	Type string `json:"type" required:"true"`
+	// the instance ID of next hop
+	NextHop string `json:"nexthop" required:"true"`
+	// The supplementary information about the route. The description can contain
+	// a maximum of 255 characters and cannot contain angle brackets (< or >).
+	Description *string `json:"description,omitempty"`
+}
+
+// CreateOpts contains all the values needed to create a new route table
+type CreateOpts struct {
+	// The VPC ID that the route table belongs to
+	VpcID string `json:"vpc_id" required:"true"`
+	// The name of the route table. The name can contain a maximum of 64 characters,
+	// which may consist of letters, digits, underscores (_), hyphens (-), and periods (.).
+	// The name cannot contain spaces.
+	Name string `json:"name" required:"true"`
+	// The supplementary information about the route table. The description can contain
+	// a maximum of 255 characters and cannot contain angle brackets (< or >).
+	Description string `json:"description,omitempty"`
+	// The route information
+	Routes []RouteOpts `json:"routes,omitempty"`
+}
+
+// ToRouteTableCreateMap builds a create request body from CreateOpts
+func (opts CreateOpts) ToRouteTableCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "routetable")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// route table
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRouteTableCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular route table based on its unique ID
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request
+type UpdateOptsBuilder interface {
+	ToRouteTableUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the values used when updating a route table
+type UpdateOpts struct {
+	Name        string                 `json:"name,omitempty"`
+	Description *string                `json:"description,omitempty"`
+	Routes      map[string][]RouteOpts `json:"routes,omitempty"`
+}
+
+// ToRouteTableUpdateMap builds an update body based on UpdateOpts
+func (opts UpdateOpts) ToRouteTableUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "routetable")
+}
+
+// Update allows route tables to be updated
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToRouteTableUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular route table based on its unique ID
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}
+
+// ActionOptsBuilder allows extensions to add additional parameters to the
+// Action request: associate or disassociate subnets with a route table
+type ActionOptsBuilder interface {
+	ToRouteTableActionMap() (map[string]interface{}, error)
+}
+
+// ActionSubnetsOpts contains the subnets list that associate or disassociate with a route tabl
+type ActionSubnetsOpts struct {
+	Associate    []string `json:"associate,omitempty"`
+	Disassociate []string `json:"disassociate,omitempty"`
+}
+
+// ActionOpts contains the values used when associating or disassociating subnets with a route table
+type ActionOpts struct {
+	Subnets ActionSubnetsOpts `json:"subnets" required:"true"`
+}
+
+// ToRouteTableActionMap builds an update body based on UpdateOpts.
+func (opts ActionOpts) ToRouteTableActionMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "routetable")
+}
+
+// Action will associate or disassociate subnets with a particular route table based on its unique ID
+func Action(c *golangsdk.ServiceClient, id string, opts ActionOptsBuilder) (r ActionResult) {
+	b, err := opts.ToRouteTableActionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Post(actionURL(c, id), b, &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routables/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routables/results.go
@@ -1,0 +1,123 @@
+package routables
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// Route represents a route object in a route table
+type Route struct {
+	Type            string `json:"type"`
+	DestinationCIDR string `json:"destination"`
+	NextHop         string `json:"nexthop"`
+	Description     string `json:"description"`
+}
+
+// Subnet represents a subnet object associated with a route table
+type Subnet struct {
+	ID string `json:"id"`
+}
+
+// RouteTable represents a route table
+type RouteTable struct {
+	// Name is the human readable name for the route table
+	Name string `json:"name"`
+
+	// Description is the supplementary information about the route table
+	Description string `json:"description"`
+
+	// ID is the unique identifier for the route table
+	ID string `json:"id"`
+
+	// the VPC ID that the route table belongs to.
+	VpcID string `json:"vpc_id"`
+
+	// project id
+	TenantID string `json:"tenant_id"`
+
+	// Default indicates whether it is a default route table
+	Default bool `json:"default"`
+
+	// Routes is an array of static routes that the route table will host
+	Routes []Route `json:"routes"`
+
+	// Subnets is an array of subnets that associated with the route table
+	Subnets []Subnet `json:"subnets"`
+}
+
+// RouteTablePage is the page returned by a pager when traversing over a
+// collection of route tables
+type RouteTablePage struct {
+	pagination.MarkerPageBase
+}
+
+// LastMarker returns the last route table ID in a ListResult
+func (r RouteTablePage) LastMarker() (string, error) {
+	tables, err := ExtractRouteTables(r)
+	if err != nil {
+		return "", err
+	}
+	if len(tables) == 0 {
+		return "", nil
+	}
+	return tables[len(tables)-1].ID, nil
+}
+
+// IsEmpty checks whether a RouteTablePage struct is empty.
+func (r RouteTablePage) IsEmpty() (bool, error) {
+	tables, err := ExtractRouteTables(r)
+	return len(tables) == 0, err
+}
+
+// ExtractRouteTables accepts a Page struct, specifically a RouteTablePage struct,
+// and extracts the elements into a slice of RouteTable structs.
+func ExtractRouteTables(r pagination.Page) ([]RouteTable, error) {
+	var s struct {
+		RouteTables []RouteTable `json:"routetables"`
+	}
+	err := (r.(RouteTablePage)).ExtractInto(&s)
+	return s.RouteTables, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a route table
+func (r commonResult) Extract() (*RouteTable, error) {
+	var s struct {
+		RouteTable *RouteTable `json:"routetable"`
+	}
+	err := r.ExtractInto(&s)
+	return s.RouteTable, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a RouteTable
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a RouteTable
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a RouteTable
+type UpdateResult struct {
+	commonResult
+}
+
+// ActionResult represents the result of an action operation. Call its Extract
+// method to interpret it as a RouteTable
+type ActionResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routables/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/routables/urls.go
@@ -1,0 +1,17 @@
+package routables
+
+import "github.com/chnsz/golangsdk"
+
+const resourcePath = "routetables"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, id)
+}
+
+func actionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, id, "action")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984
+# github.com/chnsz/golangsdk v0.0.0-20210913091218-db72ff026f6c
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -201,6 +201,7 @@ github.com/chnsz/golangsdk/openstack/mrs/v2/clusters
 github.com/chnsz/golangsdk/openstack/mrs/v2/jobs
 github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths
 github.com/chnsz/golangsdk/openstack/networking/v1/eips
+github.com/chnsz/golangsdk/openstack/networking/v1/routables
 github.com/chnsz/golangsdk/openstack/networking/v1/security/securitygroups
 github.com/chnsz/golangsdk/openstack/networking/v1/subnets
 github.com/chnsz/golangsdk/openstack/networking/v1/vpcs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
refer to #1359 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
new resource: huaweicloud_vpc_route_table resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVpcRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVpcRouteTable_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTable_basic
=== PAUSE TestAccVpcRouteTable_basic
=== CONT  TestAccVpcRouteTable_basic
--- PASS: TestAccVpcRouteTable_basic (171.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       171.696s
```
