### PR TITLE
refactor(fgs/function): move fgs funciton to services dir

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -450,7 +450,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_member":                      ResourceMemberV3(),
 			"huaweicloud_evs_snapshot":                    ResourceEvsSnapshotV2(),
 			"huaweicloud_evs_volume":                      ResourceEvsStorageVolumeV3(),
-			"huaweicloud_fgs_function":                    ResourceFgsFunctionV2(),
+			"huaweicloud_fgs_function":                    fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_gaussdb_cassandra_instance":      resourceGeminiDBInstanceV3(),
 			"huaweicloud_gaussdb_mysql_instance":          resourceGaussDBInstance(),
 			"huaweicloud_gaussdb_opengauss_instance":      resourceOpenGaussInstance(),
@@ -629,7 +629,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cs_route_v1":                        deprecated.ResourceCsRouteV1(),
 			"huaweicloud_networking_vip_v2":                  resourceNetworkingVIPV2(),
 			"huaweicloud_networking_vip_associate_v2":        resourceNetworkingVIPAssociateV2(),
-			"huaweicloud_fgs_function_v2":                    ResourceFgsFunctionV2(),
+			"huaweicloud_fgs_function_v2":                    fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_cdn_domain_v1":                      resourceCdnDomainV1(),
 			// Deprecated
 			"huaweicloud_blockstorage_volume_v2":             resourceBlockStorageVolumeV2(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- The fgs dependencies and trigger are in the services directory, but fgs function not.
- The fgs function does not use multierror to check settings.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. use multierror to check all settings.
2. refactor acc test.
3. add import test for each test.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_basic -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (74.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       74.217s
```

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_withEpsId
=== PAUSE TestAccFgsV2Function_withEpsId
=== CONT  TestAccFgsV2Function_withEpsId
--- PASS: TestAccFgsV2Function_withEpsId (43.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       44.005s
```

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_text'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_text -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (43.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       44.078s
```

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_agency'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_agency -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_agency
=== PAUSE TestAccFgsV2Function_agency
=== CONT  TestAccFgsV2Function_agency
--- PASS: TestAccFgsV2Function_agency (89.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       89.791s
```
