### PR TITLE
fix(sfs): delete invalid parameter setting

### DIFF
--- a/docs/resources/sfs_file_system.md
+++ b/docs/resources/sfs_file_system.md
@@ -116,9 +116,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the shared file system.
 
-* `share_type` - The storage service type assigned for the shared file system, such as high-performance storage (
-  composed of SSDs) and large-capacity storage (composed of SATA disks).
-
 * `export_location` - The address for accessing the shared file system.
 
 * `share_access_id` - The UUID of the share access rule.

--- a/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go
@@ -241,7 +241,6 @@ func resourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) error
 	d.Set("share_proto", n.ShareProto)
 	d.Set("size", n.Size)
 	d.Set("description", n.Description)
-	d.Set("share_type", n.ShareType)
 	d.Set("is_public", n.IsPublic)
 	d.Set("availability_zone", n.AvailabilityZone)
 	d.Set("region", GetRegion(d, config))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `share_type` is not a parameter, but it is in the parameter setting.
It will panic the program.
```
panic: Invalid address to set: []string{"share_type"}

goroutine 297 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc000ad6000, 0x17cee40, 0xa, 0x154eac0, 0xc001526a70, 0x0, 0x0)
        /home/lance/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go:230 +0x371
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud.resourceSFSFileSystemV2Read(0xc000ad6000, 0x17c0a80, 0xc0010b3380, 0x15ad360, 0xc0015098f0)
        /home/lance/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go:244 +0x466
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud.resourceSFSFileSystemV2Create(0xc000ad6000, 0x17c0a80, 0xc0010b3380, 0x1, 0xffffffffffffffff)
        /home/lance/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/resource_huaweicloud_sfs_file_system_v2.go:219 +0xb85
```

for `share_type` and `volume_type`, it is difficult to understand.
```
    "share_network_id": null,
    "share_proto": "NFS",
    "share_type": "default",
    "size": 10,
    "snapshot_id": null,
    "status": "creating",
    "volume_type": "default"
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove invalid parameter setting: `share_type`.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccSFSFileSystemV2_basic -timeout 360m -parallel 4
=== RUN   TestAccSFSFileSystemV2_basic
=== PAUSE TestAccSFSFileSystemV2_basic
=== CONT  TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (122.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       122.275s
```
