### PR TITLE
test(cce/node): fix test cases of cce node

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3_test.go
@@ -51,25 +51,79 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccCCENodeV3_auto_assign_eip(t *testing.T) {
+	var node nodes.Nodes
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cce_node.test"
+	//clusterName here is used to provide the cluster id to fetch cce node.
+	clusterName := "huaweicloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_auto_assign_eip(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "public_ip",
 						regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
 				),
 			},
+		},
+	})
+}
+
+func TestAccCCENodeV3_existing_eip(t *testing.T) {
+	var node nodes.Nodes
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cce_node.test"
+	//clusterName here is used to provide the cluster id to fetch cce node.
+	clusterName := "huaweicloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_existing_eip(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "public_ip",
 						regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
 				),
 			},
+		},
+	})
+}
+
+func TestAccCCENodeV3_volume_extendParams(t *testing.T) {
+	var node nodes.Nodes
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cce_node.test"
+	//clusterName here is used to provide the cluster id to fetch cce node.
+	clusterName := "huaweicloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_volume_extendParams(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "root_volume.0.extend_params.test_key", "test_val"),
 					resource.TestCheckResourceAttr(resourceName, "data_volumes.0.extend_params.test_key", "test_val"),
@@ -218,7 +272,7 @@ func testAccCCENodeV3_basic(rName string) string {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "s6.large.2"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_compute_keypair.test.name
 
@@ -245,7 +299,7 @@ func testAccCCENodeV3_update(rName, updateName string) string {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "s6.large.2"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_compute_keypair.test.name
 
@@ -272,7 +326,7 @@ func testAccCCENodeV3_auto_assign_eip(rName string) string {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "s6.large.2"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_compute_keypair.test.name
 
@@ -313,7 +367,7 @@ resource "huaweicloud_vpc_eip" "test" {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "s6.large.2"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_compute_keypair.test.name
 
@@ -339,7 +393,7 @@ func testAccCCENodeV3_volume_extendParams(rName string) string {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.small.1"
+  flavor_id         = "s6.large.2"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_compute_keypair.test.name
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix test cases of cce node
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3 -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== RUN   TestAccCCENodeV3_auto_assign_eip
=== PAUSE TestAccCCENodeV3_auto_assign_eip
=== RUN   TestAccCCENodeV3_existing_eip
=== PAUSE TestAccCCENodeV3_existing_eip
=== RUN   TestAccCCENodeV3_volume_extendParams
=== PAUSE TestAccCCENodeV3_volume_extendParams
=== RUN   TestAccCCENodeV3_prePaid
=== PAUSE TestAccCCENodeV3_prePaid
=== CONT  TestAccCCENodeV3DataSource_basic
=== CONT  TestAccCCENodeV3_volume_extendParams
=== CONT  TestAccCCENodeV3_auto_assign_eip
=== CONT  TestAccCCENodeV3_existing_eip
--- PASS: TestAccCCENodeV3DataSource_basic (1593.87s)
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_existing_eip (1894.46s)
=== CONT  TestAccCCENodeV3_prePaid
--- PASS: TestAccCCENodeV3_volume_extendParams (1896.40s)
--- PASS: TestAccCCENodeV3_auto_assign_eip (1944.65s)
--- PASS: TestAccCCENodeV3_basic (1679.92s)
--- PASS: TestAccCCENodeV3_prePaid (1381.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       3276.092s
```
