### PR TITLE
fix: make user_id optional when charging_mode is prePaid and use ssh key

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -556,6 +556,10 @@ func (c *Config) getUserIDbyName(name string) (string, error) {
 		return "", fmt.Errorf("IAM user %s was not found", name)
 	}
 
+	if name != "" && name != all[0].Name {
+		return "", fmt.Errorf("IAM user %s was not found, got %s", name, all[0].Name)
+	}
+
 	return all[0].ID, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a limitation from API side:
https://support.huaweicloud.com/intl/en-us/api-ecs/en-us_topic_0167957246.html#section10
```
When chargingMode in the extendparam parameter is set to prePaid (indicating that the created ECS
is billed in yearly/monthly payments) and the ECS is logged in using an SSH key, this field(op_svc_userid) is mandatory.
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The provider can get user id by user name if ID was not specified. then user can ignore this patameter when
creating an ECS with SSH key in prePaid mode.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== CONT  TestAccComputeV2Instance_prePaid
--- PASS: TestAccComputeV2Instance_prePaid (204.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       204.681s
```
