### PR TITLE
refactor(cce): wait for job success before get cce resources

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_attach.go
@@ -236,7 +236,7 @@ func resourceCCENodeAttachV3Create(d *schema.ResourceData, meta interface{}) err
 	_, err = stateCluster.WaitForState()
 
 	addOpts := nodes.AddOpts{
-		Kind:       "Node",
+		Kind:       "List",
 		ApiVersion: "v3",
 	}
 
@@ -309,7 +309,9 @@ func resourceCCENodeAttachV3Create(d *schema.ResourceData, meta interface{}) err
 		return fmtp.Errorf("Error adding HuaweiCloud Node: %s", err)
 	}
 
-	nodeID, err := getResourceIDFromJob(nodeClient, s.JobID, "CreateNode", "InstallNode")
+	nodeID, err := getResourceIDFromJob(nodeClient, s.JobID, "CreateNode", "InstallNode",
+		d.Timeout(schema.TimeoutCreate))
+
 	if err != nil {
 		return err
 	}
@@ -320,7 +322,7 @@ func resourceCCENodeAttachV3Create(d *schema.ResourceData, meta interface{}) err
 		Target:       []string{"Active"},
 		Refresh:      waitForCceNodeActive(nodeClient, clusterid, nodeID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        120 * time.Second,
+		Delay:        20 * time.Second,
 		PollInterval: 20 * time.Second,
 	}
 	_, err = stateConf.WaitForState()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
wait for job success before get cce resources
The following resources are affected:
huaweicloud_cce_cluster
huaweicloud_cce_node
huaweicloud_cce_node_attach
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCEClusterV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (530.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       530.653s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (880.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       880.701s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeAttachV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeAttachV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeAttachV3_basic
=== PAUSE TestAccCCENodeAttachV3_basic
=== CONT  TestAccCCENodeAttachV3_basic
--- PASS: TestAccCCENodeAttachV3_basic (806.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       806.487s
```
