### PR TITLE
feat(cce/node_attach): support reset in node_attach

### DIFF
--- a/docs/resources/cce_node_attach.md
+++ b/docs/resources/cce_node_attach.md
@@ -37,15 +37,14 @@ The following arguments are supported:
 * `server_id` - (Required, String, ForceNew) Specifies the ecs server id. Changing this parameter will create a new
   resource.
 
-* `os` - (Required, String, ForceNew) Specifies the operating System of the node. Changing this parameter will create a
-  new resource.
+* `os` - (Required, String) Specifies the operating System of the node. Changing this parameter will reset the node.
   + For VM nodes, clusters of v1.13 and later support *EulerOS 2.5* and *CentOS 7.6*.
 
-* `key_pair` - (Optional, String, ForceNew) Specifies the key pair name when logging in to select the key pair mode.
-  This parameter and `password` are alternative. Changing this parameter will create a new resource.
+* `key_pair` - (Optional, String) Specifies the key pair name when logging in to select the key pair mode.
+  This parameter and `password` are alternative. Changing this parameter will reset the node.
 
-* `password` - (Optional, String, ForceNew) Specifies the root password when logging in to select the password mode.
-  This parameter must be salted and alternative to `key_pair`. Changing this parameter will create a new resource.
+* `password` - (Optional, String) Specifies the root password when logging in to select the password mode.
+  This parameter must be salted and alternative to `key_pair`. Changing this parameter will reset the node.
 
 * `max_pods` - (Optional, Int, ForceNew) Specifies the the maximum number of instances a node is allowed to create.
   Changing this parameter will create a new resource.
@@ -68,7 +67,20 @@ Changing this parameter will create a new resource.
 * `postinstall` - (Optional, String, ForceNew) Specifies the script required after installation. The input value can be
   a Base64 encoded string or not. Changing this parameter will create a new resource.
 
+* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format. Changing this parameter will
+  create a new resource.
+
 * `tags` - (Optional, Map) Specifies the tags of a VM node, key/value pair format.
+
+* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint
+  contains the following parameters:
+
+  + `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit. Only letters,
+    digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix
+    of a key.
+  + `value` - (Required, String, ForceNew) A value must start with a letter or digit and can contain a maximum of 63 characters,
+    including letters, digits, hyphens (-), underscores (_), and periods (.).
+  + `effect` - (Required, String, ForceNew) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
 
 ## Attributes Reference
 
@@ -91,4 +103,5 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 20 minute.
+* `update` - Default is 20 minute.
 * `delete` - Default is 20 minute.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1
+	github.com/chnsz/golangsdk v0.0.0-20210928074820-0a4d68220e60
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1 h1:RkyH6o19n+Q7LtL4M4hrWO0P01WkwKA23FDR4LKQE1g=
-github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20210928074820-0a4d68220e60 h1:1yPUsuYuHe5EOZLQEAyROlTQEnpZV5wt6znJ3Gf/Umg=
+github.com/chnsz/golangsdk v0.0.0-20210928074820-0a4d68220e60/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/resource_huaweicloud_cce_node_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_attach_test.go
@@ -13,6 +13,7 @@ func TestAccCCENodeAttachV3_basic(t *testing.T) {
 	var node nodes.Nodes
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_cce_node_attach.test"
 	//clusterName here is used to provide the cluster id to fetch cce node.
 	clusterName := "huaweicloud_cce_cluster.test"
@@ -29,6 +30,27 @@ func TestAccCCENodeAttachV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "os", "EulerOS 2.5"),
+				),
+			},
+			{
+				Config: testAccCCENodeAttachV3_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "os", "EulerOS 2.5"),
+				),
+			},
+			{
+				Config: testAccCCENodeAttachV3_reset(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "os", "CentOS 7.6"),
 				),
 			},
 		},
@@ -41,29 +63,14 @@ func testAccCCENodeAttachV3_Base(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-resource "huaweicloud_compute_keypair" "test" {
-  name = "%s"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
-}
-
-resource "huaweicloud_cce_cluster" "test" {
-  name                   = "%s"
-  cluster_type           = "VirtualMachine"
-  flavor_id              = "cce.s1.small"
-  vpc_id                 = huaweicloud_vpc.test.id
-  subnet_id              = huaweicloud_vpc_subnet.test.id
-  container_network_type = "overlay_l2"
-}
-`, testAccCCEClusterV3_Base(rName), rName, rName)
-}
-
-func testAccCCENodeAttachV3_basic(rName string) string {
-	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_images_image" "test" {
   name        = "EulerOS 2.5 64bit"
   most_recent = true
+}
+
+resource "huaweicloud_compute_keypair" "test" {
+  name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
 
 resource "huaweicloud_compute_instance" "test" {
@@ -88,16 +95,32 @@ resource "huaweicloud_compute_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      image_id, tags
+      image_id, tags, name
     ]
   }
 }
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+`, testAccCCEClusterV3_Base(rName), rName, rName, rName)
+}
+
+func testAccCCENodeAttachV3_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "huaweicloud_cce_node_attach" "test" {
   cluster_id = huaweicloud_cce_cluster.test.id
   server_id  = huaweicloud_compute_instance.test.id
   key_pair   = huaweicloud_compute_keypair.test.name
   os         = "EulerOS 2.5"
+  name       = "%s"
 
   tags = {
     foo = "bar"
@@ -105,4 +128,42 @@ resource "huaweicloud_cce_node_attach" "test" {
   }
 }
 `, testAccCCENodeAttachV3_Base(rName), rName)
+}
+
+func testAccCCENodeAttachV3_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_node_attach" "test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+  server_id  = huaweicloud_compute_instance.test.id
+  key_pair   = huaweicloud_compute_keypair.test.name
+  os         = "EulerOS 2.5"
+  name       = "%s"
+
+  tags = {
+    foo        = "bar_update"
+    key_update = "value_update"
+  }
+}
+`, testAccCCENodeAttachV3_Base(rName), rNameUpdate)
+}
+
+func testAccCCENodeAttachV3_reset(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_node_attach" "test" {
+  cluster_id = huaweicloud_cce_cluster.test.id
+  server_id  = huaweicloud_compute_instance.test.id
+  key_pair   = huaweicloud_compute_keypair.test.name
+  os         = "CentOS 7.6"
+  name       = "%s"
+
+  tags = {
+    foo        = "bar_update"
+    key_update = "value_update"
+  }
+}
+`, testAccCCENodeAttachV3_Base(rName), rNameUpdate)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/urls.go
@@ -26,3 +26,7 @@ func removeNodeURL(c *golangsdk.ServiceClient, clusterid string) string {
 func addNodeURL(c *golangsdk.ServiceClient, clusterid string) string {
 	return c.ServiceURL(rootPath, clusterid, resourcePath, "add")
 }
+
+func resetNodeURL(c *golangsdk.ServiceClient, clusterid string) string {
+	return c.ServiceURL(rootPath, clusterid, resourcePath, "reset")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/trigger/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/trigger/requests.go
@@ -24,7 +24,7 @@ type CreateOpts struct {
 	//   DISABLED
 	TriggerStatus string `json:"trigger_status,omitempty"`
 	// Message code.
-	EventTypeCode string `json:"event_type_code" required:"true"`
+	EventTypeCode string `json:"event_type_code,omitempty"`
 	// Event struct.
 	EventData map[string]interface{} `json:"event_data" required:"true"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/swr/v2/namespaces/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/swr/v2/namespaces/results.go
@@ -40,3 +40,34 @@ type GetResult struct {
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
+
+type Access struct {
+	// ID of the access
+	ID int `json:"id"`
+	// Name of the Namespace
+	Name string `json:"name"`
+	// Creator Name of the Namespace
+	CreatorName string `json:"creator_name"`
+	// Permission of current user
+	SelfAuth User `json:"self_auth"`
+	// Permission of other users
+	OthersAuths []User `json:"others_auths"`
+}
+
+type CreateAccessResult struct {
+	golangsdk.ErrResult
+}
+
+type GetAccessResult struct {
+	commonResult
+}
+
+type DeleteAccessResult struct {
+	golangsdk.ErrResult
+}
+
+func (r GetAccessResult) Extract() (*Access, error) {
+	var s Access
+	err := r.ExtractInto(&s)
+	return &s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/swr/v2/namespaces/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/swr/v2/namespaces/urls.go
@@ -9,3 +9,7 @@ func rootURL(client *golangsdk.ServiceClient) string {
 func resourceURL(client *golangsdk.ServiceClient, name string) string {
 	return client.ServiceURL("manage", "namespaces", name)
 }
+
+func accessURL(client *golangsdk.ServiceClient, namespace string) string {
+	return client.ServiceURL("manage", "namespaces", namespace, "access")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1
+# github.com/chnsz/golangsdk v0.0.0-20210928074820-0a4d68220e60
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support reset in node_attach
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeAttachV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeAttachV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeAttachV3_basic
=== PAUSE TestAccCCENodeAttachV3_basic
=== CONT  TestAccCCENodeAttachV3_basic
--- PASS: TestAccCCENodeAttachV3_basic (1303.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1303.427s
```
