### PR TITLE
feat(bms): add a data source to get available BMS flavors

### DIFF
--- a/docs/data-sources/bms_flavors.md
+++ b/docs/data-sources/bms_flavors.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Bare Metal Server (BMS)"
+---
+
+# huaweicloud_bms_flavors
+
+Use this data source to get available BMS flavors.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_bms_flavors" "demo" {
+  availability_zone = "cn-north-1a"
+  vcpus             = 48
+}
+
+# Create BMS instance with the matched flavor
+resource "huaweicloud_bms_instance" "instance" {
+  flavor_id = data.huaweicloud_bms_flavors.demo.flavors[0].id
+
+  # Other properties...
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the flavors.
+  If omitted, the provider-level region will be used.
+
+* `availability_zone` - (Optional, String) Specifies the AZ name.
+
+* `vcpus` - (Optional, Int) Specifies the number of vCPUs in the BMS flavor.
+
+* `memory` - (Optional, Int) Specifies the memory size(GB) in the BMS flavor.
+
+* `cpu_arch` - (Optional, String) Specifies the CPU architecture of the BMS flavor.
+  The value can be x86_64 and aarch64, defaults to **x86_64**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `flavors` - Indicates the flavors information. Structure is documented below.
+
+The `flavors` block contains:
+
+* `id` - The id or name of the BMS flavor.
+* `vcpus` - The number of vCPUs.
+* `memory` - The memory size in GB.
+* `cpu_arch` - The CPU architecture of the BMS flavor.
+* `operation` - The operation status of the BMS flavor in an each AZs.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20210923031548-f3f0e90684f4
+	github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/chnsz/golangsdk v0.0.0-20210915060946-9b6e7408a88f h1:/NYp/qWzlOuyLvN
 github.com/chnsz/golangsdk v0.0.0-20210915060946-9b6e7408a88f/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20210923031548-f3f0e90684f4 h1:klN2L96Z1PCR78HhxbD0/1i+FoRrJZBPz6h0qj4gJ/s=
 github.com/chnsz/golangsdk v0.0.0-20210923031548-f3f0e90684f4/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1 h1:RkyH6o19n+Q7LtL4M4hrWO0P01WkwKA23FDR4LKQE1g=
+github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/data_source_huaweicloud_bms_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_bms_flavors.go
@@ -1,0 +1,163 @@
+package huaweicloud
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/bms/v1/flavors"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceBmsFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBmsFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cpu_arch": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "x86_64",
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vcpus": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"memory": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cpu_arch": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operation": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	bmsClient, err := config.BmsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud BMS client: %s", err)
+	}
+
+	az := d.Get("availability_zone").(string)
+	listOpts := flavors.ListOpts{
+		AvailabilityZone: az,
+	}
+
+	allFlavors, err := flavors.List(bmsClient, listOpts).Extract()
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve BMS flavors: %s ", err)
+	}
+
+	var vcpus string
+	if v, ok := d.GetOk("vcpus"); ok {
+		vcpus = strconv.Itoa(v.(int))
+	}
+	mem := d.Get("memory").(int) * 1024
+
+	filter := map[string]interface{}{
+		"VCPUs":                vcpus,
+		"RAM":                  mem,
+		"OsExtraSpecs.CPUArch": d.Get("cpu_arch"),
+	}
+
+	filterFlavors, err := utils.FliterSliceWithField(allFlavors, filter)
+	if err != nil {
+		return fmtp.DiagErrorf("filter BMS flavors failed: %s", err)
+	}
+	logp.Printf("filter %d bms flavors from %d through options %v", len(filterFlavors), len(allFlavors), filter)
+
+	var ids []string
+	var resultFlavors []map[string]interface{}
+
+	for _, item := range filterFlavors {
+		flavor := item.(flavors.Flavor)
+
+		// ignore abandon and sellout flavors
+		if az != "" {
+			status := flavor.OsExtraSpecs.OperationStatus
+			azStatusRaw := flavor.OsExtraSpecs.OperationAZ
+			azStatusList := strings.Split(azStatusRaw, ",")
+			if strings.Contains(azStatusRaw, az) {
+				for i := 0; i < len(azStatusList); i++ {
+					azStatus := azStatusList[i]
+					if azStatus == (az+"(abandon)") || azStatus == (az+"(sellout)") || azStatus == (az+"obt_sellout") {
+						continue
+					}
+				}
+			} else if status == "abandon" || strings.Contains(status, "sellout") {
+				continue
+			}
+		}
+
+		ids = append(ids, flavor.ID)
+		resultFlavors = append(resultFlavors, flattenBmsFlavor(flavor))
+	}
+
+	if len(resultFlavors) < 1 {
+		return fmtp.DiagErrorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	d.Set("region", GetRegion(d, config))
+	d.Set("flavors", resultFlavors)
+
+	return nil
+}
+
+func flattenBmsFlavor(flavor flavors.Flavor) map[string]interface{} {
+	vcpus, _ := strconv.Atoi(flavor.VCPUs)
+	ram := int(flavor.RAM / 1024)
+
+	return map[string]interface{}{
+		"id":        flavor.ID,
+		"vcpus":     vcpus,
+		"memory":    ram,
+		"cpu_arch":  flavor.OsExtraSpecs.CPUArch,
+		"operation": flavor.OsExtraSpecs.OperationAZ,
+	}
+}

--- a/huaweicloud/data_source_huaweicloud_bms_flavors_test.go
+++ b/huaweicloud/data_source_huaweicloud_bms_flavors_test.go
@@ -1,0 +1,50 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccBmsFlavorsDataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_bms_flavors.demo"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBmsFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBmsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.vcpus", "48"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.cpu_arch", "x86_64"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBmsFlavorDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find bms flavors data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("BMS flavors data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccBmsFlavorsDataSource_basic = `
+data "huaweicloud_bms_flavors" "demo" {
+  vcpus = 48
+}
+`

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -272,6 +272,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"huaweicloud_antiddos":                             dataSourceAntiDdosV1(),
 			"huaweicloud_availability_zones":                   DataSourceAvailabilityZones(),
+			"huaweicloud_bms_flavors":                          DataSourceBmsFlavors(),
 			"huaweicloud_cce_addon_template":                   DataSourceCCEAddonTemplateV3(),
 			"huaweicloud_cce_cluster":                          DataSourceCCEClusterV3(),
 			"huaweicloud_cce_node":                             DataSourceCCENodeV3(),

--- a/huaweicloud/utils/filter.go
+++ b/huaweicloud/utils/filter.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+)
+
+// FliterSliceWithField can filter the slice all through a map filter.
+// If the field is a nested value, using dot(.) to split them, e.g. "SubBlock.SubField".
+// If value in the map is zero, it will be ignored.
+func FliterSliceWithField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
+	return fliterSliceWithFieldRaw(all, filter, true)
+}
+
+// FliterSliceWithZeroField can filter the slice all through a map filter.
+func FliterSliceWithZeroField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
+	return fliterSliceWithFieldRaw(all, filter, false)
+}
+
+func fliterSliceWithFieldRaw(all interface{}, filter map[string]interface{}, ignoreZero bool) ([]interface{}, error) {
+	var result []interface{}
+	var matched bool
+
+	allValue := reflect.ValueOf(all)
+	if allValue.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("options type is not a slice")
+	}
+
+	newFilter := filter
+	if ignoreZero {
+		for key, val := range filter {
+			keyValue := reflect.ValueOf(val)
+			if keyValue.IsZero() {
+				log.Printf("[DEBUG] ignore zero field %s", key)
+				delete(newFilter, key)
+			}
+		}
+	}
+
+	for i := 0; i < allValue.Len(); i++ {
+		refValue := allValue.Index(i)
+		if refValue.Kind() == reflect.Ptr {
+			refValue = refValue.Elem()
+		}
+		if refValue.Kind() != reflect.Struct {
+			return nil, fmt.Errorf("object in slice is not a struct")
+		}
+
+		matched = true
+		for key, val := range newFilter {
+			actual, err := getStructField(refValue, key)
+			if err != nil {
+				return nil, fmt.Errorf("get slice field %s failed: %s", key, err)
+			}
+
+			if actual != val {
+				log.Printf("[DEBUG] can not match slice[%d] field %s: expect %v, but got %v", i, key, val, actual)
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			result = append(result, refValue.Interface())
+		}
+	}
+	return result, nil
+}
+
+func getStructField(v reflect.Value, field string) (interface{}, error) {
+	var subField interface{}
+	var err error
+	structValue := v
+
+	parts := strings.Split(field, ".")
+	for _, key := range parts {
+		subField, err = getStructFieldRaw(structValue, key)
+		if err != nil {
+			return nil, err
+		}
+		structValue = reflect.ValueOf(subField)
+	}
+	return subField, nil
+}
+
+func getStructFieldRaw(v reflect.Value, field string) (interface{}, error) {
+	if v.Kind() == reflect.Struct {
+		value := reflect.Indirect(v).FieldByName(field)
+		if value.IsValid() {
+			return value.Interface(), nil
+		}
+
+		return nil, fmt.Errorf("reflect: can not find the field %s", field)
+	}
+	return nil, fmt.Errorf("reflect: Value is not a struct")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/flavors/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/flavors/requests.go
@@ -1,0 +1,25 @@
+package flavors
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// ListOpts allows the filtering flavors through the API.
+type ListOpts struct {
+	// Specifies the availability_zone, e.g. cn-north-1a
+	AvailabilityZone string `q:"availability_zone"`
+}
+
+// List BMS flavors
+func List(c *golangsdk.ServiceClient, opts ListOpts) (r ListResult) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := listURL(c) + q.String()
+	_, r.Err = c.Get(url, &r.Body, nil)
+
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/flavors/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/flavors/results.go
@@ -1,0 +1,76 @@
+package flavors
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Flavor represent (virtual) hardware configurations for BMS
+type Flavor struct {
+	// ID is the flavor's unique ID.
+	ID string `json:"id"`
+	// Name is the name of the flavor.
+	Name string `json:"name"`
+	// VCPUs indicates how many (virtual) CPUs are available for this flavor.
+	VCPUs string `json:"vcpus"`
+	// RAM is the amount of memory, measured in MB.
+	RAM int `json:"ram"`
+	// Disk is the amount of root disk, measured in GB.
+	Disk string `json:"disk"`
+	// IsPublic indicates whether the flavor is public.
+	IsPublic bool `json:"os-flavor-access:is_public"`
+	// the shortcut links of the flavor.
+	Links []golangsdk.Link `json:"links"`
+	// the extended fields of the BMS flavor
+	OsExtraSpecs OsExtraSpecs `json:"os_extra_specs"`
+
+	// the following are reserved attributes
+	Swap       string  `json:"swap"`
+	Ephemeral  int     `json:"OS-FLV-EXT-DATA:ephemeral"`
+	Disabled   bool    `json:"OS-FLV-DISABLED:disabled"`
+	RxTxFactor float64 `json:"rxtx_factor"`
+}
+
+// OsExtraSpecs os_extra_specs struct
+type OsExtraSpecs struct {
+	// the resource type corresponding to the flavor. The value is ironic.
+	Type string `json:"resource_type"`
+	// the CPU architecture of the BMS. The value can be: x86_64 and aarch64
+	CPUArch string `json:"capabilities:cpu_arch"`
+	// the type of the BMS flavor in the format of flavor abbreviation.
+	// For example, if the flavor name is physical.o2.medium, the flavor type is o2m.
+	FlavorType string `json:"capabilities:board_type"`
+	// a flavor of the Ironic type.
+	HypervisorType string `json:"capabilities:hypervisor_type"`
+	// whether the BMS flavor supports EVS disks: true/false
+	SupportEvs string `json:"baremetal:__support_evs"`
+	// the boot source of the BMS. The value can be: LocalDisk and Volume
+	BootFrom string `json:"baremetal:extBootType"`
+	// the maximum number of NICs on the BMS
+	NetNum string `json:"baremetal:net_num"`
+	// the physical CPU specifications
+	CPUDetail string `json:"baremetal:cpu_detail"`
+	// the physical memory specifications
+	MemoryDetail string `json:"baremetal:memory_detail"`
+	// the physical disk specifications
+	DiskDetail string `json:"baremetal:disk_detail"`
+	// the physical NIC specifications
+	NetcardDetail string `json:"baremetal:netcard_detail"`
+	// Specifies the status of the BMS flavor. The value can be: normal, abandon, sellout, obt, promotion
+	OperationStatus string `json:"cond:operation:status"`
+	// the BMS flavor status in an AZ.
+	OperationAZ string `json:"cond:operation:az"`
+}
+
+// ListResult is the response from a List operation.
+type ListResult struct {
+	golangsdk.Result
+}
+
+// Extract provides access to the list of flavors from the List operation.
+func (r ListResult) Extract() ([]Flavor, error) {
+	var s struct {
+		Flavors []Flavor `json:"flavors"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Flavors, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/flavors/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/flavors/urls.go
@@ -1,0 +1,9 @@
+package flavors
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("baremetalservers", "flavors")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20210923031548-f3f0e90684f4
+# github.com/chnsz/golangsdk v0.0.0-20210927025605-c34a9b6ce2e1
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -84,6 +84,7 @@ github.com/chnsz/golangsdk/openstack/bcs/v2/blockchains
 github.com/chnsz/golangsdk/openstack/blockstorage/extensions/volumeactions
 github.com/chnsz/golangsdk/openstack/blockstorage/v2/volumes
 github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers
+github.com/chnsz/golangsdk/openstack/bms/v1/flavors
 github.com/chnsz/golangsdk/openstack/bss/v2/orders
 github.com/chnsz/golangsdk/openstack/cbr/v3/policies
 github.com/chnsz/golangsdk/openstack/cbr/v3/vaults


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* add a commom method to filter slice
FliterSliceWithField can filter the slice all through a map filter.
If the field is a nested value, using dot(.) to split them, e.g. "SubBlock.SubField".
If value in the map is zero, it will be ignored.

* add huaweicloud_bms_flavors data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccBmsFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccBmsFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsFlavorsDataSource_basic
=== PAUSE TestAccBmsFlavorsDataSource_basic
=== CONT  TestAccBmsFlavorsDataSource_basic
--- PASS: TestAccBmsFlavorsDataSource_basic (34.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       34.228s
```
