### PR TITLE
fix(sign/resign): add region to sign headers

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -200,8 +200,9 @@ func genClient(c *Config, ao golangsdk.AuthOptionsProvider) (*golangsdk.Provider
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if client.AKSKAuthOptions.AccessKey != "" {
 				golangsdk.ReSign(req, golangsdk.SignOptions{
-					AccessKey: client.AKSKAuthOptions.AccessKey,
-					SecretKey: client.AKSKAuthOptions.SecretKey,
+					AccessKey:  client.AKSKAuthOptions.AccessKey,
+					SecretKey:  client.AKSKAuthOptions.SecretKey,
+					RegionName: client.AKSKAuthOptions.Region,
 				})
 			}
 			return nil
@@ -294,6 +295,9 @@ func buildClientByAKSK(c *Config) error {
 		ao.IdentityEndpoint = c.IdentityEndpoint
 		ao.AccessKey = c.AccessKey
 		ao.SecretKey = c.SecretKey
+		if c.Region != "" {
+			ao.Region = c.Region
+		}
 		if c.SecurityToken != "" {
 			ao.SecurityToken = c.SecurityToken
 			ao.WithUserCatalog = true

--- a/huaweicloud/resource_huaweicloud_dis_stream_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dis_stream_v2_test.go
@@ -71,7 +71,10 @@ func testAccCheckDisStreamV2Destroy(s *terraform.State) error {
 		url = client.ServiceURL(url)
 
 		_, err = client.Get(url, nil, &golangsdk.RequestOpts{
-			MoreHeaders: map[string]string{"Content-Type": "application/json"}})
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+				"region":       HW_REGION_NAME,
+			}})
 		if err == nil {
 			return fmtp.Errorf("huaweicloud_dis_stream_v2 still exists at %s", url)
 		}
@@ -100,7 +103,10 @@ func testAccCheckDisStreamV2Exists() resource.TestCheckFunc {
 		url = client.ServiceURL(url)
 
 		_, err = client.Get(url, nil, &golangsdk.RequestOpts{
-			MoreHeaders: map[string]string{"Content-Type": "application/json"}})
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+				"region":       HW_REGION_NAME,
+			}})
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				return fmtp.Errorf("huaweicloud_dis_stream_v2.stream is not exist")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -372,8 +372,6 @@ github.com/hashicorp/terraform-plugin-sdk/v2/plugin
 github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210831081626-d823fe11ceba
-## explicit
 # github.com/jen20/awspolicyequivalence v1.1.0
 ## explicit
 github.com/jen20/awspolicyequivalence


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Due to DIS API limit, we must provide region name in request header.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1563 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add region to AK/SK option and request headers of DIS stream.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccDisStreamV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccDisStreamV2_basic -timeout 360m -parallel 4
=== RUN   TestAccDisStreamV2_basic
=== PAUSE TestAccDisStreamV2_basic
=== CONT  TestAccDisStreamV2_basic
--- PASS: TestAccDisStreamV2_basic (31.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       31.237s
```

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionGraphTrigger_dis'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionGraphTrigger_dis -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphTrigger_dis
=== PAUSE TestAccFunctionGraphTrigger_dis
=== CONT  TestAccFunctionGraphTrigger_dis
--- PASS: TestAccFunctionGraphTrigger_dis (77.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       77.315s
```
