### PR TITLE
chore: remove ElasticLBClient and change the key for LoadBalancerClient

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -745,19 +745,19 @@ func (c *Config) NatGatewayClient(region string) (*golangsdk.ServiceClient, erro
 	return c.NewServiceClient("nat", region)
 }
 
-// client for v2.0 api
+// ElbV2Client is the client for elb v2.0 (openstack) api
 func (c *Config) ElbV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("elbv2", region)
 }
 
-// client for v3 api
+// ElbV3Client is the client for elb v3 api
 func (c *Config) ElbV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("elbv3", region)
 }
 
-// client for v2 api
+// LoadBalancerClient is the client for elb v2 api
 func (c *Config) LoadBalancerClient(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("loadbalancer", region)
+	return c.NewServiceClient("elb", region)
 }
 
 func (c *Config) FwV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -745,10 +745,6 @@ func (c *Config) NatGatewayClient(region string) (*golangsdk.ServiceClient, erro
 	return c.NewServiceClient("nat", region)
 }
 
-func (c *Config) ElasticLBClient(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("elb", region)
-}
-
 // client for v2.0 api
 func (c *Config) ElbV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("elbv2", region)

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -164,11 +164,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "nat",
 		Version: "v2",
 	},
-	"elb": {
-		Name:             "elb",
-		Version:          "v1.0",
-		WithOutProjectID: true,
-	},
 	"elbv2": {
 		Name:             "elb",
 		Version:          "v2.0",

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -173,7 +173,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "elb",
 		Version: "v3",
 	},
-	"loadbalancer": {
+	"elb": {
 		Name:    "elb",
 		Version: "v2",
 	},

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -713,16 +713,6 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "security group", "v1", t)
 
-	// test endpoint of elb v1.0
-	serviceClient, err = nil, nil
-	serviceClient, err = config.ElasticLBClient(HW_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud ELB v1.0 client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://elb.%s.%s/v1.0/", HW_REGION_NAME, config.Cloud)
-	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "elb", "v1.0", t)
-
 	// test endpoint of elb v2.0
 	serviceClient, err = nil, nil
 	serviceClient, err = config.ElbV2Client(HW_REGION_NAME)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
config.ElasticLBClient does not used any more, so we can drop it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccServiceEndpoints_Network'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_Network -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_Network
2021/09/29 10:38:14 [DEBUG] customer endpoints: map[]
    endpoints_test.go:1027: vpc v1 endpoint:     https://vpc.cn-north-4.myhuaweicloud.com/v1/
    endpoints_test.go:1027: networking v2.0 endpoint:    https://vpc.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:1027: nat v2 endpoint:     https://nat.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1027: security group v1 endpoint:  https://vpc.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1027: elb v2.0 endpoint:   https://elb.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:1027: elb v3 endpoint:     https://elb.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1027: elb v2 endpoint:     https://elb.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1027: fw v2.0 endpoint:    https://vpc.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:765: DNS endpoint:         https://dns.myhuaweicloud.com/v2/
    endpoints_test.go:777: DNS region endpoint:  https://dns.cn-north-4.myhuaweicloud.com/v2/
    endpoints_test.go:789: VPCEP endpoint:       https://vpcep.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/
--- PASS: TestAccServiceEndpoints_Network (3.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       3.803s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (110.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       110.975s
```
