### PR TITLE
feat(waf/reference_tables): supports name field filtering for huaweicloud_waf_reference_tables

### DIFF
--- a/docs/data-sources/waf_reference_tables.md
+++ b/docs/data-sources/waf_reference_tables.md
@@ -10,6 +10,7 @@ Use this data source to get a list of WAF reference tables.
 
 ```hcl
 data "huaweicloud_waf_reference_tables" "reftables" {
+  name = "reference_table_name"
 }
 ```
 
@@ -19,6 +20,8 @@ The following arguments are supported:
 
 * `region` - (Optional, String) The region in which to create the WAF reference table resource.
   If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) The name of the reference table. The value is case sensitive and matches exactly.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
@@ -15,11 +16,8 @@ func TestAccDataSourceReferenceTablesV1_basic(t *testing.T) {
 	dataSourceName := "data.huaweicloud_waf_reference_tables.ref_table"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		Providers: acceptance.TestAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReferenceTablesV1_conf(name),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add a `name` argument for `huaweicloud_waf_reference_tables` to filter data.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceReferenceTablesV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceReferenceTablesV1_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceReferenceTablesV1_basic
--- PASS: TestAccDataSourceReferenceTablesV1_basic (373.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       373.79s

```
