### PR TITLE
support update flavor and security_group_id in GaussDB(for Redis) instance

### DIFF
--- a/docs/resources/gaussdb_redis_instance.md
+++ b/docs/resources/gaussdb_redis_instance.md
@@ -65,8 +65,7 @@ The following arguments are supported:
   digits, hyphens (-), and underscores (_). Chinese characters must be in UTF-8 or Unicode format.
 
 * `flavor` - (Required, String) Specifies the instance specifications. For details,
-  see [DB Instance Specifications](https://support.huaweicloud.com/intl/en-us/redisug-nosql/nosql_05_0059.html). Do
-  nothing in update method if change this parameter.
+  see [DB Instance Specifications](https://support.huaweicloud.com/intl/en-us/redisug-nosql/nosql_05_0059.html).
 
 * `node_num` - (Optional, Int) Specifies the number of nodes, ranges from 2 to 12. Defaults to 3.
 
@@ -84,7 +83,7 @@ The following arguments are supported:
   new resource.
 
 * `security_group_id` - (Optional, String) Specifies the security group ID. Required if the selected subnet doesn't
-  enable network ACL. Do nothing in update method if change this parameter.
+  enable network ACL.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id, Only valid for users who
   have enabled the enterprise multi-project service. Changing this parameter will create a new resource.

--- a/huaweicloud/resource_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_redis_instance_test.go
@@ -34,6 +34,7 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", password),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "3"),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "80"),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "geminidb.redis.large.4"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 				),
 			},
@@ -45,6 +46,7 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", newPassword),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "4"),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "geminidb.redis.xlarge.4"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 				),
 			},
@@ -119,7 +121,7 @@ data "huaweicloud_networking_secgroup" "test" {
 resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%s"
   password    = "%s"
-  flavor      = "geminidb.redis.xlarge.4"
+  flavor      = "geminidb.redis.large.4"
   volume_size = 80
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id


### PR DESCRIPTION
**What this PR does / why we need it**:
support update flavor and security_group_id in GaussDB(for Redis) instance

**Which issue this PR fixes**:
```
None
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```
None
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
```
$ make testacc TEST=./huaweicloud TESTARGS='-run TestAccGaussRedisInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccGaussRedisInstance_basic -timeout 360m
=== RUN   TestAccGaussRedisInstance_basic
=== PAUSE TestAccGaussRedisInstance_basic
=== CONT  TestAccGaussRedisInstance_basic
--- PASS: TestAccGaussRedisInstance_basic(1015.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-huaweicloud/huaweicloud       1017.218s
```
