### PR TITLE
fix(dns): fix region client issue

### DIFF
--- a/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_recordset_v2.go
@@ -362,7 +362,8 @@ func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interfa
 		logp.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
 
 		// try to ues the DNS region endpoint
-		client, clientErr := config.DnsWithRegionClient(region)
+		var clientErr error
+		client, clientErr = config.DnsWithRegionClient(region)
 		if clientErr != nil {
 			// it looks tricky as we return the fetching error rather than clientErr
 			return nil, "", err

--- a/huaweicloud/resource_huaweicloud_dns_zone_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2.go
@@ -259,7 +259,8 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 		logp.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
 		// an error occurred while fetching the zone with DNS global endpoint
 		// try to fetch it again with DNS region endpoint
-		dnsClient, clientErr := config.DnsWithRegionClient(GetRegion(d, config))
+		var clientErr error
+		dnsClient, clientErr = config.DnsWithRegionClient(GetRegion(d, config))
 		if clientErr != nil {
 			// it looks tricky as we return the fetching error rather than clientErr
 			return CheckDeleted(d, err, "zone")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccDNSV2'   ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccDNSV2 -timeout 360m -parallel 4
=== RUN   TestAccDNSV2PtrRecord_basic
=== PAUSE TestAccDNSV2PtrRecord_basic
=== RUN   TestAccDNSV2PtrRecord_withEpsId
=== PAUSE TestAccDNSV2PtrRecord_withEpsId
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== RUN   TestAccDNSV2Zone_readTTL
=== PAUSE TestAccDNSV2Zone_readTTL
=== RUN   TestAccDNSV2Zone_withEpsId
=== PAUSE TestAccDNSV2Zone_withEpsId
=== CONT  TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_withEpsId
    provider_test.go:176: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccDNSV2Zone_withEpsId (0.00s)
=== CONT  TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_readTTL (47.48s)
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2Zone_private (51.65s)
=== CONT  TestAccDNSV2RecordSet_private
--- PASS: TestAccDNSV2Zone_basic (86.38s)
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_readTTL (59.38s)
=== CONT  TestAccDNSV2PtrRecord_withEpsId
    provider_test.go:176: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccDNSV2PtrRecord_withEpsId (0.00s)
--- PASS: TestAccDNSV2PtrRecord_basic (109.22s)
--- PASS: TestAccDNSV2RecordSet_private (74.27s)
--- PASS: TestAccDNSV2RecordSet_basic (109.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       196.285s
```
