### PR TITLE
refactor: improve on images resource and data source

### DIFF
--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -12,7 +12,6 @@ to `huaweicloud_images_image_v2`
 ```hcl
 data "huaweicloud_images_image" "ubuntu" {
   name        = "Ubuntu 18.04 server 64bit"
-  visibility  = "public"
   most_recent = true
 }
 ```
@@ -26,21 +25,17 @@ data "huaweicloud_images_image" "ubuntu" {
 
 * `name` - (Optional, String) The name of the image.
 
+* `visibility` - (Optional, String) The visibility of the image. Must be one of
+  "public", "private" or "shared".
+
 * `owner` - (Optional, String) The owner (UUID) of the image.
 
-* `size_min` - (Optional, Int) The minimum size (in bytes) of the image to return.
-
-* `size_max` - (Optional, Int) The maximum size (in bytes) of the image to return.
+* `tag` - (Optional, String) Search for images with a specific tag in "Key=Value" format.
 
 * `sort_direction` - (Optional, String) Order the results in either `asc` or `desc`.
 
 * `sort_key` - (Optional, String) Sort images based on a certain key. Must be one of
   "name", "container_format", "disk_format", "status", "id" or "size". Defaults to `name`.
-
-* `tag` - (Optional, String) Search for images with a specific tag.
-
-* `visibility` - (Optional, String) The visibility of the image. Must be one of
-  "public", "private", "community", or "shared". Defaults to `private`.
 
 ## Attributes Reference
 

--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -11,6 +11,9 @@ Manages an Image resource within HuaweiCloud IMS.
 ### Creating an image from ECS
 
 ```hcl
+variable "instance_name" {}
+variable "image_name" {}
+
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_vpc_subnet" "test" {
@@ -18,7 +21,7 @@ data "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
+  name              = var.instance_name
   image_name        = "Ubuntu 18.04 server 64bit"
   security_groups   = ["default"]
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
@@ -29,7 +32,7 @@ resource "huaweicloud_compute_instance" "test" {
 }
 
 resource "huaweicloud_images_image" "test" {
-  name        = "%s"
+  name        = var.image_name
   instance_id = huaweicloud_compute_instance.test.id
   description = "created by Terraform"
 
@@ -64,19 +67,19 @@ The following arguments are supported:
 
 * `description` - (Optional, String, ForceNew) A description of the image.
 
-* `min_ram` - (Optional, Int, ForceNew) The minimum memory of the image in the unit of MB. The default value is 0,
-  indicating that the memory is not restricted.
-
-* `max_ram` - (Optional, Int, ForceNew) The maximum memory of the image in the unit of MB.
-
-* `tags` - (Optional, Map) The tags of the image.
-
 * `instance_id` - (Optional, String, ForceNew) The ID of the ECS that needs to be converted into an image. This
   parameter is mandatory when you create a privete image from an ECS.
 
 * `image_url` - (Optional, String, ForceNew) The URL of the external image file in the OBS bucket. This parameter is
   mandatory when you create a private image from an external file uploaded to an OBS bucket. The format is *OBS bucket
   name:Image file name*.
+
+* `min_ram` - (Optional, Int, ForceNew) The minimum memory of the image in the unit of MB. The default value is 0,
+  indicating that the memory is not restricted.
+
+* `max_ram` - (Optional, Int, ForceNew) The maximum memory of the image in the unit of MB.
+
+* `tags` - (Optional, Map) The tags of the image.
 
 * `min_disk` - (Optional, Int, ForceNew) The minimum size of the system disk in the unit of GB. This parameter is
   mandatory when you create a private image from an external file uploaded to an OBS bucket. The value ranges from 1 GB

--- a/huaweicloud/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/data_source_huaweicloud_images_image_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccImsImageDataSource_basic(t *testing.T) {
-	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	imageName := "CentOS 7.4 64bit"
 	dataSourceName := "data.huaweicloud_images_image.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -20,15 +20,12 @@ func TestAccImsImageDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImageDataSource_ubuntu(rName),
-			},
-			{
-				Config: testAccImsImageDataSource_basic(rName),
+				Config: testAccImsImageDataSource_public(imageName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagesV2DataSourceID(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "protected", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "visibility", "private"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", imageName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
 				),
 			},
@@ -45,22 +42,20 @@ func TestAccImsImageDataSource_testQueries(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImageDataSource_ubuntu(rName),
+				Config: testAccImsImageDataSource_base(rName),
+			},
+			{
+				Config: testAccImsImageDataSource_queryName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesV2DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "private"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
 			},
 			{
 				Config: testAccImsImageDataSource_queryTag(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID(dataSourceName),
-				),
-			},
-			{
-				Config: testAccImsImageDataSource_querySizeMin(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID(dataSourceName),
-				),
-			},
-			{
-				Config: testAccImsImageDataSource_querySizeMax(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
@@ -84,7 +79,16 @@ func testAccCheckImagesV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccImsImageDataSource_ubuntu(rName string) string {
+func testAccImsImageDataSource_public(imageName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_images_image" "test" {
+  name        = "%s"
+  most_recent = true
+}
+`, imageName)
+}
+
+func testAccImsImageDataSource_base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -121,11 +125,10 @@ resource "huaweicloud_images_image" "test" {
     key = "value"
   }
 }
-
 `, rName, rName)
 }
 
-func testAccImsImageDataSource_basic(rName string) string {
+func testAccImsImageDataSource_queryName(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -133,7 +136,7 @@ data "huaweicloud_images_image" "test" {
   most_recent = true
   name        = huaweicloud_images_image.test.name
 }
-`, testAccImsImageDataSource_ubuntu(rName))
+`, testAccImsImageDataSource_base(rName))
 }
 
 func testAccImsImageDataSource_queryTag(rName string) string {
@@ -145,29 +148,5 @@ data "huaweicloud_images_image" "test" {
   visibility  = "private"
   tag         = "foo=bar"
 }
-`, testAccImsImageDataSource_ubuntu(rName))
-}
-
-func testAccImsImageDataSource_querySizeMin(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_images_image" "test" {
-  most_recent = true
-  visibility  = "private"
-  size_min    = "13000000"
-}
-`, testAccImsImageDataSource_ubuntu(rName))
-}
-
-func testAccImsImageDataSource_querySizeMax(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_images_image" "test" {
-  most_recent = true
-  visibility  = "private"
-  size_max    = "23000000"
-}
-`, testAccImsImageDataSource_ubuntu(rName))
+`, testAccImsImageDataSource_base(rName))
 }

--- a/huaweicloud/resource_huaweicloud_images_image_test.go
+++ b/huaweicloud/resource_huaweicloud_images_image_test.go
@@ -47,6 +47,11 @@ func TestAccImsImage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
make acceptance test happy for image resource
using cloudimages/v2 APIs to query image
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccImsImage_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccImsImage_basic -timeout 360m -parallel 4
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== CONT  TestAccImsImage_basic
--- PASS: TestAccImsImage_basic (362.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       362.512s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccImsImageDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccImsImageDataSource -timeout 360m -parallel 4
=== RUN   TestAccImsImageDataSource_basic
=== PAUSE TestAccImsImageDataSource_basic
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_basic
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_basic (29.95s)
--- PASS: TestAccImsImageDataSource_testQueries (424.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       424.850s
```
