### PR TITLE
fix(MRS): fix test add data_volume_count in test config

### DIFF
--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -383,13 +383,7 @@ The `nodes` block supports:
 * `root_volume_size` - (Required, Int, ForceNew) Specifies the system disk size of the nodes. Changing this will create
   a new MapReduce cluster resource.
 
-* `data_volume_type` - (Optional, String, ForceNew) Specifies the data disk flavor of the nodes. Required
-  if `data_volume_count` is not empty. Changing this will create a new MapReduce cluster resource.
-
-* `data_volume_size` - (Optional, Int, ForceNew) Specifies the data disk size of the nodes. Required
-  if `data_volume_count` is not empty. Changing this will create a new MapReduce cluster resource.
-
-* `data_volume_count` - (Optional, Int, ForceNew) Specifies the data disk number of the nodes. The number configuration
+* `data_volume_count` - (Required, Int, ForceNew) Specifies the data disk number of the nodes. The number configuration
   of each node are as follows:
   + master_nodes: 1.
   + analysis_core_nodes: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
@@ -398,6 +392,17 @@ The `nodes` block supports:
   + streaming_task_nodes: minimum is zero and the maximum is subject to the configuration of the corresponding flavor.
 
   Changing this will create a new MapReduce cluster resource.
+  
+* `data_volume_type` - (Optional, String, ForceNew) Specifies the data disk flavor of the nodes.
+  Required if `data_volume_count` is greater than zero. Changing this will create a new MapReduce cluster resource.
+   The following disk types are supported:
+  + `SATA`: common I/O disk
+  + `SAS`: high I/O disk
+  + `SSD`: ultra-high I/O disk
+
+* `data_volume_size` - (Optional, Int, ForceNew) Specifies the data disk size of the nodes,in GB. The value range is 10
+  to 32768. Required if `data_volume_count` is greater than zero. Changing this will create a new MapReduce
+  cluster resource.
 
 * `assigned_roles` - (Optional, List, ForceNew) Specifies the roles deployed in a node group.This argument is mandatory
  when the cluster type is CUSTOM. Each character string represents a role expression.

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_test.go
@@ -29,9 +29,9 @@ func TestAccMrsMapReduceCluster_basic(t *testing.T) {
 		acctest.RandIntRange(0, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_basic(rName, password),
@@ -78,9 +78,9 @@ func TestAccMrsMapReduceCluster_keypair(t *testing.T) {
 		acctest.RandIntRange(0, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_keypair(rName, password),
@@ -112,9 +112,9 @@ func TestAccMrsMapReduceCluster_analysis(t *testing.T) {
 		acctest.RandIntRange(0, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_analysis(rName, password, buildGroupNodeNumbers(2, 0, 1, 0)),
@@ -173,9 +173,9 @@ func TestAccMrsMapReduceCluster_stream(t *testing.T) {
 		acctest.RandIntRange(0, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_stream(rName, password, buildGroupNodeNumbers(0, 2, 0, 1)),
@@ -234,9 +234,9 @@ func TestAccMrsMapReduceCluster_hybrid(t *testing.T) {
 		acctest.RandIntRange(0, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_hybrid(rName, password, buildGroupNodeNumbers(2, 2, 1, 1)),
@@ -317,8 +317,8 @@ func TestAccMrsMapReduceCluster_custom_compact(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMrsCustom(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_customCompact(rName, password, 3),
@@ -357,8 +357,8 @@ func TestAccMrsMapReduceCluster_custom_seperate(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMrsCustom(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_customSeperate(rName, password, 3),
@@ -398,8 +398,8 @@ func TestAccMrsMapReduceCluster_custom_fullsize(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMrsCustom(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2ClusterDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceClusterConfig_customFullsize(rName, password, 3),
@@ -546,6 +546,7 @@ resource "huaweicloud_mapreduce_cluster" "test" {
     node_number       = 1
     root_volume_type  = "SAS"
     root_volume_size  = 300
+    data_volume_count = 0
   }
 
   tags = {
@@ -593,6 +594,7 @@ resource "huaweicloud_mapreduce_cluster" "test" {
     node_number       = 1
     root_volume_type  = "SAS"
     root_volume_size  = 300
+    data_volume_count = 0
   }
 
   tags = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. fix test: add data_volume_count in test config
2. check assigned_roles diff only when type=custom

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx



## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run=TestAccMrsMapReduceCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run=TestAccMrsMapReduceCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_basic
=== PAUSE TestAccMrsMapReduceCluster_basic
=== CONT  TestAccMrsMapReduceCluster_basic
--- PASS: TestAccMrsMapReduceCluster_basic (742.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       742.534s
```
```
make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run=TestAccMrsMapReduceCluster_custom_compact'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run=TestAccMrsMapReduceCluster_custom_compact -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_custom_compact
=== PAUSE TestAccMrsMapReduceCluster_custom_compact
=== CONT  TestAccMrsMapReduceCluster_custom_compact
--- PASS: TestAccMrsMapReduceCluster_custom_compact (1837.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       1838.132s
```