### PR TITLE
fix(waf/domain): wrong argument "keep_proxy" in docs

### DIFF
--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -56,7 +56,7 @@ The following arguments are supported:
   and basically all other non-HTTP/S traffic. If a proxy such as public network ELB (or Nginx) has been used, set
   proxy `true` to ensure that the WAF security policy takes effect for the real source IP address.
 
-* `keep_proxy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
+* `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
   Defaults to `true`.
 
 * `protect_status` - (Optional, Int) The protection status of domain, `0`: suspended, `1`: enabled.

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -69,7 +69,8 @@ The following arguments are supported:
 * `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain. If not specified, a new
   policy will be created automatically. Changing this create a new domain.
 
-* `keep_proxy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name. Defaults to true.
+* `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
+  Defaults to true.
 
 * `proxy` - (Optional, Bool) Specifies whether a proxy is configured.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1585

- The argument keep_proxy name is wrong, the correct name should be: keep_policy

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```

```
