### PR TITLE
feat: add more querying options for image data source

### DIFF
--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -12,7 +12,30 @@ to `huaweicloud_images_image_v2`
 ```hcl
 data "huaweicloud_images_image" "ubuntu" {
   name        = "Ubuntu 18.04 server 64bit"
+  visibility  = "public"
   most_recent = true
+}
+
+data "huaweicloud_images_image" "centos-1" {
+  architecture = "x86"
+  os_version   = "CentOS 7.4 64bit"
+  visibility   = "public"
+  most_recent  = true
+}
+
+data "huaweicloud_images_image" "centos-2" {
+  architecture = "x86"
+  name_regex   = "^CentOS 7.4"
+  visibility   = "public"
+  most_recent  = true
+}
+
+data "huaweicloud_images_image" "bms_image" {
+  architecture = "x86"
+  image_type   = "Ironic"
+  os_version   = "CentOS 7.4 64bit"
+  visibility   = "public"
+  most_recent  = true
 }
 ```
 
@@ -21,12 +44,25 @@ data "huaweicloud_images_image" "ubuntu" {
 * `region` - (Optional, String) The region in which to obtain the images. If omitted, the provider-level region will be
   used.
 
-* `most_recent` - (Optional, Bool) If more than one result is returned, use the most recent image.
+* `most_recent` - (Optional, Bool) If more than one result is returned, use the latest updated image.
 
-* `name` - (Optional, String) The name of the image.
+* `name` - (Optional, String) The name of the image. Cannot be used simultaneously with `name_regex`.
+
+* `name_regex` - (Optional, String) The regular expressian of the name of the image.
+  Cannot be used simultaneously with `name`.
 
 * `visibility` - (Optional, String) The visibility of the image. Must be one of
-  "public", "private" or "shared".
+  **public**, **private** or **shared**.
+
+* `architecture` (Optional, String) Specifies the image architecture type. The value can be **x86** and **arm**.
+
+* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**,
+  **RedHat**, **SUSE**, **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**,
+  **CoreOS**, or **EulerOS**.
+
+* `os_version` - (Optional, String) Specifies the OS version. For example, *CentOS 7.4 64bit* or *Ubuntu 18.04 server 64bit*.
+
+* `image_type` (Optional, String) Specifies the environment where the image is used. For a BMS image, the value is **Ironic**.
 
 * `owner` - (Optional, String) The owner (UUID) of the image.
 

--- a/huaweicloud/data_source_huaweicloud_images_image.go
+++ b/huaweicloud/data_source_huaweicloud_images_image.go
@@ -231,8 +231,8 @@ type imageSort []cloudimages.Image
 func (a imageSort) Len() int      { return len(a) }
 func (a imageSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a imageSort) Less(i, j int) bool {
-	itime := a[i].CreatedAt
-	jtime := a[j].CreatedAt
+	itime := a[i].UpdatedAt
+	jtime := a[j].UpdatedAt
 	return itime.Unix() < jtime.Unix()
 }
 

--- a/huaweicloud/data_source_huaweicloud_images_image.go
+++ b/huaweicloud/data_source_huaweicloud_images_image.go
@@ -1,6 +1,7 @@
 package huaweicloud
 
 import (
+	"regexp"
 	"sort"
 	"strconv"
 	"time"
@@ -35,6 +36,13 @@ func DataSourceImagesImageV2() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+
+			"name_regex": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validation.StringIsValidRegExp,
 			},
 
 			"visibility": {
@@ -73,6 +81,26 @@ func DataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+
+			"architecture": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"x86", "arm",
+				}, false),
+			},
+			"os": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"os_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			// Deprecated values
@@ -153,14 +181,23 @@ func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error
 		return fmtp.Errorf("Error creating HuaweiCloud image client: %s", err)
 	}
 
+	visibility := d.Get("visibility").(string)
+	if visibility == "public" {
+		visibility = "gold"
+	}
+
 	listOpts := cloudimages.ListOpts{
-		Name:       d.Get("name").(string),
-		Visibility: d.Get("visibility").(string),
-		Owner:      d.Get("owner").(string),
-		Status:     "active",
-		SortKey:    d.Get("sort_key").(string),
-		SortDir:    d.Get("sort_direction").(string),
-		Tag:        d.Get("tag").(string),
+		Name:           d.Get("name").(string),
+		Owner:          d.Get("owner").(string),
+		SortKey:        d.Get("sort_key").(string),
+		SortDir:        d.Get("sort_direction").(string),
+		Tag:            d.Get("tag").(string),
+		Platform:       d.Get("os").(string),
+		OsVersion:      d.Get("os_version").(string),
+		Architecture:   d.Get("architecture").(string),
+		VirtualEnvType: d.Get("image_type").(string),
+		Imagetype:      visibility,
+		Status:         "active",
 	}
 
 	logp.Printf("[DEBUG] List Options: %#v", listOpts)
@@ -181,18 +218,39 @@ func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error
 			"Please change your search criteria and try again.")
 	}
 
-	if len(allImages) > 1 {
+	// filter images by name_regex
+	var filteredImages []cloudimages.Image
+	if nameRegex, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(nameRegex.(string))
+		if err != nil {
+			return fmtp.Errorf("name_regex format error: %s", err)
+		}
+
+		for _, image := range allImages {
+			if r.MatchString(image.Name) {
+				filteredImages = append(filteredImages, image)
+			}
+		}
+	} else {
+		filteredImages = allImages[:]
+	}
+
+	if len(filteredImages) < 1 {
+		return fmtp.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(filteredImages) > 1 {
 		recent := d.Get("most_recent").(bool)
-		logp.Printf("[DEBUG] Multiple results found and `most_recent` is set to: %t", recent)
+		logp.Printf("[DEBUG] Multiple images %d found and `most_recent` is set to: %t", len(filteredImages), recent)
 		if recent {
-			image = mostRecentImage(allImages)
+			image = mostRecentImage(filteredImages)
 		} else {
-			logp.Printf("[DEBUG] Multiple results found: %#v", allImages)
 			return fmtp.Errorf("Your query returned more than one result. Please try a more " +
 				"specific search criteria, or set `most_recent` attribute to true.")
 		}
 	} else {
-		image = allImages[0]
+		image = filteredImages[0]
 	}
 
 	logp.Printf("[DEBUG] Single Image found: %s", image.ID)
@@ -212,6 +270,9 @@ func dataSourceImagesImageV2Attributes(d *schema.ResourceData, image *cloudimage
 	d.Set("owner", image.Owner)
 	d.Set("protected", image.Protected)
 	d.Set("visibility", image.Visibility)
+	d.Set("image_type", image.VirtualEnvType)
+	d.Set("os", image.Platform)
+	d.Set("os_version", image.OsVersion)
 	d.Set("checksum", image.Checksum)
 	d.Set("file", image.File)
 	d.Set("schema", image.Schema)

--- a/huaweicloud/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/data_source_huaweicloud_images_image_test.go
@@ -20,10 +20,28 @@ func TestAccImsImageDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImageDataSource_public(imageName),
+				Config: testAccImsImageDataSource_publicName(imageName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagesV2DataSourceID(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", imageName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImageDataSource_osVersion(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesV2DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImageDataSource_nameRegex("^CentOS 7.4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
@@ -79,13 +97,36 @@ func testAccCheckImagesV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccImsImageDataSource_public(imageName string) string {
+func testAccImsImageDataSource_publicName(imageName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_images_image" "test" {
   name        = "%s"
+  visibility  = "public"
   most_recent = true
 }
 `, imageName)
+}
+
+func testAccImsImageDataSource_nameRegex(regexp string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_images_image" "test" {
+  architecture = "x86"
+  name_regex   = "%s"
+  visibility   = "public"
+  most_recent  = true
+}
+`, regexp)
+}
+
+func testAccImsImageDataSource_osVersion(osVersion string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_images_image" "test" {
+  architecture = "x86"
+  os_version   = "%s"
+  visibility   = "public"
+  most_recent  = true
+}
+`, osVersion)
 }
 
 func testAccImsImageDataSource_base(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* add more querying options for image data source
    add the following arguments: `name_regex`, `architecture`, `os`, `os_version` and `image_type`.
* use updated time to sort ims images

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccImsImageDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccImsImageDataSource -timeout 360m -parallel 4
=== RUN   TestAccImsImageDataSource_basic
=== PAUSE TestAccImsImageDataSource_basic
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_basic
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_basic (75.47s)
--- PASS: TestAccImsImageDataSource_testQueries (413.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       413.394s
```
