### PR TITLE
chore: deprecate huaweicloud_images_image_v2 resource

### DIFF
--- a/docs/resources/images_image_v2.md
+++ b/docs/resources/images_image_v2.md
@@ -6,6 +6,8 @@ subcategory: "Deprecated"
 
 Manages a Image resource within HuaweiCloud IMS.
 
+!> **WARNING:** It has been deprecated, please use `huaweicloud_images_image` instead.
+
 ## Example Usage
 
 ```hcl

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -579,7 +579,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_queue_v1":                       ResourceDmsQueuesV1(),
 			"huaweicloud_dms_group_v1":                       ResourceDmsGroupsV1(),
 			"huaweicloud_dms_instance_v1":                    ResourceDmsInstancesV1(),
-			"huaweicloud_images_image_v2":                    resourceImagesImageV2(),
 			"huaweicloud_lb_certificate_v2":                  ResourceCertificateV2(),
 			"huaweicloud_lb_loadbalancer_v2":                 ResourceLoadBalancerV2(),
 			"huaweicloud_lb_listener_v2":                     ResourceListenerV2(),
@@ -663,6 +662,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rts_stack_v1":                       resourceRTSStackV1(),
 			"huaweicloud_rts_software_config_v1":             resourceSoftwareConfigV1(),
 			"huaweicloud_cts_tracker":                        deprecated.ResourceCTSTrackerV1(),
+			"huaweicloud_images_image_v2":                    deprecated.ResourceImagesImageV2(),
 		},
 	}
 

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_v2_test.go
@@ -1,10 +1,11 @@
-package huaweicloud
+package deprecated
 
 import (
 	"testing"
 
 	"github.com/chnsz/golangsdk/openstack/imageservice/v2/images"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,8 +16,8 @@ func TestAccImagesImageV2_basic(t *testing.T) {
 	var image images.Image
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDeprecated(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDeprecated(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -52,8 +53,8 @@ func TestAccImagesImageV2_name(t *testing.T) {
 	var image images.Image
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDeprecated(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDeprecated(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -80,8 +81,8 @@ func TestAccImagesImageV2_tags(t *testing.T) {
 	var image images.Image
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDeprecated(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDeprecated(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -121,10 +122,9 @@ func TestAccImagesImageV2_visibility(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckDeprecated(t)
-			testAccPreCheckAdminOnly(t)
+			acceptance.TestAccPreCheckDeprecated(t)
 		},
-		Providers:    testAccProviders,
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -143,8 +143,8 @@ func TestAccImagesImageV2_timeout(t *testing.T) {
 	var image images.Image
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDeprecated(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDeprecated(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -158,8 +158,8 @@ func TestAccImagesImageV2_timeout(t *testing.T) {
 }
 
 func testAccCheckImagesImageV2Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	imageClient, err := config.ImageV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud Image: %s", err)
 	}
@@ -189,8 +189,8 @@ func testAccCheckImagesImageV2Exists(n string, image *images.Image) resource.Tes
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud Image: %s", err)
 		}
@@ -221,8 +221,8 @@ func testAccCheckImagesImageV2HasTag(n, tag string) resource.TestCheckFunc {
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud Image: %s", err)
 		}
@@ -257,8 +257,8 @@ func testAccCheckImagesImageV2TagCount(n string, expected int) resource.TestChec
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud Image: %s", err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

* without **HW_DEPRECATED_ENVIRONMENT** env
```
$ make testacc TEST='./huaweicloud/services/acceptance/deprecated' TESTARGS='-run TestAccImagesImageV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccImagesImageV2_basic -timeout 360m -parallel 4
=== RUN   TestAccImagesImageV2_basic
=== PAUSE TestAccImagesImageV2_basic
=== CONT  TestAccImagesImageV2_basic
    acceptance.go:290: This environment does not support deprecated tests
--- SKIP: TestAccImagesImageV2_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        0.059s
```

* with **HW_DEPRECATED_ENVIRONMENT** env
```
$ make testacc TEST='./huaweicloud/services/acceptance/deprecated' TESTARGS='-run TestAccImagesImageV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccImagesImageV2_basic -timeout 360m -parallel 4
=== RUN   TestAccImagesImageV2_basic
=== PAUSE TestAccImagesImageV2_basic
=== CONT  TestAccImagesImageV2_basic
--- PASS: TestAccImagesImageV2_basic (348.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        348.520s

$ make testacc TEST='./huaweicloud/services/acceptance/deprecated' TESTARGS='-run TestAccImagesImageV2_visibility'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccImagesImageV2_visibility -timeout 360m -parallel 4
=== RUN   TestAccImagesImageV2_visibility
=== PAUSE TestAccImagesImageV2_visibility
=== CONT  TestAccImagesImageV2_visibility
--- PASS: TestAccImagesImageV2_visibility (312.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        312.467s
```
