### PR TITLE
feat(dli/database): add new sql database resource support

### DIFF
--- a/docs/resources/dli_database.md
+++ b/docs/resources/dli_database.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# huaweicloud_dli_database
+
+Manages DLI SQL database resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a database
+
+```hcl
+variable "database_name" {}
+
+resource "huaweicloud_dli_database" "test" {
+  name = var.database_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the DLI database resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new database resource.
+
+* `name` - (Required, String, ForceNew) Specifies the database name. The name consists of 1 to 128 characters, starting
+  with a letter or digit. Only letters, digits and underscores (_) are allowed and the name cannot be all digits.
+  Changing this parameter will create a new database resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of a queue.
+  Changing this parameter will create a new database resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.
+  The value 0 indicates the default enterprise project. Changing this parameter will create a new database resource.
+
+* `owner` - (Optional, String) Specifies the name of the SQL database owner.
+  The owner must be IAM user.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. For database resources, the ID is the database name.
+
+## Import
+
+DLI SQL databases can be imported by their `name`, e.g.
+
+```
+$ terraform import huaweicloud_dli_database.test terraform_test
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -443,6 +443,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_instance":                    dcs.ResourceDcsInstance(),
 			"huaweicloud_dds_instance":                    ResourceDdsInstanceV3(),
 			"huaweicloud_dis_stream":                      ResourceDisStreamV2(),
+			"huaweicloud_dli_database":                    dli.ResourceDliSqlDatabaseV1(),
 			"huaweicloud_dli_queue":                       dli.ResourceDliQueue(),
 			"huaweicloud_dms_group":                       ResourceDmsGroupsV1(),
 			"huaweicloud_dms_instance":                    ResourceDmsInstancesV1(),

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_test.go
@@ -1,0 +1,71 @@
+package dli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/databases"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+)
+
+func getDatabaseResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.DliV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HuaweiCloud DLI v1 client: %s", err)
+	}
+
+	return dli.GetDliSqlDatabaseByName(c, state.Primary.ID)
+}
+
+func TestAccDliDatabase_basic(t *testing.T) {
+	var database databases.Database
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_dli_database.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&database,
+		getDatabaseResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliDatabase_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "For terraform acc test"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDliDatabase_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_database" "test" {
+  name                  = "%s"
+  description           = "For terraform acc test"
+  enterprise_project_id = "%s"
+}
+`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID)
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_database.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_database.go
@@ -1,0 +1,170 @@
+package dli
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dli/v1/databases"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceDliSqlDatabaseV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceDliSqlDatabaseV1Create,
+		ReadContext:   ResourceDliSqlDatabaseV1Read,
+		UpdateContext: ResourceDliSqlDatabaseV1Update,
+		DeleteContext: ResourceDliSqlDatabaseV1Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9][\w_]{0,127}$`),
+						"The name consists of 1 to 128 characters, starting with a letter or digit. "+
+							"Only letters, digits and underscores (_) are allowed."),
+					validation.StringMatch(regexp.MustCompile(`[A-Za-z_]`), "The name cannot be all digits."),
+				),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceDliSqlDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v1 client: %s", err)
+	}
+
+	dbName := d.Get("name").(string)
+	opts := databases.CreateOpts{
+		Name:                dbName,
+		Description:         d.Get("description").(string),
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+	}
+	_, err = databases.Create(c, opts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DLI database")
+	}
+	d.SetId(dbName)
+
+	return ResourceDliSqlDatabaseV1Read(ctx, d, meta)
+}
+
+func setDliSqlDatabaseV1Parameters(d *schema.ResourceData, resp databases.Database) error {
+	mErr := multierror.Append(nil,
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
+		d.Set("owner", resp.Owner),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func GetDliSqlDatabaseByName(c *golangsdk.ServiceClient, dbName string) (databases.Database, error) {
+	resp, err := databases.List(c, databases.ListOpts{
+		Keyword: dbName, // Fuzzy matching.
+	})
+	if err != nil {
+		return databases.Database{}, fmtp.Errorf("Error getting database: %s", err)
+	}
+
+	if len(resp.Databases) < 1 {
+		return databases.Database{}, fmtp.Errorf("Unable to find the specified database (%s): %s", dbName, err)
+	}
+	for _, db := range resp.Databases {
+		if db.Name == dbName {
+			return db, nil
+		}
+	}
+
+	return databases.Database{}, fmtp.Errorf("Only find some databases with this character (%s) in the name", dbName)
+}
+
+func ResourceDliSqlDatabaseV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v1 client: %s", err)
+	}
+
+	db, err := GetDliSqlDatabaseByName(c, d.Id())
+	if err != nil {
+		return fmtp.DiagErrorf("Error getting SQL database: %s", err)
+	}
+
+	err = setDliSqlDatabaseV1Parameters(d, db)
+	if err != nil {
+		return fmtp.DiagErrorf("An error occurred during resource parameter setting for SQL database: %s", err)
+	}
+	return nil
+}
+
+func ResourceDliSqlDatabaseV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v1 client: %s", err)
+	}
+
+	_, err = databases.UpdateDBOwner(c, d.Id(), databases.UpdateDBOwnerOpts{
+		NewOwner: d.Get("owner").(string),
+	})
+	if err != nil {
+		return fmtp.DiagErrorf("Error updating SQL database owner: %s", err)
+	}
+
+	return ResourceDliSqlDatabaseV1Read(ctx, d, meta)
+}
+
+func ResourceDliSqlDatabaseV1Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v1 client: %s", err)
+	}
+	err = databases.Delete(c, d.Id()).ExtractErr()
+	if err != nil {
+		return fmtp.DiagErrorf("Error deleting SQL database: %s", err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/databases/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/databases/requests.go
@@ -1,0 +1,105 @@
+package databases
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+)
+
+// CreateOpts is a structure which allows to create a new database using given parameters.
+type CreateOpts struct {
+	// Name of the created database.
+	// NOTE: The default database is a built-in database. You cannot create a database named default.
+	Name string `json:"database_name" required:"true"`
+	// Information about the created database.
+	Description string `json:"description,omitempty"`
+	// Enterprise project ID. The value 0 indicates the default enterprise project.
+	// NOTE: Users who have enabled Enterprise Management can set this parameter to bind a specified project.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// Database tag.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// Create is a method to create a new database by CreateOpts.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*RequestResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
+	if err == nil {
+		var r RequestResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ListOpts is a structure which allows to obtain databases using given parameters.
+type ListOpts struct {
+	// Specifies whether to display the permission information. The value can be true or false.
+	// The default value is false.
+	IsDesplay bool `q:"with-priv"`
+	// The value should be no less than 0. The default value is 0.
+	Offset int `q:"offset"`
+	// Number of returned data records. The value must be greater than or equal to 0.
+	// By default, all data records are returned.
+	Limit int `q:"limit"`
+	// Database name filtering keyword. Fuzzy match is used to obtain all databases whose names contain the keyword.
+	Keyword string `q:"keyword"`
+	// Database tag. The format is key=value, for example:
+	// GET /v1.0/{project_id}/databases?offset=0&limit=10&with-priv=true&tags=foo%3Dbar
+	// In the preceding information, = needs to be escaped to %3D, foo indicates the tag key, and bar indicates the tag
+	// value.
+	Tags string `q:"tags"`
+}
+
+// List is a method to obtain a list of databases by ListOpts.
+func List(c *golangsdk.ServiceClient, opts ListOpts) (*ListResp, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var rst golangsdk.Result
+	_, err = c.Get(url, &rst.Body, nil)
+	if err == nil {
+		var r ListResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// UpdateDBOwnerOpts is a structure which allows to update database owner using given name.
+type UpdateDBOwnerOpts struct {
+	// Name of the new owner. The new user must be a sub-user of the current tenant.
+	NewOwner string `json:"new_owner" required:"true"`
+}
+
+// UpdateDBOwner is a method to update database owner by UpdateDBOwnerOpts.
+func UpdateDBOwner(c *golangsdk.ServiceClient, dbName string, opts UpdateDBOwnerOpts) (*RequestResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(userURL(c, dbName), b, &rst.Body, nil)
+	if err == nil {
+		var r RequestResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Delete is a method to remove the exist database by database name.
+func Delete(c *golangsdk.ServiceClient, dbName string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, dbName), nil)
+	return &r
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/databases/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/databases/results.go
@@ -1,0 +1,41 @@
+package databases
+
+// RequestResp is a object that represents the result of Create and UpdateDBOwner operation.
+type RequestResp struct {
+	// Whether the request is successfully executed. Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+}
+
+// ListResp is a object that represents the result of List operation.
+type ListResp struct {
+	// Indicates whether the request is successfully executed.
+	// Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+	// Total number of databases.
+	DatabaseCount int `json:"database_count"`
+	// Database information.
+	Databases []Database `json:"databases"`
+}
+
+// Database is a object that represents the database detail.
+type Database struct {
+	// Name of a database.
+	Name string `json:"database_name"`
+	// Creator of a database.
+	Owner string `json:"owner"`
+	// Number of tables in a database.
+	TableNumber int `json:"table_number"`
+	// Information about a database.
+	Description string `json:"description"`
+	// Whether database is shared.
+	IsShared bool `json:"is_shared"`
+	// Enterprise project ID. The value 0 indicates the default enterprise project.
+	// NOTE: Users who have enabled Enterprise Management can set this parameter to bind a specified project.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Resource ID.
+	ResourceId string `json:"resource_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/databases/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/databases/urls.go
@@ -1,0 +1,17 @@
+package databases
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "databases"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, dbName string) string {
+	return c.ServiceURL(rootPath, dbName)
+}
+
+func userURL(c *golangsdk.ServiceClient, dbName string) string {
+	return c.ServiceURL(rootPath, dbName, "owner")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,6 +128,7 @@ github.com/chnsz/golangsdk/openstack/dcs/v2/tags
 github.com/chnsz/golangsdk/openstack/dcs/v2/whitelists
 github.com/chnsz/golangsdk/openstack/dds/v3/flavors
 github.com/chnsz/golangsdk/openstack/dds/v3/instances
+github.com/chnsz/golangsdk/openstack/dli/v1/databases
 github.com/chnsz/golangsdk/openstack/dli/v1/queues
 github.com/chnsz/golangsdk/openstack/dms/v1/availablezones
 github.com/chnsz/golangsdk/openstack/dms/v1/groups


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The `huaweicloud_dli_database` resource support the database management for the DLI service.
- Create a new database
- Obtain database detail information
- Update database owner
- Delete exist database

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1601 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new DLI SQL database support.
2. add related ducuments and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDliDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDliDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccDliDatabase_basic
=== PAUSE TestAccDliDatabase_basic
=== CONT  TestAccDliDatabase_basic
--- PASS: TestAccDliDatabase_basic (38.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       38.658s
```
