### PR TITLE
feat(gaussdb/mysql): add type and az_status to flavors data source

### DIFF
--- a/docs/data-sources/gaussdb_mysql_flavors.md
+++ b/docs/data-sources/gaussdb_mysql_flavors.md
@@ -38,5 +38,7 @@ The `flavors` block contains:
 * `name` - The name of the gaussdb mysql flavor.
 * `vcpus` - Indicates the CPU size.
 * `memory` - Indicates the memory size in GB.
+* `type` - Indicates the arch type of the flavor.
 * `mode` - Indicates the database mode.
 * `version` - Indicates the database version.
+* `az_status` - Indicates the flavor status in each az.

--- a/docs/data-sources/gaussdb_mysql_flavors.md
+++ b/docs/data-sources/gaussdb_mysql_flavors.md
@@ -41,4 +41,4 @@ The `flavors` block contains:
 * `type` - Indicates the arch type of the flavor.
 * `mode` - Indicates the database mode.
 * `version` - Indicates the database version.
-* `az_status` - Indicates the flavor status in each az.
+* `az_status` - Indicates the flavor status in each availability zone.

--- a/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_mysql_flavors.go
@@ -51,6 +51,10 @@ func dataSourceGaussdbMysqlFlavors() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"mode": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -58,6 +62,11 @@ func dataSourceGaussdbMysqlFlavors() *schema.Resource {
 						"version": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						"az_status": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -88,11 +97,13 @@ func dataSourceGaussdbMysqlFlavorsRead(d *schema.ResourceData, meta interface{})
 		val := item.(map[string]interface{})
 
 		flavors = append(flavors, map[string]interface{}{
-			"vcpus":   val["vcpus"],
-			"memory":  val["ram"],
-			"name":    val["spec_code"],
-			"mode":    val["instance_mode"],
-			"version": val["version_name"],
+			"vcpus":     val["vcpus"],
+			"memory":    val["ram"],
+			"name":      val["spec_code"],
+			"type":      val["type"],
+			"mode":      val["instance_mode"],
+			"version":   val["version_name"],
+			"az_status": val["az_status"],
 		})
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1587 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== PAUSE TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== CONT  TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
--- PASS: TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic (36.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       36.568s
```
