### PR TITLE
feat(dli/package): add new dependent package resource support

### DIFF
--- a/docs/resources/dli_package.md
+++ b/docs/resources/dli_package.md
@@ -8,17 +8,15 @@ Manages DLI package resource within HuaweiCloud
 
 ## Example Usage
 
-### Upload the specified python script as a dependent package
+### Upload the specified python script as a resource package
 
 ```hcl
 variable "group_name" {}
-variable "package_name" {}
 variable "access_domain_name" {}
 
 resource "huaweicloud_dli_package" "queue" {
   group_name  = var.group_name
-  object_name = var.package_name
-  object_path = "https://${var.access_domain_name}/dli/packages/"
+  object_path = "https://${var.access_domain_name}/dli/packages/object_file.py"
   type        = "pyFile"
 }
 ```
@@ -37,28 +35,26 @@ The following arguments are supported:
 * `type` - (Required, String, ForceNew) Specifies the package type.
   + **jar**: `.jar` or jar related files.
   + **pyFile**: `.py` or python related files.
-  + **file**: other user files.
+  + **file**: Other user files.
 
   Changing this parameter will delete the current package and upload a new package.
 
 * `object_path` - (Required, String, ForceNew) Specifies the OBS storage path where the package is located.
-  For example, The OBS storage path should be a folder path, such as `https://{access_domain_name}/dli/packages/`, with
-  a slash on the right side. Changing this parameter will delete the current package and upload a new package.
-
-* `object_name` - (Required, String, ForceNew) Specifies the package name.
+  For example, `https://{bucket_name}.obs.{region}.myhuaweicloud.com/dli/packages/object_file.py`.
   Changing this parameter will delete the current package and upload a new package.
 
 * `is_async` - (Optional, Bool, ForceNew) Specifies whether to upload resource packages in asynchronous mode.
   The default value is **false**. Changing this parameter will delete the current package and upload a new package.
 
-* `owner` - (Optional, String) Specifies the name of the package owner.
-  The owner must be IAM user.
+* `owner` - (Optional, String) Specifies the name of the package owner. The owner must be IAM user.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Resource ID. The ID is constructed from the `group_name` and `object_name`, separated by slash.
+
+* `object_name` - The package name.
 
 * `status` - Status of a package group to be uploaded.
 

--- a/docs/resources/dli_package.md
+++ b/docs/resources/dli_package.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# huaweicloud_dli_package
+
+Manages DLI package resource within HuaweiCloud
+
+## Example Usage
+
+### Upload the specified python script as a dependent package
+
+```hcl
+variable "group_name" {}
+variable "package_name" {}
+variable "access_domain_name" {}
+
+resource "huaweicloud_dli_package" "queue" {
+  group_name  = var.group_name
+  object_name = var.package_name
+  object_path = "https://${var.access_domain_name}/dli/packages/"
+  type        = "pyFile"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to upload packages.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will delete the current package and upload a new package.
+
+* `group_name` - (Required, String, ForceNew) Specifies the group name which the package belongs to.
+  Changing this parameter will delete the current package and upload a new package.
+
+* `type` - (Required, String, ForceNew) Specifies the package type.
+  + **jar**: `.jar` or jar related files.
+  + **pyFile**: `.py` or python related files.
+  + **file**: other user files.
+
+  Changing this parameter will delete the current package and upload a new package.
+
+* `object_path` - (Required, String, ForceNew) Specifies the OBS storage path where the package is located.
+  For example, The OBS storage path should be a folder path, such as `https://{access_domain_name}/dli/packages/`, with
+  a slash on the right side. Changing this parameter will delete the current package and upload a new package.
+
+* `object_name` - (Required, String, ForceNew) Specifies the package name.
+  Changing this parameter will delete the current package and upload a new package.
+
+* `is_async` - (Optional, Bool, ForceNew) Specifies whether to upload resource packages in asynchronous mode.
+  The default value is **false**. Changing this parameter will delete the current package and upload a new package.
+
+* `owner` - (Optional, String) Specifies the name of the package owner.
+  The owner must be IAM user.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. The ID is constructed from the `group_name` and `object_name`, separated by slash.
+
+* `status` - Status of a package group to be uploaded.
+
+* `created_at` - Time when a queue is created.
+
+* `updated_at` - The last time when the package configuration update has complated.

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -832,6 +832,10 @@ func (c *Config) DliV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dli", region)
 }
 
+func (c *Config) DliV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("dliv2", region)
+}
+
 func (c *Config) DisV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("disv2", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -294,6 +294,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dli",
 		Version: "v1.0",
 	},
+	"dliv2": {
+		Name:    "dli",
+		Version: "v2.0",
+	},
 	"disv2": {
 		Name:    "dis",
 		Version: "v2",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -929,6 +929,18 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	}
 	t.Logf("dli endpoint:\t %s", actualURL)
 
+	// test the endpoint of DLI v2.0 service
+	serviceClient, err = config.DliV2Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating dli v2 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://dli.%s.%s/v2.0/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("dli endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("dli endpoint:\t %s", actualURL)
+
 	serviceClient, err = config.DwsV1Client(HW_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating dws css client: %s", err)

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -451,6 +451,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_instance":                    ResourceDdsInstanceV3(),
 			"huaweicloud_dis_stream":                      dis.ResourceDisStream(),
 			"huaweicloud_dli_database":                    dli.ResourceDliSqlDatabaseV1(),
+			"huaweicloud_dli_package":                     dli.ResourceDliPackageV2(),
 			"huaweicloud_dli_queue":                       dli.ResourceDliQueue(),
 			"huaweicloud_dli_table":                       dli.ResourceDliTableJob(),
 			"huaweicloud_dms_group":                       ResourceDmsGroupsV1(),

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_package_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_package_test.go
@@ -44,8 +44,9 @@ func TestAccDliPackage_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "pyFile"),
-					resource.TestCheckResourceAttr(resourceName, "object_path",
-						fmt.Sprintf("https://%s/dli/packages/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "object_path", fmt.Sprintf(
+						"https://%s.obs.%s.myhuaweicloud.com/dli/packages/simple_pyspark_test_DLF_refresh.py",
+						rName, acceptance.HW_REGION_NAME)),
 					resource.TestCheckResourceAttr(resourceName, "object_name", "simple_pyspark_test_DLF_refresh.py"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -126,8 +127,7 @@ EOF
 resource "huaweicloud_dli_package" "test" {
   group_name  = "%s"
   type        = "pyFile"
-  object_path = "https://${huaweicloud_obs_bucket_object.test.bucket}/dli/packages/"
-  object_name = "simple_pyspark_test_DLF_refresh.py"
+  object_path = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/dli/packages/simple_pyspark_test_DLF_refresh.py"
 }
 `, rName, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY, rName)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_package_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_package_test.go
@@ -1,0 +1,133 @@
+package dli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+)
+
+func getPackageResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.DliV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HuaweiCloud DLI v2 client: %s", err)
+	}
+
+	return dli.GetDliDependentPackageInfo(c, state.Primary.ID)
+}
+
+func TestAccDliPackage_basic(t *testing.T) {
+	var pkg resources.Resource
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dli_package.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pkg,
+		getPackageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliPackage_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "pyFile"),
+					resource.TestCheckResourceAttr(resourceName, "object_path",
+						fmt.Sprintf("https://%s/dli/packages/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "object_name", "simple_pyspark_test_DLF_refresh.py"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDliPackage_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket = "%s"
+  acl    = "private"
+}
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket  = huaweicloud_obs_bucket.test.bucket
+  key     = "dli/packages/simple_pyspark_test_DLF_refresh.py"
+  content = <<EOF
+#!/usr/bin/env python
+# _*_ coding: utf-8 _*_
+
+import sys
+import logging
+from operator import add
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql import SQLContext
+
+sparkSession = SparkSession.builder.appName("simple pyspark test DLF refresh").getOrCreate()
+sc = SQLContext(sparkSession.sparkContext)
+
+logging.basicConfig(format='%%(message)s', level=logging.INFO)
+logger = logging.getLogger("Whatever")
+logger.info("[DBmethods.py] HELLOOOOOOOOOOO")
+
+
+sc._jsc.hadoopConfiguration().set("fs.obs.access.key", "%s")
+sc._jsc.hadoopConfiguration().set("fs.obs.secret.key", "%s")
+sc._jsc.hadoopConfiguration().set("fs.obs.endpoint", "obs.cn-north-4.myhuaweicloud.com")
+
+
+# Read private bucket with encryption using AK/SK
+private_encrypted_file = "obs://dedicated-for-terraform-acc-test/dli/spark/people.csv"
+
+df = sparkSession.read.options(header='True', inferSchema='True', delimiter=',').csv(private_encrypted_file)
+df.show()
+df.printSchema()
+print(df)
+print(df.count())
+print(time.time())
+
+
+my_string_to_print = "{} - {}".format(int(time.time()), df.count()/2)
+file_name = "my_file-{}-{}".format(int(time.time()), df.count()/2)
+
+
+print(my_string_to_print)
+print(file_name)
+
+private_encrypted_output_folder = "obs://dedicated-for-terraform-acc-test/dli/result/"
+# my_string_to_print.write.mode('overwrite').csv(private_encrypted_output_folder)
+
+final_path = "{}{}".format(private_encrypted_output_folder, file_name)
+print(final_path)
+
+
+sparkSession.sparkContext.parallelize([my_string_to_print]).coalesce(1).saveAsTextFile(final_path)
+
+
+EOF
+  content_type = "text/py"
+}
+
+resource "huaweicloud_dli_package" "test" {
+  group_name  = "%s"
+  type        = "pyFile"
+  object_path = "https://${huaweicloud_obs_bucket_object.test.bucket}/dli/packages/"
+  object_name = "simple_pyspark_test_DLF_refresh.py"
+}
+`, rName, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY, rName)
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_package.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_package.go
@@ -1,0 +1,266 @@
+package dli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+const (
+	jarFile    = "jar"
+	pythonFile = "pyFile"
+	userFile   = "file"
+)
+
+var uploadPath = map[string]string{
+	jarFile:    "jars",
+	pythonFile: "pyfiles",
+	userFile:   "files",
+}
+
+func ResourceDliPackageV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceDliDependentPackageV2Create,
+		ReadContext:   ResourceDliDependentPackageV2Read,
+		UpdateContext: ResourceDliDependentPackageV2Update,
+		DeleteContext: ResourceDliDependentPackageV2Delete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				// If you want to add a new package type, please update all relevant codes.
+				ValidateFunc: validation.StringInSlice([]string{
+					jarFile, pythonFile, userFile,
+				}, false),
+			},
+			"object_path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"object_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_async": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDliDependentPackageCreateOpts(d *schema.ResourceData) resources.CreateGroupAndUploadOpts {
+	result := resources.CreateGroupAndUploadOpts{
+		Paths:   []string{fmt.Sprintf("%s%s", d.Get("object_path").(string), d.Get("object_name").(string))},
+		Kind:    d.Get("type").(string),
+		Group:   d.Get("group_name").(string),
+		IsAsync: d.Get("is_async").(bool),
+	}
+	return result
+}
+
+func buildDliDependentPackageUploadOpts(d *schema.ResourceData) resources.UploadOpts {
+	result := resources.UploadOpts{
+		Paths: []string{
+			fmt.Sprintf("%s/%s", d.Get("object_path").(string), d.Get("object_name").(string)),
+		},
+		Group: d.Get("group_name").(string),
+	}
+	return result
+}
+
+func ResourceDliDependentPackageV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v2 client: %s", err)
+	}
+
+	resList, err := resources.List(c, resources.ListOpts{})
+	if err != nil {
+		return fmtp.DiagErrorf("Error getting group informations: %s", err)
+	}
+
+	// filter data by group name
+	filterData, err := utils.FilterSliceWithField(resList.Groups, map[string]interface{}{
+		"GroupName": d.Get("group_name").(string),
+	})
+
+	if len(filterData) == 0 {
+		opt := buildDliDependentPackageCreateOpts(d)
+		_, err = resources.CreateGroupAndUpload(c, opt)
+		if err != nil {
+			return fmtp.DiagErrorf("A error occurred when creating group and upload package: %s", err)
+		}
+	} else {
+		opt := buildDliDependentPackageUploadOpts(d)
+		resType := d.Get("type").(string)
+
+		_, err = resources.Upload(c, uploadPath[resType], opt)
+		if err != nil {
+			return fmtp.DiagErrorf("Error uploading %s package to OBS bucket: %s", resType, err)
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("group_name").(string), d.Get("object_name").(string)))
+
+	pkg, err := GetDliDependentPackageInfo(c, d.Id())
+	if err != nil {
+		return fmtp.DiagErrorf("An error occurred while getting the package: %s", err)
+	}
+	if owner, ok := d.GetOk("owner"); ok && owner.(string) != pkg.Owner {
+		return ResourceDliDependentPackageV2Update(ctx, d, meta)
+	}
+
+	return ResourceDliDependentPackageV2Read(ctx, d, meta)
+}
+
+func setDliDependentPackageParameters(d *schema.ResourceData, resp *resources.Resource) error {
+	mErr := multierror.Append(nil,
+		d.Set("object_name", resp.ResourceName),
+		d.Set("type", resp.ResourceType),
+		d.Set("status", resp.Status),
+		d.Set("created_at", time.Unix(int64(resp.CreateTime)/1000, 0).Format("2006-01-02 15:04:05")),
+		d.Set("updated_at", time.Unix(int64(resp.CreateTime)/1000, 0).Format("2006-01-02 15:04:05")),
+		d.Set("owner", resp.Owner),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+	return nil
+}
+
+func getGroupNameAndPackageName(id string) (groupName, packageName string, err error) {
+	names := strings.Split(id, "/")
+	if len(names) < 2 {
+		err = fmtp.Errorf("ID is incomplete, missing key information")
+		return
+	}
+	return names[0], names[1], nil
+}
+
+func GetDliDependentPackageInfo(c *golangsdk.ServiceClient, id string) (*resources.Resource, error) {
+	var resp *resources.Resource
+	groupName, packageName, err := getGroupNameAndPackageName(id)
+	if err != nil {
+		return resp, fmt.Errorf("error parsing resource ID (%s): %s", id, err)
+	}
+
+	opt := resources.ResourceLocatedOpts{
+		Group: groupName,
+	}
+	resp, err = resources.Get(c, packageName, opt)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func ResourceDliDependentPackageV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v2 client: %s", err)
+	}
+
+	resp, err := GetDliDependentPackageInfo(c, d.Id())
+	if err != nil {
+		return fmtp.DiagErrorf("An error occurred while getting the package: %s", err)
+	}
+
+	err = setDliDependentPackageParameters(d, resp)
+	if err != nil {
+		return fmtp.DiagErrorf("An error occurred during package resource parameters setting: %s", err)
+	}
+	return nil
+}
+
+func ResourceDliDependentPackageV2Update(ctx context.Context, d *schema.ResourceData,
+	meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v2 client: %s", err)
+	}
+
+	opt := resources.UpdateOpts{
+		ResourceName: d.Get("object_name").(string),
+		GroupName:    d.Get("group_name").(string),
+		NewOwner:     d.Get("owner").(string),
+	}
+	_, err = resources.UpdateOwner(c, opt)
+	if err != nil {
+		return fmtp.DiagErrorf("Error updating package owner: %s", err)
+	}
+
+	return ResourceDliDependentPackageV2Read(ctx, d, meta)
+}
+
+func ResourceDliDependentPackageV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	c, err := config.DliV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud DLI v2 client: %s", err)
+	}
+
+	groupName, packageName, err := getGroupNameAndPackageName(d.Id())
+	if err != nil {
+		return fmtp.DiagErrorf("Error parsing resource ID (%s): %s", d.Id(), err)
+	}
+
+	opt := resources.ResourceLocatedOpts{
+		Group: groupName,
+	}
+	err = resources.Delete(c, packageName, opt).ExtractErr()
+	if err != nil {
+		return fmtp.DiagErrorf("Error deleting DLI dependent package (%s): %s", packageName, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/requests.go
@@ -1,0 +1,172 @@
+package resources
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+)
+
+// CreateGroupAndUploadOpts is a structure which allows to create a new resource group and upload package file to the
+// group using given parameters.
+type CreateGroupAndUploadOpts struct {
+	// List of OBS object paths. The OBS object path refers to the OBS object URL.
+	Paths []string `json:"paths" required:"true"`
+	// File type of a package group.
+	//   jar: JAR file
+	//   pyFile: User Python file
+	//   file: User file
+	//   modelFile: User AI model file
+	// NOTE: If the same group of packages to be uploaded contains different file types, select file as the type of the
+	// file to be uploaded.
+	Kind string `json:"kind" required:"true"`
+	// Name of the group to be created.
+	Group string `json:"group" required:"true"`
+	// Whether to upload resource packages in asynchronous mode.
+	// The default value is false, indicating that the asynchronous mode is not used.
+	// You are advised to upload resource packages in asynchronous mode.
+	IsAsync bool `json:"is_async,omitempty"`
+	// Resource tag.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// CreateGroupAndUpload is a method to create a new resource group and upload package from the specified OBS bucket.
+func CreateGroupAndUpload(c *golangsdk.ServiceClient, opts CreateGroupAndUploadOpts) (*Group, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
+	if err == nil {
+		var r Group
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// UploadOpts is a stucture which allows to upload resource package to the specified group using given parameters.
+type UploadOpts struct {
+	// List of OBS object paths. The OBS object path refers to the OBS object URL.
+	Paths []string `json:"paths" required:"true"`
+	// Name of a package group.
+	Group string `json:"group" required:"true"`
+}
+
+// Upload is a method to upload resource package to the specified group.
+func Upload(c *golangsdk.ServiceClient, typePath string, opts UploadOpts) (*Group, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(resourceURL(c, typePath), b, &rst.Body, nil)
+	if err == nil {
+		var r Group
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ResourceLocatedOpts is a structure which specify the resource package located.
+type ResourceLocatedOpts struct {
+	// Name of the package group returned when the resource package is uploaded.
+	Group string `q:"group" required:"true"`
+}
+
+// Get is a method to obtain the resource (packages) from the specified group.
+func Get(c *golangsdk.ServiceClient, resourceName string, opts ResourceLocatedOpts) (*Resource, error) {
+	url := resourceURL(c, resourceName)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var rst golangsdk.Result
+	_, err = c.Get(url, &rst.Body, nil)
+	if err == nil {
+		var r Resource
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ListOpts is a structure which allows to obtain resources groups using given parameters.
+type ListOpts struct {
+	// Specifies the file type.
+	Kind string `q:"kind"`
+	// Specifies a label for filtering.
+	Tags string `q:"tags"`
+}
+
+// List is a method to obtain a list of the groups and resources.
+func List(c *golangsdk.ServiceClient, opts ListOpts) (*ListResp, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var rst golangsdk.Result
+	_, err = c.Get(url, &rst.Body, nil)
+	if err == nil {
+		var r ListResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// UpdateOpts is a structure which allows to update package owner or group owner using given parameters.
+type UpdateOpts struct {
+	// New username. The name contains 5 to 32 characters, including only digits, letters, underscores (_), and
+	// hyphens (-). It cannot start with a digit.
+	NewOwner string `json:"new_owner,omitempty"`
+	// Group name. The name contains a maximum of 64 characters. Only digits, letters, periods (.), underscores (_),
+	// and hyphens (-) are allowed.
+	GroupName string `json:"group_name,omitempty"`
+	// Package name. The name can contain only digits, letters, underscores (_), exclamation marks (!), hyphens (-),
+	// and periods (.), but cannot start with a period.
+	// The length (including the file name extension) cannot exceed 128 characters.
+	ResourceName string `json:"resource_name,omitempty"`
+}
+
+// UpdateOwner is a method to update package owner or group owner.
+func UpdateOwner(c *golangsdk.ServiceClient, opts UpdateOpts) (*UpdateResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, "owner"), b, &rst.Body, nil)
+	if err == nil {
+		var r UpdateResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Delete is a method to remove resource package from the specified group.
+func Delete(c *golangsdk.ServiceClient, resourceName string, opts ResourceLocatedOpts) *golangsdk.ErrResult {
+	var rst golangsdk.ErrResult
+	url := resourceURL(c, resourceName)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		rst.Err = err
+		return &rst
+	}
+	url += query.String()
+
+	_, rst.Err = c.Delete(url, nil)
+	if err == nil {
+		return &rst
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/results.go
@@ -1,0 +1,115 @@
+package resources
+
+// Group is a object that represents the group create or group list operations.
+type Group struct {
+	// Module name.
+	GroupName string `json:"group_name"`
+	// Status of a package group to be uploaded.
+	Status string `json:"status"`
+	// List of names of resource packages contained in the group.
+	Resources []string `json:"resources"`
+	// Details about a group resource package.
+	Details []Detail `json:"details"`
+	// UNIX timestamp when a package group is uploaded.
+	CreateTime int `json:"create_time"`
+	// UNIX timestamp when a package group is updated.
+	UpdateTime int `json:"update_time"`
+	// Whether to upload resource packages in asynchronous mode.
+	// The default value is false, indicating that the asynchronous mode is not used.
+	// You are advised to upload resource packages in asynchronous mode.
+	IsAsync bool `json:"is_async"`
+	// Owner of a resource package.
+	Owner string `json:"owner"`
+	// The description, moduleName and moduleType are supported by function response of specified file upload.
+	// Description of a resource module.
+	Description string `json:"description"`
+	// Name of a resource module.
+	ModuleName string `json:"module_name"`
+	// Type of a resource module.
+	//   jar: User JAR file
+	//   pyFile: User Python file
+	//   file: User file
+	ModuleType string `json:"module_type"`
+}
+
+// Group is a object that represents the detail about a group resource package.
+type Detail struct {
+	// UNIX time when a resource package is uploaded. The timestamp is expressed in milliseconds.
+	CreateTime int `json:"create_time" required:"true"`
+	// UNIX time when the uploaded resource package is uploaded. The timestamp is expressed in milliseconds.
+	UpdateTime int `json:"update_time"`
+	// Resource type.
+	ResourceType string `json:"resource_type" required:"true"`
+	// Resource name.
+	ResourceName string `json:"resource_name"`
+	// Value UPLOADING indicates that the resource package group is being uploaded.
+	// Value READY indicates that the resource package has been uploaded.
+	// Value FAILED indicates that the resource package fails to be uploaded.
+	Status string `json:"status"`
+	// Name of the resource packages in a queue.
+	UnderlyingName string `json:"underlying_name"`
+	// Whether to upload resource packages in asynchronous mode.
+	// The default value is false, indicating that the asynchronous mode is not used.
+	// You are advised to upload resource packages in asynchronous mode.
+	IsAsync bool `json:"is_async"`
+}
+
+// ListResp is a object that represents the List method result.
+type ListResp struct {
+	// List of names, type and other informations of uploaded user resources.
+	Resources []Resource `json:"resources"`
+	// List of built-in resource groups. For details about the groups, see Table 5.
+	Modules []Module `json:"modules"`
+	// Uploaded package groups of a user.
+	Groups []Group `json:"groups"`
+	// Total number of returned resource packages.
+	Total int `json:"total" required:"true"`
+}
+
+// Resource is a object that represents the names, type and other informations of uploaded user resources.
+type Resource struct {
+	// UNIX timestamp when a resource package is uploaded.
+	CreateTime int `json:"create_time"`
+	// UNIX timestamp when the uploaded resource package is uploaded.
+	UpdateTime int `json:"update_time"`
+	// Resource type.
+	ResourceType string `json:"resource_type"`
+	// Resource name.
+	ResourceName string `json:"resource_name"`
+	// Value UPLOADING indicates that the resource package is being uploaded.
+	// Value READY indicates that the resource package has been uploaded.
+	// Value FAILED indicates that the resource package fails to be uploaded.
+	Status string `json:"status"`
+	// Name of the resource package in the queue.
+	UnderlyingName string `json:"underlying_name"`
+	// Owner of a resource package.
+	Owner string `json:"owner"`
+}
+
+// Module is a object that represents the built-in resource group.
+type Module struct {
+	// Module name.
+	ModuleName string `json:"module_name"`
+	// Module type.
+	ModuleType string `json:"module_type"`
+	// Value UPLOADING indicates that the package group is being uploaded.
+	// Value READY indicates that the package group has been uploaded.
+	// Value FAILED indicates that the package group fails to be uploaded.
+	Status string `json:"status"`
+	// List of names of resource packages contained in the group.
+	Resources []string `json:"resources"`
+	// Module description.
+	Description string `json:"description"`
+	// UNIX timestamp when a package group is uploaded.
+	CreateTime int `json:"create_time"`
+	// UNIX timestamp when a package group is updated.
+	UpdateTime int `json:"update_time"`
+}
+
+// UpdateResp is a object that represents the update method result.
+type UpdateResp struct {
+	// Whether the request is successfully executed. Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/urls.go
@@ -1,0 +1,13 @@
+package resources
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "resources"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, subPath string) string {
+	return c.ServiceURL(rootPath, subPath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -132,6 +132,7 @@ github.com/chnsz/golangsdk/openstack/dis/v2/streams
 github.com/chnsz/golangsdk/openstack/dli/v1/databases
 github.com/chnsz/golangsdk/openstack/dli/v1/queues
 github.com/chnsz/golangsdk/openstack/dli/v1/tables
+github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources
 github.com/chnsz/golangsdk/openstack/dms/v1/availablezones
 github.com/chnsz/golangsdk/openstack/dms/v1/groups
 github.com/chnsz/golangsdk/openstack/dms/v1/instances


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add DLI package resource to manage OBS object and DLI resource group. 
User can upload some package (contians jar files, python files and other customer files) and build a resource group to manage them.

**Which issue this PR fixes**:
fixes #1599 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new package resource and related test.
2. add related document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDliDependentPackage_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDliDependentPackage_basic -timeout 360m -parallel 4
=== RUN   TestAccDliDependentPackage_basic
=== PAUSE TestAccDliDependentPackage_basic
=== CONT  TestAccDliDependentPackage_basic
--- PASS: TestAccDliDependentPackage_basic (47.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       48.166s
```
