### PR TITLE
feat: support more than 5 routes when creating route table

### DIFF
--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_test.go
@@ -76,6 +76,36 @@ func TestAccVpcRouteTable_basic(t *testing.T) {
 	})
 }
 
+func TestAccVpcRouteTable_multiRoutes(t *testing.T) {
+	var route routetables.RouteTable
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc_route_table.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&route,
+		getRouteTableResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTable_multiRoutes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform with multi routes"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "6"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccVpcRouteTable_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test1" {
@@ -173,6 +203,61 @@ resource "huaweicloud_vpc_route_table" "test" {
     type        = "peering"
     nexthop     = huaweicloud_vpc_peering_connection.test.id
     description = "peering rule"
+  }
+}
+`, testAccVpcRouteTable_base(rName), rName, rName)
+}
+
+func testAccVpcRouteTable_multiRoutes(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_peering_connection" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  peer_vpc_id = huaweicloud_vpc.test2.id
+}
+
+resource "huaweicloud_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test1.id
+  description = "created by terraform with multi routes"
+
+  route {
+    destination = "172.16.1.0/24"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering one rule"
+  }
+  route {
+    destination = "172.16.2.0/24"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering two rule"
+  }
+  route {
+    destination = "172.16.3.0/24"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering three rule"
+  }
+  route {
+    destination = "172.16.4.0/24"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering four rule"
+  }
+  route {
+    destination = "172.16.5.0/24"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering five rule"
+  }
+  route {
+    destination = "172.16.6.0/24"
+    type        = "peering"
+    nexthop     = huaweicloud_vpc_peering_connection.test.id
+    description = "peering six rule"
   }
 }
 `, testAccVpcRouteTable_base(rName), rName, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The API has a limitation: cant not add more than 5 routes when creating a route table:
```
Error: Error creating VPC route table: 
Bad request with: [POST https://vpc.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/routetables],
error message: {"code":"VPC.2800","message":"The num of routes to update is more than 5."}
```
but we can call the updating API to add 5+ routes, then the issue can be fixed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteTable_multiRoutes'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteTable_multiRoutes -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTable_multiRoutes
=== PAUSE TestAccVpcRouteTable_multiRoutes
=== CONT  TestAccVpcRouteTable_multiRoutes
--- PASS: TestAccVpcRouteTable_multiRoutes (93.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       93.514s
```
