### PR TITLE
fix(scm): for security, do not print the private key in the log

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mrs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
@@ -555,7 +556,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpnaas_ipsec_policy":             deprecated.ResourceVpnIPSecPolicyV2(),
 			"huaweicloud_vpnaas_service":                  deprecated.ResourceVpnServiceV2(),
 			"huaweicloud_vpnaas_site_connection":          deprecated.ResourceVpnSiteConnectionV2(),
-			"huaweicloud_scm_certificate":                 resourceScmCertificateV3(),
+			"huaweicloud_scm_certificate":                 scm.ResourceScmCertificate(),
 			"huaweicloud_waf_certificate":                 waf.ResourceWafCertificateV1(),
 			"huaweicloud_waf_domain":                      waf.ResourceWafDomainV1(),
 			"huaweicloud_waf_policy":                      waf.ResourceWafPolicyV1(),

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -49,13 +49,6 @@ var (
 	HW_ADMIN                        = os.Getenv("HW_ADMIN")
 	HW_ENTERPRISE_PROJECT_ID_TEST   = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
 	HW_USER_ID                      = os.Getenv("HW_USER_ID")
-
-	HW_CERTIFICATE_KEY_PATH         = os.Getenv("HW_CERTIFICATE_KEY_PATH")
-	HW_CERTIFICATE_CHAIN_PATH       = os.Getenv("HW_CERTIFICATE_CHAIN_PATH")
-	HW_CERTIFICATE_PRIVATE_KEY_PATH = os.Getenv("HW_CERTIFICATE_PRIVATE_KEY_PATH")
-	HW_CERTIFICATE_SERVICE          = os.Getenv("HW_CERTIFICATE_SERVICE")
-	HW_CERTIFICATE_PROJECT          = os.Getenv("HW_CERTIFICATE_PROJECT")
-	HW_CERTIFICATE_PROJECT_UPDATED  = os.Getenv("HW_CERTIFICATE_PROJECT_UPDATED")
 )
 
 var testAccProviders map[string]*schema.Provider
@@ -342,14 +335,4 @@ func envVarFile(varName string) (string, error) {
 		return "", fmtp.Errorf("Error closing temp file: %s", err)
 	}
 	return tmpFile.Name(), nil
-}
-
-func testAccPreCheckScm(t *testing.T) {
-	if HW_CERTIFICATE_KEY_PATH == "" || HW_CERTIFICATE_CHAIN_PATH == "" ||
-		HW_CERTIFICATE_PRIVATE_KEY_PATH == "" || HW_CERTIFICATE_SERVICE == "" ||
-		HW_CERTIFICATE_PROJECT == "" || HW_CERTIFICATE_PROJECT_UPDATED == "" {
-		t.Skip("HW_CERTIFICATE_KEY_PATH, HW_CERTIFICATE_CHAIN_PATH, HW_CERTIFICATE_PRIVATE_KEY_PATH, " +
-			"HW_CERTIFICATE_SERVICE, HW_CERTIFICATE_PROJECT and HW_CERTIFICATE_TARGET_UPDATED " +
-			"can not be empty for SCM certificate tests")
-	}
 }

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -47,6 +48,13 @@ var (
 	HW_DEST_REGION     = os.Getenv("HW_DEST_REGION")
 	HW_DEST_PROJECT_ID = os.Getenv("HW_DEST_PROJECT_ID")
 	HW_CHARGING_MODE   = os.Getenv("HW_CHARGING_MODE")
+
+	HW_CERTIFICATE_KEY_PATH         = os.Getenv("HW_CERTIFICATE_KEY_PATH")
+	HW_CERTIFICATE_CHAIN_PATH       = os.Getenv("HW_CERTIFICATE_CHAIN_PATH")
+	HW_CERTIFICATE_PRIVATE_KEY_PATH = os.Getenv("HW_CERTIFICATE_PRIVATE_KEY_PATH")
+	HW_CERTIFICATE_SERVICE          = os.Getenv("HW_CERTIFICATE_SERVICE")
+	HW_CERTIFICATE_PROJECT          = os.Getenv("HW_CERTIFICATE_PROJECT")
+	HW_CERTIFICATE_PROJECT_UPDATED  = os.Getenv("HW_CERTIFICATE_PROJECT_UPDATED")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -370,5 +378,16 @@ func TestAccPreCheckOBS(t *testing.T) {
 func TestAccPreCheckChargingMode(t *testing.T) {
 	if HW_CHARGING_MODE != "prePaid" {
 		t.Skip("This environment does not support prepaid tests")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckScm(t *testing.T) {
+	if HW_CERTIFICATE_KEY_PATH == "" || HW_CERTIFICATE_CHAIN_PATH == "" ||
+		HW_CERTIFICATE_PRIVATE_KEY_PATH == "" || HW_CERTIFICATE_SERVICE == "" ||
+		HW_CERTIFICATE_PROJECT == "" || HW_CERTIFICATE_PROJECT_UPDATED == "" {
+		t.Skip("HW_CERTIFICATE_KEY_PATH, HW_CERTIFICATE_CHAIN_PATH, HW_CERTIFICATE_PRIVATE_KEY_PATH, " +
+			"HW_CERTIFICATE_SERVICE, HW_CERTIFICATE_PROJECT and HW_CERTIFICATE_TARGET_UPDATED " +
+			"can not be empty for SCM certificate tests")
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- For security, the private key must be shielded when printing log.
- Move the code files to service path.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1631

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/scm' TESTARGS='-run TestAccScmCertification'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/scm -v -run TestAccScmCertification -timeout 360m -parallel 4
=== RUN   TestAccScmCertification_basic
=== PAUSE TestAccScmCertification_basic
=== RUN   TestAccScmCertification_push
=== PAUSE TestAccScmCertification_push
=== RUN   TestAccScmCertification_batchPush
=== PAUSE TestAccScmCertification_batchPush
=== CONT  TestAccScmCertification_basic
=== CONT  TestAccScmCertification_batchPush
=== CONT  TestAccScmCertification_push
--- PASS: TestAccScmCertification_batchPush (52.03s)
--- PASS: TestAccScmCertification_push (80.61s)
--- PASS: TestAccScmCertification_basic (88.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/scm       89.063s

```
