### PR TITLE
feat(waf/instance): support create ELB mode WAF dedicated instances

### DIFF
--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -65,6 +65,9 @@ The following arguments are supported:
 * `cpu_architecture` - (Optional, String, ForceNew) The ECS cpu architecture of instance, Default value is `x86`.
   Changing this will create a new instance.
 
+* `group_id` - (Optional, String, ForceNew) The instance group ID used by the WAF dedicated instance in ELB mode.
+  Changing this will create a new instance.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -562,7 +562,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rule_blacklist":              waf.ResourceWafRuleBlackListV1(),
 			"huaweicloud_waf_rule_data_masking":           waf.ResourceWafRuleDataMaskingV1(),
 			"huaweicloud_waf_rule_web_tamper_protection":  waf.ResourceWafRuleWebTamperProtectionV1(),
-			"huaweicloud_waf_dedicated_instance":          waf.ResourceWafDedicatedInstanceV1(),
+			"huaweicloud_waf_dedicated_instance":          waf.ResourceWafDedicatedInstance(),
 			"huaweicloud_waf_dedicated_domain":            waf.ResourceWafDedicatedDomainV1(),
 			"huaweicloud_waf_reference_table":             waf.ResourceWafReferenceTableV1(),
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Support create EBL mode WAF dedicated instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1592

**Special notes for your reviewer**:

This PR depends on: #1628, pls merge it first.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_basic
=== PAUSE TestAccWafDedicatedInstance_basic
=== RUN   TestAccWafDedicatedInstance_elb_model
=== PAUSE TestAccWafDedicatedInstance_elb_model
=== CONT  TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_elb_model
--- PASS: TestAccWafDedicatedInstance_elb_model (354.64s)
--- PASS: TestAccWafDedicatedInstance_basic (410.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       410.836s
```
