### PR TITLE
feat(waf/instance): add group_id attribute in data source huaweicloud_waf_dedicated_instances

### DIFF
--- a/docs/data-sources/waf_dedicated_instances.md
+++ b/docs/data-sources/waf_dedicated_instances.md
@@ -70,3 +70,5 @@ The `instances` block supports:
 * `access_status` - The access status of the instance. `0`: inaccessible, `1`: accessible.
 
 * `upgradable` - The instance is to support upgrades. `0`: Cannot be upgraded, `1`: Can be upgraded.
+
+* `group_id` - The instance group ID used by the WAF dedicated instance in ELB mode.

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_instances_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_instances_test.go
@@ -5,28 +5,28 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
-func TestAccDataSourceWafDedicatedInstancesV1_basic(t *testing.T) {
+func TestAccDataSourceWafDedicatedInstances_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceName1 := "data.huaweicloud_waf_dedicated_instances.instance_1"
 	resourceName2 := "data.huaweicloud_waf_dedicated_instances.instance_2"
+
+	dc := acceptance.InitDataSourceCheck(resourceName1)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers: acceptance.TestAccProviders,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafDedicatedInstancesV1_conf(name),
+				Config: testAccWafDedicatedInstances_conf(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceWafDedicatedInstanceV1Exists(resourceName1),
-
+					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName1, "name", name),
 					resource.TestCheckResourceAttr(resourceName1, "instances.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName1, "instances.0.available_zone"),
@@ -50,20 +50,7 @@ func TestAccDataSourceWafDedicatedInstancesV1_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceWafDedicatedInstanceV1Exists(r string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[r]
-		if !ok {
-			return fmtp.Errorf("Can't find WAF dedicated instance data source: %s.", r)
-		}
-		if rs.Primary.ID == "" {
-			return fmtp.Errorf("The WAF dedicated instance data source ID not set.")
-		}
-		return nil
-	}
-}
-
-func testAccWafDedicatedInstancesV1_conf(name string) string {
+func testAccWafDedicatedInstances_conf(name string) string {
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We need to query group id of WAF dedicated instance in ELB mode.
Please add the group_id attribute to the data source huaweicloud_waf_dedicated_instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1639

**Special notes for your reviewer**:

This PR depends on: #1628 and #1638 pls merge them first.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafDedicatedInstances'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafDedicatedInstances -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafDedicatedInstances_basic
=== PAUSE TestAccDataSourceWafDedicatedInstances_basic
=== CONT  TestAccDataSourceWafDedicatedInstances_basic
--- PASS: TestAccDataSourceWafDedicatedInstances_basic (306.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       306.247s
```
