### PR TITLE
Deprecate vpc_route and vpc_route_ids data source

### DIFF
--- a/docs/data-sources/vpc_route.md
+++ b/docs/data-sources/vpc_route.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud_vpc_route
+
+!> **WARNING:** It has been deprecated, use `huaweicloud_vpc_route_table` to get the route details.
 
 Provides details about a specific VPC route. This is an alternative to `huaweicloud_vpc_route_v2`
 

--- a/docs/data-sources/vpc_route_ids.md
+++ b/docs/data-sources/vpc_route_ids.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud_vpc_route_ids
+
+!> **WARNING:** It has been deprecated, use `huaweicloud_vpc_route_table` to get the route details.
 
 Provides a list of route ids for a vpc_id. This is an alternative to `huaweicloud_vpc_route_ids_v2`
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -340,8 +340,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eip":                              vpc.DataSourceVpcEip(),
 			"huaweicloud_vpc_ids":                              vpc.DataSourceVpcIdsV1(),
 			"huaweicloud_vpc_peering_connection":               vpc.DataSourceVpcPeeringConnectionV2(),
-			"huaweicloud_vpc_route":                            vpc.DataSourceVpcRouteV2(),
-			"huaweicloud_vpc_route_ids":                        vpc.DataSourceVpcRouteIdsV2(),
 			"huaweicloud_vpc_route_table":                      vpc.DataSourceVPCRouteTable(),
 			"huaweicloud_vpc_subnet":                           vpc.DataSourceVpcSubnetV1(),
 			"huaweicloud_vpc_subnet_ids":                       vpc.DataSourceVpcSubnetIdsV1(),
@@ -363,8 +361,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_v1":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpc_ids_v1":                vpc.DataSourceVpcIdsV1(),
 			"huaweicloud_vpc_peering_connection_v2": vpc.DataSourceVpcPeeringConnectionV2(),
-			"huaweicloud_vpc_route_v2":              vpc.DataSourceVpcRouteV2(),
-			"huaweicloud_vpc_route_ids_v2":          vpc.DataSourceVpcRouteIdsV2(),
 			"huaweicloud_vpc_subnet_v1":             vpc.DataSourceVpcSubnetV1(),
 			"huaweicloud_vpc_subnet_ids_v1":         vpc.DataSourceVpcSubnetIdsV1(),
 			"huaweicloud_cce_cluster_v3":            DataSourceCCEClusterV3(),
@@ -385,6 +381,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_role_v3":          iam.DataSourceIdentityRoleV3(),
 			"huaweicloud_cdm_flavors_v1":            DataSourceCdmFlavorV1(),
 			"huaweicloud_dis_partition_v2":          DataSourceDisPartitionV2(),
+
+			// Deprecated ongoing (without DeprecationMessage), used by other providers
+			"huaweicloud_vpc_route":        vpc.DataSourceVpcRouteV2(),
+			"huaweicloud_vpc_route_ids":    vpc.DataSourceVpcRouteIdsV2(),
+			"huaweicloud_vpc_route_v2":     vpc.DataSourceVpcRouteV2(),
+			"huaweicloud_vpc_route_ids_v2": vpc.DataSourceVpcRouteIdsV2(),
 
 			// Deprecated
 			"huaweicloud_compute_availability_zones_v2": dataSourceComputeAvailabilityZonesV2(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_ids_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_ids_test.go
@@ -16,7 +16,9 @@ func TestAccVpcRouteIdsDataSource_basic(t *testing.T) {
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheckDeprecated(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_test.go
@@ -16,7 +16,9 @@ func TestAccVpcRouteDataSource_basic(t *testing.T) {
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheckDeprecated(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**huaweicloud_vpc_route** and **huaweicloud_vpc_route_ids** have many limitations to use, and we can get the route details with `huaweicloud_vpc_route_table`, so make them as deprecated.
 
**Note:** As they are used by other cloud providers, the `DeprecationMessage` will be added later.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

- without deprecated environment
```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteDataSource_basic
=== PAUSE TestAccVpcRouteDataSource_basic
=== CONT  TestAccVpcRouteDataSource_basic
    acceptance.go:290: This environment does not support deprecated tests
--- SKIP: TestAccVpcRouteDataSource_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       0.059s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteIdsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteIdsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteIdsDataSource_basic
=== PAUSE TestAccVpcRouteIdsDataSource_basic
=== CONT  TestAccVpcRouteIdsDataSource_basic
    acceptance.go:290: This environment does not support deprecated tests
--- SKIP: TestAccVpcRouteIdsDataSource_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       0.051s
```

- with deprecated environment
```$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteDataSource_basic
=== PAUSE TestAccVpcRouteDataSource_basic
=== CONT  TestAccVpcRouteDataSource_basic

--- PASS: TestAccVpcRouteDataSource_basic (78.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       78.844s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteIdsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteIdsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteIdsDataSource_basic
=== PAUSE TestAccVpcRouteIdsDataSource_basic
=== CONT  TestAccVpcRouteIdsDataSource_basic
--- PASS: TestAccVpcRouteIdsDataSource_basic (76.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       77.016s


```
