### PR TITLE
fix: retrieve the default route table if name was not specified

### DIFF
--- a/docs/data-sources/vpc_route_table.md
+++ b/docs/data-sources/vpc_route_table.md
@@ -11,7 +11,13 @@ Provides details about a specific VPC route table.
 ```hcl
 variable "vpc_id" {}
 
-data "huaweicloud_vpc_route_table" "rtb" {
+# get the default route table
+data "huaweicloud_vpc_route_table" "default" {
+  vpc_id = var.vpc_id
+}
+
+# get a custom route table
+data "huaweicloud_vpc_route_table" "custom" {
   vpc_id = var.vpc_id
   name   = "demo"
 }

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_route_table.go
@@ -112,11 +112,13 @@ func dataSourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta
 			}
 		}
 	} else {
-		if len(allRouteTables) > 1 {
-			return fmtp.DiagErrorf("Your query returned more than one result. " +
-				"Please try a more specific search criteria.")
+		// find the default route table if name was not specified
+		for _, rtb := range allRouteTables {
+			if rtb.Default {
+				rtbID = rtb.ID
+				break
+			}
 		}
-		rtbID = allRouteTables[0].ID
 	}
 
 	if rtbID == "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

If `name` was not specified, try to retrieve the default route table.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteTableDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteTableDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTableDataSource_basic
=== PAUSE TestAccVpcRouteTableDataSource_basic
=== CONT  TestAccVpcRouteTableDataSource_basic
--- PASS: TestAccVpcRouteTableDataSource_basic (125.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       125.302s

```
