### PR TITLE
feat(vpc): support description field in resource and data source

### DIFF
--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -21,16 +21,15 @@ data "huaweicloud_vpc" "vpc" {
 The arguments of this data source act as filters for querying the available VPCs in the current region. The given
 filters must match exactly one VPC whose data will be exported as attributes.
 
-* `region` - (Optional, String) Specifies the region in which to obtain the vpc. If omitted, the provider-level region
+* `region` - (Optional, String) Specifies the region in which to obtain the VPC. If omitted, the provider-level region
   will be used.
+
+* `name` - (Optional, String) Specifies an unique name for the VPC. The value is a string of no more than 64 characters
+  and can contain digits, letters, underscores (_), and hyphens (-).
 
 * `id` - (Optional, String) Specifies the id of the VPC to retrieve.
 
-* `status` - (Optional, String) Specifies the current status of the desired VPC. Can be either CREATING, OK, DOWN,
-  PENDING_UPDATE, PENDING_DELETE, or ERROR.
-
-* `name` - (Optional, String) Specifies an unique name for the VPC. The name must be unique for a tenant. The value is a
-  string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-).
+* `status` - (Optional, String) Specifies the current status of the desired VPC. The value can be CREATING, OK or ERROR.
 
 * `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
 
@@ -38,4 +37,7 @@ filters must match exactly one VPC whose data will be exported as attributes.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `routes` - The list of route information with destination and nexthop fields.
+* `description` - The supplementary information about the VPC. The value is a string of
+  no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `tags` - The key/value pairs to associate with the VPC.

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -37,37 +37,30 @@ resource "huaweicloud_vpc" "vpc_with_tags" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the vpc resource. If omitted, the
-  provider-level region will be used. Changing this creates a new resource. Changing this creates a new vpc resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC. If omitted, the
+  provider-level region will be used. Changing this creates a new VPC resource.
+
+* `name` - (Required, String) Specifies the name of the VPC. The name must be unique for a tenant. The value is a string
+  of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-).
 
 * `cidr` - (Required, String) Specifies the range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to
   10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
 
-* `name` - (Required, String) Specifies the name of the VPC. The name must be unique for a tenant. The value is a string
-  of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-). Changing this updates
-  the name of the existing VPC.
+* `description` - (Optional, String) Specifies supplementary information about the VPC. The value is a string of
+  no more than 255 characters and cannot contain angle brackets (< or >).
 
-* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the vpc.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the VPC.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the vpc. Changing this
-  creates a new vpc.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the VPC. Changing this
+  creates a new VPC resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the VPC.
+* `id` - The VPC ID in UUID format.
 
-* `status` - The current status of the desired VPC. Can be either CREATING, OK, DOWN, PENDING_UPDATE, PENDING_DELETE, or
-  ERROR.
-
-* `routes` - The route information. Structure is documented below.
-
-The `routes` block contains:
-
-* `destination` - The destination network segment of a route.
-
-* `nexthop` - The next hop of a route.
+* `status` - The current status of the VPC. Possible values are as follows: CREATING, OK or ERROR.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e
+	github.com/chnsz/golangsdk v0.0.0-20211026080201-2a5668b22f37
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/chnsz/golangsdk v0.0.0-20211011034408-8066461493b8 h1:yTKPNdmNyQjLHr+
 github.com/chnsz/golangsdk v0.0.0-20211011034408-8066461493b8/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e h1:Rhy/5nOHqwRDUy5SsquUPIPfFrY9vDOynuu5W938P7w=
 github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20211026080201-2a5668b22f37 h1:pMDjiFlRojqAnVJA6HfLKqI3Hc0s0rJe4xdhPwzAIsU=
+github.com/chnsz/golangsdk v0.0.0-20211026080201-2a5668b22f37/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test.go
@@ -111,8 +111,8 @@ func testAccDataSourceVpc_byCidr(rName, cidr string) string {
 %s
 
 data "huaweicloud_vpc" "test" {
-	cidr = huaweicloud_vpc.test.cidr
-  }
+  cidr = huaweicloud_vpc.test.cidr
+}
 `, testAccDataSourceVpc_base(rName, cidr))
 }
 
@@ -121,7 +121,7 @@ func testAccDataSourceVpc_byName(rName, cidr string) string {
 %s
 
 data "huaweicloud_vpc" "test" {
-	name = huaweicloud_vpc.test.name
-  }
+  name = huaweicloud_vpc.test.name
+}
 `, testAccDataSourceVpc_base(rName, cidr))
 }

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -32,6 +32,7 @@ func TestAccVpcV1_basic(t *testing.T) {
 					testAccCheckVpcV1Exists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
 					resource.TestCheckResourceAttr(resourceName, "status", "OK"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
@@ -42,6 +43,7 @@ func TestAccVpcV1_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcV1Exists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by acc test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_updated"),
 				),
@@ -195,8 +197,9 @@ func testAccCheckVpcV1Exists(n string, vpc *vpcs.Vpc) resource.TestCheckFunc {
 func testAccVpcV1_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
-  name = "%s"
-  cidr = "192.168.0.0/16"
+  name        = "%s"
+  cidr        = "192.168.0.0/16"
+  description = "created by acc test"
 
   tags = {
     foo = "bar"
@@ -209,8 +212,9 @@ resource "huaweicloud_vpc" "test" {
 func testAccVpcV1_update(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
-  name = "%s"
-  cidr ="192.168.0.0/16"
+  name        = "%s"
+  cidr        ="192.168.0.0/16"
+  description = "updated by acc test"
 
   tags = {
     foo1 = "bar"

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
@@ -1,16 +1,21 @@
 package vpc
 
 import (
+	"context"
+
+	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceVpcV1() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceVpcV1Read,
+		ReadContext: dataSourceVpcV1Read,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -38,13 +43,19 @@ func DataSourceVpcV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"shared": {
-				Type:     schema.TypeBool,
-				Optional: true,
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"routes": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "use huaweicloud_vpc_route_table data source to get all routes",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"destination": {
@@ -62,11 +73,11 @@ func DataSourceVpcV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcV1Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{
@@ -77,27 +88,36 @@ func dataSourceVpcV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	epsID := config.GetEnterpriseProjectID(d)
-
 	if epsID != "" {
 		listOpts.EnterpriseProjectID = epsID
 	}
 
 	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve vpcs: %s", err)
+		return fmtp.DiagErrorf("Unable to retrieve vpcs: %s", err)
 	}
 
 	if len(refinedVpcs) < 1 {
-		return fmtp.Errorf("Your query returned no results. " +
+		return fmtp.DiagErrorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(refinedVpcs) > 1 {
-		return fmtp.Errorf("Your query returned more than one result." +
+		return fmtp.DiagErrorf("Your query returned more than one result." +
 			" Please try a more specific search criteria")
 	}
 
 	Vpc := refinedVpcs[0]
+
+	logp.Printf("[INFO] Retrieved Vpc using given filter %s: %+v", Vpc.ID, Vpc)
+	d.SetId(Vpc.ID)
+
+	d.Set("region", config.GetRegion(d))
+	d.Set("name", Vpc.Name)
+	d.Set("cidr", Vpc.CIDR)
+	d.Set("enterprise_project_id", Vpc.EnterpriseProjectID)
+	d.Set("status", Vpc.Status)
+	d.Set("description", Vpc.Description)
 
 	var s []map[string]interface{}
 	for _, route := range Vpc.Routes {
@@ -107,18 +127,18 @@ func dataSourceVpcV1Read(d *schema.ResourceData, meta interface{}) error {
 		}
 		s = append(s, mapping)
 	}
+	d.Set("routes", s)
 
-	logp.Printf("[INFO] Retrieved Vpc using given filter %s: %+v", Vpc.ID, Vpc)
-	d.SetId(Vpc.ID)
-
-	d.Set("name", Vpc.Name)
-	d.Set("cidr", Vpc.CIDR)
-	d.Set("enterprise_project_id", Vpc.EnterpriseProjectID)
-	d.Set("status", Vpc.Status)
-	d.Set("id", Vpc.ID)
-	d.Set("region", config.GetRegion(d))
-	if err := d.Set("routes", s); err != nil {
-		return err
+	// save VirtualPrivateCloudV2 tags
+	if vpcV2Client, err := config.NetworkingV2Client(config.GetRegion(d)); err == nil {
+		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
+			tagmap := utils.TagsToMap(resourceTags.Tags)
+			if err := d.Set("tags", tagmap); err != nil {
+				return fmtp.DiagErrorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+			}
+		} else {
+			logp.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/requests.go
@@ -115,6 +115,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	Name                string `json:"name,omitempty"`
 	CIDR                string `json:"cidr,omitempty"`
+	Description         string `json:"description,omitempty"`
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }
 
@@ -156,9 +157,10 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a vpc.
 type UpdateOpts struct {
-	CIDR             string `json:"cidr,omitempty"`
-	Name             string `json:"name,omitempty"`
-	EnableSharedSnat *bool  `json:"enable_shared_snat,omitempty"`
+	Name             string  `json:"name,omitempty"`
+	CIDR             string  `json:"cidr,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	EnableSharedSnat *bool   `json:"enable_shared_snat,omitempty"`
 }
 
 // ToVpcUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/results.go
@@ -27,6 +27,9 @@ type Vpc struct {
 	// unique.
 	Name string `json:"name"`
 
+	// Description provides supplementary information about the VPC
+	Description string `json:"description"`
+
 	//Specifies the range of available subnets in the VPC.
 	CIDR string `json:"cidr"`
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e
+# github.com/chnsz/golangsdk v0.0.0-20211026080201-2a5668b22f37
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- add `description` field
- deprecate `routes` field

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== CONT  TestAccVpcDataSource_basic
--- PASS: TestAccVpcDataSource_basic (52.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       52.098s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1_basic (85.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       85.699s
```
