### PR TITLE
feat(ecs/instance): add new data source for multiple instance obtains

### DIFF
--- a/docs/data-sources/compute_instances.md
+++ b/docs/data-sources/compute_instances.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Elastic Cloud Server (ECS)"
+---
+
+# huaweicloud_compute_instances
+
+Use this data source to get the list of the compute instances.
+
+## Example Usage
+
+```hcl
+variable "name_regex" {}
+
+data "huaweicloud_compute_instances" "test" {
+  name = var.name_regex
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the instances.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the instance name, which can be queried with a regular expression.
+  The instance name supports fuzzy matching query too.
+
+* `flavor_name` - (Optional, String) Specifies the flavor name of the instance.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+* `status` - (Optional, String) Specifies the status of the instance. The valid values are as follows:
+  + **ACTIVE**: The instance is running properly.
+  + **SHUTOFF**: The instance has been properly stopped.
+  + **ERROR**: An error has occurred on the instance.
+
+* `image_id` - (Optional, String) Specifies the image ID of the instance.
+
+* `flavor_id` - (Optional, String) Specifies the flavor ID.
+
+* `availability_zone` - (Optional, String) Specifies the availability zone where the instance is located.
+  Please following [reference](https://developer.huaweicloud.com/intl/en-us/endpoint?ECS) for this argument.
+
+* `key_pair` - (Optional, String) Specifies the key pair that is used to authenticate the instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `instances` - List of ECS instance details. The object structure of each ECS instance is documented below.
+
+The `instances` block supports:
+
+* `id` - The instance ID in UUID format.
+
+* `name` - The instance name.
+
+* `image_id` - The image ID of the instance.
+
+* `flavor_id` - The flavor ID.
+
+* `flavor_name` - The flavor name of the instance.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `status` - The instance status.
+
+* `availability_zone` - The availability zone where the instance is located.
+
+* `key_pair` - The key pair that is used to authenticate the instance.
+
+* `security_group_ids` - An array of one or more security group IDs to associate with the instance.
+
+* `user_data` - The user data (information after encoding) configured during instance creation.
+
+* `volume_attached` - An array of one or more disks to attach to the instance. The object structure is documented below.
+
+* `scheduler_hints` - The scheduler with hints on how the instance should be launched.
+  The object structure is documented below.
+
+* `tags` - The key/value pairs to associate with the instance.
+
+The `volume_attached` block supports:
+
+* `volume_id` - The volume id on that attachment.
+
+* `is_sys_volume` - Whether the volume is the system disk.
+
+The `scheduler_hints` block supports:
+
+* `group` - The UUID of a server group where the instance will be placed into.

--- a/huaweicloud/data_source_huaweicloud_compute_instances.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances.go
@@ -1,0 +1,310 @@
+package huaweicloud
+
+import (
+	"context"
+	"strings"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func DataSourceComputeInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceComputeInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"flavor_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"key_pair": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"flavor_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"flavor_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_pair": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"user_data": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"volume_attached": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"volume_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"is_sys_volume": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"scheduler_hints": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"group": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEcsListOptsWithoutIP(d *schema.ResourceData, conf *config.Config) *cloudservers.ListOpts {
+	result := cloudservers.ListOpts{
+		Limit:               100,
+		EnterpriseProjectID: GetEnterpriseProjectID(d, conf),
+		Name:                d.Get("name").(string),
+		Flavor:              d.Get("flavor_id").(string),
+		Status:              d.Get("status").(string),
+	}
+
+	return &result
+}
+
+func filterCloudServers(d *schema.ResourceData, servers []cloudservers.CloudServer) ([]cloudservers.CloudServer,
+	[]string) {
+	result := make([]cloudservers.CloudServer, 0, len(servers))
+	ids := make([]string, 0, len(servers))
+
+	for _, server := range servers {
+		if flavorName, ok := d.GetOk("flavor_name"); ok && flavorName != server.Flavor.Name {
+			continue
+		}
+		if iamgeId, ok := d.GetOk("image_id"); ok && iamgeId != server.Image.ID {
+			continue
+		}
+		if az, ok := d.GetOk("availability_zone"); ok && az != server.AvailabilityZone {
+			continue
+		}
+		if keypair, ok := d.GetOk("key_pair"); ok && keypair != server.KeyName {
+			continue
+		}
+		result = append(result, server)
+		ids = append(ids, server.ID)
+	}
+
+	return result, ids
+}
+
+func queryEcsInstances(client *golangsdk.ServiceClient, opt *cloudservers.ListOpts) ([]cloudservers.CloudServer, error) {
+	pages, err := cloudservers.List(client, opt).AllPages()
+	if err != nil {
+		return []cloudservers.CloudServer{}, fmtp.Errorf("Error getting cloud servers: %s", err)
+	}
+	return cloudservers.ExtractServers(pages)
+}
+
+func dataSourceComputeInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	ecsClient, err := conf.ComputeV1Client(GetRegion(d, conf))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud ECS v1 client: %s", err)
+	}
+
+	opt := buildEcsListOptsWithoutIP(d, conf)
+
+	allServers, err := queryEcsInstances(ecsClient, opt)
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve cloud servers: %s", err)
+	}
+
+	servers, ids := filterCloudServers(d, allServers)
+	// Save the data source ID using a hash code constructed using all instance IDs.
+	d.SetId(hashcode.Strings(ids))
+
+	return setComputeInstancesParams(d, conf, servers)
+}
+
+func IsSystemVolume(index string) bool {
+	if index == "0" {
+		return true
+	}
+	return false
+}
+
+func parseEcsInstanceSecurityGroupIds(groups []cloudservers.SecurityGroups) []string {
+	result := make([]string, len(groups))
+
+	for i, sg := range groups {
+		result[i] = sg.ID
+	}
+
+	return result
+}
+
+func parseEcsInstanceSchedulerHintInfo(hints cloudservers.OsSchedulerHints) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(hints.Group))
+
+	for i, val := range hints.Group {
+		result[i] = map[string]interface{}{
+			"group": val,
+		}
+	}
+
+	return result
+}
+
+func parseEcsInstanceVolumeAttachedInfo(attachList []cloudservers.VolumeAttached) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(attachList))
+
+	for i, volume := range attachList {
+		result[i] = map[string]interface{}{
+			"volume_id":     volume.ID,
+			"is_sys_volume": IsSystemVolume(volume.BootIndex),
+		}
+	}
+
+	return result
+}
+
+func parseEcsInstanceTagInfo(tags []string) map[string]interface{} {
+	result := map[string]interface{}{}
+	for _, tag := range tags {
+		kv := strings.SplitN(tag, "=", 2)
+		if len(kv) != 2 {
+			logp.Printf("[WARN] Invalid key/value format of tag: %s", tag)
+			continue
+		}
+		result[kv[0]] = kv[1]
+	}
+
+	return result
+}
+
+func setComputeInstancesParams(d *schema.ResourceData, config *config.Config,
+	servers []cloudservers.CloudServer) diag.Diagnostics {
+	result := make([]map[string]interface{}, len(servers))
+
+	for i, val := range servers {
+		server := map[string]interface{}{
+			"id":                    val.ID,
+			"user_data":             val.UserData,
+			"name":                  val.Name,
+			"flavor_name":           val.Flavor.Name,
+			"status":                val.Status,
+			"enterprise_project_id": val.EnterpriseProjectID,
+			"flavor_id":             val.Flavor.ID,
+			"image_id":              val.Image.ID,
+			"availability_zone":     val.AvailabilityZone,
+			"key_pair":              val.KeyName,
+		}
+
+		server["security_group_ids"] = parseEcsInstanceSecurityGroupIds(val.SecurityGroups)
+
+		if len(val.OsSchedulerHints.Group) > 0 {
+			server["scheduler_hints"] = parseEcsInstanceSchedulerHintInfo(val.OsSchedulerHints)
+		}
+
+		if len(val.VolumeAttached) > 0 {
+			server["volume_attached"] = parseEcsInstanceVolumeAttachedInfo(val.VolumeAttached)
+		}
+
+		if len(val.Tags) > 0 {
+			server["tags"] = parseEcsInstanceTagInfo(val.Tags)
+		}
+
+		result[i] = server
+	}
+
+	if err := d.Set("instances", result); err != nil {
+		return fmtp.DiagErrorf("Error setting cloud server list: %s", err)
+	}
+	return nil
+}

--- a/huaweicloud/data_source_huaweicloud_compute_instances_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances_test.go
@@ -1,0 +1,86 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccComputeInstancesDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.huaweicloud_compute_instances.test"
+	var instance servers.Server
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstancesDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
+					testAccCheckComputeInstancesDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "instances.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.image_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.flavor_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.availability_zone"),
+					resource.TestCheckResourceAttr(dataSourceName, "instances.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "instances.0.security_group_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeInstancesDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Can't find compute instances data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("Data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeInstancesDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = data.huaweicloud_vpc_subnet.test.id
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+data "huaweicloud_compute_instances" "test" {
+  name = huaweicloud_compute_instance.test.name
+}
+`, testAccCompute_data, rName)
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -284,6 +284,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdm_flavors":                          DataSourceCdmFlavorV1(),
 			"huaweicloud_compute_flavors":                      DataSourceEcsFlavors(),
 			"huaweicloud_compute_instance":                     DataSourceComputeInstance(),
+			"huaweicloud_compute_instances":                    DataSourceComputeInstances(),
 			"huaweicloud_csbs_backup":                          dataSourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy":                   dataSourceCSBSBackupPolicyV1(),
 			"huaweicloud_dcs_az":                               deprecated.DataSourceDcsAZV1(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data-source to provide a new way to obtain a list of ECS instances.

**Which issue this PR fixes**:
fixes #1611

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data-source, related document and test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstancesDataSource_basic
=== PAUSE TestAccComputeInstancesDataSource_basic
=== CONT  TestAccComputeInstancesDataSource_basic
--- PASS: TestAccComputeInstancesDataSource_basic (177.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       178.074s
```
