### PR TITLE
fix(utils): fix the wrong function name where utils is located

### DIFF
--- a/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
+++ b/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
@@ -105,7 +105,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 		"OsExtraSpecs.CPUArch": d.Get("cpu_arch"),
 	}
 
-	filterFlavors, err := utils.FliterSliceWithField(allFlavors, filter)
+	filterFlavors, err := utils.FilterSliceWithField(allFlavors, filter)
 	if err != nil {
 		return fmtp.DiagErrorf("filter BMS flavors failed: %s", err)
 	}

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_maintainwindow.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_maintainwindow.go
@@ -60,7 +60,7 @@ func dataSourceDcsMaintainWindowRead(_ context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	filteredMVs, err := utils.FliterSliceWithField(v.MaintainWindows, map[string]interface{}{
+	filteredMVs, err := utils.FilterSliceWithField(v.MaintainWindows, map[string]interface{}{
 		"ID":      d.Get("seq").(int),
 		"Begin":   d.Get("begin").(string),
 		"End":     d.Get("end").(string),

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
@@ -81,7 +81,7 @@ func dataSourceWafReferenceTablesRead(d *schema.ResourceData, meta interface{}) 
 		return fmtp.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 	// filter data by name
-	filterData, err := utils.FliterSliceWithField(r.Items, map[string]interface{}{
+	filterData, err := utils.FilterSliceWithField(r.Items, map[string]interface{}{
 		"Name": d.Get("name").(string),
 	})
 	tables := make([]map[string]interface{}, 0, len(filterData))

--- a/huaweicloud/utils/filter.go
+++ b/huaweicloud/utils/filter.go
@@ -13,19 +13,19 @@ const (
 	matchRuleByNumGt = 1  // number value match by : greater than
 )
 
-// FliterSliceWithField can filter the slice all through a map filter.
+// FilterSliceWithField can filter the slice all through a map filter.
 // If the field is a nested value, using dot(.) to split them, e.g. "SubBlock.SubField".
 // If value in the map is zero, it will be ignored.
-func FliterSliceWithField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
-	return fliterSliceWithFieldRaw(all, filter, true)
+func FilterSliceWithField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
+	return filterSliceWithFieldRaw(all, filter, true)
 }
 
-// FliterSliceWithZeroField can filter the slice all through a map filter.
-func FliterSliceWithZeroField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
-	return fliterSliceWithFieldRaw(all, filter, false)
+// FilterSliceWithZeroField can filter the slice all through a map filter.
+func FilterSliceWithZeroField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
+	return filterSliceWithFieldRaw(all, filter, false)
 }
 
-func fliterSliceWithFieldRaw(all interface{}, filter map[string]interface{}, ignoreZero bool) ([]interface{}, error) {
+func filterSliceWithFieldRaw(all interface{}, filter map[string]interface{}, ignoreZero bool) ([]interface{}, error) {
 	var result []interface{}
 	var matched bool
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The name of the public funtion `FliterSliceWithField` is wrong.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rename the public function `FliterSliceWithField` to `FilterSliceWithField`.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
