### PR TITLE
fix: normalize the value of EIP status

### DIFF
--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_eip_test.go
@@ -24,9 +24,9 @@ func TestAccVpcEipDataSource_basic(t *testing.T) {
 				Config: testAccDataSourceVpcEipConfig_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "status", "DOWN"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "UNBOUND"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "5_bgp"),
-					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_size", "8"),
+					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_size", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_share_type", "PER"),
 				),
 			},
@@ -42,7 +42,7 @@ resource "huaweicloud_vpc_eip" "test" {
   }
   bandwidth {
     name        = "%s"
-    size        = 8
+    size        = 5
     share_type  = "PER"
     charge_mode = "traffic"
   }

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eip.go
@@ -98,9 +98,9 @@ func dataSourceVpcEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(Eip.ID)
 	d.Set("region", config.GetRegion(d))
+	d.Set("status", NormalizeEIPStatus(Eip.Status))
 	d.Set("public_ip", Eip.PublicAddress)
 	d.Set("port_id", Eip.PortID)
-	d.Set("status", Eip.Status)
 	d.Set("type", Eip.Type)
 	d.Set("private_ip", Eip.PrivateAddress)
 	d.Set("bandwidth_id", Eip.BandwidthID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

the status of **data.huaweicloud_vpc_eip** is not normalized, so fix it.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcEipDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcEipDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEipDataSource_basic (54.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       54.761s
```
