### PR TITLE
fix(validation): fix wrong regular expressions

### DIFF
--- a/huaweicloud/resource_huaweicloud_cci_pvc.go
+++ b/huaweicloud/resource_huaweicloud_cci_pvc.go
@@ -73,9 +73,12 @@ func ResourceCCIPersistentVolumeClaimV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"),
-					"The name consists of 1 to 63 characters, including lowercase letters, digits and hyphens, "+
-						"and must start and end with lowercase letters and digits"),
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`),
+						"The name can only consist of lowercase letters, numbers, and hyphens (-), "+
+							"and it must start and end with a letter or digit."),
+					validation.StringLenBetween(1, 63),
+				),
 			},
 			"volume_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_pvc.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_pvc.go
@@ -74,9 +74,12 @@ func ResourceCcePersistentVolumeClaimsV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"),
-					"The name consists of 1 to 63 characters, including lowercase letters, digits and hyphens, "+
-						"and must start and end with lowercase letters and digits"),
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`),
+						"The name can only consist of lowercase letters, numbers, and hyphens (-), "+
+							"and it must start and end with a letter or digit."),
+					validation.StringLenBetween(1, 63),
+				),
 			},
 			"access_modes": {
 				Type:     schema.TypeSet,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The verification rules for CCE and CCI pvc names are wrong.
The `"^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"` seems 2 to 63 characters, not 1 to 63 characters.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
