### PR TITLE
fix(cce): fix a nil pointer bug in cce node and node pool

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -445,7 +445,9 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 		volume["hw_passthrough"] = pairObject.HwPassthrough
 		volume["extend_params"] = pairObject.ExtendParam
 		volume["extend_param"] = ""
-		volume["kms_key_id"] = pairObject.Metadata.SystemCmkid
+		if pairObject.Metadata != nil {
+			volume["kms_key_id"] = pairObject.Metadata.SystemCmkid
+		}
 		volumes = append(volumes, volume)
 	}
 	if err := d.Set("data_volumes", volumes); err != nil {

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -693,7 +693,9 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 		volume["hw_passthrough"] = pairObject.HwPassthrough
 		volume["extend_params"] = pairObject.ExtendParam
 		volume["extend_param"] = ""
-		volume["kms_key_id"] = pairObject.Metadata.SystemCmkid
+		if pairObject.Metadata != nil {
+			volume["kms_key_id"] = pairObject.Metadata.SystemCmkid
+		}
 		volumes = append(volumes, volume)
 	}
 	if err := d.Set("data_volumes", volumes); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix a nil pointer bug in cce node and node pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix a nil pointer bug in cce node and node pool
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (761.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       761.182s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1375.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1375.327s
```
