### PR TITLE
fix(elb): set computed to true for l4_flavor_id and l7_flavor_id in schema

### DIFF
--- a/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -137,11 +138,13 @@ func ResourceLoadBalancerV3() *schema.Resource {
 			"l4_flavor_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"l7_flavor_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"name": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When creating an ELB instance, if neither `l4_flavor_id` nor `l7_flavor_id` is set, the server will set the default value. 
If the `computed ` value is not set to true in the schema, the Terraform will prompt the resource to change when it is apply/plan next time. 

So, set computed to true for l4_flavor_id and l7_flavor_id in the schema. And move the code file to the service path, including `resource_huaweicloud_elb_listener.go` that has a reference relationship.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1633

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/elb' TESTARGS='-run TestAccElbV3LoadBalancer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccElbV3LoadBalancer -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEpsId (62.61s)
--- PASS: TestAccElbV3LoadBalancer_basic (102.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       102.196s

```


