### PR TITLE
refactor(data/ecs): refactor data source of compute instance

### DIFF
--- a/huaweicloud/data_source_huaweicloud_compute_instances.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances.go
@@ -146,7 +146,7 @@ func DataSourceComputeInstances() *schema.Resource {
 	}
 }
 
-func buildEcsListOptsWithoutIP(d *schema.ResourceData, conf *config.Config) *cloudservers.ListOpts {
+func buildListOptsWithoutIP(d *schema.ResourceData, conf *config.Config) *cloudservers.ListOpts {
 	result := cloudservers.ListOpts{
 		Limit:               100,
 		EnterpriseProjectID: GetEnterpriseProjectID(d, conf),
@@ -198,7 +198,7 @@ func dataSourceComputeInstancesRead(_ context.Context, d *schema.ResourceData, m
 		return fmtp.DiagErrorf("Error creating HuaweiCloud ECS v1 client: %s", err)
 	}
 
-	opt := buildEcsListOptsWithoutIP(d, conf)
+	opt := buildListOptsWithoutIP(d, conf)
 
 	allServers, err := queryEcsInstances(ecsClient, opt)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
With the submission of #1645, there is redundancy between codes of `huaweicloud_compute_instance` and  `huaweicloud_compute_instances`, and functions design of `huaweicloud_compute_instance` gradually does not meet the current standards.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
depend on: #1645 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. improve code reuse.
2. refactor parameter setting and parameter analysis functions.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (186.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       186.169s
```
