### PR TITLE
feat(waf/group): add a resource to manage ELB instances bound to the WAF instance group

### DIFF
--- a/docs/resources/waf_instance_group_associcate.md
+++ b/docs/resources/waf_instance_group_associcate.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_instance_group_associate
+
+Associate ELB instances to a WAF instance group.
+
+## Example Usage
+
+```hcl
+variable "group_id" {}
+variable "elb_instance_id" {}
+
+resource "huaweicloud_waf_instance_group_associate" "group_associate" {
+  group_id      = group_id
+  load_balances = [elb_instance_id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which the WAF instance group created.
+  If omitted, the provider-level region will be used. Changing this setting will create a new resource.
+
+* `group_id` - (Required, String, ForceNew) Specifies the ID of instance group.
+  Changing this will create a new instance.
+
+* `load_balances` - (Required, List) Specifies the IDs of the ELB instances bound to the instance group.
+  This is an array of security group ids.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID in UUID format.
+
+## Import
+
+The instance group associate can be imported using the group ID, e.g.:
+
+```sh
+terraform import huaweicloud_waf_instance_group_associate.group_associate 0be1e69d-1987-4d9c-9dc5-fc7eed592398
+```

--- a/docs/resources/waf_instance_group_associcate.md
+++ b/docs/resources/waf_instance_group_associcate.md
@@ -13,8 +13,8 @@ variable "group_id" {}
 variable "elb_instance_id" {}
 
 resource "huaweicloud_waf_instance_group_associate" "group_associate" {
-  group_id      = group_id
-  load_balances = [elb_instance_id]
+  group_id       = var.group_id
+  load_balancers = [var.elb_instance_id]
 }
 ```
 
@@ -26,10 +26,10 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this setting will create a new resource.
 
 * `group_id` - (Required, String, ForceNew) Specifies the ID of the WAF instance group.
-  Changing this will create a new instance.
+  Changing this will create a new resource.
 
-* `load_balances` - (Required, List) Specifies the IDs of the ELB instances bound to the WAF instance group.
-  This is an array of security group ids.
+* `load_balancers` - (Required, List) Specifies the IDs of the ELB instances bound to the WAF instance group.
+  This is an array of ELB instance ids.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_instance_group_associcate.md
+++ b/docs/resources/waf_instance_group_associcate.md
@@ -25,10 +25,10 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which the WAF instance group created.
   If omitted, the provider-level region will be used. Changing this setting will create a new resource.
 
-* `group_id` - (Required, String, ForceNew) Specifies the ID of instance group.
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the WAF instance group.
   Changing this will create a new instance.
 
-* `load_balances` - (Required, List) Specifies the IDs of the ELB instances bound to the instance group.
+* `load_balances` - (Required, List) Specifies the IDs of the ELB instances bound to the WAF instance group.
   This is an array of security group ids.
 
 ## Attributes Reference

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -581,6 +581,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_instance":          waf.ResourceWafDedicatedInstance(),
 			"huaweicloud_waf_dedicated_domain":            waf.ResourceWafDedicatedDomainV1(),
 			"huaweicloud_waf_instance_group":              waf.ResourceWafInstanceGroup(),
+			"huaweicloud_waf_instance_group_associate":    waf.ResourceWafInstGroupAssociate(),
 			"huaweicloud_waf_reference_table":             waf.ResourceWafReferenceTableV1(),
 
 			// Legacy

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
@@ -1,0 +1,93 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/pools"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccWafInsGroupAssociate_basic(t *testing.T) {
+	var group pools.Pool
+	resourceName := "huaweicloud_waf_instance_group_associate.group_associate"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&group,
+		getWafInstanceGroupFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafInsGroupAssoicate_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "load_balances.#", "1"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "load_balances.0",
+						"${huaweicloud_elb_loadbalancer.elb.id}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName,
+						"group_id", "${huaweicloud_waf_instance_group.group_1.id}"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccWafInsGroupAssoicate_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+resource "huaweicloud_waf_instance_group" "group_1" {
+  name   = "%s"
+  vpc_id = huaweicloud_vpc.vpc_1.id
+}
+
+resource "huaweicloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.huaweicloud_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.huaweicloud_compute_flavors.flavors.ids[0]
+  vpc_id             = huaweicloud_vpc.vpc_1.id
+  subnet_id          = huaweicloud_vpc_subnet.vpc_subnet_1.id
+  group_id           = huaweicloud_waf_instance_group.group_1.id
+  
+  security_group = [
+    huaweicloud_networking_secgroup.secgroup.id
+  ]
+}
+
+
+resource "huaweicloud_elb_loadbalancer" "elb" {
+  name              = "%s"
+  vpc_id            = huaweicloud_vpc.vpc_1.id
+  cross_vpc_backend = true
+  ipv4_subnet_id    = huaweicloud_vpc_subnet.vpc_subnet_1.subnet_id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.zones.names[0],
+    data.huaweicloud_availability_zones.zones.names[1]
+  ]
+}
+
+resource "huaweicloud_waf_instance_group_associate" "group_associate" {
+  group_id      = huaweicloud_waf_instance_group.group_1.id
+  load_balances = [huaweicloud_elb_loadbalancer.elb.id]
+
+  depends_on = [huaweicloud_waf_dedicated_instance.instance_1]
+}
+`, baseDependResource(name), name, name, name)
+}

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
@@ -32,8 +32,8 @@ func TestAccWafInsGroupAssociate_basic(t *testing.T) {
 				Config: testAccWafInsGroupAssoicate_conf(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "load_balances.#", "1"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "load_balances.0",
+					resource.TestCheckResourceAttr(resourceName, "load_balancers.#", "1"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "load_balancers.0",
 						"${huaweicloud_elb_loadbalancer.elb.id}"),
 					acceptance.TestCheckResourceAttrWithVariable(resourceName,
 						"group_id", "${huaweicloud_waf_instance_group.group_1.id}"),
@@ -84,8 +84,8 @@ resource "huaweicloud_elb_loadbalancer" "elb" {
 }
 
 resource "huaweicloud_waf_instance_group_associate" "group_associate" {
-  group_id      = huaweicloud_waf_instance_group.group_1.id
-  load_balances = [huaweicloud_elb_loadbalancer.elb.id]
+  group_id       = huaweicloud_waf_instance_group.group_1.id
+  load_balancers = [huaweicloud_elb_loadbalancer.elb.id]
 
   depends_on = [huaweicloud_waf_dedicated_instance.instance_1]
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group_associate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group_associate.go
@@ -36,7 +36,7 @@ func ResourceWafInstGroupAssociate() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"load_balances": {
+			"load_balancers": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -68,7 +68,7 @@ func resourceWafInsGroupAssociateCreate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	elbIDs := d.Get("load_balances").(*schema.Set).List()
+	elbIDs := d.Get("load_balancers").(*schema.Set).List()
 	mErr := addELBInstances(client, groupID, elbIDs)
 	if mErr.ErrorOrNil() != nil {
 		return diag.FromErr(mErr)
@@ -109,7 +109,7 @@ func resourceWafInsGroupAssociateRead(_ context.Context, d *schema.ResourceData,
 	}
 	mErr := multierror.Append(nil,
 		d.Set("group_id", group.ID),
-		d.Set("load_balances", loadBalances),
+		d.Set("load_balancers", loadBalances),
 	)
 
 	if mErr.ErrorOrNil() != nil {
@@ -127,7 +127,7 @@ func resourceWafInsGroupAssociateUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	mErr := &multierror.Error{}
-	oldVal, newVal := d.GetChange("load_balances")
+	oldVal, newVal := d.GetChange("load_balancers")
 	oldValSet := oldVal.(*schema.Set)
 	newValSet := newVal.(*schema.Set)
 
@@ -156,7 +156,7 @@ func resourceWafInsGroupAssociateDelete(_ context.Context, d *schema.ResourceDat
 		return fmtp.DiagErrorf("error in creating HuaweiCloud WAF dedicated client : %s", err)
 	}
 	// remove the bound ELB instances before deleting the group
-	elbIDs := d.Get("load_balances").(*schema.Set)
+	elbIDs := d.Get("load_balancers").(*schema.Set)
 	if elbIDs.Len() > 0 {
 		mErr := batchRemoveELBInstances(client, d.Id(), elbIDs.List())
 		if mErr.ErrorOrNil() != nil {

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group_associate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group_associate.go
@@ -70,7 +70,7 @@ func resourceWafInsGroupAssociateCreate(ctx context.Context, d *schema.ResourceD
 
 	elbIDs := d.Get("load_balances").(*schema.Set).List()
 	mErr := addELBInstances(client, groupID, elbIDs)
-	if mErr != nil && mErr.ErrorOrNil() != nil {
+	if mErr.ErrorOrNil() != nil {
 		return diag.FromErr(mErr)
 	}
 	d.SetId(groupID)
@@ -112,7 +112,7 @@ func resourceWafInsGroupAssociateRead(_ context.Context, d *schema.ResourceData,
 		d.Set("load_balances", loadBalances),
 	)
 
-	if err = mErr.ErrorOrNil(); err != nil {
+	if mErr.ErrorOrNil() != nil {
 		return fmtp.DiagErrorf("error setting WAF dedicated group attributes: %s", err)
 	}
 
@@ -142,7 +142,7 @@ func resourceWafInsGroupAssociateUpdate(ctx context.Context, d *schema.ResourceD
 		errs := batchRemoveELBInstances(client, d.Id(), removeBindings.List())
 		mErr = multierror.Append(mErr, errs.Errors...)
 	}
-	if err = mErr.ErrorOrNil(); err != nil {
+	if mErr.ErrorOrNil() != nil {
 		return fmtp.DiagErrorf("error setting WAF dedicated group attributes: %s", err)
 	}
 
@@ -159,7 +159,7 @@ func resourceWafInsGroupAssociateDelete(_ context.Context, d *schema.ResourceDat
 	elbIDs := d.Get("load_balances").(*schema.Set)
 	if elbIDs.Len() > 0 {
 		mErr := batchRemoveELBInstances(client, d.Id(), elbIDs.List())
-		if err = mErr.ErrorOrNil(); err != nil {
+		if mErr.ErrorOrNil() != nil {
 			return fmtp.DiagErrorf("error in removing ELB instances from group: %s", err)
 		}
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group_associate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group_associate.go
@@ -1,0 +1,169 @@
+package waf
+
+import (
+	"context"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/pools"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceWafInstGroupAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafInsGroupAssociateCreate,
+		ReadContext:   resourceWafInsGroupAssociateRead,
+		UpdateContext: resourceWafInsGroupAssociateUpdate,
+		DeleteContext: resourceWafInsGroupAssociateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"load_balances": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceWafInsGroupAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("error creating HuaweiCloud WAF dedicated client : %s", err)
+	}
+
+	groupID := d.Get("group_id").(string)
+	group, err := pools.Get(client, groupID)
+	if err != nil {
+		return fmtp.DiagErrorf("Error querying WAF instance group: %s", err)
+	}
+
+	if len(group.Bindings) > 0 {
+		// Remove the bound instance
+		for _, v := range group.Bindings {
+			err = pools.RemoveELB(client, groupID, v.ID)
+			if err != nil {
+				return fmtp.DiagErrorf("Error removing load balance[%s] from the group[%s]: %s", v, groupID, err)
+			}
+		}
+	}
+
+	elbIDs := d.Get("load_balances").(*schema.Set).List()
+	mErr := addELBInstances(client, groupID, elbIDs)
+	if mErr != nil && mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+	d.SetId(groupID)
+
+	return resourceWafInsGroupAssociateRead(ctx, d, meta)
+}
+
+func addELBInstances(c *golangsdk.ServiceClient, groupID string, ids []interface{}) *multierror.Error {
+	var mErr *multierror.Error
+	for _, v := range ids {
+		lbID := v.(string)
+		_, e := pools.AddELB(c, groupID, lbID)
+		if e != nil {
+			err := fmtp.Errorf("Error in binding load balance[%s] to the group[%s]: %s", lbID, groupID, e)
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+	return mErr
+}
+
+func resourceWafInsGroupAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("error creating HuaweiCloud WAF dedicated client : %s", err)
+	}
+
+	group, err := pools.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Error querying WAF instance group")
+	}
+
+	loadBalances := make([]interface{}, 0, len(group.Bindings))
+	for _, v := range group.Bindings {
+		loadBalances = append(loadBalances, v.Name)
+	}
+	mErr := multierror.Append(nil,
+		d.Set("group_id", group.ID),
+		d.Set("load_balances", loadBalances),
+	)
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return fmtp.DiagErrorf("error setting WAF dedicated group attributes: %s", err)
+	}
+
+	return nil
+}
+
+func resourceWafInsGroupAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("error creating HuaweiCloud WAF dedicated client : %s", err)
+	}
+
+	mErr := &multierror.Error{}
+	oldVal, newVal := d.GetChange("load_balances")
+	oldValSet := oldVal.(*schema.Set)
+	newValSet := newVal.(*schema.Set)
+
+	addBindings := newValSet.Difference(oldValSet)
+	removeBindings := oldValSet.Difference(newValSet)
+
+	if addBindings.Len() > 0 {
+		errs := addELBInstances(client, d.Id(), addBindings.List())
+		mErr = multierror.Append(mErr, errs.Errors...)
+	}
+	if removeBindings.Len() > 0 {
+		errs := batchRemoveELBInstances(client, d.Id(), removeBindings.List())
+		mErr = multierror.Append(mErr, errs.Errors...)
+	}
+	if err = mErr.ErrorOrNil(); err != nil {
+		return fmtp.DiagErrorf("error setting WAF dedicated group attributes: %s", err)
+	}
+
+	return resourceWafInsGroupAssociateRead(ctx, d, meta)
+}
+
+func resourceWafInsGroupAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("error in creating HuaweiCloud WAF dedicated client : %s", err)
+	}
+	// remove the bound ELB instances before deleting the group
+	elbIDs := d.Get("load_balances").(*schema.Set)
+	if elbIDs.Len() > 0 {
+		mErr := batchRemoveELBInstances(client, d.Id(), elbIDs.List())
+		if err = mErr.ErrorOrNil(); err != nil {
+			return fmtp.DiagErrorf("error in removing ELB instances from group: %s", err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We cannot add ELB instances before the instance group is used to create the ELB engine, 
so, we need a resource to manage the associate between groups and  ELB instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1675

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafInsGroupAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafInsGroupAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccWafInsGroupAssociate_basic
=== PAUSE TestAccWafInsGroupAssociate_basic
=== CONT  TestAccWafInsGroupAssociate_basic
--- PASS: TestAccWafInsGroupAssociate_basic (329.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       329.265s

```
