### PR TITLE
fix(iam): add warning message when deleting project failed

### DIFF
--- a/docs/resources/identity_project.md
+++ b/docs/resources/identity_project.md
@@ -7,7 +7,9 @@ subcategory: "Identity and Access Management (IAM)"
 Manages a Project resource within HuaweiCloud Identity And Access Management service. This is an alternative
 to `huaweicloud_identity_project_v3`
 
-Note: You _must_ have security admin privileges in your HuaweiCloud cloud to use this resource.
+-> You _must_ have security admin privileges in your HuaweiCloud cloud to use this resource.
+
+!>  Deleting projects is not supported. The project is only removed from the state, but it remains in the cloud.
 
 ## Example Usage
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Deleting projects is not supported (no such API), we can print the warning message and return to success temporarily.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

the acceptance testing will also fail since the project still exists.
```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run TestAccIdentityV3Project_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityV3Project_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityV3Project_basic
=== PAUSE TestAccIdentityV3Project_basic
=== CONT  TestAccIdentityV3Project_basic
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: Project still exists
--- FAIL: TestAccIdentityV3Project_basic (52.78s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       52.864s
FAIL


$ terraform destroy
...

huaweicloud_identity_project.project_1: Destroying... [id=0e1e6f457700f4652f5ac0190d2e9ae9]
huaweicloud_identity_project.project_1: Destruction complete after 0s

Warning: Deleting projects is not supported, and it will return to success temporarily.

Destroy complete! Resources: 1 destroyed.
```
