### PR TITLE
feat(cbr/vault): add a new vaults data source support for cbr service

### DIFF
--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# huaweicloud_cbr_vaults
+
+Use this data source to get available CBR vaults within Huaweicloud.
+
+## Example Usage
+
+### Get vaults for all server type
+
+```hcl
+data "huaweicloud_cbr_vaults" "test" {
+  type = "server"
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CBR vaults.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Optional, String) Specifies the object type of the CBR vault. The vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `consistent_level` - (Optional, String) Specifies the backup specifications.
+  The valid values are as follows:
+  + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
+  + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
+
+  Only server type vaults support application consistent.
+
+* `protection_type` - (Optional, String) Specifies the protection type of the CBR vault.
+  The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
+
+* `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
+  type vault. Default to **false**.
+
+* `enterprise_project_id` - (Optional, String) Specifies a unique ID in UUID format of enterprise project.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+  The `policy_id` cannot be used with the vault of replicate protection type.
+
+* `status` - (Optional, String) Specifies the CBR vault status, including **available**, **lock**, **frozen** and **error**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in hashcode format.
+
+* `vaults` - List of CBR vault details. The object structure of each CBR vault is documented below.
+
+The `vaults` block supports:
+
+* `id` - The vault ID in UUID format.
+
+* `name` - The CBR vault name.
+
+* `type` - The object type of the CBR vault.
+
+* `consistent_level` - The backup specifications.
+
+* `protection_type` - The protection type of the CBR vault.
+
+* `size` - The vault capacity, in GB.
+
+* `auto_expand_enabled` - Whether to enable automatic expansion of the backup protection type vault.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `policy_id` - The policy associated with the CBR vault.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+* `tags` - The key/value pairs to associate with the CBR vault.
+
+* `resources` - An array of one or more resources to attach to the CBR vault.
+  The [object](#cbr_vault_resources) structure is documented below.
+
+The `resources` block supports:
+
+* `server_id` - The ID of the ECS instance to be backed up.
+
+* `excludes` - An array of disk IDs which will be excluded in the backup.
+
+* `includes` - An array of disk or SFS file system IDs which will be included in the backup.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -282,6 +282,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddos":                             dataSourceAntiDdosV1(),
 			"huaweicloud_availability_zones":                   DataSourceAvailabilityZones(),
 			"huaweicloud_bms_flavors":                          bms.DataSourceBmsFlavors(),
+			"huaweicloud_cbr_vaults":                           cbr.DataSourceCbrVaultsV3(),
 			"huaweicloud_cce_addon_template":                   DataSourceCCEAddonTemplateV3(),
 			"huaweicloud_cce_cluster":                          DataSourceCCEClusterV3(),
 			"huaweicloud_cce_clusters":                         cce.DataSourceCCEClusters(),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -1,0 +1,223 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+)
+
+func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.huaweicloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_ReplicaServer(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_serverReplication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "replication"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "50"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "800"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCbrVaultsV3_ReplicaTurbo(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrVaultsV3_turboReplication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "replication"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "1000"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCbrVaultsV3_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cbr_vaults" "test" {
+  name = huaweicloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_serverBasic(rName))
+}
+
+func testAccCbrVaultsV3_serverReplication(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cbr_vaults" "test" {
+  name = huaweicloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_serverReplication(rName))
+}
+
+func testAccCbrVaultsV3_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cbr_vaults" "test" {
+  name = huaweicloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_volumeBasic(rName))
+}
+
+func testAccCbrVaultsV3_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cbr_vaults" "test" {
+  name = huaweicloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_turboBasic(rName))
+}
+
+func testAccCbrVaultsV3_turboReplication(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cbr_vaults" "test" {
+  name = huaweicloud_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_turboReplication(rName))
+}

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
@@ -1,0 +1,275 @@
+package cbr
+
+import (
+	"context"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceCbrVaultsV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCbrVaultsV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				//If the validation content has changed, please update the resource type map.
+				ValidateFunc: validation.StringInSlice([]string{
+					VaultTypeServer, VaultTypeDisk, VaultTypeTurbo,
+				}, false),
+			},
+			"consistent_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"crash_consistent", "app_consistent",
+				}, false),
+			},
+			"protection_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"backup", "replication",
+				}, false),
+			},
+			"size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 10485760),
+			},
+			"auto_expand_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vaults": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"consistent_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protection_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"auto_expand_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"allocated": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"used": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"spec_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"resources": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"server_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"excludes": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"includes": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildVaultListOpts(d *schema.ResourceData, config *config.Config) vaults.ListOpts {
+	return vaults.ListOpts{
+		Limit:               100,
+		CloudType:           "public",
+		Name:                d.Get("name").(string),
+		ObjectType:          d.Get("type").(string),
+		ProtectType:         d.Get("protection_type").(string),
+		PolicyID:            d.Get("policy_id").(string),
+		EnterpriseProjectID: common.GetEnterpriseProjectID(d, config),
+		Status:              d.Get("status").(string),
+	}
+}
+
+func filterCbrVaults(d *schema.ResourceData, vaultList []vaults.Vault) ([]interface{}, error) {
+	return utils.FilterSliceWithField(vaultList, map[string]interface{}{
+		"Billing.ConsistentLevel": d.Get("consistent_level").(string),
+		"Billing.Size":            d.Get("size").(int),
+		"AutoExpand":              d.Get("auto_expand_enabled").(bool),
+	})
+}
+
+func getCbrPolicyOfSpecificVault(client *golangsdk.ServiceClient, vaultId string) (*policies.Policy, error) {
+	opt := policies.ListOpts{
+		VaultID: vaultId,
+	}
+	pages, err := policies.List(client, opt).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := policies.ExtractPolicies(pages)
+	if len(resp) > 0 {
+		return &resp[0], nil
+	}
+	return nil, fmtp.Errorf("No policies are bound to the vault.")
+}
+
+func setCbrAllVaultParameters(client *golangsdk.ServiceClient, d *schema.ResourceData,
+	vaultList []interface{}) error {
+	result := make([]map[string]interface{}, len(vaultList))
+	ids := make([]string, len(vaultList))
+	for i, val := range vaultList {
+		vault := val.(vaults.Vault)
+		vMap := map[string]interface{}{
+			"id":                    vault.ID,
+			"name":                  vault.Name,
+			"enterprise_project_id": vault.EnterpriseProjectID,
+			"type":                  vault.Billing.ObjectType,
+			"protection_type":       vault.Billing.ProtectType,
+			"status":                vault.Billing.Status,
+			"consistent_level":      vault.Billing.ConsistentLevel,
+			"size":                  vault.Billing.Size,
+			"allocated":             vault.Billing.Allocated,
+			"used":                  vault.Billing.Used,
+			"spec_code":             vault.Billing.SpecCode,
+			"storage":               vault.Billing.StorageUnit,
+			"auto_expand_enabled":   vault.AutoExpand,
+			"tags":                  utils.TagsToMap(vault.Tags),
+			"resources":             makeCbrVaultResources(vault.Billing.ObjectType, vault.Resources),
+		}
+
+		// Query the CBR policy which bound to the vault by ID
+		if policy, err := getCbrPolicyOfSpecificVault(client, vault.ID); err != nil {
+			logp.Printf("[DEBUG] Unable to find the policy for specific vault: %s", err)
+		} else {
+			vMap["policy_id"] = policy.ID
+		}
+		result[i] = vMap
+		ids[i] = vault.ID
+	}
+
+	d.SetId(hashcode.Strings(ids))
+
+	return d.Set("vaults", result)
+}
+
+func dataSourceCbrVaultsV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.CbrV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud CBR v3 client: %s", err)
+	}
+
+	opt := buildVaultListOpts(d, config)
+
+	pages, err := vaults.List(client, opt).AllPages()
+	if err != nil {
+		return fmtp.DiagErrorf("Error getting vault details: %s", err)
+	}
+	resp, err := vaults.ExtractVaults(pages)
+
+	// Use the following parameters to filter the result of the List method return: consistent_level, size and
+	// auto_expand_enabled.
+	vaultList, err := filterCbrVaults(d, *resp)
+	if err != nil {
+		return fmtp.DiagErrorf("Error filting vaults by consistent_level, size and auto_expand_enabled: %s", err)
+	}
+
+	// Set the ID and other parameters.
+	err = setCbrAllVaultParameters(client, d, vaultList)
+	if err != nil {
+		return fmtp.DiagErrorf("Error setting vaults parameter: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, the terraform don't have the data source to query the list of VBR vaults.

**Which issue this PR fixes**:
fixes #1677

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new vault data source support.
2. add related test and document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCbrVaultsV3_BasicServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCbrVaultsV3_BasicServer -timeout 360m -parallel 4
=== RUN   TestAccCbrVaultsV3_BasicServer
=== PAUSE TestAccCbrVaultsV3_BasicServer
=== CONT  TestAccCbrVaultsV3_BasicServer
--- PASS: TestAccCbrVaultsV3_BasicServer (345.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       346.933s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCbrVaultsV3_ReplicaServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCbrVaultsV3_ReplicaServer -timeout 360m -parallel 4
=== RUN   TestAccCbrVaultsV3_ReplicaServer
=== PAUSE TestAccCbrVaultsV3_ReplicaServer
=== CONT  TestAccCbrVaultsV3_ReplicaServer
--- PASS: TestAccCbrVaultsV3_ReplicaServer (37.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       37.716s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCbrVaultsV3_BasicVolume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCbrVaultsV3_BasicVolume -timeout 360m -parallel 4
=== RUN   TestAccCbrVaultsV3_BasicVolume
=== PAUSE TestAccCbrVaultsV3_BasicVolume
=== CONT  TestAccCbrVaultsV3_BasicVolume
--- PASS: TestAccCbrVaultsV3_BasicVolume (72.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       72.896s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCbrVaultsV3_BasicTurbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCbrVaultsV3_BasicTurbo -timeout 360m -parallel 4
=== RUN   TestAccCbrVaultsV3_BasicTurbo
=== PAUSE TestAccCbrVaultsV3_BasicTurbo
=== CONT  TestAccCbrVaultsV3_BasicTurbo
--- PASS: TestAccCbrVaultsV3_BasicTurbo (428.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       429.092s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCbrVaultsV3_ReplicaTurbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCbrVaultsV3_ReplicaTurbo -timeout 360m -parallel 4
=== RUN   TestAccCbrVaultsV3_ReplicaTurbo
=== PAUSE TestAccCbrVaultsV3_ReplicaTurbo
=== CONT  TestAccCbrVaultsV3_ReplicaTurbo
--- PASS: TestAccCbrVaultsV3_ReplicaTurbo (39.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       40.034s
```