### PR TITLE
feat(VPC): add new data source: vpcs

### DIFF
--- a/docs/data-sources/vpcs.md
+++ b/docs/data-sources/vpcs.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# huaweicloud_vpcs
+
+Use this data source to get a list of VPC.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+variable "vpc_name" {}
+
+data "huaweicloud_vpcs" "vpc" {
+  name = var.vpc_name
+  tags {
+    foo = "bar,value"
+  }
+}
+
+output "vpc_ids" {
+  value = data.huaweicloud_vpcs.vpc.vpcs[*].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPCs in the current region.
+ All VPCs that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the VPC. If omitted, the provider-level region
+  will be used.
+
+* `id` - (Optional, String) Specifies the id of the desired VPC.
+
+* `name` - (Optional, String) Specifies the name of the desired VPC. The value is a string of no more than 64 characters
+  and can contain digits, letters, underscores (_) and hyphens (-).
+
+* `status` - (Optional, String) Specifies the current status of the desired VPC. The value can be CREATING, OK or ERROR.
+
+* `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired VPC belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired VPC.
+
+ -> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+  The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+  tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+  The values are in the OR relationship.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+* `vpcs` - Indicates a list of all VPCs found. Structure is documented below.
+
+The `vpcs` block supports:
+
+* `id` - Indicates the ID of the VPC.
+* `name` - Indicates the name of the VPC.
+* `cidr` - Indicates the cidr block of the VPC.
+* `status` - Indicates the current status of the VPC.
+* `enterprise_project_id` - Indicates the the enterprise project ID of the VPC.
+* `description` - Indicates the description of the VPC.
+* `tags` - Indicates the key/value pairs which associated with the VPC.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -342,6 +342,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vbs_backup_policy":                    dataSourceVBSBackupPolicyV2(),
 			"huaweicloud_vbs_backup":                           dataSourceVBSBackupV2(),
 			"huaweicloud_vpc":                                  vpc.DataSourceVpcV1(),
+			"huaweicloud_vpcs":                                 vpc.DataSourceVpcs(),
 			"huaweicloud_vpc_bandwidth":                        vpc.DataSourceBandWidth(),
 			"huaweicloud_vpc_eip":                              vpc.DataSourceVpcEip(),
 			"huaweicloud_vpc_ids":                              vpc.DataSourceVpcIdsV1(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
@@ -1,0 +1,229 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVpcsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.huaweicloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_basic(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
+						"${huaweicloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_base(rName, cidr string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%s"
+  cidr = "%s"
+}
+`, rName, cidr)
+}
+
+func testAccDataSourceVpcs_basic(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcs" "test" {
+  id = huaweicloud_vpc.test.id
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_byCidr(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.huaweicloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_byCidr(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_byCidr(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcs" "test" {
+  cidr = huaweicloud_vpc.test.cidr
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_byName(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.huaweicloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_byName(randName, randCidr),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
+						"${huaweicloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_byName(rName, cidr string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcs" "test" {
+  name = huaweicloud_vpc.test.name
+}
+`, testAccDataSourceVpcs_base(rName, cidr))
+}
+
+func TestAccVpcsDataSource_byAll(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	randCidr := acceptance.RandomCidr()
+	dataSourceName := "data.huaweicloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_byAll(randName, randCidr, acceptance.HW_ENTERPRISE_PROJECT_ID),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
+						"${huaweicloud_vpc.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_byAll(rName, cidr, enterpriseProjectID string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcs" "test" {
+  id                    = huaweicloud_vpc.test.id
+  name                  = huaweicloud_vpc.test.name
+  cidr                  = huaweicloud_vpc.test.cidr
+  enterprise_project_id = "%s"
+  status                = "OK"
+}
+`, testAccDataSourceVpcs_base(rName, cidr), enterpriseProjectID)
+}
+
+func TestAccVpcsDataSource_tags(t *testing.T) {
+	randName1 := acceptance.RandomAccResourceName()
+	randName2 := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_vpcs.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcs_tags(randName1, randName2),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.foo", randName1),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName1),
+					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcs_tags(rName1, rName2 string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test1" {
+  name = "%s"
+  cidr = "172.16.0.0/24"
+  tags = {
+    foo = "%s"
+  }
+}
+
+resource "huaweicloud_vpc" "test2" {
+  name = "%s"
+  cidr = "10.12.2.0/24"
+  tags = {
+    foo = "%s"
+  }
+}
+
+data "huaweicloud_vpcs" "test" {
+  tags = {
+    foo = "%s"
+  }
+  depends_on = [
+    huaweicloud_vpc.test1,
+    huaweicloud_vpc.test2,
+  ]
+}
+`, rName1, rName1, rName2, rName2, rName1)
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -1,0 +1,196 @@
+package vpc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceVpcs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vpcs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.NetworkingV1Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+	}
+
+	vpcV2Client, err := config.NetworkingV2Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud VPC V2 client: %s", err)
+	}
+
+	listOpts := vpcs.ListOpts{
+		ID:                  d.Get("id").(string),
+		Name:                d.Get("name").(string),
+		Status:              d.Get("status").(string),
+		CIDR:                d.Get("cidr").(string),
+		EnterpriseProjectID: config.GetEnterpriseProjectID(d),
+	}
+
+	vpcList, err := vpcs.List(client, listOpts)
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve vpcs: %s", err)
+	}
+
+	logp.Printf("[DEBUG] Retrieved Vpc using given filter: %+v", vpcList)
+
+	var vpcs []map[string]interface{}
+	tagFilter := d.Get("tags").(map[string]interface{})
+	var ids []string
+	for _, vpcResource := range vpcList {
+		vpc := map[string]interface{}{
+			"id":                    vpcResource.ID,
+			"name":                  vpcResource.Name,
+			"cidr":                  vpcResource.CIDR,
+			"enterprise_project_id": vpcResource.EnterpriseProjectID,
+			"status":                vpcResource.Status,
+			"description":           vpcResource.Description,
+		}
+
+		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", vpcResource.ID).Extract(); err == nil {
+			tagmap := utils.TagsToMap(resourceTags.Tags)
+			tags, isMatch := filterByTags(tagmap, tagFilter)
+			if isMatch {
+				vpc["tags"] = tags
+			} else {
+				continue
+			}
+		} else {
+			return fmtp.DiagErrorf("Error query tags of VPC (%s): %s", d.Id(), err)
+		}
+
+		vpcs = append(vpcs, vpc)
+		ids = append(ids, vpcResource.ID)
+	}
+	logp.Printf("[DEBUG]Vpc List after filter, count=%d :%+v", len(vpcs), vpcs)
+
+	mErr := d.Set("vpcs", vpcs)
+	if mErr != nil {
+		return fmtp.DiagErrorf("set vpcs err:%s", mErr)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	return nil
+}
+
+// if filterTags = {"foo":"a,b"} , the rawTags must hava a key is "foo" and value is "a" OR "b"
+func filterByTags(rawTags map[string]string, filterTags map[string]interface{}) (map[string]string, bool) {
+	if len(filterTags) < 1 {
+		return rawTags, true
+	}
+	if len(filterTags) > 0 && len(rawTags) < 1 {
+		return nil, false
+	}
+
+	isMatch := true
+	for key, value := range filterTags {
+		isMatch = isMatch && isTagMatch(rawTags, key, value.(string))
+	}
+
+	if isMatch {
+		return rawTags, true
+	}
+
+	return nil, false
+}
+
+func isTagMatch(rawTags map[string]string, filterKey, filterValue string) bool {
+	if rawTag, ok := rawTags[filterKey]; ok {
+		if filterValue != "" {
+			filterTagValues := strings.Split(filterValue, ",")
+			return utils.StrSliceContains(filterTagValues, rawTag)
+
+		} else {
+			return true
+		}
+
+	} else {
+		return false
+	}
+
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
add new data source:  `huaweicloud_vpcs`

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1678 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_basic
--- PASS: TestAccVpcsDataSource_basic (35.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       35.464s
```
```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcsDataSource -timeout 360m -parallel 4
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== RUN   TestAccVpcsDataSource_byCidr
=== PAUSE TestAccVpcsDataSource_byCidr
=== RUN   TestAccVpcsDataSource_byName
=== PAUSE TestAccVpcsDataSource_byName
=== RUN   TestAccVpcsDataSource_byAll
=== PAUSE TestAccVpcsDataSource_byAll
=== RUN   TestAccVpcsDataSource_tags
=== PAUSE TestAccVpcsDataSource_tags
=== CONT  TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_byAll
=== CONT  TestAccVpcsDataSource_tags
=== CONT  TestAccVpcsDataSource_byName
--- PASS: TestAccVpcsDataSource_byName (44.30s)
=== CONT  TestAccVpcsDataSource_byCidr
--- PASS: TestAccVpcsDataSource_basic (46.10s)
--- PASS: TestAccVpcsDataSource_byAll (47.97s)
--- PASS: TestAccVpcsDataSource_tags (51.22s)
--- PASS: TestAccVpcsDataSource_byCidr (34.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       78.909s
```
