### PR TITLE
feat(iam/provider): add a resource for managing the configuration information of providers

### DIFF
--- a/docs/resources/identity_provider_oidc_config.md
+++ b/docs/resources/identity_provider_oidc_config.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_provider_oidc_config
+
+Manages the configuration information of the identity provider that uses the open connection protocol within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable provider_id {}
+resource "huaweicloud_identity_provider_oidc_config" "config" {
+  provider_id            = var.provider_id
+  access_type            = "program_console"
+  provider_url           = "https://accounts.example.com"
+  client_id              = "client_id_example"
+  authorization_endpoint = "https://accounts.example.com/o/oauth2/v2/auth"
+  scopes                 = ["openid"]
+  signing_key            = jsonencode(
+  {
+    keys = [
+      {
+        alg = "RS256"
+        e   = "AQAB"
+        kid = "your_kid"
+        kty = "RSA"
+        n   = "the_value_of_n"
+        use = "sig"
+      }
+    ]
+  }
+  )
+}
+```
+
+<!--markdownlint-disable MD033-->
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `provider_id` - (Required, String, ForceNew) Specifies the identity provider ID.
+  Changing this creates a new resource.
+
+* `access_type` - (Required, String) Specifies the access type of the identity provider.
+  Available options are:
+  + `program`: programmatic access only.
+  + `program_console`: programmatic access and management console access.
+
+* `provider_url` - (Required, String) Specifies the URL of the identity provider.
+  This field corresponds to the iss field in the ID token.
+
+* `client_id` - (Required, String) Specifies the ID of a client registered with the identity provider.
+
+* `signing_key` - (Required, String) The public key in json string format, used to sign the ID token of the identity
+  provider.
+
+* `authorization_endpoint` - (Optional, String) Specifies the authorization endpoint of the identity provider.
+  This field is required only if the access type is set to `program_console`.
+
+* `scopes` - (Optional, List) Specifies the scopes of authorization requests. It is an array of one or more scopes.
+  Valid values are *openid*, *email*, *profile* and other values defined by you.
+  This field is required only if the access type is set to `program_console`.
+
+-> **NOTE:** 1. *openid* must be specified for scopes.
+<br/>2. A maximum of 10 values can be specified.
+
+* `response_type` - (Optional, String) Response type. Only support *id_token* currently.
+  This field is required only if the access type is set to `program_console`.
+
+* `response_mode` - (Optional, String) Response mode.
+  Valid values are *form_post* and *fragment*, default value is *form_post*.
+  This field is required only if the access type is set to `program_console`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+## Import
+
+The configuration information of the identity provider can be imported using the `provider_id`, e.g.
+
+```
+$ terraform import huaweicloud_identity_provider_oidc_config.config example_com_provider_oidc
+```

--- a/go.sum
+++ b/go.sum
@@ -71,10 +71,6 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20211030022355-e5b519b9f8fa h1:D2GHiHPTxDDBuC2133r12uppPKEQwYqz41xthlOxP/g=
-github.com/chnsz/golangsdk v0.0.0-20211030022355-e5b519b9f8fa/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20211103084042-252dae81b0cc h1:PNLFEiwClpgfYFC66TWyptABu/bDZoOoSmwSwc+D8IA=
-github.com/chnsz/golangsdk v0.0.0-20211103084042-252dae81b0cc/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20211104073851-76d1b6395a61 h1:6g9ejuErd4ciglOmiwmFtgethjCSdLMkqjzD4YVMbNU=
 github.com/chnsz/golangsdk v0.0.0-20211104073851-76d1b6395a61/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -501,6 +501,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_role":                   iam.ResourceIdentityRole(),
 			"huaweicloud_identity_role_assignment":        iam.ResourceIdentityRoleAssignmentV3(),
 			"huaweicloud_identity_user":                   iam.ResourceIdentityUserV3(),
+			"huaweicloud_identity_provider_oidc_config":   iam.ResourceIdentityProviderOidcConfig(),
 			"huaweicloud_iec_eip":                         resourceIecNetworkEip(),
 			"huaweicloud_iec_keypair":                     resourceIecKeypair(),
 			"huaweicloud_iec_network_acl":                 resourceIecNetworkACL(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_oidc_config_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_oidc_config_test.go
@@ -1,0 +1,126 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getProviderOidcConfigFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.IAMNoVersionClient(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HuaweiCloud IAM without version: %s", err)
+	}
+	return oidcconfig.Get(client, state.Primary.ID)
+}
+
+func TestAccIdentityProviderOidcConfig_basic(t *testing.T) {
+	var oidcConfig oidcconfig.OpenIDConnectConfig
+	var name = acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_identity_provider_oidc_config.config"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&oidcConfig,
+		getProviderOidcConfigFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProviderOidcConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "client_id", "client_id_example"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "program"),
+					//resource.TestCheckResourceAttr(resourceName, "scopes.#", "0"),
+				),
+			},
+			{
+				Config: testAccIdentityProviderOidcConfig_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "client_id", "client_id_demo"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "program_console"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.1", "email"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIdentityProviderOidcConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "oidc"
+}
+
+resource "huaweicloud_identity_provider_oidc_config" "config" {
+  provider_id            = huaweicloud_identity_provider.provider_1.id
+  access_type            = "program"
+  provider_url           = "https://accounts.example.com"
+  client_id              = "client_id_example"
+  signing_key            = jsonencode(
+  {
+    keys = [
+      {
+        alg = "RS256"
+        e   = "AQAB"
+        kid = "d05ef20c4512645vv1..."
+        kty = "RSA"
+        n   = "cws_cnjiwsbvweolwn_-vnl..."
+        use = "sig"
+      },
+    ]
+  }
+  )
+}
+`, name)
+}
+
+func testAccIdentityProviderOidcConfig_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "oidc"
+}
+
+resource "huaweicloud_identity_provider_oidc_config" "config" {
+  provider_id            = huaweicloud_identity_provider.provider_1.id
+  access_type            = "program_console"
+  provider_url           = "https://accounts.example.com"
+  client_id              = "client_id_demo"
+  authorization_endpoint = "https://accounts.example.com/o/oauth2/v2/auth"
+  scopes                 = ["openid", "email"]
+  signing_key            = jsonencode(
+  {
+    keys = [
+      {
+        alg = "RS256"
+        e   = "AQAB"
+        kid = "d05ef20c4512645vv1..."
+        kty = "RSA"
+        n   = "cws_cnjiwsbvweolwn_-vnl..."
+        use = "sig"
+      },
+    ]
+  }
+  )
+}
+`, name)
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider_oidc_config.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider_oidc_config.go
@@ -1,0 +1,230 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func ResourceIdentityProviderOidcConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resIdeProviderOidcConfigCreate,
+		ReadContext:   resIdeProviderOidcConfigRead,
+		UpdateContext: resIdeProviderOidcConfigUpdate,
+		DeleteContext: resIdeProviderOidcConfigDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"provider_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"access_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"program", "program_console"}, false),
+			},
+			"provider_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"signing_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+					return equal
+				},
+			},
+			"authorization_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scopes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 10,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"response_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "id_token",
+			},
+			"response_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "form_post",
+				ValidateFunc: validation.StringInSlice([]string{"fragment", "form_post"}, false),
+			},
+		},
+	}
+}
+
+func resIdeProviderOidcConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud IAM client without version number: %s", err)
+	}
+
+	accessType := d.Get("access_type").(string)
+	opts := oidcconfig.CreateOpts{
+		AccessMode: accessType,
+		IdpURL:     d.Get("provider_url").(string),
+		ClientID:   d.Get("client_id").(string),
+		SigningKey: d.Get("signing_key").(string),
+	}
+	if accessType == "program_console" {
+		opts.AuthorizationEndpoint = d.Get("authorization_endpoint").(string)
+		opts.Scope = getScopes(d)
+		opts.ResponseType = d.Get("response_type").(string)
+		opts.ResponseMode = d.Get("response_mode").(string)
+	}
+	logp.Printf("[DEBUG] Create access type of provider: %#v", opts)
+
+	providerID := d.Get("provider_id").(string)
+	_, err = oidcconfig.Get(client, providerID)
+	if err != nil && errors.As(err, &golangsdk.ErrDefault404{}) {
+		_, err = oidcconfig.Create(client, providerID, opts)
+	} else {
+		err = updateOidcConfig(client, d)
+	}
+
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating provider access type: %s", err)
+	}
+	d.SetId(providerID)
+
+	return resIdeProviderOidcConfigRead(ctx, d, meta)
+}
+
+func resIdeProviderOidcConfigRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud IAM client without version number: %s", err)
+	}
+	// ID is the provider name
+	providerID := d.Id()
+	accessType, err := oidcconfig.Get(client, providerID)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error in querying provider access type")
+	}
+
+	scopes := make([]string, 0)
+	if len(accessType.Scope) > 0 {
+		scopes = strings.Split(accessType.Scope, scopeSpilt)
+	}
+	mErr := multierror.Append(
+		d.Set("provider_id", d.Id()),
+		d.Set("access_type", accessType.AccessMode),
+		d.Set("provider_url", accessType.IdpURL),
+		d.Set("client_id", accessType.ClientID),
+		d.Set("signing_key", accessType.SigningKey),
+		d.Set("scopes", scopes),
+		d.Set("authorization_endpoint", accessType.AuthorizationEndpoint),
+	)
+
+	if accessType.AccessMode == "program_console" {
+		mErr = multierror.Append(
+			mErr,
+			d.Set("response_mode", accessType.ResponseMode),
+			d.Set("response_type", accessType.ResponseType),
+		)
+	}
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		logp.Printf("[ERROR] Error setting identity provider config %s: %s", d.Id(), err)
+		return fmtp.DiagErrorf("Error setting identity provider config : %s", err)
+	}
+	return nil
+}
+
+func getScopes(d *schema.ResourceData) string {
+	scopes := utils.ExpandToStringList(d.Get("scopes").([]interface{}))
+	str := strings.Join(scopes, scopeSpilt)
+	return str
+}
+
+func updateOidcConfig(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	accessType := d.Get("access_type").(string)
+	opts := oidcconfig.UpdateOpenIDConnectConfigOpts{
+		AccessMode: accessType,
+		IdpURL:     d.Get("provider_url").(string),
+		ClientID:   d.Get("client_id").(string),
+		SigningKey: d.Get("signing_key").(string),
+	}
+
+	if accessType == "program_console" {
+		opts.AuthorizationEndpoint = d.Get("authorization_endpoint").(string)
+		opts.Scope = getScopes(d)
+		opts.ResponseType = d.Get("response_type").(string)
+		opts.ResponseMode = d.Get("response_mode").(string)
+	}
+	logp.Printf("[DEBUG] Update access type of provider: %#v", opts)
+	providerID := d.Get("provider_id").(string)
+	_, err := oidcconfig.Update(client, providerID, opts)
+	return err
+}
+
+func resIdeProviderOidcConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error updating HuaweiCloud IAM client without version number: %s", err)
+	}
+	err = updateOidcConfig(client, d)
+	if err != nil {
+		return fmtp.DiagErrorf("Error updating the access type of provider: %s", err)
+	}
+
+	return resIdeProviderOidcConfigRead(ctx, d, meta)
+}
+
+func resIdeProviderOidcConfigDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error updating HuaweiCloud IAM client without version number: %s", err)
+	}
+	// The oidc configuration cannot be removed from the provider, so we set it to an invalid value.
+	signingKey := `{"keys": [{"use": "sig", "e": "AQAB", "kty": "RSA", "alg": "RS256", "n": "..", "kid": ".."}]}`
+	opts := oidcconfig.UpdateOpenIDConnectConfigOpts{
+		AccessMode:            "program_console",
+		IdpURL:                "https://idp_url",
+		ClientID:              "__client_id__",
+		AuthorizationEndpoint: "https://endpoint",
+		Scope:                 "openid",
+		ResponseType:          "id_token",
+		ResponseMode:          "form_post",
+		SigningKey:            signingKey,
+	}
+	providerID := d.Get("provider_id").(string)
+	_, err = oidcconfig.Update(client, providerID, opts)
+	if err != nil {
+		return fmtp.DiagErrorf("error deleting access type: %s", err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/flinkjob/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/flinkjob/results.go
@@ -180,6 +180,9 @@ type JobConfBase struct {
 	TmSlotNum        int    `json:"tm_slot_num"`
 	ResumeMaxNum     int    `json:"resume_max_num"`
 	CheckpointPath   string `json:"checkpoint_path"`
+	Feature          string `json:"feature"`
+	FlinkVersion     string `json:"flink_version"`
+	Image            string `json:"image"`
 }
 
 type ListResp struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/requests.go
@@ -1,0 +1,83 @@
+package oidcconfig
+
+import "github.com/chnsz/golangsdk"
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type CreateOpts struct {
+	AccessMode            string `json:"access_mode" required:"true"`
+	IdpURL                string `json:"idp_url" required:"true"`
+	ClientID              string `json:"client_id" required:"true"`
+	SigningKey            string `json:"signing_key" required:"true"`
+	AuthorizationEndpoint string `json:"authorization_endpoint,omitempty"`
+	Scope                 string `json:"scope,omitempty"`
+	ResponseType          string `json:"response_type,omitempty"`
+	ResponseMode          string `json:"response_mode,omitempty"`
+}
+
+type responseBody struct {
+	Config OpenIDConnectConfig `json:"openid_connect_config"`
+}
+
+func Create(c *golangsdk.ServiceClient, idpID string, opts CreateOpts) (*OpenIDConnectConfig, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "openid_connect_config")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(resourceURL(c, idpID), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Config, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, idpID string) (*OpenIDConnectConfig, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, idpID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Config, nil
+	}
+	return nil, err
+}
+
+type UpdateOpenIDConnectConfigOpts struct {
+	AccessMode            string `json:"access_mode" required:"true"`
+	IdpURL                string `json:"idp_url" required:"true"`
+	ClientID              string `json:"client_id" required:"true"`
+	SigningKey            string `json:"signing_key" required:"true"`
+	AuthorizationEndpoint string `json:"authorization_endpoint,omitempty"`
+	Scope                 string `json:"scope,omitempty"`
+	ResponseType          string `json:"response_type,omitempty"`
+	ResponseMode          string `json:"response_mode,omitempty"`
+}
+
+func Update(c *golangsdk.ServiceClient, idpID string, opts UpdateOpenIDConnectConfigOpts) (*OpenIDConnectConfig, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "openid_connect_config")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, idpID), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Config, nil
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/results.go
@@ -1,0 +1,12 @@
+package oidcconfig
+
+type OpenIDConnectConfig struct {
+	AccessMode            string `json:"access_mode"`
+	IdpURL                string `json:"idp_url"`
+	ClientID              string `json:"client_id"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	Scope                 string `json:"scope"`
+	ResponseType          string `json:"response_type"`
+	ResponseMode          string `json:"response_mode"`
+	SigningKey            string `json:"signing_key"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/urls.go
@@ -1,0 +1,7 @@
+package oidcconfig
+
+import "github.com/chnsz/golangsdk"
+
+func resourceURL(c *golangsdk.ServiceClient, idpID string) string {
+	return c.ServiceURL("v3.0", "OS-FEDERATION", "identity-providers", idpID, "openid-connect-config")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,6 +179,7 @@ github.com/chnsz/golangsdk/openstack/geminidb/v3/backups
 github.com/chnsz/golangsdk/openstack/geminidb/v3/configurations
 github.com/chnsz/golangsdk/openstack/geminidb/v3/flavors
 github.com/chnsz/golangsdk/openstack/geminidb/v3/instances
+github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig
 github.com/chnsz/golangsdk/openstack/identity/v2/tenants
 github.com/chnsz/golangsdk/openstack/identity/v2/tokens
 github.com/chnsz/golangsdk/openstack/identity/v3.0/acl


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Set the access information and access type for the OIDC provider, but it cannot be deleted. 
It can only be set to the default value when deleting.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1423

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run TestAccIdentityProviderOidcConfig_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityProviderOidcConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityProviderOidcConfig_basic
=== PAUSE TestAccIdentityProviderOidcConfig_basic
=== CONT  TestAccIdentityProviderOidcConfig_basic
--- PASS: TestAccIdentityProviderOidcConfig_basic (64.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       64.341s
```
