### PR TITLE
fix(sfs): fix the wrong doc name and update schema

### DIFF
--- a/docs/data-sources/sfs_file_system.md
+++ b/docs/data-sources/sfs_file_system.md
@@ -2,19 +2,17 @@
 subcategory: "Scalable File Service (SFS)"
 ---
 
-# huaweicloud_sfs_file_sharing
+# huaweicloud_sfs_file_system
 
-Provides information about an Shared File System (SFS). This is an alternative to `huaweicloud_sfs_file_sharing_v2`
+Provides information about an Shared File System (SFS) within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
 variable "share_name" {}
-variable "share_id" {}
 
-data "huaweicloud_sfs_file_sharing" "shared_file" {
+data "huaweicloud_sfs_file_system" "shared_file" {
   name = var.share_name
-  id   = var.share_id
 }
 ```
 
@@ -36,32 +34,23 @@ In addition to all arguments above, the following attributes are exported:
 
 * `size` - The size (GB) of the shared file system.
 
-* `share_type` - The storage service type for the shared file system, such as high-performance storage (composed of
-  SSDs) or large-capacity storage (composed of SATA disks).
-
-* `status` - The status of the shared file system.
-
-* `host` - The host name of the shared file system.
-
-* `is_public` - The level of visibility for the shared file system.
+* `is_public` - Whether a file system can be publicly seen.
 
 * `share_proto` - The protocol for sharing file systems.
 
-* `volume_type` - The volume type.
-
-* `metadata` - Metadata key and value pairs as a dictionary of strings.
+* `metadata` - The key and value pairs information of the shared file system.
 
 * `export_location` - The path for accessing the shared file system.
 
-* `access_level` - The level of the access rule.
+* `share_access_id` - The UUID of the share access rule.
 
 * `access_rules_status` - The status of the share access rule.
+
+* `access_level` - The level of the access rule.
 
 * `access_type` - The type of the share access rule.
 
 * `access_to` - The access that the back end grants or denies.
-
-* `share_access_id` - The UUID of the share access rule.
 
 * `mount_id` - The UUID of the mount location of the shared file system.
 

--- a/huaweicloud/data_source_huaweicloud_sfs_file_system_v2.go
+++ b/huaweicloud/data_source_huaweicloud_sfs_file_system_v2.go
@@ -23,6 +23,15 @@ func DataSourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -31,23 +40,7 @@ func DataSourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"share_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"project_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"status": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"host": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -55,19 +48,7 @@ func DataSourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"share_proto": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"volume_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"export_location": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -76,13 +57,7 @@ func DataSourceSFSFileSystemV2() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"export_locations": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"access_level": {
+			"export_location": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -90,7 +65,7 @@ func DataSourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"share_access_id": {
+			"access_level": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -103,6 +78,10 @@ func DataSourceSFSFileSystemV2() *schema.Resource {
 				Computed: true,
 			},
 			"mount_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"share_access_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -153,18 +132,12 @@ func dataSourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("availability_zone", share.AvailabilityZone)
 	d.Set("description", share.Description)
-	d.Set("host", share.Host)
-	d.Set("id", share.ID)
 	d.Set("is_public", share.IsPublic)
 	d.Set("name", share.Name)
-	d.Set("project_id", share.ProjectID)
 	d.Set("share_proto", share.ShareProto)
-	d.Set("share_type", share.ShareType)
 	d.Set("size", share.Size)
 	d.Set("status", share.Status)
-	d.Set("volume_type", share.VolumeType)
 	d.Set("export_location", share.ExportLocation)
-	d.Set("export_locations", share.ExportLocations)
 	d.Set("metadata", share.Metadata)
 	d.Set("region", GetRegion(d, config))
 

--- a/huaweicloud/data_source_huaweicloud_sfs_file_system_v2_test.go
+++ b/huaweicloud/data_source_huaweicloud_sfs_file_system_v2_test.go
@@ -13,6 +13,8 @@ import (
 
 func TestAccSFSFileSystemV2DataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "data.huaweicloud_sfs_file_system.share_1"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -20,10 +22,10 @@ func TestAccSFSFileSystemV2DataSource_basic(t *testing.T) {
 			{
 				Config: testAccSFSFileSystemV2DataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSFSFileSystemV2DataSourceID("data.huaweicloud_sfs_file_system_v2.shares"),
-					resource.TestCheckResourceAttr("data.huaweicloud_sfs_file_system_v2.shares", "name", rName),
-					resource.TestCheckResourceAttr("data.huaweicloud_sfs_file_system_v2.shares", "status", "available"),
-					resource.TestCheckResourceAttr("data.huaweicloud_sfs_file_system_v2.shares", "size", "1"),
+					testAccCheckSFSFileSystemV2DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "size", "10"),
 				),
 			},
 		},
@@ -49,23 +51,22 @@ func testAccSFSFileSystemV2DataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_vpc" "vpc_default" {
   name = "vpc-default"
-  enterprise_project_id = "0"
 }
 
 data "huaweicloud_availability_zones" "myaz" {}
 
-resource "huaweicloud_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="%s"
-	availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-	access_to = data.huaweicloud_vpc.vpc_default.id
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+resource "huaweicloud_sfs_file_system" "sfs_1" {
+  share_proto  = "NFS"
+  size         = 10
+  name         = "%s"
+  description  = "sfs_c2c_test-file"
+  access_to    = data.huaweicloud_vpc.vpc_default.id
+  access_level = "rw"
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
 }
-data "huaweicloud_sfs_file_system_v2" "shares" {
-  id = huaweicloud_sfs_file_system_v2.sfs_1.id
+
+data "huaweicloud_sfs_file_system" "share_1" {
+  id = huaweicloud_sfs_file_system.sfs_1.id
 }
 `, rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* the document name is wrong, should be **sfs_file_system.md**

* the following attributes wil be **removed**:
  - export_locations --- not shown in doc, use `export_location` instead;
  - volume_type --- removed in resource
  - share_type --- removed in resource
  - host --- removed in resource
  - project_id --- meaningless


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSFSFileSystemV2DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSFSFileSystemV2DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccSFSFileSystemV2DataSource_basic
=== PAUSE TestAccSFSFileSystemV2DataSource_basic
=== CONT  TestAccSFSFileSystemV2DataSource_basic
--- PASS: TestAccSFSFileSystemV2DataSource_basic (63.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       63.313s
```
