### PR TITLE
doc: fix the wrong doc name of vpc peering connection accepter

### DIFF
--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -65,4 +65,6 @@ This resource provides the following timeouts configuration options:
 
 VPC Peering resources can be imported using the `vpc peering id`, e.g.
 
-> $ terraform import huaweicloud_vpc_peering_connection.test_connection 22b76469-08e3-4937-8c1d-7aad34892be1
+```
+$ terraform import huaweicloud_vpc_peering_connection.test_connection 22b76469-08e3-4937-8c1d-7aad34892be1
+```

--- a/docs/resources/vpc_peering_connection_accepter.md
+++ b/docs/resources/vpc_peering_connection_accepter.md
@@ -7,10 +7,11 @@ subcategory: "Virtual Private Cloud (VPC)"
 Provides a resource to manage the accepter's side of a VPC Peering Connection. This is an alternative
 to `huaweicloud_vpc_peering_connection_accepter_v2`
 
-When a cross-tenant (requester's tenant differs from the accepter's tenant) VPC Peering Connection is created, a VPC
-Peering Connection resource is automatically created in the accepter's account. The requester can use
-the `huaweicloud_vpc_peering_connection` resource to manage its side of the connection and the accepter can use
-the `huaweicloud_vpc_peering_connection_accepter` resource to "adopt" its side of the connection into management.
+-> **NOTE:** When a cross-tenant (requester's tenant differs from the accepter's tenant) VPC Peering Connection
+  is created, a VPC Peering Connection resource is automatically created in the accepter's account.
+  The requester can use the `huaweicloud_vpc_peering_connection` resource to manage its side of the connection and
+  the accepter can use the `huaweicloud_vpc_peering_connection_accepter` resource to accept its side of the connection
+  into management.
 
 ## Example Usage
 
@@ -67,11 +68,11 @@ The following arguments are supported:
 
 ## Removing huaweicloud_vpc_peering_connection_accepter from your configuration
 
-huaweicloud allows a cross-tenant VPC Peering Connection to be deleted from either the requester's or accepter's side.
+HuaweiCloud allows a cross-tenant VPC Peering Connection to be deleted from either the requester's or accepter's side.
 However, Terraform only allows the VPC Peering Connection to be deleted from the requester's side by removing the
-corresponding `huaweicloud_vpc_peering_connection` resource from your configuration. Removing
-a `huaweicloud_vpc_peering_connection_accepter` resource from your configuration will remove it from your state file and
-management, but will not destroy the VPC Peering Connection.
+corresponding `huaweicloud_vpc_peering_connection` resource from your configuration.
+Removing a `huaweicloud_vpc_peering_connection_accepter` resource from your configuration will remove it from your
+state file and management, but will not destroy the VPC Peering Connection.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
@@ -34,10 +34,6 @@ func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"vpc_peering_connection_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -46,6 +42,11 @@ func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 			"accept": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"status": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

the document name of `huaweicloud_vpc_peering_connection_accepter` is wrong, so fix it.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
