### PR TITLE
fix(elb/pool): add HTTPS and QUIC as options to protocol

### DIFF
--- a/docs/resources/elb_pool.md
+++ b/docs/resources/elb_pool.md
@@ -32,11 +32,13 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Human-readable description for the pool.
 
-* `protocol` - (Required, String, ForceNew) The protocol - can either be TCP, UDP or HTTP.
+* `protocol` - (Required, String, ForceNew) The protocol - can either be TCP, UDP, HTTP, HTTPS or QUIC.
 
-  + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP.
+  + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP or QUIC.
   + When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
-  + When the protocol used by the listener is HTTP or TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
+  + When the protocol used by the listener is HTTP, the protocol of the backend pool must be HTTP.
+  + When the protocol used by the listener is HTTPS, the protocol of the backend pool must be HTTPS.
+  + When the protocol used by the listener is TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
 
       Changing this creates a new pool.
 

--- a/huaweicloud/resource_huaweicloud_elb_pool.go
+++ b/huaweicloud/resource_huaweicloud_elb_pool.go
@@ -50,7 +50,7 @@ func ResourcePoolV3() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"TCP", "UDP", "HTTP",
+					"TCP", "UDP", "HTTP", "HTTPS", "QUIC",
 				}, false),
 			},
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1711 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccElbV3Pool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccElbV3Pool -timeout 360m -parallel 4
=== RUN   TestAccElbV3Pool_basic
=== PAUSE TestAccElbV3Pool_basic
=== CONT  TestAccElbV3Pool_basic
--- PASS: TestAccElbV3Pool_basic (153.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       153.129s
```
