### PR TITLE
fix(obs): ignore FsNotSupport error when refreshing

### DIFF
--- a/huaweicloud/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket.go
@@ -1057,7 +1057,7 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 	output, err := obsClient.GetBucketEncryption(bucket)
 	if err != nil {
 		if obsError, ok := err.(obs.ObsError); ok {
-			if obsError.Code == "NoSuchEncryptionConfiguration" {
+			if obsError.Code == "NoSuchEncryptionConfiguration" || obsError.Code == "FsNotSupport" {
 				d.Set("encryption", false)
 				d.Set("kms_key_id", nil)
 				return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

when creating a parallel file system with terraform, we will encounter the following error:
```
Error: Error getting encryption configuration of OBS bucket xxxx: FsNotSupport,
 Reason: file system not support this request: bucket-encryption
```

we should the FsNotSupport error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_basic -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (60.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       60.253s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_parallelFS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_parallelFS -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== CONT  TestAccObsBucket_parallelFS
--- PASS: TestAccObsBucket_parallelFS (30.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       30.096s
```
