### PR TITLE
feat(ecs): support to configure source/destination check for ECS nic

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -298,6 +298,10 @@ The `network` block supports:
 * `fixed_ip_v4` - (Optional, String, ForceNew) Specifies a fixed IPv4 address to be used on this network.
   Changing this creates a new instance.
 
+* `source_dest_check` - (Optional, Bool) Specifies whether the ECS processes only traffic that is destined specifically
+  for it. This function is enabled by default but should be disabled if the ECS functions as a SNAT server or has a
+  virtual IP address bound to it.
+
 * `access_network` - (Optional, Bool) Specifies if this network should be used for provisioning access.
   Accepts true or false. Defaults to false.
 

--- a/docs/resources/compute_interface_attach.md
+++ b/docs/resources/compute_interface_attach.md
@@ -112,11 +112,16 @@ The following arguments are supported:
   _NOTE_: This option cannot be used with port_id. You must specifiy a network_id. The IP address must lie in a range on
   the supplied network.
 
+* `source_dest_check` - (Optional, Bool) Specifies whether the ECS processes only traffic that is destined specifically
+  for it. This function is enabled by default but should be disabled if the ECS functions as a SNAT server or has a
+  virtual IP address bound to it.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - The resource ID in format of ECS instance ID and port ID separated by a slash.
+* `mac` - The MAC address of the NIC.
 
 ## Timeouts
 

--- a/huaweicloud/compute_instance_v2_networking.go
+++ b/huaweicloud/compute_instance_v2_networking.go
@@ -22,12 +22,13 @@ import (
 
 // InstanceNIC is a structured representation of a servers.Server virtual NIC
 type InstanceNIC struct {
-	NetworkID string
-	PortID    string
-	FixedIPv4 string
-	FixedIPv6 string
-	MAC       string
-	Fetched   bool
+	NetworkID       string
+	PortID          string
+	FixedIPv4       string
+	FixedIPv6       string
+	MAC             string
+	SourceDestCheck bool
+	Fetched         bool
 }
 
 // InstanceNetwork represents a collection of network information that a
@@ -90,9 +91,10 @@ func getInstanceAddresses(d *schema.ResourceData, meta interface{}, server *clou
 			}
 
 			instanceNIC := InstanceNIC{
-				NetworkID: networkID,
-				PortID:    addr.PortID,
-				MAC:       addr.MacAddr,
+				NetworkID:       networkID,
+				PortID:          addr.PortID,
+				MAC:             addr.MacAddr,
+				SourceDestCheck: len(p.AllowedAddressPairs) == 0,
 			}
 			if addr.Version == "6" {
 				instanceNIC.FixedIPv6 = addr.Addr
@@ -157,12 +159,13 @@ func flattenInstanceNetworks(
 
 			if isExist {
 				v := map[string]interface{}{
-					"uuid":           nic.NetworkID,
-					"port":           nic.PortID,
-					"fixed_ip_v4":    nic.FixedIPv4,
-					"fixed_ip_v6":    nic.FixedIPv6,
-					"mac":            nic.MAC,
-					"access_network": instanceNetwork.AccessNetwork,
+					"uuid":              nic.NetworkID,
+					"port":              nic.PortID,
+					"fixed_ip_v4":       nic.FixedIPv4,
+					"fixed_ip_v6":       nic.FixedIPv6,
+					"source_dest_check": nic.SourceDestCheck,
+					"mac":               nic.MAC,
+					"access_network":    instanceNetwork.AccessNetwork,
 				}
 				networks = append(networks, v)
 				break

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -13,6 +11,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccComputeV2Instance_basic(t *testing.T) {
@@ -34,8 +33,10 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "security_groups.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "network.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.0.port"),
+					resource.TestCheckResourceAttr(resourceName, "network.0.source_dest_check", "true"),
 				),
 			},
 			{

--- a/huaweicloud/resource_huaweicloud_compute_interface_attach.go
+++ b/huaweicloud/resource_huaweicloud_compute_interface_attach.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/attachinterfaces"
+	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
@@ -17,6 +18,7 @@ func ResourceComputeInterfaceAttachV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComputeInterfaceAttachV2Create,
 		Read:   resourceComputeInterfaceAttachV2Read,
+		Update: resourceComputeInterfaceAttachV2Update,
 		Delete: resourceComputeInterfaceAttachV2Delete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -60,6 +62,15 @@ func ResourceComputeInterfaceAttachV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"source_dest_check": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"mac": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -101,10 +112,11 @@ func resourceComputeInterfaceAttachV2Create(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	portID := attachment.PortID
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ATTACHING"},
 		Target:     []string{"ATTACHED"},
-		Refresh:    computeInterfaceAttachV2AttachFunc(computeClient, instanceId, attachment.PortID),
+		Refresh:    computeInterfaceAttachV2AttachFunc(computeClient, instanceId, portID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
@@ -115,11 +127,21 @@ func resourceComputeInterfaceAttachV2Create(d *schema.ResourceData, meta interfa
 	}
 
 	// Use the instance ID and port ID as the resource ID.
-	id := fmt.Sprintf("%s/%s", instanceId, attachment.PortID)
+	id := fmt.Sprintf("%s/%s", instanceId, portID)
 
 	logp.Printf("[DEBUG] Created huaweicloud_compute_interface_attach %s: %#v", id, attachment)
 
 	d.SetId(id)
+
+	if sourceDestCheck := d.Get("source_dest_check").(bool); !sourceDestCheck {
+		nicClient, err := config.NetworkingV2Client(GetRegion(d, config))
+		if err != nil {
+			return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		}
+		if err := disableSourceDestCheck(nicClient, portID); err != nil {
+			return fmtp.Errorf("Error disable source dest check on port(%s) of instance(%s) failed: %s", portID, d.Id(), err)
+		}
+	}
 
 	return resourceComputeInterfaceAttachV2Read(d, meta)
 }
@@ -129,6 +151,10 @@ func resourceComputeInterfaceAttachV2Read(d *schema.ResourceData, meta interface
 	computeClient, err := config.ComputeV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud compute client: %s", err)
+	}
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
 
 	instanceId, portId, err := computeInterfaceAttachV2ParseID(d.Id())
@@ -152,7 +178,36 @@ func resourceComputeInterfaceAttachV2Read(d *schema.ResourceData, meta interface
 		firstAddress := attachment.FixedIPs[0].IPAddress
 		d.Set("fixed_ip", firstAddress)
 	}
+
+	if port, err := ports.Get(networkingClient, attachment.PortID).Extract(); err == nil {
+		d.Set("source_dest_check", len(port.AllowedAddressPairs) == 0)
+		d.Set("mac", port.MACAddress)
+	}
+
 	return nil
+}
+
+func resourceComputeInterfaceAttachV2Update(d *schema.ResourceData, meta interface{}) error {
+	var err error
+
+	config := meta.(*config.Config)
+	nicClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	portID := d.Get("port_id").(string)
+	if sourceDestCheck := d.Get("source_dest_check").(bool); !sourceDestCheck {
+		err = disableSourceDestCheck(nicClient, portID)
+	} else {
+		err = enableSourceDestCheck(nicClient, portID)
+	}
+
+	if err != nil {
+		return fmtp.Errorf("Error updating source_dest_check on port(%s) of instance(%s) failed: %s", portID, d.Id(), err)
+	}
+
+	return resourceComputeInterfaceAttachV2Read(d, meta)
 }
 
 func resourceComputeInterfaceAttachV2Delete(d *schema.ResourceData, meta interface{}) error {

--- a/huaweicloud/resource_huaweicloud_compute_interface_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_interface_attach_test.go
@@ -29,6 +29,7 @@ func TestAccComputeV2InterfaceAttach_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InterfaceAttachExists(resourceName, &ai),
 					testAccCheckComputeV2InterfaceAttachIP(&ai, "192.168.0.199"),
+					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "true"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1706 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (168.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       168.349s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2InterfaceAttach_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2InterfaceAttach_Basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2InterfaceAttach_Basic
=== PAUSE TestAccComputeV2InterfaceAttach_Basic
=== CONT  TestAccComputeV2InterfaceAttach_Basic

--- PASS: TestAccComputeV2InterfaceAttach_Basic (214.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       214.683s
```
