### PR TITLE
feat(rds/engine): add new rds engine data source support

### DIFF
--- a/docs/data-sources/rds_engine_versions.md
+++ b/docs/data-sources/rds_engine_versions.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_engine_versions
+
+Use this data source to obtain all version information of the specified engine type of HuaweiCloud RDS.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rds_engine_versions" "test" {
+  type = "SQLServer"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the RDS engine versions.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the RDS engine type.
+  The valid values are **MySQL**, **PostgreSQL** and **SQLServer**, default to **MySQL**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID in hashcode format.
+
+* `versions` - List of RDS versions. Structure is documented below.
+
+The `versions` block contains:
+
+* `id` - Version ID.
+
+* `name` - Version name.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20211127094219-4219ea24299a
+	github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20211127094219-4219ea24299a h1:2+Mfd3Lku72WL4aUO+mbtmAxkdLMZfes+ddkWgMSeXo=
-github.com/chnsz/golangsdk v0.0.0-20211127094219-4219ea24299a/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8 h1:NeMqYMGL6S6oaBZMQdJm/hCZfvfaYplJ2RItLRq1Qec=
+github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mrs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
@@ -338,6 +339,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_secgroup":                  DataSourceNetworkingSecGroupV2(),
 			"huaweicloud_obs_bucket_object":                    DataSourceObsBucketObject(),
 			"huaweicloud_rds_flavors":                          DataSourceRdsFlavorV3(),
+			"huaweicloud_rds_engine_versions":                  rds.DataSourceRdsEngineVersionsV3(),
 			"huaweicloud_sfs_file_system":                      DataSourceSFSFileSystemV2(),
 			"huaweicloud_vbs_backup_policy":                    dataSourceVBSBackupPolicyV2(),
 			"huaweicloud_vbs_backup":                           dataSourceVBSBackupV2(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_engine_versions_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_engine_versions_test.go
@@ -1,0 +1,34 @@
+package rds
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccRdsEngineVersionsV3DataSource_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_rds_engine_versions.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "MySQL"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+const testAccRdsEngineVersionsV3DataSource_basic string = "data \"huaweicloud_rds_engine_versions\" \"test\" {}"

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_engine_versions.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_engine_versions.go
@@ -1,0 +1,88 @@
+package rds
+
+import (
+	"context"
+	"sort"
+
+	"github.com/chnsz/golangsdk/openstack/rds/v3/instances"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceRdsEngineVersionsV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsEngineVersionsV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"MySQL", "PostgreSQL", "SQLServer",
+				}, false),
+				Default: "MySQL",
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceRdsEngineVersionsV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.RdsV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud RDS v3 client: %s", err)
+	}
+
+	engineType := d.Get("type").(string)
+	engine, err := instances.ListEngine(client, engineType)
+	if err != nil {
+		return fmtp.DiagErrorf("Error getting version list of specific database engine: %s", err)
+	}
+
+	versions := engine.Versions
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Name < versions[j].Name
+	})
+	logp.Printf("After sorting, the engine version list is: %+v", versions)
+
+	ids := make([]string, len(versions))
+	result := make([]map[string]interface{}, len(versions))
+
+	for i, engine := range versions {
+		vMap := map[string]interface{}{
+			"id":   engine.ID,
+			"name": engine.Name,
+		}
+		result[i] = vMap
+		ids[i] = engine.ID
+	}
+
+	d.SetId(hashcode.Strings(ids))
+
+	return diag.FromErr(d.Set("versions", result))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20211127094219-4219ea24299a
+# github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add the data source for obtaining the RDS engine version to enhance the ease of use of HuaweiCloud provider resources.

**Which issue this PR fixes**:
Reference #1728

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to obtain the version informations.
2. add related document and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run=TestAccRdsEngineVersionsV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run=TestAccRdsEngineVersionsV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsEngineVersionsV3DataSource_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_basic (38.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       38.115s
```
