### PR TITLE
feat(iec): add lines attribute into site data source

### DIFF
--- a/docs/data-sources/iec_sites.md
+++ b/docs/data-sources/iec_sites.md
@@ -18,13 +18,11 @@ data "huaweicloud_iec_sites" "iec_sites" {}
 
 The following arguments are supported:
 
-* `area` - (Optional, String) Specifies the area of the iec sites located.
+* `area` - (Optional, String) Specifies the area of the IEC sites located.
 
-* `province` - (Optional, String) Specifies the province of the iec sites located.
+* `province` - (Optional, String) Specifies the province of the IEC sites located.
 
-* `city` - (Optional, String) Specifies the city of the iec sites located.
-
-* `operator` - (Optional, String) Specifies the operator supported of the iec sites.
+* `city` - (Optional, String) Specifies the city of the IEC sites located.
 
 ## Attributes Reference
 
@@ -32,14 +30,19 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a data source ID in UUID format.
 
-* `sites` - An array of one or more iec service sites. The sites object structure is documented below.
+* `sites` - An array of one or more IEC service sites. The sites object structure is documented below.
 
 The `sites` block supports:
 
-* `id` - The id of the iec service site.
-* `name` - The name of the iec service site.
-* `area` - The area of the iec service site located.
-* `province` - The province of the iec service site located.
-* `city` - The city of the iec service site located.
-* `operator` - The operator information of the iec service site.
-* `status` - The current status of the iec service site.
+* `id` - The ID of the IEC service site.
+* `name` - The name of the IEC service site.
+* `area` - The area of the IEC service site located.
+* `province` - The province of the IEC service site located.
+* `city` - The city of the IEC service site located.
+* `status` - The status of the IEC service site.
+
+* `lines` - An array of one or more EIP lines. The object structure is documented below.
+  + `id` - The ID of the EIP line.
+  + `name` - The name of the EIP line.
+  + `operator` - The operator information of the EIP line.
+  + `ip_version` - The supported IP version.

--- a/huaweicloud/data_source_huaweicloud_iec_sites_test.go
+++ b/huaweicloud/data_source_huaweicloud_iec_sites_test.go
@@ -2,10 +2,7 @@ package huaweicloud
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,13 +16,12 @@ func TestAccIECSitesDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIECSitesConfig(),
+				Config: testAccIECSitesConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIECSitesDataSourceID(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "sites.#", regexp.MustCompile("[1-9]\\d*")),
-					resource.TestCheckResourceAttr(resourceName, "region", HW_REGION_NAME),
-					resource.TestCheckResourceAttr(resourceName, "area", "east"),
-					resource.TestCheckResourceAttr(resourceName, "city", "hangzhou"),
+					resource.TestCheckResourceAttrSet(resourceName, "sites.#"),
+					resource.TestCheckResourceAttr(resourceName, "sites.0.area", "east"),
+					resource.TestCheckResourceAttrSet(resourceName, "sites.0.lines.#"),
 				),
 			},
 		},
@@ -36,22 +32,18 @@ func testAccCheckIECSitesDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Root module has no resource called %s", n)
+			return fmt.Errorf("Root module has no resource called %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("IEC sites data source ID not set")
+			return fmt.Errorf("IEC sites data source ID not set")
 		}
 		return nil
 	}
 }
 
-func testAccIECSitesConfig() string {
-	return fmt.Sprintf(`
+var testAccIECSitesConfig string = `
 data "huaweicloud_iec_sites" "sites_test" {
-  region = "%s"
-  area   = "east"
-  city   = "hangzhou"
+  area = "east"
 }
-	`, HW_REGION_NAME)
-}
+`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- remove `operator` as the API does not support it any more;
- add `lines` to show multi-lines of a site.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIECSitesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIECSitesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIECSitesDataSource_basic
=== PAUSE TestAccIECSitesDataSource_basic
=== CONT  TestAccIECSitesDataSource_basic
--- PASS: TestAccIECSitesDataSource_basic (28.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       28.233s
```
