### PR TITLE
bugfix(config): mask security fields when logging

### DIFF
--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -205,28 +205,38 @@ func FormatHeaders(headers http.Header, seperator string) string {
 	return strings.Join(redactedHeaders, seperator)
 }
 
-// "password" is apply to the most request JSON body
-// "adminPass" is apply to the ecs instance request JSON body
-// "adminPwd" is apply to the css cluster request JSON body
-// "secret" is apply to the AK/SK response JSON body
-var securityFields = []string{"password", "adminPass", "adminPwd", "secret"}
-
 func maskSecurityFields(data map[string]interface{}) bool {
-	for _, field := range securityFields {
-		if _, ok := data[field].(string); ok {
-			data[field] = "***"
-			return true
-		}
-	}
-
-	for _, v := range data {
-		switch v.(type) {
+	for k, val := range data {
+		switch val.(type) {
+		case string:
+			if isSecurityFields(k) {
+				data[k] = "***"
+			}
 		case map[string]interface{}:
-			subData := v.(map[string]interface{})
+			subData := val.(map[string]interface{})
 			if masked := maskSecurityFields(subData); masked {
 				return true
 			}
 		}
 	}
+	return false
+}
+
+func isSecurityFields(field string) bool {
+	// "password" is apply to the most request JSON body
+	// "secret" is apply to the AK/SK response JSON body
+	if strings.Contains(field, "password") || strings.Contains(field, "secret") {
+		return true
+	}
+
+	// "adminPass" is apply to the ecs/bms instance request JSON body
+	// "adminPwd" is apply to the css cluster request JSON body
+	securityFields := []string{"adminPass", "adminPwd"}
+	for _, key := range securityFields {
+		if key == field {
+			return true
+		}
+	}
+
 	return false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**password** is a very important field in API request body and has many variants, they should be masked when loging.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

After huaweicloud_dms_kafka_instance, huaweicloud_compute_instance, huaweicloud_rds_instance.instance were created, all security fields have been masked in log file.

```
  "adminPass": "***",
  "kafka_manager_password": "***",
  "password": "***",
```
