### PR TITLE
feat(iec): support to specify ip address for vip

### DIFF
--- a/docs/resources/iec_vip.md
+++ b/docs/resources/iec_vip.md
@@ -20,10 +20,14 @@ resource "huaweicloud_iec_vip" "vip_test" {
 
 The following arguments are supported:
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the network to which the vip belongs. Changing this
-  parameter creates a new vip resource.
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the network to which the vip belongs.
+  Changing this parameter creates a new vip resource.
 
-* `port_ids` - (Required, List) Specifies an array of IDs of the ports to attach the vip to.
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address desired in the subnet for this vip.
+  If you don't specify it, an available IP address from the specified subnet will be allocated to this vip.
+  Changing this parameter creates a new vip resource.
+
+* `port_ids` - (Optional, List) Specifies an array of IDs of the ports to attach the vip to.
 
 ## Attributes Reference
 
@@ -32,8 +36,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The id of the vip.
 
 * `mac_address` - The MAC address of the vip.
-
-* `fixed_ips` - An array of IP addresses binding to the vip.
 
 * `allowed_addresses` - An array of IP addresses of the ports to attach the vip to.
 

--- a/huaweicloud/resource_huaweicloud_iec_server_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_server_test.go
@@ -154,7 +154,7 @@ resource "huaweicloud_iec_server" "server_test" {
   
   coverage_sites {
     site_id  = data.huaweicloud_iec_sites.sites_test.sites[0].id
-    operator = data.huaweicloud_iec_sites.sites_test.sites[0].operator
+    operator = data.huaweicloud_iec_sites.sites_test.sites[0].lines[0].operator
   }
 }
 `, rName, rName, rName, rName, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecServerResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecServerResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecServerResource_basic
--- PASS: TestAccIecServerResource_basic (131.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       131.153s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecVipResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecVipResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecVipResource_basic
=== PAUSE TestAccIecVipResource_basic
=== CONT  TestAccIecVipResource_basic
--- PASS: TestAccIecVipResource_basic (74.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       74.700s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecVipResource_associate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecVipResource_associate -timeout 360m -parallel 4
=== RUN   TestAccIecVipResource_associate
=== PAUSE TestAccIecVipResource_associate
=== CONT  TestAccIecVipResource_associate
--- PASS: TestAccIecVipResource_associate (167.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       167.835s
```
