### PR TITLE
feat(iam/provider): add a resource to manage the conversion rules of identity provider

### DIFF
--- a/docs/resources/identity_provider_conversion.md
+++ b/docs/resources/identity_provider_conversion.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_provider_conversion
+
+Manage the conversion rules of identity provider within HuaweiCloud IAM service.
+
+## Example Usage
+
+```hcl
+variable provider_id {}
+
+resource "huaweicloud_identity_provider_conversion" "conversion" {
+  provider_id = var.provider_id
+
+  conversion_rules {
+    local {
+      username = "Tom"
+    }
+    remote {
+      attribute = "Tom"
+    }
+  }
+
+  conversion_rules {
+    local {
+      username = "FederationUser"
+    }
+    remote {
+      attribute = "username"
+      condition = "any_one_of"
+      value     = ["Tom", "Jerry"]
+    }
+  }
+}
+```
+
+<!--markdownlint-disable MD033-->
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `provider_id` - (Required, String) The ID of the identity provider used to manage the conversion rules.
+
+* `conversion_rules` - (Required, List) Specifies the identity conversion rules of the identity provider.
+  You can use identity conversion rules to map the identities of existing users to Huawei Cloud and manage their access
+  to cloud resources.
+  The [object](#conversion_rules) structure is documented below.
+
+<a name="conversion_rules"></a>
+The `conversion_rules` block supports:
+
+* `local` - (Required, List) Specifies the federated user information on the cloud platform.
+
+* `remote` - (Required, List) Specifies Federated user information in the IDP system.
+
+-> **NOTE:** If the protocol of identity provider is SAML, this field is an expression consisting of assertion
+attributes and operators.
+If the protocol of identity provider is OIDC, the value of this field is determined by the ID token.
+
+The `local` block supports:
+
+* `username` - (Required, String) Specifies the name of a federated user on the cloud platform.
+
+* `group` - (Optional, String) Specifies the user group to which the federated user belongs on the cloud platform.
+
+The `remote` block supports:
+
+* `attribute` - (Required, String) Specifies the attribute in the IDP assertion.
+
+* `condition` - (Optional, String) Specifies the condition of conversion rule.
+  Available options are:
+  + `any_one_of`: The rule is matched only if the specified strings appear in the attribute type.
+  + `not_any_of`: The rule is matched only if the specified strings do not appear in the attribute type.
+
+-> **NOTE:** 1. The condition result is Boolean rather than the argument that is passed as input.
+<br/>2. In a remote array, `any_one_of` and `not_any_of` are mutually exclusive and cannot be set at the same time.
+
+* `value` - (Optional, List) Specifies the rule is matched only if the specified strings appear in the attribute type.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of conversion rules.
+
+## Import
+
+Identity provider conversion rules are imported using the `provider_id`, e.g.
+
+```
+$ terraform import huaweicloud_identity_provider_conversion.conversion example_com_provider_oidc
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -662,6 +662,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_user_v3":                   iam.ResourceIdentityUserV3(),
 			"huaweicloud_identity_group_v3":                  iam.ResourceIdentityGroupV3(),
 			"huaweicloud_identity_group_membership_v3":       iam.ResourceIdentityGroupMembershipV3(),
+			"huaweicloud_identity_provider_conversion":       iam.ResourceIAMProviderConversion(),
 			"huaweicloud_cdm_cluster_v1":                     ResourceCdmClusterV1(),
 			"huaweicloud_ges_graph_v1":                       ResourceGesGraphV1(),
 			"huaweicloud_cloudtable_cluster_v2":              resourceCloudtableClusterV2(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_conversion_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_conversion_test.go
@@ -1,0 +1,129 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
+)
+
+func getProviderConversionFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.IAMNoVersionClient(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HuaweiCloud IAM without version: %s", err)
+	}
+	providerID := state.Primary.Attributes["provider_id"]
+	conversionID := iam.MappingIDPrefix + providerID
+	return mappings.Get(client, conversionID)
+}
+
+func TestAccIdentityProviderConversion_basic(t *testing.T) {
+	var provider providers.Provider
+	var name = acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_identity_provider_conversion.conversion"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&provider,
+		getProviderConversionFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProviderConversion_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.0.local.0.username", "Tom"),
+				),
+			},
+			{
+				Config: testAccIdentityProviderConversion_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.0.local.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.0.local.0.username", "Tom"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.1.remote.0.value.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIdentityProviderConversion_conf(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "oidc"
+}
+
+resource "huaweicloud_identity_provider_conversion" "conversion" {
+  provider_id = huaweicloud_identity_provider.provider_1.id
+
+  conversion_rules {
+    local {
+      username = "Tom"
+    }
+    remote {
+      attribute = "Tom"
+    }
+  }
+}
+`, name)
+}
+
+func testAccIdentityProviderConversion_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "oidc"
+}
+
+resource "huaweicloud_identity_provider_conversion" "conversion" {
+  provider_id = huaweicloud_identity_provider.provider_1.id
+
+  conversion_rules {
+    local {
+      username = "Tom"
+    }
+    local {
+      username = "federateduser"
+    }
+    remote {
+      attribute = "Tom"
+    }
+    remote {
+      attribute = "federatedgroup"
+    }
+  }
+
+  conversion_rules {
+    local {
+      username = "Jams"
+    }
+    remote {
+      attribute = "username"
+      condition = "any_one_of"
+      value     = ["Tom", "Jerry"]
+    }
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider_conversion.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider_conversion.go
@@ -1,0 +1,261 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+const MappingIDPrefix = "mapping_"
+
+func ResourceIAMProviderConversion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIAMProviderConversionCreate,
+		ReadContext:   resourceIAMProviderConversionRead,
+		UpdateContext: resourceIAMProviderConversionUpdate,
+		DeleteContext: resourceIAMProviderConversionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"provider_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"conversion_rules": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"local": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"group": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"remote": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 10,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"attribute": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"condition": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"any_one_of", "not_any_of"}, false),
+									},
+									"value": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIAMProviderConversionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud IAM without version client: %s", err)
+	}
+	providerID := d.Get("provider_id").(string)
+	conversionID := MappingIDPrefix + providerID
+
+	// Check if the mappingID exists, update if it exists, otherwise create it.
+	r, err := mappings.List(client).AllPages()
+	err404 := golangsdk.ErrDefault404{}
+	if err != nil && !errors.As(err, &err404) {
+		return fmtp.DiagErrorf("error in querying or extract conversions: %s", err)
+	}
+
+	conversions, err := mappings.ExtractMappings(r)
+	if err != nil {
+		return fmtp.DiagErrorf("error in extracting provider conversions: %s", err)
+	}
+
+	filterData, err := utils.FilterSliceWithField(conversions, map[string]interface{}{
+		"ID": conversionID,
+	})
+	if err != nil {
+		return fmtp.DiagErrorf("error in filtering conversions: %s", err)
+	}
+
+	conversionRules := d.Get("conversion_rules").([]interface{})
+	mappingOpts := buildConversionRules(conversionRules)
+	// Create the mapping if it does not exist, otherwise update it.
+	if len(filterData) == 0 {
+		_, err = mappings.Create(client, conversionID, mappingOpts)
+	} else {
+		_, err = mappings.Update(client, conversionID, mappingOpts)
+	}
+	if err != nil {
+		return fmtp.DiagErrorf("error in creating/updating mapping: %s", err)
+	}
+	d.SetId(conversionID)
+
+	return resourceIAMProviderConversionRead(ctx, d, meta)
+}
+
+func buildConversionRules(conversionRules []interface{}) mappings.MappingOption {
+	rules := make([]mappings.MappingRule, 0, len(conversionRules))
+
+	for _, cr := range conversionRules {
+		convRule := cr.(map[string]interface{})
+
+		// build local rules
+		local := convRule["local"].([]interface{})
+		localRules := make([]mappings.LocalRule, 0, len(local))
+		for _, v := range local {
+			lRule := v.(map[string]interface{})
+			r := mappings.LocalRule{
+				User: mappings.LocalRuleVal{
+					Name: lRule["username"].(string),
+				},
+			}
+			group, ok := lRule["group"]
+			if ok && len(group.(string)) > 0 {
+				r.Group = &mappings.LocalRuleVal{
+					Name: group.(string),
+				}
+			}
+			localRules = append(localRules, r)
+		}
+		// build remote rule
+		remote := convRule["remote"].([]interface{})
+		remoteRules := make([]mappings.RemoteRule, 0, len(remote))
+		for _, v := range remote {
+			rRule := v.(map[string]interface{})
+			r := mappings.RemoteRule{
+				Type: rRule["attribute"].(string),
+			}
+			if condition, ok := rRule["condition"]; ok {
+				values := utils.ExpandToStringList(rRule["value"].([]interface{}))
+				if condition.(string) == "any_one_of" {
+					r.AnyOneOf = values
+				} else if condition.(string) == "not_any_of" {
+					r.NotAnyOf = values
+				}
+			}
+			remoteRules = append(remoteRules, r)
+		}
+
+		rule := mappings.MappingRule{
+			Local:  localRules,
+			Remote: remoteRules,
+		}
+		rules = append(rules, rule)
+	}
+	opts := mappings.MappingOption{
+		Rules: rules,
+	}
+	return opts
+}
+
+func resourceIAMProviderConversionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud IAM client without version number: %s", err)
+	}
+
+	conversionID := d.Id()
+	conversions, err := mappings.Get(client, conversionID)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error in querying conversion rules")
+	}
+
+	conversionRules := buildConversionRulesAttr(conversions)
+	providerID := strings.Replace(conversionID, MappingIDPrefix, "", -1)
+	mErr := multierror.Append(
+		d.Set("provider_id", providerID),
+		d.Set("conversion_rules", conversionRules),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		logp.Printf("[ERROR] Error setting identity provider attributes %s: %s", d.Id(), mErr, conversionID)
+		return fmtp.DiagErrorf("Error setting identity provider conversion rules: %s", mErr)
+	}
+	return nil
+}
+
+func resourceIAMProviderConversionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud IAM client without version number: %s", err)
+	}
+
+	conversionRules := d.Get("conversion_rules").([]interface{})
+	conversionRuleOpts := buildConversionRules(conversionRules)
+	conversionID := d.Id()
+	_, err = mappings.Update(client, conversionID, conversionRuleOpts)
+	if err != nil {
+		return fmtp.DiagErrorf("Failed to update the provider conversion rules: %s", err)
+	}
+
+	return resourceIAMProviderConversionRead(ctx, d, meta)
+}
+
+func resourceIAMProviderConversionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud IAM client without version number: %s", err)
+	}
+
+	providerID := d.Get("provider_id").(string)
+	_, err = providers.Get(client, providerID)
+	if err != nil && errors.As(err, &golangsdk.ErrDefault404{}) {
+		d.SetId("")
+		return nil
+	}
+
+	conversionID := d.Id()
+	opts := getDefaultConversionOpts()
+	_, err = mappings.Update(client, conversionID, *opts)
+
+	if err != nil {
+		return fmtp.DiagErrorf("Error resetting provider conversion rules to default value" +
+			"(the conversion rules can not be deleted, it can be reset to default value).")
+	}
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Manages the conversion rules of OIDC protocol identity providers within HuaweiCloud IAM service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1423

**Special notes for your reviewer**:

This PR depends on: #1625, pls merge it first.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run TestAccIdentityProviderConversion_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityProviderConversion_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityProviderConversion_basic
=== PAUSE TestAccIdentityProviderConversion_basic
=== CONT  TestAccIdentityProviderConversion_basic
--- PASS: TestAccIdentityProviderConversion_basic (60.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       60.139s
```
