### PR TITLE
fix(security group): Add new validation of the protocol type setting

### DIFF
--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -46,8 +46,9 @@ The following arguments are supported:
   group rule. This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
   Changing this creates a new security group rule.
 
-* `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol type, valid values are __tcp__, __udp__
-  and __icmp__. This is required if you want to specify a port range. Changing this creates a new security group rule.
+* `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol type, valid values are __tcp__, __udp__,
+  __icmp__ and __icmpv6__. If omitted, the protocol means that all protocols are supported.
+  This is required if you want to specify a port range. Changing this creates a new security group rule.
 
 * `port_range_min` - (Optional, Int, ForceNew) Specifies the lower part of the allowed port range, valid integer value
   needs to be between 1 and 65535. Changing this creates a new security group rule.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**
The resource failed to properly set any type of security group policy.
When the security group rule was created, the protocol was set to "any", but the protocol value was not stored correctly in the state. As a result, changes occurred:
  - `null` -> `any`

For about API response, only protocol values (None, 'tcp', 'udp', 'icmp', 'icmpv6') and integer representations (0 to 255) are supported. So, add a new validation for protocol.
Any one of them is verified as true means that the protocol is filled in correctly:
- Whether the protocol is one of `udp`, `tcp`, `icmp` and `icmpv6`.
- Whether the protocol is range from 0 to 255.
- If omitted, protocol means `any` (will not be set).

**Which issue this PR fixes**:
fixes #1749

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add new validation of the protocol type setting.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2SecGroupRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingV2SecGroupRule -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== RUN   TestAccNetworkingV2SecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingV2SecGroupRule_remoteGroup
=== RUN   TestAccNetworkingV2SecGroupRule_lowerCaseCIDR
=== PAUSE TestAccNetworkingV2SecGroupRule_lowerCaseCIDR
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_lowerCaseCIDR
=== CONT  TestAccNetworkingV2SecGroupRule_remoteGroup
--- PASS: TestAccNetworkingV2SecGroupRule_lowerCaseCIDR (103.36s)
--- PASS: TestAccNetworkingV2SecGroupRule_remoteGroup (115.01s)
--- PASS: TestAccNetworkingV2SecGroupRule_basic (115.36s)
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (115.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       115.526s
```
