### PR TITLE
fix(gaussdb/cassandra): get rid of db version validation

### DIFF
--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -109,7 +109,7 @@ The `datastore` block supports:
 
 * `engine` - (Optional, String, ForceNew) Specifies the database engine. Only "GeminiDB-Cassandra" is supported now.
 
-* `version` - (Optional, String, ForceNew) Specifies the database version. Only "3.11" is supported now.
+* `version` - (Optional, String, ForceNew) Specifies the database version.
 
 * `storage_engine` - (Optional, String, ForceNew) Specifies the storage engine. Only "rocksDB" is supported now.
 

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -128,9 +128,6 @@ func resourceGeminiDBInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"3.11",
-							}, true),
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccGeminiDBInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccGeminiDBInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstance_basic
=== PAUSE TestAccGeminiDBInstance_basic
=== CONT  TestAccGeminiDBInstance_basic
--- PASS: TestAccGeminiDBInstance_basic (1160.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1160.427s

```
