### PR TITLE
docs(ims/image): remove redundant parameter

### DIFF
--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -87,7 +87,6 @@ In addition to all arguments above, the following attributes are exported:
   and tags.
 * `min_disk_gb` - The minimum amount of disk space required to use the image.
 * `min_ram_mb` - The minimum amount of ram required to use the image.
-* `properties` - Freeform information about the image.
 * `protected` - Whether or not the image is protected.
 * `schema` - The path to the JSON-schema that represent the image or image.
 * `size_bytes` - The size of the image (in bytes).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Parameter `properties` does not exist.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove redundant parameter 'properties'.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
