### PR TITLE
docs(cce/cluster): supplementary structure description

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -149,8 +149,9 @@ The following arguments are supported:
 * `multi_az` - (Optional, Bool, ForceNew) Enable multiple AZs for the cluster, only when using HA flavors. Changing this
   parameter will create a new cluster resource. This parameter and `masters` are alternative
 
-* `masters` - (Optional, List, ForceNew) Advanced configuration of master nodes. Changing this creates a new cluster.
-  This parameter and `multi_az` are alternative.
+* `masters` - (Optional, List, ForceNew) Advanced configuration of master nodes.
+  The [object](#cce_cluster_masters) structure is documented below.
+  This parameter and `multi_az` are alternative. Changing this parameter will create a new cluster resource.
 
 * `eip` - (Optional, String, ForceNew) EIP address of the cluster. Changing this parameter will create a new cluster
   resource.
@@ -204,6 +205,7 @@ The following arguments are supported:
   hibernated, resources such as workloads cannot be created or managed in the cluster, and the cluster cannot be
   deleted.
 
+<a name="cce_cluster_masters"></a>
 The `masters` block supports:
 
 * `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone of the master node. Changing this


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter `masters` miss a structure declaration, and the user cannot see whether it is a structure or a slice.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplementary structure description.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
