### PR TITLE
feat(iec): support multi line for eip

### DIFF
--- a/docs/resources/iec_eip.md
+++ b/docs/resources/iec_eip.md
@@ -23,6 +23,9 @@ The following arguments are supported:
 * `site_id` - (Required, String, ForceNew) Specifies the ID of IEC sevice site. Changing this parameter creates a new
   resource.
 
+* `line_id` - (Optional, String, ForceNew) Specifies the line ID of IEC sevice site.
+  Changing this parameter creates a new resource.
+
 * `port_id` - (Optional, String) Specifies the port ID which this eip will associate with.
 
 ## Attributes Reference

--- a/huaweicloud/resource_huaweicloud_iec_eip_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_eip_test.go
@@ -31,6 +31,7 @@ func TestAccIecEIPResource_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$")),
 					resource.TestCheckResourceAttrSet(resourceName, "site_info"),
 					resource.TestCheckResourceAttrSet(resourceName, "site_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "line_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "bandwidth_id"),
 				),
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

we can select **lines** when creating EIPs both by console and API, so update it in the provider.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIecEIPResource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIecEIPResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecEIPResource_basic
=== PAUSE TestAccIecEIPResource_basic
=== CONT  TestAccIecEIPResource_basic
--- PASS: TestAccIecEIPResource_basic (58.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       58.718s
```
