### PR TITLE
fix(template): fix case support for parameters

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -12,6 +12,7 @@ package common
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -153,5 +154,14 @@ func refreshOrderStatus(c *golangsdk.ServiceClient, orderNum string) resource.St
 			return nil, "Error", err
 		}
 		return r, strconv.Itoa(r.OrderInfo.Status), nil
+	}
+}
+
+func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		if strings.ToLower(old) == strings.ToLower(new) {
+			return true
+		}
+		return false
 	}
 }

--- a/huaweicloud/resource_huaweicloud_rds_configuration_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_configuration_v3.go
@@ -6,6 +6,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/rds/v3/configurations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
@@ -54,8 +55,9 @@ func ResourceRdsConfigurationV3() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: common.CaseInsensitiveFunc(),
 						},
 						"version": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The datastore version input of resource `huaweicloud_rds_parametergroup` does not support case-insensitive.
- 'mysql': no change
- 'MySQL': rebuild

**Which issue this PR fixes**:
#1748 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a behavior of 'DiffSuppressFunc' to support case-insensitive for database version.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccRdsConfigurationV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccRdsConfigurationV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsConfigurationV3_basic
=== PAUSE TestAccRdsConfigurationV3_basic
=== CONT  TestAccRdsConfigurationV3_basic
--- PASS: TestAccRdsConfigurationV3_basic (124.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       125.556s
```
