### PR TITLE
fix(waf/group): fix argument load_balances to load_balancers

### DIFF
--- a/docs/data-sources/waf_instance_groups.md
+++ b/docs/data-sources/waf_instance_groups.md
@@ -52,4 +52,4 @@ The `groups` block supports:
 
 * `read_timeout` - The time for reading timeout in the forwarding policy.
 
-* `load_balances` - The IDs of the ELB instances that has been bound to the instance group.
+* `load_balancers` - The IDs of the ELB instances that has been bound to the instance group.

--- a/docs/resources/waf_instance_group.md
+++ b/docs/resources/waf_instance_group.md
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `read_timeout` - The time for reading timeout in the forwarding policy.
 
-* `load_balances` - The IDs of the ELB instances that has been bound to the instance group.
+* `load_balancers` - The IDs of the ELB instances that has been bound to the instance group.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_instance_groups_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_instance_groups_test.go
@@ -36,9 +36,44 @@ resource "huaweicloud_vpc" "vpc_1" {
   cidr = "192.168.0.0/24"
 }
 
+resource "huaweicloud_vpc_subnet" "vpc_subnet_1" {
+  name       = "%s_waf"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.vpc_1.id
+}
+
+resource "huaweicloud_networking_secgroup" "secgroup" {
+  name        = "%s_waf"
+  description = "terraform security group acceptance test"
+}
+
+data "huaweicloud_availability_zones" "zones" {}
+
+data "huaweicloud_compute_flavors" "flavors" {
+  availability_zone = data.huaweicloud_availability_zones.zones.names[1]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+}
+
+resource "huaweicloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.huaweicloud_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.huaweicloud_compute_flavors.flavors.ids[0]
+  vpc_id             = huaweicloud_vpc.vpc_1.id
+  subnet_id          = huaweicloud_vpc_subnet.vpc_subnet_1.id
+  
+  security_group = [
+    huaweicloud_networking_secgroup.secgroup.id
+  ]
+}
+
 resource "huaweicloud_waf_instance_group" "group_1" {
   name   = "%s"
   vpc_id = huaweicloud_vpc.vpc_1.id
+
+  depends_on = [huaweicloud_waf_dedicated_instance.instance_1]
 }
 
 data "huaweicloud_waf_instance_groups" "groups_1" {
@@ -48,5 +83,5 @@ data "huaweicloud_waf_instance_groups" "groups_1" {
     huaweicloud_waf_instance_group.group_1
   ]
 }
-`, name, name, name)
+`, name, name, name, name, name, name)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_test.go
@@ -39,10 +39,17 @@ func TestAccWafInstanceGroup_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafInstanceGroup_conf(name),
+				Config: testAccWafInstanceGroup_conf(name, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testAccWafInstanceGroup_conf(name, name+"_updated"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_updated"),
 				),
 			},
 			{
@@ -54,16 +61,51 @@ func TestAccWafInstanceGroup_basic(t *testing.T) {
 	})
 }
 
-func testAccWafInstanceGroup_conf(name string) string {
+func testAccWafInstanceGroup_conf(baseName, groupName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "vpc_1" {
   name = "%s_waf"
   cidr = "192.168.0.0/24"
 }
 
+resource "huaweicloud_vpc_subnet" "vpc_subnet_1" {
+  name       = "%s_waf"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.vpc_1.id
+}
+
+resource "huaweicloud_networking_secgroup" "secgroup" {
+  name        = "%s_waf"
+  description = "terraform security group acceptance test"
+}
+
+data "huaweicloud_availability_zones" "zones" {}
+
+data "huaweicloud_compute_flavors" "flavors" {
+  availability_zone = data.huaweicloud_availability_zones.zones.names[1]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+}
+
+resource "huaweicloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.huaweicloud_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.huaweicloud_compute_flavors.flavors.ids[0]
+  vpc_id             = huaweicloud_vpc.vpc_1.id
+  subnet_id          = huaweicloud_vpc_subnet.vpc_subnet_1.id
+  
+  security_group = [
+    huaweicloud_networking_secgroup.secgroup.id
+  ]
+}
+
 resource "huaweicloud_waf_instance_group" "group_1" {
   name   = "%s"
   vpc_id = huaweicloud_vpc.vpc_1.id
+
+  depends_on = [huaweicloud_waf_dedicated_instance.instance_1]
 }
-`, name, name)
+`, baseName, baseName, baseName, baseName, groupName)
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_instance_groups.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_instance_groups.go
@@ -73,7 +73,7 @@ func DataSourceWafInstanceGroups() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"load_balances": {
+						"load_balancers": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -176,7 +176,7 @@ func DataSourceWafInstanceGroupsRead(_ context.Context, d *schema.ResourceData, 
 			"connection_timeout": g.Option.ConnectTimeout,
 			"write_timeout":      g.Option.SendTimeout,
 			"read_timeout":       g.Option.ReadTimeout,
-			"load_balances":      loadBalances,
+			"load_balancers":     loadBalances,
 			"domain_names":       domainNames,
 		}
 		grps = append(grps, group)

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_instance_group.go
@@ -71,7 +71,7 @@ func ResourceWafInstanceGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"load_balances": {
+			"load_balancers": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -132,7 +132,7 @@ func resourceWafInstanceGroupRead(_ context.Context, d *schema.ResourceData, met
 	for _, v := range pool.Bindings {
 		loadBalances = append(loadBalances, v.Name)
 	}
-	d.Set("load_balances", loadBalances)
+	d.Set("load_balancers", loadBalances)
 	d.Set("description", pool.Description)
 
 	if err = mErr.ErrorOrNil(); err != nil {
@@ -173,7 +173,7 @@ func resourceWafInstanceGroupDelete(_ context.Context, d *schema.ResourceData, m
 		return fmtp.DiagErrorf("error in creating HuaweiCloud WAF dedicated client : %s", err)
 	}
 	// remove the bound ELB instances before deleting the group
-	elbs := d.Get("load_balances").([]interface{})
+	elbs := d.Get("load_balancers").([]interface{})
 	if len(elbs) > 0 {
 		mErr := batchRemoveELBInstances(client, d.Id(), elbs)
 		if err = mErr.ErrorOrNil(); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In order to unify the parameters, we need to change xxx to xxx.

- in data source `huaweicloud_waf_instance_groups` modify the argument in a compatible way.
- in resource `huaweicloud_waf_instance_group` because it is an attribute, so directly modified and not compatible.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### huaweicloud_waf_instance_group
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafInstanceGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafInstanceGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccWafInstanceGroup_basic
=== PAUSE TestAccWafInstanceGroup_basic
=== CONT  TestAccWafInstanceGroup_basic
--- PASS: TestAccWafInstanceGroup_basic (387.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       387.135s
```

### huaweicloud_waf_instance_groups
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafInstanceGroups_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafInstanceGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafInstanceGroups_basic
=== PAUSE TestAccDataSourceWafInstanceGroups_basic
=== CONT  TestAccDataSourceWafInstanceGroups_basic
--- PASS: TestAccDataSourceWafInstanceGroups_basic (319.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       319.619s

```
