### PR TITLE
feat: add huaweicloud_iec_bandwidths data source

### DIFF
--- a/docs/data-sources/iec_bandwidths.md
+++ b/docs/data-sources/iec_bandwidths.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Intelligent EdgeCloud (IEC)"
+---
+
+# huaweicloud_iec_bandwidths
+
+Use this data source to get a list of bandwidths belong to a specific IEC site.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_iec_sites" "sites_test" {}
+
+data "huaweicloud_iec_bandwidths" "demo" {
+  site_id = data.huaweicloud_iec_sites.sites_test.sites[0].id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `site_id` - (Required, String) Specifies the ID of the IEC site.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `site_info` - The located information of the iec site. It contains area, province and city.
+
+* `bandwidths` - A list of all the bandwidths found. The object is documented below.
+
+The `bandwidths` block supports:
+
+* `id` - The ID of the bandwidth.
+* `name` - The name of the bandwidth.
+* `size` - The size of the bandwidth.
+* `share_type` - Whether the bandwidth is shared or exclusive.
+* `charge_mode` - The charging mode of the bandwidth.
+* `line` - The line name of the bandwidth.
+* `status` - The status of the bandwidth.

--- a/huaweicloud/data_source_huaweicloud_iec_bandwidths.go
+++ b/huaweicloud/data_source_huaweicloud_iec_bandwidths.go
@@ -1,0 +1,126 @@
+package huaweicloud
+
+import (
+	"context"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+
+	"github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths"
+	iec_common "github.com/chnsz/golangsdk/openstack/iec/v1/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func dataSourceIECBandWidths() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIECBandWidthsRead,
+
+		Schema: map[string]*schema.Schema{
+			"site_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"site_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bandwidths": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"share_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"charge_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"line": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIECBandWidthsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	iecClient, err := config.IECV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud IEC client: %s", err)
+	}
+
+	listOpts := bandwidths.ListOpts{
+		SiteID: d.Get("site_id").(string),
+	}
+
+	allBWs, err := bandwidths.List(iecClient, listOpts).Extract()
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to extract iec bandwidths: %s", err)
+	}
+
+	total := len(allBWs.BandWidth)
+	if total < 1 {
+		return fmtp.DiagErrorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	logp.Printf("[INFO] Retrieved [%d] IEC bandwidths using given filter", total)
+	firstBW := allBWs.BandWidth[0]
+	d.SetId(firstBW.ID)
+	d.Set("site_info", firstBW.SiteInfo)
+
+	iecBWs := make([]map[string]interface{}, total)
+	for i, item := range allBWs.BandWidth {
+		iecBWs[i] = map[string]interface{}{
+			"id":          item.ID,
+			"name":        item.Name,
+			"size":        item.Size,
+			"share_type":  item.ShareType,
+			"charge_mode": item.ChargeMode,
+			"status":      item.Status,
+			"line":        getLineName(item.Operator),
+		}
+	}
+	if err := d.Set("bandwidths", iecBWs); err != nil {
+		return fmtp.DiagErrorf("Error saving IEC bandwidths: %s", err)
+	}
+
+	return nil
+}
+
+func getLineName(operator iec_common.Operator) string {
+	if operator.Name != "" {
+		return operator.Name
+	} else if operator.I18nName != "" {
+		return operator.I18nName
+	} else if operator.Sa != "" {
+		return operator.Sa
+	}
+
+	return ""
+}

--- a/huaweicloud/data_source_huaweicloud_iec_bandwidths_test.go
+++ b/huaweicloud/data_source_huaweicloud_iec_bandwidths_test.go
@@ -1,0 +1,77 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIECBandWidthsDataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_iec_bandwidths.bandwidths"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		CheckDestroy:              testAccCheckIecEIPDestroy,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIECBWsDataSource_config,
+			},
+			{
+				Config: testAccIECBWsDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIECBandWidthsDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bandwidths.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "site_info"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidths.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidths.1.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidths.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidths.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidths.0.line"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidths.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIECBandWidthsDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find IEC public IPs data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("IEC public IPs data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+var testAccIECBWsDataSource_config string = `
+data "huaweicloud_iec_sites" "sites_test" {}
+
+resource "huaweicloud_iec_eip" "eip_test1" {
+  site_id = data.huaweicloud_iec_sites.sites_test.sites[0].id
+}
+
+resource "huaweicloud_iec_eip" "eip_test2" {
+  site_id = data.huaweicloud_iec_sites.sites_test.sites[0].id
+  line_id = data.huaweicloud_iec_sites.sites_test.sites[0].lines[1].id
+}
+`
+
+func testAccIECBWsDataSource_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iec_bandwidths" "bandwidths" {
+  site_id = data.huaweicloud_iec_sites.sites_test.sites[0].id
+}
+`, testAccIECBWsDataSource_config)
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -320,6 +320,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_role":                        iam.DataSourceIdentityRoleV3(),
 			"huaweicloud_identity_custom_role":                 iam.DataSourceIdentityCustomRole(),
 			"huaweicloud_identity_group":                       iam.DataSourceIdentityGroup(),
+			"huaweicloud_iec_bandwidths":                       dataSourceIECBandWidths(),
 			"huaweicloud_iec_eips":                             dataSourceIECNetworkEips(),
 			"huaweicloud_iec_flavors":                          dataSourceIecFlavors(),
 			"huaweicloud_iec_images":                           dataSourceIecImages(),

--- a/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths/requests.go
@@ -1,0 +1,83 @@
+package bandwidths
+
+import (
+	"net/http"
+
+	"github.com/chnsz/golangsdk"
+)
+
+func Get(client *golangsdk.ServiceClient, bandwidthId string) (r GetResult) {
+	url := GetURL(client, bandwidthId)
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	return
+}
+
+type UpdateOpts struct {
+	// Specifies the bandwidth name. The value is a string of 1 to 64
+	// characters that can contain letters, digits, underscores (_), and hyphens (-).
+	Name string `json:"name,omitempty"`
+
+	// Specifies the bandwidth size. The value ranges from 1 Mbit/s to
+	// 300 Mbit/s.
+	Size int `json:"size,omitempty"`
+}
+
+type UpdateOptsBuilder interface {
+	ToBandwidthsUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToBandwidthsUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "bandwidth")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Update(client *golangsdk.ServiceClient, bandwidthId string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToBandwidthsUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(UpdateURL(client, bandwidthId), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	return
+}
+
+type ListOpts struct {
+	Limit  int    `q:"limit"`
+	Offset int    `q:"offset"`
+	SiteID string `q:"site_id"`
+}
+
+type ListBandwidthsOptsBuilder interface {
+	ToListBandwidthsQuery() (string, error)
+}
+
+func (opts ListOpts) ToListBandwidthsQuery() (string, error) {
+	b, err := golangsdk.BuildQueryString(&opts)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func List(client *golangsdk.ServiceClient, opts ListBandwidthsOptsBuilder) (r ListResult) {
+	listURL := listURL(client)
+	if opts != nil {
+		query, err := opts.ToListBandwidthsQuery()
+		if err != nil {
+			r.Err = err
+			return r
+		}
+		listURL += query
+	}
+
+	_, r.Err = client.Get(listURL, &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths/results.go
@@ -1,0 +1,51 @@
+package bandwidths
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/common"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+//BandWidthObject 带宽的结构体，用于创建和更新请求
+type BandWidthObject struct {
+	BandWidth common.Bandwidth `json:"bandwidth"`
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r GetResult) Extract() (*BandWidthObject, error) {
+	var entity BandWidthObject
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+func (r UpdateResult) Extract() (*BandWidthObject, error) {
+	var entity BandWidthObject
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}
+
+// BandWidths 共享带宽列表对象
+type BandWidths struct {
+	BandWidth []common.Bandwidth `json:"bandwidths"`
+	Count     int                `json:"count"`
+}
+
+type ListResult struct {
+	commonResult
+}
+
+func (r ListResult) Extract() (*BandWidths, error) {
+	var entity BandWidths
+	err := r.ExtractIntoStructPtr(&entity, "")
+	return &entity, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths/urls.go
@@ -1,0 +1,17 @@
+package bandwidths
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+func GetURL(c *golangsdk.ServiceClient, bandwidthID string) string {
+	return c.ServiceURL("bandwidths", bandwidthID)
+}
+
+func UpdateURL(c *golangsdk.ServiceClient, bandwidthID string) string {
+	return c.ServiceURL("bandwidths", bandwidthID)
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("bandwidths")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/common/common.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/iec/v1/common/common.go
@@ -367,6 +367,10 @@ type AllowedAddressPair struct {
 }
 
 type Bandwidth struct {
+	// Specifies the bandwidth ID, which uniquely identifies the
+	// bandwidth.
+	ID string `json:"id"`
+
 	// Specifies the bandwidth name. The value is a string of 1 to 64
 	// characters that can contain letters, digits, underscores (_), and hyphens (-).
 	Name string `json:"name"`
@@ -374,10 +378,6 @@ type Bandwidth struct {
 	// Specifies the bandwidth size. The value ranges from 1 Mbit/s to
 	// 300 Mbit/s.
 	Size int `json:"size"`
-
-	// Specifies the bandwidth ID, which uniquely identifies the
-	// bandwidth.
-	ID string `json:"id"`
 
 	// Specifies whether the bandwidth is shared or exclusive. The
 	// value can be PER or WHOLE.
@@ -387,9 +387,6 @@ type Bandwidth struct {
 	// bandwidth, whose type is set to WHOLE, supports up to 20 elastic IP addresses. The
 	// bandwidth, whose type is set to PER, supports only one elastic IP address.
 	PublicipInfo []PublicIpinfo `json:"publicip_info"`
-
-	// Specifies the tenant ID of the user.
-	TenantId string `json:"tenant_id"`
 
 	// Specifies the bandwidth type.
 	BandwidthType string `json:"bandwidth_type"`
@@ -404,11 +401,11 @@ type Bandwidth struct {
 
 	CreateTime time.Time `json:"create_time,omitempty"`
 
+	UpdateTime time.Time `json:"update_time,omitempty"`
+
 	SiteInfo string `json:"site_info,omitempty"`
 
 	Operator Operator `json:"operator,omitempty"`
-
-	UpdateTime time.Time `json:"update_time,omitempty"`
 
 	PoolID string `json:"pool_id,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v1/cluster/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v1/cluster/results.go
@@ -65,6 +65,9 @@ type Cluster struct {
 	IsMrsManagerFinish    bool              `json:"ismrsManagerFinish"`
 	PeriodType            int               `json:"periodType"`
 	Scale                 string            `json:"scale"`
+	EipId                 string            `json:"eipId"`
+	EipAddress            string            `json:"eipAddress"`
+	Eipv6Address          string            `json:"eipv6Address"`
 }
 
 type Component struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -198,6 +198,7 @@ github.com/chnsz/golangsdk/openstack/identity/v3/projects
 github.com/chnsz/golangsdk/openstack/identity/v3/roles
 github.com/chnsz/golangsdk/openstack/identity/v3/tokens
 github.com/chnsz/golangsdk/openstack/identity/v3/users
+github.com/chnsz/golangsdk/openstack/iec/v1/bandwidths
 github.com/chnsz/golangsdk/openstack/iec/v1/cloudvolumes
 github.com/chnsz/golangsdk/openstack/iec/v1/common
 github.com/chnsz/golangsdk/openstack/iec/v1/firewalls


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new data source **huaweicloud_iec_bandwidths**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccIECBandWidthsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccIECBandWidthsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIECBandWidthsDataSource_basic
=== PAUSE TestAccIECBandWidthsDataSource_basic
=== CONT  TestAccIECBandWidthsDataSource_basic
--- PASS: TestAccIECBandWidthsDataSource_basic (76.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       76.545s
```
