### PR TITLE
fix(node pool): redesign the initial node count

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -50,7 +50,8 @@ The following arguments are supported:
 
 * `name` - (Required, String) Node Pool Name.
 
-* `initial_node_count` - (Required, Int) Initial number of expected nodes in the node pool.
+* `initial_node_count` - (Required, Int) Specifies the initial number of expected nodes in the node pool.
+  This parameter can be also used to manually scale the node count afterwards.
 
 * `flavor_id` - (Required, String, ForceNew) Specifies the flavor id. Changing this parameter will create a new
   resource.
@@ -163,6 +164,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `billing_mode` - Billing mode of a node.
 
+* `current_node_count` - The current number of the nodes.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
@@ -180,8 +183,9 @@ $ terraform import huaweicloud_cce_node_pool.my_node_pool 5c20fdad-7288-11eb-b81
 
 Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`, `subnet_id`, `preinstall`, `posteinstall`, `taints`. It is generally recommended running `terraform plan`
-after importing a node pool. You can then decide if changes should be applied to the node pool, or the resource
+`password`, `subnet_id`, `preinstall`, `posteinstall`, `taints` and `initial_node_count`.
+It is generally recommended running `terraform plan` after importing a node pool.
+You can then decide if changes should be applied to the node pool, or the resource
 definition should be updated to align with the node pool. Also you can ignore changes as below.
 
 ```

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -266,6 +266,10 @@ func ResourceCCENodePool() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"current_node_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -410,10 +414,10 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("os", s.Spec.NodeTemplate.Os)
 	d.Set("billing_mode", s.Spec.NodeTemplate.BillingMode)
 	d.Set("key_pair", s.Spec.NodeTemplate.Login.SshKey)
-	d.Set("initial_node_count", s.Spec.InitialNodeCount)
 	d.Set("scall_enable", s.Spec.Autoscaling.Enable)
 	d.Set("min_node_count", s.Spec.Autoscaling.MinNodeCount)
 	d.Set("max_node_count", s.Spec.Autoscaling.MaxNodeCount)
+	d.Set("current_node_count", s.Status.CurrentNode)
 	d.Set("scale_down_cooldown_time", s.Spec.Autoscaling.ScaleDownCooldownTime)
 	d.Set("priority", s.Spec.Autoscaling.Priority)
 	d.Set("type", s.Spec.Type)

--- a/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool_test.go
@@ -33,6 +33,7 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "current_node_count", "1"),
 				),
 			},
 			{
@@ -40,12 +41,15 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCENodePoolImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"initial_node_count",
+				},
 			},
 			{
 				Config: testAccCCENodePool_update(rName, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "current_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "9"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
initial_node_count represents both the initial number of nodes and the current number of nodes. The parameters have multiple meanings and do not conform to the design principles.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1757

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a current_node_count parameters to show the current number of nodes.
2. remove the setting of initial_node_count.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1233.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1233.522s
```
