### PR TITLE
refactor(DIS): add an attributes: partitions

### DIFF
--- a/docs/resources/dis_stream.md
+++ b/docs/resources/dis_stream.md
@@ -88,6 +88,18 @@ In addition to all arguments above, the following attributes are exported:
 
 * `stream_id` - Indicates a stream ID in UUID format.
 
+* `partitions` - The information of stream partitions. Structure is documented below.
+
+The `partitions` block contains:
+
+* `id` - The ID of the partition.
+
+* `status` - The status of the partition.
+
+* `hash_range` - Possible value range of the hash key used by each partition.
+
+* `sequence_number_range` - Sequence number range of each partition.
+
 ## Import
 
 Dis stream can be imported by `stream_name`. For example,

--- a/huaweicloud/services/acceptance/dis/resource_huaweicloud_dis_streams_test.go
+++ b/huaweicloud/services/acceptance/dis/resource_huaweicloud_dis_streams_test.go
@@ -43,6 +43,7 @@ func TestAccResourceDisStream_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "stream_name", name),
+					resource.TestCheckResourceAttr(resourceName, "partitions.#", "1"),
 				),
 			},
 			{
@@ -50,6 +51,7 @@ func TestAccResourceDisStream_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "stream_name", name),
+					resource.TestCheckResourceAttr(resourceName, "partitions.#", "4"),
 				),
 			},
 			{
@@ -94,6 +96,7 @@ func TestAccResourceDisStream_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "partition_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scale_min_partition_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scale_max_partition_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "partitions.#", "1"),
 				),
 			},
 			{
@@ -104,6 +107,7 @@ func TestAccResourceDisStream_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "partition_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scale_min_partition_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scale_max_partition_count", "4"),
+					resource.TestCheckResourceAttr(resourceName, "partitions.#", "2"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add a new attributes `partitions` in dis_stream

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1500

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dis' TESTARGS='-run=TestAccResourceDisStream_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dis -v -run=TestAccResourceDisStream_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDisStream_basic
=== PAUSE TestAccResourceDisStream_basic
=== CONT  TestAccResourceDisStream_basic
--- PASS: TestAccResourceDisStream_basic (38.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dis       38.574s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dis' TESTARGS='-run=TestAccResourceDisStream_all'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dis -v -run=TestAccResourceDisStream_all -timeout 360m -parallel 4
=== RUN   TestAccResourceDisStream_all
=== PAUSE TestAccResourceDisStream_all
=== CONT  TestAccResourceDisStream_all
--- PASS: TestAccResourceDisStream_all (29.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dis       29.222s
```
