### PR TITLE
refactor(bcs/instance): update kafka obtain and status check methods

### DIFF
--- a/huaweicloud/resource_huaweicloud_bcs_instance.go
+++ b/huaweicloud/resource_huaweicloud_bcs_instance.go
@@ -9,13 +9,13 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/bcs/v2/blockchains"
 	"github.com/chnsz/golangsdk/openstack/cce/v3/clusters"
-	"github.com/chnsz/golangsdk/openstack/dms/v1/instances"
+	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -522,7 +522,7 @@ func resourceBCSInstanceV2Delete(d *schema.ResourceData, meta interface{}) error
 			return fmtp.Errorf("Error creating HuaweiCloud Kafka client: %s", err)
 		}
 		kafkaName := d.Get("kafka.0.name").(string)
-		listOpts := instances.ListDmsInstanceOpts{
+		listOpts := instances.ListOpts{
 			Engine: "kafka",
 			Name:   kafkaName,
 		}
@@ -530,7 +530,7 @@ func resourceBCSInstanceV2Delete(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmtp.Errorf("Error getting kafka instance in queue (%s): %s", kafkaName, err)
 		}
-		res, err := instances.ExtractDmsInstances(pages)
+		res, err := instances.ExtractInstances(pages)
 		if err != nil {
 			return fmtp.Errorf("Error quering HuaweiCloud kafka instances: %s", err)
 		}
@@ -548,7 +548,7 @@ func resourceBCSInstanceV2Delete(d *schema.ResourceData, meta interface{}) error
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"DELETING", "RUNNING"},
 			Target:     []string{"DELETED"},
-			Refresh:    deprecated.DmsInstancesV1StateRefreshFunc(dmsClient, kafkaID),
+			Refresh:    dms.DmsKafkaInstanceStateRefreshFunc(dmsClient, kafkaID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource `huaweicloud_dms_instance` will be deprecated, and the available resource is `huaweicloud_dms_kafka_instance`.
Therefore, the method reference should be updated to the method to which `huaweicloud_dms_kafka_instance` belongs.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Use the method to which `huaweicloud_dms_kafka_instance` belongs to update the Kafka status check method reference.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccBCSV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccBCSV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccBCSV2Instance_basic
=== PAUSE TestAccBCSV2Instance_basic
=== CONT  TestAccBCSV2Instance_basic
--- PASS: TestAccBCSV2Instance_basic (1110.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1111.061s
```
