### PR TITLE
chore: move encoding functions into utils package

### DIFF
--- a/huaweicloud/resource_huaweicloud_as_configuration_v1.go
+++ b/huaweicloud/resource_huaweicloud_as_configuration_v1.go
@@ -1,8 +1,6 @@
 package huaweicloud
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"regexp"
 
 	"github.com/chnsz/golangsdk"
@@ -11,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -63,15 +62,7 @@ func ResourceASConfiguration() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 							// just stash the hash for state & diff comparisons
-							StateFunc: func(v interface{}) string {
-								switch v.(type) {
-								case string:
-									hash := sha1.Sum([]byte(v.(string)))
-									return hex.EncodeToString(hash[:])
-								default:
-									return ""
-								}
-							},
+							StateFunc: utils.HashAndHexEncode,
 						},
 						"disk": {
 							Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_attach.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -93,30 +94,16 @@ func ResourceCCENodeAttachV3() *schema.Resource {
 				ForceNew: true,
 			},
 			"preinstall": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						return installScriptHashSum(v.(string))
-					default:
-						return ""
-					}
-				},
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: utils.DecodeHashAndHexEncode,
 			},
 			"postinstall": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						return installScriptHashSum(v.(string))
-					default:
-						return ""
-					}
-				},
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: utils.DecodeHashAndHexEncode,
 			},
 			"taints": {
 				Type:     schema.TypeList,

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -200,30 +200,16 @@ func ResourceCCENodePool() *schema.Resource {
 				Computed: true,
 			},
 			"preinstall": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						return installScriptHashSum(v.(string))
-					default:
-						return ""
-					}
-				},
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: utils.DecodeHashAndHexEncode,
 			},
 			"postinstall": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						return installScriptHashSum(v.(string))
-					default:
-						return ""
-					}
-				},
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				StateFunc: utils.DecodeHashAndHexEncode,
 			},
 			"runtime": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -2,8 +2,6 @@ package huaweicloud
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -259,15 +257,7 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				// just stash the hash for state & diff comparisons
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
-					default:
-						return ""
-					}
-				},
+				StateFunc: utils.HashAndHexEncode,
 			},
 			"stop_before_destroy": {
 				Type:     schema.TypeBool,

--- a/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
+++ b/huaweicloud/resource_huaweicloud_ecs_instance_v1.go
@@ -1,8 +1,6 @@
 package huaweicloud
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -56,15 +54,7 @@ func resourceEcsInstanceV1() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				// just stash the hash for state & diff comparisons
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
-					default:
-						return ""
-					}
-				},
+				StateFunc: utils.HashAndHexEncode,
 			},
 			"password": {
 				Type:      schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_iec_server.go
+++ b/huaweicloud/resource_huaweicloud_iec_server.go
@@ -1,8 +1,6 @@
 package huaweicloud
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -15,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -201,15 +200,7 @@ func resourceIecServer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				// just stash the hash for state & diff comparisons
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
-					default:
-						return ""
-					}
-				},
+				StateFunc: utils.HashAndHexEncode,
 			},
 
 			// computed fields

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -2,8 +2,6 @@ package bms
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -103,15 +101,7 @@ func ResourceBmsInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				// just stash the hash for state & diff comparisons
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
-					default:
-						return ""
-					}
-				},
+				StateFunc: utils.HashAndHexEncode,
 			},
 			"admin_pass": {
 				Type:      schema.TypeString,

--- a/huaweicloud/utils/encoding.go
+++ b/huaweicloud/utils/encoding.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// HashAndHexEncode is one of the implementations of SchemaStateFunc.
+// The function gets the hash of v then returns the hexadecimal encoding string.
+// If the type of v is not string, just returns an empty string.
+func HashAndHexEncode(v interface{}) string {
+	switch v.(type) {
+	case string:
+		hash := sha1.Sum([]byte(v.(string)))
+		return hex.EncodeToString(hash[:])
+	default:
+		return ""
+	}
+}
+
+// DecodeHashAndHexEncode is one of the implementations of SchemaStateFunc.
+// The function tries to decode v if it is in base64 format, then gets the hash of
+// decode string and returns the hexadecimal encoding string.
+// If the type of v is not string, just returns an empty string.
+func DecodeHashAndHexEncode(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return installScriptHashSum(v.(string))
+	default:
+		return ""
+	}
+}
+
+func installScriptHashSum(script string) string {
+	// Check whether the script is not Base64 encoded.
+	// Always calculate hash of base64 decoded value since we
+	// check against double-encoding when setting it
+	v, base64DecodeError := base64.StdEncoding.DecodeString(script)
+	if base64DecodeError != nil {
+		v = []byte(script)
+	}
+
+	hash := sha1.Sum(v)
+	return hex.EncodeToString(hash[:])
+}
+
+// TryBase64EncodeToString will encode the script with base64.
+// If the script is already base64 encoded, returns it directly.
+func TryBase64EncodeToString(script string) string {
+	if _, err := base64.StdEncoding.DecodeString(script); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte(script))
+	}
+	return script
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

move all encoding functions into utils package

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run TestAccFgsV2Function_text'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFgsV2Function_text -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (34.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       34.764s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (183.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       183.263s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic

--- PASS: TestAccCCENodeV3_basic (840.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       840.743s
```
