### PR TITLE
fix(dms/kafka): fix the problem that the product_id queried is still the original value due to caching after the storage capacity is resized

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -29,7 +29,8 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   storage_spec_code  = data.huaweicloud_dms_product.product_1.storage_spec_code
   availability_zones = [
     data.huaweicloud_availability_zones.zones.names[0],
-    data.huaweicloud_availability_zones.zones.names[1]
+    data.huaweicloud_availability_zones.zones.names[1],
+    data.huaweicloud_availability_zones.zones.names[2]
   ]
   
   vpc_id            = var.vpc_id
@@ -57,9 +58,9 @@ The following arguments are supported:
 * `product_id` - (Required, String) Specifies a product ID, which includes bandwidth, partition, broker and default
   storage capacity.
 
--> **NOTE:** Change this to change the bandwidth, partition and broker of the Kafka instances. Please note that the
-broker changes may cause storage capacity changes. So, if you specify the value of `storage_space`, you need to manually
-modify the value of `storage_space` after changing the `product_id`.
+  -> **NOTE:** Change this to change the bandwidth, partition and broker of the Kafka instances. Please note that the
+  broker changes may cause storage capacity changes. So, if you specify the value of `storage_space`, you need to
+  manually modify the value of `storage_space` after changing the `product_id`.
 
 * `engine_version` - (Required, String, ForceNew) Specifies the version of the kafka engine. Valid values are "1.1.0"
   and "2.3.0". Changing this creates a new instance resource.
@@ -82,6 +83,10 @@ modify the value of `storage_space` after changing the `product_id`.
 * `availability_zones` - (Required, List, ForceNew) The codes of the AZ where the Kafka instances reside.
   The parameter value can not be left blank or an empty array. Changing this creates a new instance resource.
 
+  -> **NOTE:** Deploy one availability zone or at least three availability zones. Do not select two availability zones.
+  Deploy to more availability zones, the better the reliability and SLA coverage.
+  [Learn more](https://support.huaweicloud.com/en-us/kafka_faq/kafka-faq-200426002.html)
+
 * `manager_user` - (Required, String, ForceNew) Specifies the username for logging in to the Kafka Manager. The username
   consists of 4 to 64 characters and can contain letters, digits, hyphens (-), and underscores (_). Changing this
   creates a new instance resource.
@@ -92,10 +97,10 @@ modify the value of `storage_space` after changing the `product_id`.
   =+\\|[{}]:'",<.>/?). Changing this creates a new instance resource.
 
 * `storage_space` - (Optional, Int) Specifies the message storage capacity, the unit is GB. Value range:
-  + When bandwidth is 100MB: 600–90000 GB
-  + When bandwidth is 300MB: 1200–90000 GB
-  + When bandwidth is 600MB: 2400–90000 GB
-  + When bandwidth is 1200MB: 4800–90000 GB
+  + When bandwidth is 100MB: 600–90,000 GB
+  + When bandwidth is 300MB: 1,200–90,000 GB
+  + When bandwidth is 600MB: 2,400–90,000 GB
+  + When bandwidth is 1,200MB: 4,800–90,000 GB
 
   The storage capacity of the product used by default.
 
@@ -110,7 +115,7 @@ modify the value of `storage_space` after changing the `product_id`.
   -> **NOTE:** If `access_user` and `password` are specified, Kafka SASL_SSL will be automatically enabled.
 
 * `description` - (Optional, String) Specifies the description of the DMS kafka instance. It is a character string
-  containing not more than 1024 characters.
+  containing not more than 1,024 characters.
 
 * `maintain_begin` - (Optional, String) Specifies the time at which a maintenance time window starts. Format: HH:mm. The
   start time and end time of a maintenance time window must indicate the time segment of a supported maintenance time
@@ -130,7 +135,7 @@ modify the value of `storage_space` after changing the `product_id`.
   + When bandwidth is 100MB: 3
   + When bandwidth is 300MB: 3
   + When bandwidth is 600MB: 4
-  + When bandwidth is 1200MB: 8
+  + When bandwidth is 1,200MB: 8
 
   Changing this creates a new instance resource.
 

--- a/examples/dms/kafka-instance/README.md
+++ b/examples/dms/kafka-instance/README.md
@@ -1,0 +1,56 @@
+# Create a cluster DMS Kafka instances
+
+This example creates a cluster DMS kafka instances based on the example
+[examples/dms/kafka-instance](https://github.com/huaweicloud/terraform-provider-huaweicloud/tree/master/examples/dms/kafka-instance)
+. You can replace the VPC, Subnet and Security Group with the resources already created in HuaweiCloud.
+
+To run, configure your HuaweiCloud provider as described in the
+[document](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs).
+
+## The Kafka instance configuration
+
+| Attributes | Value |
+| ---- | ---- |
+| Instance Type | cluster |
+| Version | 2.3.0 |
+| Bandwidth | 100MB |
+| TPS | 50,000 |
+| Number of Partitions | 300 |
+| IO Type | high |
+
+### FAQ
+
+- **How to obtain the bandwidth, TPS, and number of partitions of the Kafka instances?**
+
+  The **bandwidth**, **TPS**, and the **number of partitions** are included in the product and do not need to be
+  specified when creating a resource. If you want to modify them, please modify the argument `product_id`.
+
+  The expected `product_id` can be obtained in the following way.
+
+  ```hcl
+  data "huaweicloud_dms_product" "product_1" {
+    engine            = "kafka"
+    instance_type     = "cluster"
+    version           = "2.3.0"
+    bandwidth         = "100MB"
+    storage_spec_code = "dms.physical.storage.high"
+  }
+  ```
+
+## Usage
+
+```shell
+terraform init
+terraform plan
+terraform apply
+terraform destroy
+```
+
+The creation of the DMS Kafka instance takes about 20 minutes.
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.12.0 |
+| huaweicloud | >= 1.31.1 |

--- a/examples/dms/kafka-instance/main.tf
+++ b/examples/dms/kafka-instance/main.tf
@@ -1,0 +1,56 @@
+# Create a VPC.
+resource "huaweicloud_vpc" "vpc_1" {
+  name = var.vpc_name
+  cidr = "192.168.0.0/24"
+}
+
+# Create a subnet under the VPC that created above.
+resource "huaweicloud_vpc_subnet" "vpc_subnet_1" {
+  name       = var.subnet_name
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.vpc_1.id
+}
+
+# Create a security group.
+resource "huaweicloud_networking_secgroup" "secgroup" {
+  name        = var.security_group_name
+  description = "terraform security group"
+}
+
+# List the availability zones in the current region.
+data "huaweicloud_availability_zones" "zones" {}
+
+# Find the product ID according to the Kafka instance information to be created.
+data "huaweicloud_dms_product" "product_1" {
+  engine            = "kafka"
+  instance_type     = "cluster"
+  version           = "2.3.0"
+  bandwidth         = "100MB"
+  storage_spec_code = "dms.physical.storage.high"
+}
+
+# Create the DMS Kafka instance.
+resource "huaweicloud_dms_kafka_instance" "kafka_instance_1" {
+  name        = "instance_1"
+  description = "kafka instance demo"
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.zones.names[0],
+    data.huaweicloud_availability_zones.zones.names[1],
+    data.huaweicloud_availability_zones.zones.names[2],
+  ]
+
+  product_id        = data.huaweicloud_dms_product.product_1.id
+  engine_version    = "2.3.0"
+  storage_spec_code = data.huaweicloud_dms_product.product_1.storage_spec_code
+
+  vpc_id            = huaweicloud_vpc.vpc_1.id
+  network_id        = huaweicloud_vpc_subnet.vpc_subnet_1.id
+  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+
+  access_user      = var.access_user_name
+  password         = var.access_user_password
+  manager_user     = var.manager_user
+  manager_password = var.manager_password
+}

--- a/examples/dms/kafka-instance/variables.tf
+++ b/examples/dms/kafka-instance/variables.tf
@@ -1,0 +1,34 @@
+variable "vpc_name" {
+  description = "The name of the Huaweicloud VPC"
+  default     = "tf_vpc_demo"
+}
+
+variable "subnet_name" {
+  description = "The name of the Huaweicloud Subnet"
+  default     = "tf_subnet_demo"
+}
+
+variable "security_group_name" {
+  description = "The name of the Huaweicloud Security Group"
+  default     = "tf_secgroup_demo"
+}
+
+variable "access_user_name" {
+  description = "The access user of the Kafka instance"
+  default     = "user"
+}
+
+variable "access_user_password" {
+  description = "The access password of the Kafka instance"
+  default     = "Kafkatest@123"
+}
+
+variable "manager_user" {
+  description = "The manager user of the Kafka instance"
+  default     = "kafka-user"
+}
+
+variable "manager_password" {
+  description = "The manager password of the Kafka instance"
+  default     = "Kafkatest@123"
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix the problem that the `product_id` queried is still the original value due to caching after the storage capacity is resized.
- Add a unit test case to test the old script.
- Add DMS Kafka instance resources usage example.
- Added description to the `availability_zones` argument in the document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsKafkaInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaInstance -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaInstances_basic
=== PAUSE TestAccDmsKafkaInstances_basic
=== RUN   TestAccDmsKafkaInstances_withEpsId
=== PAUSE TestAccDmsKafkaInstances_withEpsId
=== RUN   TestAccDmsKafkaInstances_compatible
=== PAUSE TestAccDmsKafkaInstances_compatible
=== CONT  TestAccDmsKafkaInstances_basic
=== CONT  TestAccDmsKafkaInstances_compatible
=== CONT  TestAccDmsKafkaInstances_withEpsId
--- PASS: TestAccDmsKafkaInstances_withEpsId (564.85s)
--- PASS: TestAccDmsKafkaInstances_compatible (602.14s)
--- PASS: TestAccDmsKafkaInstances_basic (1161.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1161.986s

```
