### PR TITLE
feat(EIP): add a new resource: vpc_eips

### DIFF
--- a/docs/data-sources/vpc_eips.md
+++ b/docs/data-sources/vpc_eips.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_vpc_eips
+
+Use this data source to get a list of EIPs.
+
+## Example Usage
+
+An example filter by name and tag
+
+```hcl
+variable "public_ip" {}
+
+data "huaweicloud_vpc_eips" "eip" {
+  public_ips = [var.public_ip]
+  tags {
+    foo = "bar,value"
+  }
+}
+
+output "eip_ids" {
+  value = data.huaweicloud_vpc_eips.eip.eips[*].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available EIPs in the current region.
+ All EIPs that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain the EIP. If omitted, the provider-level region
+  will be used.
+
+* `ids` - (Optional, List) Specifies an array of one or more IDs of the desired EIP.
+
+* `public_ips` - (Optional, List) Specifies an array of one or more public ip addresses of the desired EIP.
+
+* `port_ids` - (Optional, List) Specifies an array of one or more port ids which bound to the desired EIP.
+
+* `ip_version` - (Optional, Int) Specifies ip version of the desired EIP. The options are:
+    + `4`: IPv4.
+    + `6`: IPv6.
+
+  The default value is `4`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired EIP belongs to.
+
+* `tags` - (Optional, Map) Specifies the included key/value pairs which associated with the desired EIP.
+
+ -> A maximum of 10 tag keys are allowed for each query operation. Each tag key can have up to 10 tag values.
+  The tag key cannot be left blank or set to an empty string. Each tag key must be unique, and each tag value in a
+  tag must be unique, use commas(,) to separate the multiple values. An empty for values indicates any value.
+  The values are in the OR relationship.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `eips` - Indicates a list of all EIPs found. Structure is documented below.
+
+The `eips` block supports:
+
+* `id` - The ID of the EIP.
+* `name` - The name of the EIP.
+* `public_ip` - The public ip address of the EIP.
+* `private_ip` - The private ip address of the EIP.
+* `public_ipv6` - The public ipv6 address of the EIP.
+* `port_id` - The port id bound to the EIP.
+* `ip_version` - The ip version of the EIP.
+* `status` - The status of the EIP.
+* `type` - The type of the EIP.
+* `enterprise_project_id` - The the enterprise project ID of the EIP.
+* `bandwidth_id` - The bandwidth id of the EIP.
+* `bandwidth_name` - The bandwidth name of the EIP.
+* `bandwidth_size` - The bandwidth size of the EIP.
+* `bandwidth_share_type` - The bandwidth share type of the EIP.
+* `tags` - The key/value pairs which associated with the EIP.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -355,6 +355,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpcs":                                 vpc.DataSourceVpcs(),
 			"huaweicloud_vpc_bandwidth":                        vpc.DataSourceBandWidth(),
 			"huaweicloud_vpc_eip":                              vpc.DataSourceVpcEip(),
+			"huaweicloud_vpc_eips":                             vpc.DataSourceVpcEips(),
 			"huaweicloud_vpc_ids":                              vpc.DataSourceVpcIdsV1(),
 			"huaweicloud_vpc_peering_connection":               vpc.DataSourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_route_table":                      vpc.DataSourceVPCRouteTable(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_eips_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_eips_test.go
@@ -1,0 +1,87 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVpcEipsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_vpc_eips.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEips_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "eips.0.id",
+						"${huaweicloud_vpc_eip.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEips_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpc_eips" "test" {
+  public_ips = [huaweicloud_vpc_eip.test.address]
+}
+`, testAccVpcEip_basic(rName))
+}
+
+func TestAccVpcEipsDataSource_byTag(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_vpc_eips.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEips_byTag(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "eips.0.id",
+						"${huaweicloud_vpc_eip.test.id}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVpcEips_byTag(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpc_eips" "test" {
+  public_ips = [huaweicloud_vpc_eip.test.address]
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccVpcEip_tags(rName))
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eips.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eips.go
@@ -1,0 +1,218 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceVpcEips() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcEipsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"public_ips": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"port_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntInSlice([]int{4, 6}),
+				Default:      4,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"eips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ipv6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bandwidth_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bandwidth_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth_share_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.NetworkingV1Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud Networking client: %s", err)
+	}
+
+	clientV2, err := config.NetworkingV2Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud Networking V2 client: %s", err)
+	}
+
+	listOpts := &eips.ListOpts{
+		Id:        utils.ExpandToStringList(d.Get("ids").([]interface{})),
+		PublicIp:  utils.ExpandToStringList(d.Get("public_ips").([]interface{})),
+		PortId:    utils.ExpandToStringList(d.Get("port_ids").([]interface{})),
+		IPVersion: d.Get("ip_version").(int),
+	}
+
+	epsID := config.GetEnterpriseProjectID(d)
+	if epsID != "" {
+		listOpts.EnterpriseProjectId = epsID
+	}
+
+	pages, err := eips.List(client, listOpts).AllPages()
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve eips: %s ", err)
+	}
+
+	allEips, err := eips.ExtractPublicIPs(pages)
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve eips: %s ", err)
+	}
+
+	logp.Printf("[DEBUG] Retrieved eips using given filter: %+v", allEips)
+
+	var eips []map[string]interface{}
+	tagFilter := d.Get("tags").(map[string]interface{})
+	var ids []string
+	for _, item := range allEips {
+		var tagRst map[string]string
+
+		if resourceTags, err := tags.Get(clientV2, "publicips", item.ID).Extract(); err == nil {
+			tagmap := utils.TagsToMap(resourceTags.Tags)
+			tagsAfterFilter, isMatch := filterByTags(tagmap, tagFilter)
+
+			if !isMatch {
+				continue
+			}
+
+			tagRst = tagsAfterFilter
+
+		} else {
+			return fmtp.DiagErrorf("Error query tags of eip (%s): %s", d.Id(), err)
+		}
+
+		eip := map[string]interface{}{
+			"id":                    item.ID,
+			"name":                  item.Alias,
+			"status":                NormalizeEIPStatus(item.Status),
+			"type":                  item.Type,
+			"private_ip":            item.PrivateAddress,
+			"public_ip":             item.PublicAddress,
+			"public_ipv6":           item.PublicIpv6Address,
+			"port_id":               item.PortID,
+			"enterprise_project_id": item.EnterpriseProjectID,
+			"ip_version":            item.IpVersion,
+			"bandwidth_id":          item.BandwidthID,
+			"bandwidth_size":        item.BandwidthSize,
+			"bandwidth_name":        item.BandwidthName,
+			"bandwidth_share_type":  item.BandwidthShareType,
+			"tags":                  tagRst,
+		}
+
+		eips = append(eips, eip)
+		ids = append(ids, item.ID)
+	}
+	logp.Printf("[DEBUG]Eips List after filter, count=%d :%+v", len(eips), eips)
+
+	mErr := d.Set("eips", eips)
+	if mErr != nil {
+		return fmtp.DiagErrorf("set eips err:%s", mErr)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource: vpc_eips
support filter by multi ip,port_id and tag

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcEipsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcEipsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (34.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       34.203s
```

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcEipsDataSource_byTag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcEipsDataSource_byTag -timeout 360m -parallel 4
=== RUN   TestAccVpcEipsDataSource_byTag
=== PAUSE TestAccVpcEipsDataSource_byTag
=== CONT  TestAccVpcEipsDataSource_byTag
--- PASS: TestAccVpcEipsDataSource_byTag (32.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       32.988s
```
