### PR TITLE
fix(compute/instance): fix CheckDeleted issue

### DIFF
--- a/huaweicloud/data_source_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -15,7 +15,7 @@ import (
 func TestAccComputeInstanceDataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("ecs-data-test-%s", acctest.RandString(5))
 	resourceName := "data.huaweicloud_compute_instance.this"
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/huaweicloud/data_source_huaweicloud_compute_instances_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -15,7 +15,7 @@ import (
 func TestAccComputeInstancesDataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	dataSourceName := "data.huaweicloud_compute_instances.test"
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -704,6 +704,11 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	server, err := cloudservers.Get(ecsClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "compute instance")
+	} else {
+		if server.Status == "DELETED" {
+			d.SetId("")
+			return nil
+		}
 	}
 
 	logp.Printf("[DEBUG] Retrieved compute instance %s: %+v", d.Id(), server)

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/common/tags"
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccComputeV2Instance_basic(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_instance.test"
@@ -53,7 +53,7 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 }
 
 func TestAccComputeV2Instance_disks(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_instance.test"
@@ -75,7 +75,7 @@ func TestAccComputeV2Instance_disks(t *testing.T) {
 }
 
 func TestAccComputeV2Instance_prePaid(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_instance.test"
@@ -97,7 +97,7 @@ func TestAccComputeV2Instance_prePaid(t *testing.T) {
 }
 
 func TestAccComputeV2Instance_tags(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_instance.test"
@@ -143,7 +143,7 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 }
 
 func TestAccComputeV2Instance_powerAction(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_instance.test"
@@ -213,7 +213,7 @@ func TestAccComputeV2Instance_powerAction(t *testing.T) {
 
 func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
-	computeClient, err := config.ComputeV2Client(HW_REGION_NAME)
+	computeClient, err := config.ComputeV1Client(HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud compute client: %s", err)
 	}
@@ -223,9 +223,9 @@ func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		server, err := servers.Get(computeClient, rs.Primary.ID).Extract()
+		server, err := cloudservers.Get(computeClient, rs.Primary.ID).Extract()
 		if err == nil {
-			if server.Status != "SOFT_DELETED" {
+			if server.Status != "DELETED" {
 				return fmtp.Errorf("Instance still exists")
 			}
 		}
@@ -234,7 +234,7 @@ func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) resource.TestCheckFunc {
+func testAccCheckComputeV2InstanceExists(n string, instance *cloudservers.CloudServer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -246,12 +246,12 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 		}
 
 		config := testAccProvider.Meta().(*config.Config)
-		computeClient, err := config.ComputeV2Client(HW_REGION_NAME)
+		computeClient, err := config.ComputeV1Client(HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud compute client: %s", err)
 		}
 
-		found, err := servers.Get(computeClient, rs.Primary.ID).Extract()
+		found, err := cloudservers.Get(computeClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 }
 
 func testAccCheckComputeV2InstanceTags(
-	instance *servers.Server, k, v string) resource.TestCheckFunc {
+	instance *cloudservers.CloudServer, k, v string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.ComputeV1Client(HW_REGION_NAME)
@@ -293,7 +293,7 @@ func testAccCheckComputeV2InstanceTags(
 }
 
 func testAccCheckComputeV2InstanceNoTags(
-	instance *servers.Server) resource.TestCheckFunc {
+	instance *cloudservers.CloudServer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*config.Config)
 		client, err := config.ComputeV1Client(HW_REGION_NAME)

--- a/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/servergroups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -40,7 +40,7 @@ func TestAccComputeServerGroup_basic(t *testing.T) {
 }
 
 func TestAccComputeServerGroup_scheduler(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 	var sg servergroups.ServerGroup
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_servergroup.sg_1"
@@ -64,7 +64,7 @@ func TestAccComputeServerGroup_scheduler(t *testing.T) {
 }
 
 func TestAccComputeServerGroup_members(t *testing.T) {
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 	var sg servergroups.ServerGroup
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_compute_servergroup.sg_1"
@@ -140,7 +140,7 @@ func testAccCheckComputeServerGroupExists(n string, kp *servergroups.ServerGroup
 	}
 }
 
-func testAccCheckComputeInstanceInServerGroup(instance *servers.Server, sg *servergroups.ServerGroup) resource.TestCheckFunc {
+func testAccCheckComputeInstanceInServerGroup(instance *cloudservers.CloudServer, sg *servergroups.ServerGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(sg.Members) > 0 {
 			for _, m := range sg.Members {

--- a/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,7 +18,7 @@ import (
 
 func TestAccNetworkingV2VIPAssociate_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	var instance servers.Server
+	var instance cloudservers.CloudServer
 	var vip ports.Port
 	var port ports.Port
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1793 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccComputeV2Instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccComputeV2Instance -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== RUN   TestAccComputeV2Instance_disks
=== PAUSE TestAccComputeV2Instance_disks
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== RUN   TestAccComputeV2Instance_tags
=== PAUSE TestAccComputeV2Instance_tags
=== RUN   TestAccComputeV2Instance_powerAction
=== PAUSE TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_tags
=== CONT  TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_prePaid
--- PASS: TestAccComputeV2Instance_basic (221.01s)
=== CONT  TestAccComputeV2Instance_disks
--- PASS: TestAccComputeV2Instance_prePaid (226.14s)
--- PASS: TestAccComputeV2Instance_disks (215.79s)
--- PASS: TestAccComputeV2Instance_tags (507.42s)
--- PASS: TestAccComputeV2Instance_powerAction (721.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       721.398s
```
