### PR TITLE
feat(DMS) support to modify product_id and some optimizations

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `security_group_id` - (Required, String) Specifies the ID of a security group.
 
-* `availability_zones` - (Required, List, ForceNew) The codes of the AZ where the Kafka instances reside.
+* `availability_zones` - (Required, List, ForceNew) The names of the AZ where the Kafka instances reside.
   The parameter value can not be left blank or an empty array. Changing this creates a new instance resource.
 
   -> **NOTE:** Deploy one availability zone or at least three availability zones. Do not select two availability zones.

--- a/docs/resources/dms_rabbitmq_instance.md
+++ b/docs/resources/dms_rabbitmq_instance.md
@@ -4,50 +4,41 @@ subcategory: "Distributed Message Service (DMS)"
 
 # huaweicloud_dms_rabbitmq_instance
 
+Manage DMS RabbitMQ instance resources within HuaweiCloud.
+
 ## Example Usage
 
 ### Basic Instance
 
 ```hcl
-data "huaweicloud_dms_az" "test" {}
+variable vpc_id {}
+variable subnet_id {}
+variable security_group_id {}
 
-data "huaweicloud_vpc" "test" {
-  name = "vpc-default"
-}
-
-data "huaweicloud_vpc_subnet" "test" {
-  name = "subnet-default"
-}
+data "huaweicloud_availability_zones" "zones" {}
 
 data "huaweicloud_dms_product" "test" {
   engine        = "rabbitmq"
   instance_type = "cluster"
   version       = "3.7.17"
-}
-
-resource "huaweicloud_networking_secgroup" "test" {
-  name        = "secgroup_1"
-  description = "secgroup for rabbitmq"
+  node_num      = 3
 }
 
 resource "huaweicloud_dms_rabbitmq_instance" "test" {
   name              = "instance_1"
-  description       = "rabbitmq test"
-  access_user       = "user"
-  password          = "Rabbitmqtest@123"
-  vpc_id            = data.huaweicloud_vpc.test.id
-  network_id        = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  available_zones   = [data.huaweicloud_dms_az.test.id]
   product_id        = data.huaweicloud_dms_product.test.id
   engine_version    = data.huaweicloud_dms_product.test.version
-  storage_space     = data.huaweicloud_dms_product.test.storage
   storage_spec_code = data.huaweicloud_dms_product.test.storage_spec_code
 
-  tags = {
-    key   = "value"
-    owner = "terraform"
-  }
+  vpc_id             = var.vpc_id
+  network_id         = var.subnet_id
+  security_group_id  = var.security_group_id
+  availability_zones = [
+    data.huaweicloud_availability_zones.zones.names[0]
+  ]
+
+  access_user = "user"
+  password    = "Rabbitmqtest@123"
 }
 ```
 
@@ -55,29 +46,22 @@ resource "huaweicloud_dms_rabbitmq_instance" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the DMS rabbitmq instance resource. If omitted,
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS RabbitMQ instance resource. If omitted,
   the provider-level region will be used. Changing this creates a new instance resource.
 
-* `name` - (Required, String) Specifies the name of the DMS rabbitmq instance. An instance name starts with a letter,
+* `name` - (Required, String) Specifies the name of the DMS RabbitMQ instance. An instance name starts with a letter,
   consists of 4 to 64 characters, and supports only letters, digits, hyphens (-) and underscores (_).
 
-* `description` - (Optional, String) Specifies the description of the DMS rabbitmq instance.
-  It is a character string containing not more than 1024 characters.
+* `product_id` - (Required, String) Specifies a product ID. Changing this creates a new instance resource.
 
-* `engine_version` - (Optional, String, ForceNew) Specifies the version of the rabbitmq engine. Default to "3.7.17".
+  -> **NOTE:** Change this will change number of nodes and storage capacity. If you specify the value of
+  `storage_space`, you need to manually modify the value of `storage_space` after changing the `product_id`.
+
+* `engine_version` - (Optional, String, ForceNew) Specifies the version of the RabbitMQ engine. Default to "3.7.17".
   Changing this creates a new instance resource.
 
-* `storage_space` - (Required, Int, ForceNew) Specifies the message storage space. Value range:
-  + Single-node RabbitMQ instance: 100–90000 GB
-  + Cluster RabbitMQ instance: 100 GB x Number of nodes to 90000 GB, 200 GB x Number of nodes to 90000 GB,
-    and 300 GB x Number of nodes to 90000 GB
-
-  Changing this creates a new instance resource.
-
-* `storage_spec_code` - (Required, String, ForceNew) Specifies the storage I/O specification. Value range:
-  + dms.physical.storage.high
-  + dms.physical.storage.ultra
-
+* `storage_spec_code` - (Required, String, ForceNew) Specifies the storage I/O specification.
+  Valid values are **dms.physical.storage.high** and **dms.physical.storage.ultra**.
   Changing this creates a new instance resource.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC. Changing this creates a new instance resource.
@@ -87,19 +71,28 @@ The following arguments are supported:
 
 * `security_group_id` - (Required, String) Specifies the ID of a security group.
 
-* `available_zones` - (Required, List, ForceNew) Specifies the ID of an AZ. The parameter value can not be left blank or
-  an empty array. Changing this creates a new instance resource.
-
-* `product_id` - (Required, String, ForceNew) Specifies a product ID. Changing this creates a new instance resource.
+* `availability_zones` - (Required, List, ForceNew) Specifies the names of an AZ.
+  The parameter value can not be left blank or an empty array.
+  Changing this creates a new instance resource.
 
 * `access_user` - (Required, String, ForceNew) Specifies a username. A username consists of 4 to 64 characters and
   supports only letters, digits, and hyphens (-). Changing this creates a new instance resource.
 
-* `password` - (Required, String, ForceNew) Specifies the password of the DMS rabbitmq instance. A password must meet
+* `password` - (Required, String, ForceNew) Specifies the password of the DMS RabbitMQ instance. A password must meet
   the following complexity requirements: Must be 8 to 32 characters long. Must contain at least 2 of the following
   character types: lowercase letters, uppercase letters, digits,
   and special characters (`~!@#$%^&*()-_=+\\|[{}]:'",<.>/?).
   Changing this creates a new instance resource.
+
+* `storage_space` - (Optional, Int, ForceNew) Specifies the message storage space, unit is GB. Value range:
+  + Single-node RabbitMQ instance: 100–90,000 GB
+  + Cluster RabbitMQ instance: 100 GB x number of nodes to 90,000 GB, 200 GB x number of nodes to 90,000 GB,
+    and 300 GB x number of nodes to 90,000 GB
+
+  The storage capacity of the product used by default. Changing this creates a new instance resource.
+
+* `description` - (Optional, String) Specifies the description of the DMS RabbitMQ instance.
+  It is a character string containing not more than 1,024 characters.
 
 * `maintain_begin` - (Optional, String) Specifies the time at which a maintenance time window starts. Format: HH:mm.
   The start time and end time of a maintenance time window must indicate the time segment of a supported maintenance
@@ -116,15 +109,15 @@ The following arguments are supported:
   If parameter `maintain_end` is left  blank, parameter `maintain_begin` is also blank.
   In this case, the system automatically allocates the default end time 06:00.
 
-* `ssl_enable` - (Optional, String, ForceNew) Specifies whether to enable public access for the DMS rabbitmq instance.
+* `ssl_enable` - (Optional, String, ForceNew) Specifies whether to enable public access for the DMS RabbitMQ instance.
   Changing this creates a new instance resource.
 
 * `public_ip_id` - (Optional, String) Specifies the ID of the elastic IP address (EIP)
-  bound to the DMS rabbitmq instance.
+  bound to the DMS RabbitMQ instance.
 
-* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the rabbitmq instance.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the RabbitMQ instance.
 
-* `tags` - (Optional, Map) The key/value pairs to associate with the DMS rabbitmq instance.
+* `tags` - (Optional, Map) The key/value pairs to associate with the DMS RabbitMQ instance.
 
 ## Attributes Reference
 
@@ -132,22 +125,30 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
 * `engine` - Indicates the message engine.
-* `specification` - Indicates the instance specification. For a single-node DMS rabbitmq instance, VM specifications are
-  returned. For a cluster DMS rabbitmq instance, VM specifications and the number of nodes are returned.
+* `specification` - Indicates the instance specification. For a single-node DMS RabbitMQ instance, VM specifications are
+  returned. For a cluster DMS RabbitMQ instance, VM specifications and the number of nodes are returned.
 * `used_storage_space` - Indicates the used message storage space. Unit: GB
-* `port` - Indicates the port number of the DMS rabbitmq instance.
-* `status` - Indicates the status of the DMS rabbitmq instance.
-* `enable_public_ip` - Indicates whether public access to the DMS rabbitmq instance is enabled.
+* `port` - Indicates the port number of the DMS RabbitMQ instance.
+* `status` - Indicates the status of the DMS RabbitMQ instance.
+* `enable_public_ip` - Indicates whether public access to the DMS RabbitMQ instance is enabled.
 * `resource_spec_code` - Indicates a resource specifications identifier.
-* `type` - Indicates the DMS rabbitmq instance type.
-* `user_id` - Indicates the ID of the user who created the DMS rabbitmq instance
-* `user_name` - Indicates the name of the user who created the DMS rabbitmq instance
-* `connect_address` - Indicates the IP address of the DMS rabbitmq instance.
-* `manegement_connect_address` - Indicates the management address of the DMS rabbitmq instance.
+* `type` - Indicates the DMS RabbitMQ instance type.
+* `user_id` - Indicates the ID of the user who created the DMS RabbitMQ instance
+* `user_name` - Indicates the name of the user who created the DMS RabbitMQ instance
+* `connect_address` - Indicates the IP address of the DMS RabbitMQ instance.
+* `manegement_connect_address` - Indicates the management address of the DMS RabbitMQ instance.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minute.
+* `update` - Default is 20 minute.
+* `delete` - Default is 15 minute.
 
 ## Import
 
-DMS rabbitmq instance can be imported using the instance id, e.g.
+DMS RabbitMQ instance can be imported using the instance id, e.g.
 
 ```
  $ terraform import huaweicloud_dms_rabbitmq_instance.instance_1 8d3c7938-dc47-4937-a30f-c80de381c5e3
@@ -155,7 +156,7 @@ DMS rabbitmq instance can be imported using the instance id, e.g.
 
 Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`. It is generally recommended running `terraform plan` after importing a DMS rabbitmq instance. You can then
+`password`. It is generally recommended running `terraform plan` after importing a DMS RabbitMQ instance. You can then
 decide if changes should be applied to the instance, or the resource definition should be updated to align with the
 instance. Also you can ignore changes as below.
 
@@ -165,7 +166,7 @@ resource "huaweicloud_dms_rabbitmq_instance" "instance_1" {
 
   lifecycle {
     ignore_changes = [
-      password,
+      password
     ]
   }
 }

--- a/examples/dms/rabbitMQ-instance/README.md
+++ b/examples/dms/rabbitMQ-instance/README.md
@@ -1,0 +1,54 @@
+# Create a cluster DMS RabbitMQ instances
+
+This example creates a cluster DMS RabbitMQ instances based on the example
+[examples/dms/rabbitMQ-instance](https://github.com/huaweicloud/terraform-provider-huaweicloud/tree/master/examples/dms/rabbitMQ-instance)
+. You can replace the VPC, Subnet and Security Group with the resources already created in HuaweiCloud.
+
+To run, configure your HuaweiCloud provider as described in the
+[document](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs).
+
+## The RabbitMQ instance configuration
+
+| Attributes | Value |
+| ---- | ---- |
+| Version | 3.7.17 |
+| Instance Type | cluster |
+| Nodes | 3 |
+| Storage Capacity | 300GB |
+| IO Type | high |
+
+### FAQ
+
+- **How to obtain the number of nodes of the RabbitMQ instances?**
+
+  The **number of nodes** is included in the product and do not need to be
+  specified when creating a resource. If you want to modify it, please modify the argument `product_id`.
+
+  The expected `product_id` can be obtained in the following way.
+
+  ```hcl
+  data "huaweicloud_dms_product" "product_1" {
+    engine            = "rabbitmq"
+    instance_type     = "cluster"
+    version           = "3.7.17"
+    storage_spec_code = "dms.physical.storage.high"
+  }
+  ```
+
+## Usage
+
+```shell
+terraform init
+terraform plan
+terraform apply
+terraform destroy
+```
+
+The creation of the DMS RabbitMQ instance takes about 20 minutes.
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.12.0 |
+| huaweicloud | >= 1.31.1 |

--- a/examples/dms/rabbitMQ-instance/main.tf
+++ b/examples/dms/rabbitMQ-instance/main.tf
@@ -1,0 +1,56 @@
+# Create a VPC.
+resource "huaweicloud_vpc" "vpc_1" {
+  name = var.vpc_name
+  cidr = "192.168.0.0/24"
+}
+
+# Create a subnet under the VPC that created above.
+resource "huaweicloud_vpc_subnet" "vpc_subnet_1" {
+  name       = var.subnet_name
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.vpc_1.id
+}
+
+# Create a security group.
+resource "huaweicloud_networking_secgroup" "secgroup" {
+  name        = var.security_group_name
+  description = "terraform security group"
+}
+
+# List the availability zones in the current region.
+data "huaweicloud_availability_zones" "zones" {}
+
+# Find the product ID
+data "huaweicloud_dms_product" "product_1" {
+  engine            = "rabbitmq"
+  instance_type     = "cluster"
+  version           = "3.7.17"
+  storage_spec_code = "dms.physical.storage.high"
+}
+
+# Create the DMS RabbitMQ instance.
+resource "huaweicloud_dms_rabbitmq_instance" "instance_1" {
+  name        = "instance_1"
+  description = "rabbitmq test"
+
+  access_user = "user"
+  password    = "Rabbitmqtest@123"
+
+  vpc_id            = huaweicloud_vpc.vpc_1.id
+  network_id        = huaweicloud_vpc_subnet.vpc_subnet_1.id
+  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.zones.names[0]
+  ]
+
+  product_id        = data.huaweicloud_dms_product.product_1.id
+  engine_version    = data.huaweicloud_dms_product.product_1.version
+  storage_spec_code = data.huaweicloud_dms_product.product_1.storage_spec_code
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}

--- a/examples/dms/rabbitMQ-instance/variables.tf
+++ b/examples/dms/rabbitMQ-instance/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_name" {
+  description = "The name of the Huaweicloud VPC"
+  default     = "tf_vpc_demo"
+}
+
+variable "subnet_name" {
+  description = "The name of the Huaweicloud Subnet"
+  default     = "tf_subnet_demo"
+}
+
+variable "security_group_name" {
+  description = "The name of the Huaweicloud Security Group"
+  default     = "tf_secgroup_demo"
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Support to modify `product_id`.
- Deprecated `available_zones` and use instead `availability_zones`.
- Optimization of some other fields.
- Add examples.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1781, fixes #1674

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### huaweicloud_dms_rabbitmq_instance
```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsRabbitmqInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRabbitmqInstance -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (676.43s)
--- PASS: TestAccDmsRabbitmqInstances_compatible (689.46s)
--- PASS: TestAccDmsRabbitmqInstances_basic (1063.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1063.850s
```

### huaweicloud_dms_kafka_instance
```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsKafkaInstances'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaInstances -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaInstances_basic
=== PAUSE TestAccDmsKafkaInstances_basic
=== RUN   TestAccDmsKafkaInstances_withEpsId
=== PAUSE TestAccDmsKafkaInstances_withEpsId
=== RUN   TestAccDmsKafkaInstances_compatible
=== PAUSE TestAccDmsKafkaInstances_compatible
=== CONT  TestAccDmsKafkaInstances_basic
=== CONT  TestAccDmsKafkaInstances_compatible
=== CONT  TestAccDmsKafkaInstances_withEpsId
--- PASS: TestAccDmsKafkaInstances_compatible (588.18s)
--- PASS: TestAccDmsKafkaInstances_withEpsId (643.21s)
--- PASS: TestAccDmsKafkaInstances_basic (1094.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1094.160s
```
