### PR TITLE
docs: fix the wrong parameter name

### DIFF
--- a/docs/data-sources/cce_node.md
+++ b/docs/data-sources/cce_node.md
@@ -45,7 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `subnet_id` - The ID of the subnet which the NIC belongs to.
 
-* `esc_group_id` - The ID of Ecs group which the node belongs to.
+* `ecs_group_id` - The ID of Ecs group which the node belongs to.
 
 * `tags` - Tags of a VM node, key/value pair format.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter name of the ECS group ID should be `ecs_group_id`, not `esc_group_id`.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong parameter name.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
