### PR TITLE
feat: support ipv6 for vpc vip

### DIFF
--- a/docs/resources/networking_vip.md
+++ b/docs/resources/networking_vip.md
@@ -4,7 +4,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 # huaweicloud_networking_vip
 
-Manages a Vip resource within HuaweiCloud. This is an alternative to `huaweicloud_networking_vip_v2`
+Manages a VIP resource within HuaweiCloud. This is an alternative to `huaweicloud_networking_vip_v2`
 
 ## Example Usage
 
@@ -22,15 +22,17 @@ resource "huaweicloud_networking_vip" "myvip" {
 
 The following arguments are supported:
 
-* `region` - (Optional, ForceNew) The region in which to create the vip resource. If omitted, the provider-level region
-  will be used.
+* `region` - (Optional, String, ForceNew) The region in which to create the vip resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `network_id` - (Required, ForceNew) Specifies the ID of the network to which the vip belongs.
+* `network_id` - (Required, String, ForceNew) Specifies the ID of the network to which the vip belongs.
+  Changing this creates a new resource.
 
-* `subnet_id` - (Optional, ForceNew) Specifies the subnet in which to allocate IP address for this vip.
+* `ip_version` - (Optional, Int, ForceNew) Specifies the IP version, either 4 (default) or 6.
+  Changing this creates a new resource.
 
-* `ip_address` - (Optional, ForceNew) Specifies the IP address desired in the subnet for this vip. If you don't
-  specify `ip_address`, an available IP address from the specified subnet will be allocated to this vip.
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address desired in the subnet for this vip.
+  Changing this creates a new resource.
 
 * `name` - (Optional, String) Specifies a unique name for the vip.
 
@@ -41,8 +43,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the vip.
 * `mac_address` - The MAC address of the vip.
 * `status` - The status of vip.
-* `tenant_id` - The tenant ID of the vip.
 * `device_owner` - The device owner of the vip.
+* `subnet_id` - The subnet ID in which to allocate IP address for this vip.
 
 ## Import
 

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -240,22 +240,29 @@ func IsResourceNotFound(err error) bool {
 	return ok
 }
 
-// Method FormatTimeStampRFC3339 is used to unify the time format to RFC-3339 and return a time string.
+// FormatTimeStampRFC3339 is used to unify the time format to RFC-3339 and return a time string.
 func FormatTimeStampRFC3339(timestamp int64) string {
 	createTime := time.Unix(timestamp, 0)
 	return createTime.Format(time.RFC3339)
 }
 
-// Method EncodeBase64String is used to encode a string by base64.
+// EncodeBase64String is used to encode a string by base64.
 func EncodeBase64String(str string) string {
 	strByte := []byte(str)
 	return base64.StdEncoding.EncodeToString(strByte)
 }
 
-// Method EncodeBase64IfNot is used to encode a string by base64 if it not a base64 string.
+// EncodeBase64IfNot is used to encode a string by base64 if it not a base64 string.
 func EncodeBase64IfNot(str string) string {
 	if _, err := base64.StdEncoding.DecodeString(str); err != nil {
 		return base64.StdEncoding.EncodeToString([]byte(str))
 	}
 	return str
+}
+
+// IsIPv4Address is used to check whether the addr string is IPv4 format
+func IsIPv4Address(addr string) bool {
+	pattern := "^(25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d)\\.){3}(25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d))$"
+	matched, _ := regexp.MatchString(pattern, addr)
+	return matched
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- remove `tenant_id`
- deprecate `subnet_id`, use ip_version instead
- add `ip_version`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2VIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2VIP_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIP_basic
=== PAUSE TestAccNetworkingV2VIP_basic
=== CONT  TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (116.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       116.656s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingV2VIP_ip'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingV2VIP_ip -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIP_ipv6
=== PAUSE TestAccNetworkingV2VIP_ipv6
=== CONT  TestAccNetworkingV2VIP_ipv6
--- PASS: TestAccNetworkingV2VIP_ipv6 (102.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       102.864s
```
