### PR TITLE
feat: support ipv6 for vpc EIP

### DIFF
--- a/docs/data-sources/vpc_eip.md
+++ b/docs/data-sources/vpc_eip.md
@@ -16,14 +16,14 @@ data "huaweicloud_vpc_eip" "by_address" {
 
 ## Argument Reference
 
-* `region` - (Optional, String) The region in which to obtain the EIP. If omitted, the provider-level region will be
-  used.
+* `region` - (Optional, String) Specifies the region in which to obtain the EIP.
+  If omitted, the provider-level region will be used.
 
-* `public_ip` - (Optional, String) The public ip address of the EIP.
+* `public_ip` - (Optional, String) Specifies the public **IPv4** address of the EIP.
 
-* `port_id` - (Optional, String) The port id of the EIP.
+* `port_id` - (Optional, String) Specifies the port id of the EIP.
 
-* `enterprise_project_id` - (Optional, String) The enterprise project id of the EIP.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the EIP.
 
 ## Attributes Reference
 
@@ -34,6 +34,10 @@ In addition to all arguments above, the following attributes are exported:
 * `type` - The type of the EIP.
 
 * `private_ip` - The private ip of the EIP.
+
+* `ip_version` - The IP version, either 4 or 6.
+
+* `ipv6_address` - The IPv6 address of the EIP.
 
 * `bandwidth_id` - The bandwidth id of the EIP.
 

--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -94,17 +94,17 @@ The `bandwidth` block supports:
 
 * `share_type` - (Required, String, ForceNew) Whether the bandwidth is dedicated or shared. Changing this creates a new
   resource. Possible values are as follows:
-  + *PER*: Dedicated bandwidth
-  + *WHOLE*: Shared bandwidth
+  + **PER**: Dedicated bandwidth
+  + **WHOLE**: Shared bandwidth
 
 * `name` - (Optional, String) The bandwidth name, which is a string of 1 to 64 characters that contain letters, digits,
-  underscores (_), and hyphens (-). This parameter is mandatory when `share_type` is set to *PER*.
+  underscores (_), and hyphens (-). This parameter is mandatory when `share_type` is set to **PER**.
 
 * `size` - (Optional, Int) The bandwidth size. The value ranges from 1 to 300 Mbit/s. This parameter is mandatory
-  when `share_type` is set to *PER*.
+  when `share_type` is set to **PER**.
 
 * `id` - (Optional, String, ForceNew) The shared bandwidth id. This parameter is mandatory when
-  `share_type` is set to *WHOLE*. Changing this creates a new resource.
+  `share_type` is set to **WHOLE**. Changing this creates a new resource.
 
 * `charge_mode` - (Optional, String, ForceNew) Specifies whether the bandwidth is billed by traffic or by bandwidth
   size. The value can be *traffic* or *bandwidth*. Changing this creates a new resource.

--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -47,12 +47,15 @@ resource "huaweicloud_vpc_eip" "eip_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the eip resource. If omitted, the provider-level
-  region will be used. Changing this creates a new eip resource.
+* `region` - (Optional, String, ForceNew) The region in which to create the EIP resource. If omitted, the provider-level
+  region will be used. Changing this creates a new resource.
 
 * `publicip` - (Required, List) The elastic IP address object.
 
 * `bandwidth` - (Required, List) The bandwidth object.
+
+* `name` - (Optional, String) Specifies the name of the elastic IP. The value can contain 1 to 64 characters,
+  including letters, digits, underscores (_), hyphens (-), and periods (.).
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the elastic IP.
 
@@ -75,18 +78,22 @@ The following arguments are supported:
 
 The `publicip` block supports:
 
-* `type` - (Required, String, ForceNew) The type of the eip. Changing this creates a new eip.
+* `type` - (Optional, String, ForceNew) Specifies the EIP type. Possible values are *5_bgp* (dynamic BGP)
+  and *5_sbgp* (static BGP), the default value is *5_bgp*. Changing this creates a new resource.
 
-* `ip_address` - (Optional, String, ForceNew) The value must be a valid IP address in the available IP address segment.
-  Changing this creates a new eip.
+* `ip_address` - (Optional, String, ForceNew) Specifies the EIP to be assigned. The value must be a valid **IPv4**
+  address in the available IP address range. The system automatically assigns an EIP if you do not specify it.
+  Changing this creates a new resource.
 
-* `port_id` - (Optional, String) The port id which this eip will associate with. If the value is "" or this not
-  specified, the eip will be in unbind state.
+* `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) or 6.
+
+* `port_id` - (Optional, String) The port id which this EIP will associate with. If the value is "" or not
+  specified, the EIP will be in unbind state.
 
 The `bandwidth` block supports:
 
 * `share_type` - (Required, String, ForceNew) Whether the bandwidth is dedicated or shared. Changing this creates a new
-  eip. Possible values are as follows:
+  resource. Possible values are as follows:
   + *PER*: Dedicated bandwidth
   + *WHOLE*: Shared bandwidth
 
@@ -97,18 +104,20 @@ The `bandwidth` block supports:
   when `share_type` is set to *PER*.
 
 * `id` - (Optional, String, ForceNew) The shared bandwidth id. This parameter is mandatory when
-  `share_type` is set to *WHOLE*. Changing this creates a new eip.
+  `share_type` is set to *WHOLE*. Changing this creates a new resource.
 
 * `charge_mode` - (Optional, String, ForceNew) Specifies whether the bandwidth is billed by traffic or by bandwidth
-  size. The value can be *traffic* or *bandwidth*. Changing this creates a new eip.
+  size. The value can be *traffic* or *bandwidth*. Changing this creates a new resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
-* `address` - The IP address of the eip.
-* `status` - The status of eip.
+* `address` - The IPv4 address of the EIP.
+* `ipv6_address` - The IPv6 address of the EIP.
+* `private_ip` - The private IP address bound to the EIP.
+* `status` - The status of EIP.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_eip_test.go
@@ -26,6 +26,7 @@ func TestAccVpcEipDataSource_basic(t *testing.T) {
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "UNBOUND"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_version", "4"),
 					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_size", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "bandwidth_share_type", "PER"),
 				),

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eip.go
@@ -29,6 +29,7 @@ func DataSourceVpcEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -39,6 +40,14 @@ func DataSourceVpcEip() *schema.Resource {
 			},
 			"private_ip": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ipv6_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"bandwidth_id": {
@@ -59,9 +68,9 @@ func DataSourceVpcEip() *schema.Resource {
 
 func dataSourceVpcEipRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating networking client: %s", err)
+		return fmtp.Errorf("Error creating VPC client: %s", err)
 	}
 
 	var listOpts eips.ListOpts
@@ -78,7 +87,7 @@ func dataSourceVpcEipRead(d *schema.ResourceData, meta interface{}) error {
 		listOpts.EnterpriseProjectId = epsID
 	}
 
-	pages, err := eips.List(networkingClient, listOpts).AllPages()
+	pages, err := eips.List(vpcClient, listOpts).AllPages()
 	if err != nil {
 		return err
 	}
@@ -104,6 +113,8 @@ func dataSourceVpcEipRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("region", config.GetRegion(d))
 	d.Set("status", NormalizeEIPStatus(Eip.Status))
 	d.Set("public_ip", Eip.PublicAddress)
+	d.Set("ipv6_address", Eip.PublicIpv6Address)
+	d.Set("ip_version", Eip.IpVersion)
 	d.Set("port_id", Eip.PortID)
 	d.Set("type", Eip.Type)
 	d.Set("private_ip", Eip.PrivateAddress)

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/requests.go
@@ -23,8 +23,10 @@ type ApplyOpts struct {
 }
 
 type PublicIpOpts struct {
-	Type    string `json:"type" required:"true"`
-	Address string `json:"ip_address,omitempty"`
+	Type      string `json:"type" required:"true"`
+	Address   string `json:"ip_address,omitempty"`
+	Alias     string `json:"alias,omitempty"`
+	IPVersion int    `json:"ip_version,omitempty"`
 }
 
 type BandwidthOpts struct {
@@ -70,9 +72,12 @@ type UpdateOptsBuilder interface {
 	ToPublicIpUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the request body of update method
+// UpdateOpts is a struct which represents the request body of update method
+// NOTE: ip_version and port_id can not be updated at the same time
 type UpdateOpts struct {
-	PortID string `json:"port_id,omitempty"`
+	PortID    string  `json:"port_id,omitempty"`
+	Alias     *string `json:"alias,omitempty"`
+	IPVersion int     `json:"ip_version,omitempty"`
 }
 
 func (opts UpdateOpts) ToPublicIpUpdateMap() (map[string]interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* resource/huaweicloud_vpc_eip
  + make `type` be optional and defaults to "5_bgp"
  + add `name` parameter to specify the EIP name
  + add `ip_version` to support ipv6
  + add `ipv6_address` and `private_ip` attributes

* data/huaweicloud_vpc_eip
  + add `ipv6_address` and `ip_version` attributes

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcEIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcEIP_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEIP_basic
=== PAUSE TestAccVpcEIP_basic
=== CONT  TestAccVpcEIP_basic
--- PASS: TestAccVpcEIP_basic (79.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       79.146s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcEIP_ipv6'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcEIP_ipv6 -timeout 360m -parallel 4
=== RUN   TestAccVpcEIP_ipv6
=== PAUSE TestAccVpcEIP_ipv6
=== CONT  TestAccVpcEIP_ipv6
--- PASS: TestAccVpcEIP_ipv6 (53.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       53.479s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcEipDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcEipDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEipDataSource_basic (48.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       48.312s
```
