### PR TITLE
fix(LTS): Fix the type of filter_count

### DIFF
--- a/huaweicloud/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/resource_huaweicloud_lts_stream.go
@@ -35,9 +35,8 @@ func resourceLTSStreamV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"filter_count": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the type of filter_count

1. change filter_count from `Optional` to `Computed`
2. change the type of  filter_count from `string` to `int`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccLogTankStreamV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccLogTankStreamV2_basic -timeout 360m -parallel 4
=== RUN   TestAccLogTankStreamV2_basic
=== PAUSE TestAccLogTankStreamV2_basic
=== CONT  TestAccLogTankStreamV2_basic
--- PASS: TestAccLogTankStreamV2_basic (15.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       15.884s
```
