### PR TITLE
refactor(util): turn the map filter function into a public function

### DIFF
--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eips.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_eips.go
@@ -173,14 +173,11 @@ func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta inter
 
 		if resourceTags, err := tags.Get(clientV2, "publicips", item.ID).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
-			tagsAfterFilter, isMatch := filterByTags(tagmap, tagFilter)
 
-			if !isMatch {
+			if !utils.HasMapContains(tagmap, tagFilter) {
 				continue
 			}
-
-			tagRst = tagsAfterFilter
-
+			tagRst = tagmap
 		} else {
 			return fmtp.DiagErrorf("Error query tags of eip (%s): %s", d.Id(), err)
 		}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
@@ -206,12 +206,11 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 
 		if resourceTags, err := tags.Get(clientV2, "subnets", item.ID).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
-			tags, isMatch := filterByTags(tagmap, tagFilter)
-			if isMatch {
-				subnet["tags"] = tags
-			} else {
+
+			if !utils.HasMapContains(tagmap, tagFilter) {
 				continue
 			}
+			subnet["tags"] = tagmap
 		} else {
 			return fmtp.DiagErrorf("Error query tags of subnets (%s): %s", item.ID, err)
 		}

--- a/huaweicloud/utils/testing/utils_test.go
+++ b/huaweicloud/utils/testing/utils_test.go
@@ -1,0 +1,80 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestHasMapContainsFunc_match(t *testing.T) {
+	rawMap := map[string]string{
+		"foo": "bar",
+	}
+	filter1 := map[string]interface{}{
+		"foo": "bar",
+	}
+	filter2 := map[string]interface{}{
+		"foo": "bar,dor",
+	}
+
+	if !utils.HasMapContains(rawMap, filter1) {
+		t.Fail()
+	}
+	if !utils.HasMapContains(rawMap, filter2) {
+		t.Fail()
+	}
+}
+
+func TestHasMapContainsFunc_mismatch(t *testing.T) {
+	rawMap := map[string]string{
+		"foo": "bar",
+	}
+	filter1 := map[string]interface{}{
+		"foo": "dor",
+	}
+	filter2 := map[string]interface{}{
+		"foo1": "bar",
+	}
+	filter3 := map[string]interface{}{
+		"": "bar",
+	}
+
+	if utils.HasMapContains(rawMap, filter1) {
+		t.Fail()
+	}
+	if utils.HasMapContains(rawMap, filter2) {
+		t.Fail()
+	}
+	if utils.HasMapContains(rawMap, filter3) {
+		t.Fail()
+	}
+}
+
+func TestHasMapContainsFunc_empty(t *testing.T) {
+	rawMap1 := map[string]string{
+		"foo": "bar",
+		"key": "",
+		"":    "value",
+	}
+	rawMap2 := map[string]string{}
+
+	filter1 := map[string]interface{}{
+		"foo": "",
+	}
+	filter2 := map[string]interface{}{
+		"key": "",
+	}
+	filter3 := map[string]interface{}{
+		"": "value",
+	}
+	filter4 := map[string]interface{}{}
+
+	if !utils.HasMapContains(rawMap1, filter1) || !utils.HasMapContains(rawMap1, filter2) ||
+		!utils.HasMapContains(rawMap1, filter3) || !utils.HasMapContains(rawMap1, filter4) {
+		t.Fail()
+	}
+	if utils.HasMapContains(rawMap2, filter1) || utils.HasMapContains(rawMap2, filter2) ||
+		utils.HasMapContains(rawMap2, filter3) || !utils.HasMapContains(rawMap2, filter4) {
+		t.Fail()
+	}
+}

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -266,3 +266,37 @@ func IsIPv4Address(addr string) bool {
 	matched, _ := regexp.MatchString(pattern, addr)
 	return matched
 }
+
+// This function compares whether there is a containment relationship between two maps, that is,
+// whether map A (rawMap) contains map B (filterMap).
+//   Map A is {'foo': 'bar'} and filter map B is {'foo': 'bar'} or {'foo': 'bar,dor'} will return true.
+//   Map A is {'foo': 'bar'} and filter map B is {'foo': 'dor'} or {'foo1': 'bar'} will return false.
+//   Map A is {'foo': 'bar'} and filter map B is {'foo': ''} will return true.
+//   Map A is {'foo': 'bar'} and filter map B is {'': 'bar'} or {'': ''} will return false.
+// The value of filter map 'bar,for' means that the object value can be either 'bar' or 'dor'.
+// Note: There is no spaces before and after the delimiter (,).
+func HasMapContains(rawMap map[string]string, filterMap map[string]interface{}) bool {
+	if len(filterMap) < 1 {
+		return true
+	}
+
+	hasContain := true
+	for key, value := range filterMap {
+		hasContain = hasContain && hasMapContain(rawMap, key, value.(string))
+	}
+
+	return hasContain
+}
+
+func hasMapContain(rawMap map[string]string, filterKey, filterValue string) bool {
+	if rawTag, ok := rawMap[filterKey]; ok {
+		if filterValue != "" {
+			filterTagValues := strings.Split(filterValue, ",")
+			return StrSliceContains(filterTagValues, rawTag)
+		} else {
+			return true
+		}
+	} else {
+		return false
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since function `FilterSliceWithFieldRaw` cannot support type `map` filtering well, an existing function is now updated and exposed to provide filtering string map.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #1813 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. turn the map filter function into a public function
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
