### PR TITLE
feat: support ipv6 for compute instance

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -298,6 +298,9 @@ The `network` block supports:
 * `fixed_ip_v4` - (Optional, String, ForceNew) Specifies a fixed IPv4 address to be used on this network.
   Changing this creates a new instance.
 
+* `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether the IPv6 function is enabled for the nic.
+  Defaults to false. Changing this creates a new instance.
+
 * `source_dest_check` - (Optional, Bool) Specifies whether the ECS processes only traffic that is destined specifically
   for it. This function is enabled by default but should be disabled if the ECS functions as a SNAT server or has a
   virtual IP address bound to it.
@@ -336,6 +339,7 @@ In addition to all arguments above, the following attributes are exported:
 * `public_ip` - The EIP address that is associted to the instance.
 * `access_ip_v4` - The first detected Fixed IPv4 address _or_ the Floating IP.
 * `network/fixed_ip_v4` - The Fixed IPv4 address of the Instance on that network.
+* `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that network.
 * `network/mac` - The MAC address of the NIC on that network.
 * `network/port` - The port ID corresponding to the IP address on that network.
 * `volume_attached/volume_id` - The volume id on that attachment.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20211220062704-6fcf8f15ce8f
+	github.com/chnsz/golangsdk v0.0.0-20211225020530-3788c45a3975
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20211220062704-6fcf8f15ce8f h1:NvhvEVYrACMktWzchwgdZ2tUNohBAwf8K/Slp//gFao=
 github.com/chnsz/golangsdk v0.0.0-20211220062704-6fcf8f15ce8f/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20211225020530-3788c45a3975 h1:6Xz/wFUHZEsVzYud2qTVuFQLH9S8MuPUIdpF/OP+q+Q=
+github.com/chnsz/golangsdk v0.0.0-20211225020530-3788c45a3975/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -150,13 +150,12 @@ func ResourceComputeInstanceV2() *schema.Resource {
 							Computed:    true,
 							Description: "schema: Computed",
 						},
-						"fixed_ip_v4": {
-							Type:     schema.TypeString,
+						"ipv6_enable": {
+							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							Computed: true,
 						},
-						"fixed_ip_v6": {
+						"fixed_ip_v4": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
@@ -166,6 +165,13 @@ func ResourceComputeInstanceV2() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
+						},
+						"fixed_ip_v6": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: "schema: Computed",
 						},
 						"mac": {
 							Type:     schema.TypeString,
@@ -1143,6 +1149,7 @@ func resourceComputeInstanceV2ImportState(d *schema.ResourceData, meta interface
 			"port":              nic.PortID,
 			"fixed_ip_v4":       nic.FixedIPv4,
 			"fixed_ip_v6":       nic.FixedIPv6,
+			"ipv6_enable":       nic.FixedIPv6 != "",
 			"source_dest_check": nic.SourceDestCheck,
 			"mac":               nic.MAC,
 		}
@@ -1245,8 +1252,9 @@ func resourceInstanceNicsV2(d *schema.ResourceData) []cloudservers.Nic {
 	for _, v := range networks {
 		network := v.(map[string]interface{})
 		nicRequest := cloudservers.Nic{
-			SubnetId:  network["uuid"].(string),
-			IpAddress: network["fixed_ip_v4"].(string),
+			SubnetId:   network["uuid"].(string),
+			IpAddress:  network["fixed_ip_v4"].(string),
+			Ipv6Enable: network["ipv6_enable"].(bool),
 		}
 
 		nicRequests = append(nicRequests, nicRequest)

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -79,9 +79,17 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 }
 
 type Nic struct {
-	SubnetId string `json:"subnet_id" required:"true"`
-
+	SubnetId  string `json:"subnet_id" required:"true"`
 	IpAddress string `json:"ip_address,omitempty"`
+
+	// enable ipv6 or not
+	Ipv6Enable bool `json:"ipv6_enable,omitempty"`
+	// bandWidth id when ipv6 is enabled
+	BandWidth *Ipv6BandWidth `json:"ipv6_bandwidth,omitempty"`
+}
+
+type Ipv6BandWidth struct {
+	ID string `json:"id,omitempty"`
 }
 
 type PublicIp struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20211220062704-6fcf8f15ce8f
+# github.com/chnsz/golangsdk v0.0.0-20211225020530-3788c45a3975
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add `ipv6_enable` parameter to enable ipv6 function

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (180.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       181.059s
```
