### PR TITLE
fix(elb): fix elb test eps precheck issue

### DIFF
--- a/huaweicloud/resource_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/resource_huaweicloud_elb_certificate_test.go
@@ -70,7 +70,7 @@ func TestAccElbV3Certificate_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_elb_certificate.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckElbV3CertificateDestroy,
 		Steps: []resource.TestStep{

--- a/huaweicloud/resource_huaweicloud_elb_ipgroup_test.go
+++ b/huaweicloud/resource_huaweicloud_elb_ipgroup_test.go
@@ -51,7 +51,7 @@ func TestAccElbV3IpGroup_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_elb_ipgroup.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckElbV3IpGroupDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccElbV3IpGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccElbV3IpGroup -timeout 360m -parallel 4
=== RUN   TestAccElbV3IpGroup_basic
=== PAUSE TestAccElbV3IpGroup_basic
=== RUN   TestAccElbV3IpGroup_withEpsId
=== PAUSE TestAccElbV3IpGroup_withEpsId
=== CONT  TestAccElbV3IpGroup_basic
=== CONT  TestAccElbV3IpGroup_withEpsId
    provider_test.go:169: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccElbV3IpGroup_withEpsId (0.00s)
--- PASS: TestAccElbV3IpGroup_basic (71.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       71.705s

make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccElbV3Certificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccElbV3Certificate -timeout 360m -parallel 4
=== RUN   TestAccElbV3Certificate_basic
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== RUN   TestAccElbV3Certificate_withEpsId
=== PAUSE TestAccElbV3Certificate_withEpsId
=== CONT  TestAccElbV3Certificate_basic
=== CONT  TestAccElbV3Certificate_withEpsId
    provider_test.go:169: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccElbV3Certificate_withEpsId (0.00s)
=== CONT  TestAccElbV3Certificate_client
--- PASS: TestAccElbV3Certificate_client (35.32s)
--- PASS: TestAccElbV3Certificate_basic (76.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       76.069s
```
