### PR TITLE
feat(DLI): add status check when job is async mode

### DIFF
--- a/docs/resources/dli_sql_job.md
+++ b/docs/resources/dli_sql_job.md
@@ -103,7 +103,9 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `Delete` - Default is 45 minute.
+* `create` - Default is 20 minute.
+
+* `delete` - Default is 45 minute.
 
 ## Import
 
@@ -111,4 +113,22 @@ DLI SQL job can be imported by `id`. For example,
 
 ```
 terraform import huaweicloud_dli_sql_job.example 7f803d70-c533-469f-8431-e378f3e97123
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include: `conf`, `rows` and `schema`.
+It is generally recommended running `terraform plan` after importing a resource. You can then decide if changes should
+be applied to the resource, or the resource definition should be updated to align with the resource. Also you can
+ignore changes as below.
+
+```
+resource "huaweicloud_dli_sql_job" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      conf, rows, schema
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
@@ -42,7 +42,7 @@ func TestAccResourceDliSqlJob_basic(t *testing.T) {
 				Config: testAccSqlJobBaseResource_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "sql", "DESC acc_test_table"),
+					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("DESC ", name)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", name),
 					resource.TestCheckResourceAttr(resourceName, "job_type", "DDL"),
 				),
@@ -93,42 +93,54 @@ func TestAccResourceDliSqlJob_query(t *testing.T) {
 	})
 }
 
+func TestAccResourceDliSqlJob_async(t *testing.T) {
+	var sqlJobObj sqljob.SqlJobOpts
+	resourceName := "huaweicloud_dli_sql_job.test"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&sqlJobObj,
+		getDliSqlJobResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDliSqlJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlJobResource_aync(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("SELECT * FROM ", name)),
+					resource.TestCheckResourceAttr(resourceName, "database_name", name),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "job_type", "QUERY"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rows", "schema", "conf"},
+			},
+		},
+	})
+}
+
 func testAccSqlJobBaseResource_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dli_database" "test" {
-  name        = "%s"
-  description = "For terraform acc test"
-}
-
-resource "huaweicloud_dli_table" "test" {
-  database_name = huaweicloud_dli_database.test.name
-  name          = "acc_test_table"
-  data_location = "DLI"
-  description   = "dli table test"
-
-  columns {
-    name        = "name"
-    type        = "string"
-    description = "person name"
-  }
-
-  columns {
-    name        = "addrss"
-    type        = "string"
-    description = "home address"
-  }
-
-}
+%s
 
 resource "huaweicloud_dli_sql_job" "test" {
   sql           = "DESC ${huaweicloud_dli_table.test.name}"
   database_name = huaweicloud_dli_database.test.name
 }
-
-`, name)
+`, testAccSqlJobBaseResource(name))
 }
 
-func testAccSqlJobBaseResource_query(name string) string {
+func testAccSqlJobBaseResource(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_database" "test" {
   name        = "%s"
@@ -152,15 +164,35 @@ resource "huaweicloud_dli_table" "test" {
     type        = "string"
     description = "home address"
   }
-
 }
+`, name, name)
+}
+
+func testAccSqlJobBaseResource_query(name string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "huaweicloud_dli_sql_job" "test" {
   sql           = "SELECT * FROM ${huaweicloud_dli_table.test.name}"
   database_name = huaweicloud_dli_database.test.name
+
+}
+`, testAccSqlJobBaseResource(name))
 }
 
-`, name, name)
+func testAccSqlJobResource_aync(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dli_sql_job" "test" {
+  sql           = "SELECT * FROM ${huaweicloud_dli_table.test.name}"
+  database_name = huaweicloud_dli_database.test.name
+
+  conf {
+    dli_sql_sqlasync_enabled = true
+  }
+}
+`, testAccSqlJobBaseResource(name))
 }
 
 func testAccCheckDliSqlJobDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add status check when DLI SQL job is the async mode

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1835

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccResourceDliSqlJob'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccResourceDliSqlJob -timeout 360m -parallel 4
=== RUN   TestAccResourceDliSqlJob_basic
=== PAUSE TestAccResourceDliSqlJob_basic
=== RUN   TestAccResourceDliSqlJob_query
=== PAUSE TestAccResourceDliSqlJob_query
=== RUN   TestAccResourceDliSqlJob_async
=== PAUSE TestAccResourceDliSqlJob_async
=== CONT  TestAccResourceDliSqlJob_basic
=== CONT  TestAccResourceDliSqlJob_async
=== CONT  TestAccResourceDliSqlJob_query
--- PASS: TestAccResourceDliSqlJob_query (62.65s)
--- PASS: TestAccResourceDliSqlJob_async (64.28s)
--- PASS: TestAccResourceDliSqlJob_basic (64.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       64.531s
```