### PR TITLE
fix(lb): don't retry to create resources when an error occurs

### DIFF
--- a/huaweicloud/resource_huaweicloud_lb_l7policy.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7policy.go
@@ -167,16 +167,7 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	logp.Printf("[DEBUG] Attempting to create L7 Policy")
-	var l7Policy *l7policies.L7Policy
-	//lintignore:R006
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		l7Policy, err = l7policies.Create(lbClient, createOpts).Extract()
-		if err != nil {
-			return checkForRetryableError(err)
-		}
-		return nil
-	})
-
+	l7Policy, err := l7policies.Create(lbClient, createOpts).Extract()
 	if err != nil {
 		return fmtp.Errorf("Error creating L7 Policy: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_l7rule.go
+++ b/huaweicloud/resource_huaweicloud_lb_l7rule.go
@@ -166,16 +166,7 @@ func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	logp.Printf("[DEBUG] Attempting to create L7 Rule")
-	var l7Rule *l7policies.Rule
-	//lintignore:R006
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		l7Rule, err = l7policies.CreateRule(lbClient, l7policyID, createOpts).Extract()
-		if err != nil {
-			return checkForRetryableError(err)
-		}
-		return nil
-	})
-
+	l7Rule, err := l7policies.CreateRule(lbClient, l7policyID, createOpts).Extract()
 	if err != nil {
 		return fmtp.Errorf("Error creating L7 Rule: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/resource_huaweicloud_lb_member.go
@@ -115,8 +115,6 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 		createOpts.SubnetID = v.(string)
 	}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
-
 	// Wait for LB to become active before continuing
 	poolID := d.Get("pool_id").(string)
 	timeout := d.Timeout(schema.TimeoutCreate)
@@ -125,17 +123,8 @@ func resourceMemberV2Create(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	logp.Printf("[DEBUG] Attempting to create member")
-	var member *pools.Member
-	//lintignore:R006
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		member, err = pools.CreateMember(lbClient, poolID, createOpts).Extract()
-		if err != nil {
-			return checkForRetryableError(err)
-		}
-		return nil
-	})
-
+	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	member, err := pools.CreateMember(lbClient, poolID, createOpts).Extract()
 	if err != nil {
 		return fmtp.Errorf("Error creating member: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_monitor.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor.go
@@ -136,17 +136,7 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
-	logp.Printf("[DEBUG] Attempting to create monitor")
-	var monitor *monitors.Monitor
-	//lintignore:R006
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		monitor, err = monitors.Create(lbClient, createOpts).Extract()
-		if err != nil {
-			return checkForRetryableError(err)
-		}
-		return nil
-	})
-
+	monitor, err := monitors.Create(lbClient, createOpts).Extract()
 	if err != nil {
 		return fmtp.Errorf("Unable to create monitor: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/resource_huaweicloud_lb_pool.go
@@ -162,8 +162,6 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 		createOpts.Persistence = &persistence
 	}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
-
 	// Wait for LoadBalancer to become active before continuing
 	timeout := d.Timeout(schema.TimeoutCreate)
 	lbID := createOpts.LoadbalancerID
@@ -181,17 +179,8 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	logp.Printf("[DEBUG] Attempting to create pool")
-	var pool *pools.Pool
-	//lintignore:R006
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		pool, err = pools.Create(lbClient, createOpts).Extract()
-		if err != nil {
-			return checkForRetryableError(err)
-		}
-		return nil
-	})
-
+	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	pool, err := pools.Create(lbClient, createOpts).Extract()
 	if err != nil {
 		return fmtp.Errorf("Error creating pool: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Don't retry to create LB resources when an error occurs, just raising the error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2L7Policy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2L7Policy -timeout 360m -parallel 4
=== RUN   TestAccLBV2L7Policy_basic
=== PAUSE TestAccLBV2L7Policy_basic
=== CONT  TestAccLBV2L7Policy_basic
--- PASS: TestAccLBV2L7Policy_basic (107.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       107.508s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2L7Rule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2L7Rule -timeout 360m -parallel 4
=== RUN   TestAccLBV2L7Rule_basic
=== PAUSE TestAccLBV2L7Rule_basic
=== CONT  TestAccLBV2L7Rule_basic
--- PASS: TestAccLBV2L7Rule_basic (155.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       155.377s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Listener'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Listener -timeout 360m -parallel 4
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== CONT  TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (140.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       140.406s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Member'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Member -timeout 360m -parallel 4
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (168.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       168.654s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Monitor'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Monitor -timeout 360m -parallel 4
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== RUN   TestAccLBV2Monitor_udp
=== PAUSE TestAccLBV2Monitor_udp
=== RUN   TestAccLBV2Monitor_http
=== PAUSE TestAccLBV2Monitor_http
=== CONT  TestAccLBV2Monitor_basic
=== CONT  TestAccLBV2Monitor_http
=== CONT  TestAccLBV2Monitor_udp
--- PASS: TestAccLBV2Monitor_http (143.47s)
--- PASS: TestAccLBV2Monitor_udp (149.05s)
--- PASS: TestAccLBV2Monitor_basic (182.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       182.604s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Pool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Pool -timeout 360m -parallel 4
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (145.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       145.734s
```
