### PR TITLE
fix(evs): fix the wrong package definition of evs test

### DIFF
--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -1,4 +1,4 @@
-package cbr
+package evs
 
 import (
 	"fmt"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The package definition of the evs volume test is wrong, should be `evs`, but `cbr`.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong package definition.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
