### PR TITLE
fix(evs): fix incorrect device type configuration

### DIFF
--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -41,6 +41,7 @@ func TestAccEvsVolume_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by acc test script."),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
@@ -53,6 +54,7 @@ func TestAccEvsVolume_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
 					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "device_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated by acc test script."),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar"),
@@ -124,6 +126,7 @@ resource "huaweicloud_evs_volume" "test" {
   name              = "%s"
   description       = "Created by acc test script."
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  device_type       = "SCSI"
   volume_type       = "SAS"
   size              = 100
   image_id          = data.huaweicloud_images_image.test.id
@@ -149,6 +152,7 @@ resource "huaweicloud_evs_volume" "test" {
   name              = "%s_update"
   description       = "Updated by acc test script."
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  device_type       = "SCSI"
   volume_type       = "SAS"
   size              = 200
   image_id          = data.huaweicloud_images_image.test.id

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -228,7 +228,7 @@ func resourceEvsVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func setEvsVolumeDeviceType(d *schema.ResourceData, resp *cloudvolumes.Volume) error {
-	if value, ok := resp.ImageMetadata["hw:passthrough"]; ok && value == "true" {
+	if resp.Metadata.HwPassthrough == "true" {
 		return d.Set("device_type", "SCSI")
 	}
 	return d.Set("device_type", "VBD")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `device_type` parameter configuration of the resource `huaweicloud_evs_volume` is incorrect.
- Incorrect: The device type uses the value of image volume matadata.
- Correct: The device type uses the value of volume matadata.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1851 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Use 'Metadata' replace the wrong 'ImageMetadata' use.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run=TestAccEvsVolumesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolumesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolumesDataSource_basic
=== PAUSE TestAccEvsVolumesDataSource_basic
=== CONT  TestAccEvsVolumesDataSource_basic
--- PASS: TestAccEvsVolumesDataSource_basic (291.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       291.552s
```
