### PR TITLE
fix(EIP): set port_id to computed and Deprecated

### DIFF
--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -87,9 +87,6 @@ The `publicip` block supports:
 
 * `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) or 6.
 
-* `port_id` - (Optional, String) The port id which this EIP will associate with. If the value is "" or not
-  specified, the EIP will be in unbind state.
-
 The `bandwidth` block supports:
 
 * `share_type` - (Required, String, ForceNew) Whether the bandwidth is dedicated or shared. Changing this creates a new

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_eip.go
@@ -73,8 +73,10 @@ func ResourceVpcEIPV1() *schema.Resource {
 							ValidateFunc: validation.IntInSlice([]int{4, 6}),
 						},
 						"port_id": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Computed:   true,
+							Deprecated: "use huaweicloud_networking_eip_associate instead",
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. set `port_id` to `Computed` and  `Deprecated`
2. If the user wants to bind the port, please use huaweicloud_networking_eip_associate instead

**Which issue this PR fixes**:

fixes #1854 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcEIP -timeout 360m -parallel 4
=== RUN   TestAccVpcEIP_basic
=== PAUSE TestAccVpcEIP_basic
=== RUN   TestAccVpcEIP_share
=== PAUSE TestAccVpcEIP_share
=== RUN   TestAccVpcEIP_WithEpsId
=== PAUSE TestAccVpcEIP_WithEpsId
=== RUN   TestAccVpcEIP_prePaid
=== PAUSE TestAccVpcEIP_prePaid
=== RUN   TestAccVpcEIP_ipv6
=== PAUSE TestAccVpcEIP_ipv6
=== CONT  TestAccVpcEIP_basic
=== CONT  TestAccVpcEIP_prePaid
=== CONT  TestAccVpcEIP_WithEpsId
=== CONT  TestAccVpcEIP_prePaid
    acceptance.go:390: This environment does not support prepaid tests
--- SKIP: TestAccVpcEIP_prePaid (0.00s)
=== CONT  TestAccVpcEIP_ipv6
=== CONT  TestAccVpcEIP_share
=== CONT  TestAccVpcEIP_WithEpsId
    acceptance.go:317: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccVpcEIP_WithEpsId (0.00s)
--- PASS: TestAccVpcEIP_ipv6 (31.23s)
--- PASS: TestAccVpcEIP_share (41.81s)
--- PASS: TestAccVpcEIP_basic (44.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       44.235s
```
