### PR TITLE
chore: test(acc test): Support multi-resource acceptance check

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -204,7 +204,7 @@ func TestCheckResourceAttrWithVariable(resourceName, key, varStr string) resourc
 	}
 }
 
-// CheckResourceDestroy check whether resources destroied in HuaweiCloud.
+// CheckResourceDestroy check whether resources destroyed in HuaweiCloud.
 func (rc *resourceCheck) CheckResourceDestroy() resource.TestCheckFunc {
 	if strings.Compare(rc.resourceType, dataSourceTypeCode) == 0 {
 		fmtp.Errorf("Error, you built a resourceCheck with 'InitDataSourceCheck', " +
@@ -221,12 +221,16 @@ func (rc *resourceCheck) CheckResourceDestroy() resource.TestCheckFunc {
 			}
 		}
 
+		if resourceType == "" {
+			return fmtp.Errorf("The format of the resource name is invalid, please check your configuration.")
+		}
+
+		conf := TestAccProvider.Meta().(*config.Config)
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != resourceType {
 				continue
 			}
 
-			conf := TestAccProvider.Meta().(*config.Config)
 			if rc.getResourceFunc != nil {
 				if _, err := rc.getResourceFunc(conf, rs); err == nil {
 					return fmtp.Errorf("failed to destroy resource. The resource of %s : %s still exists.",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource created by `count` will carry an index in the state, which cannot be verified by existing functions. e.g.:
`huaweicloud_evs_volume.test.0`, `huaweicloud_evs_volume.test.1`, ...

Through the expansion of existing functions, adding indexes to support the verification of multiple resources.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add multi-check methods to acceptance.
2. update acc tests of the evs volume.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run=TestAccEvsVolume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_basic
--- PASS: TestAccEvsVolume_basic (148.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       148.957s
```

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run=TestAccEvsVolume_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolume_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_withEpsId
=== PAUSE TestAccEvsVolume_withEpsId
=== CONT  TestAccEvsVolume_withEpsId
--- PASS: TestAccEvsVolume_withEpsId (82.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       82.304s
```
