### PR TITLE
feat: fix(gaussdb): add new data source to obtain all gaussdb nosql flavors

### DIFF
--- a/docs/data-sources/gaussdb_nosql_flavors.md
+++ b/docs/data-sources/gaussdb_nosql_flavors.md
@@ -1,0 +1,58 @@
+---
+subcategory: "GaussDB"
+---
+
+# huaweicloud_gaussdb_nosql_flavors
+
+Use this data source to get available HuaweiCloud GaussDB (for NoSQL) flavors.
+This is an alternative to `huaweicloud_gaussdb_cassandra_flavors`
+
+## Example Usage
+
+```hcl
+data "huaweicloud_gaussdb_nosql_flavors" "flavors" {
+  vcpus  = 4
+  memory = 8
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the GaussDB specifications.
+  If omitted, the provider-level region will be used.
+
+* `engine` - (Optional, String) Specifies the type of the database engine. The valid values are as follows:
+  + **cassandra**: The default value and means to query GaussDB (for Cassandra) instance specifications.
+  + **redis**: Means to query GaussDB (for Redis) instance specifications.
+  + **mongodb**: Means to query GaussDB (for Mongo) instance specifications.
+  + **influxdb**: Means to query GaussDB (for Influx) instance specifications.
+
+* `engine_version` - (Optional, String) Specifies the version of the database engine.
+
+* `vcpus` - (Optional, Int) Specifies the number of vCPUs.
+
+* `memory` - (Optional, Int) Specifies the memory size in gigabytes (GB).
+
+* `availability_zone` - (Optional, String) Specifies the availability zone (AZ) of the GaussDB specifications.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `flavors` - The information of the GaussDB specifications. Structure is documented below.
+
+The `flavors` block contains:
+
+* `name` - The spec code of the flavor.
+
+* `vcpus` - The number of vCPUs.
+
+* `memory` - The memory size, in GB.
+
+* `engine` - The type of the database engine.
+
+* `engine_version` - The version of the database engine.
+
+* `availability_zones` - All available zones (on sale) for current flavor.

--- a/huaweicloud/data_source_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/data_source_huaweicloud_gaussdb_redis_instance_test.go
@@ -53,10 +53,16 @@ data "huaweicloud_networking_secgroup" "test" {
   name = "default"
 }
 
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 4
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
 resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%s"
   password    = "Test@123"
-  flavor      = "nosql.redis.xlarge.4"
+  flavor      = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
   volume_size = 100
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -312,6 +312,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_dependencies":                     fgs.DataSourceFunctionGraphDependencies(),
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": dataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_flavors":            gaussdb.DataSourceCassandraFlavors(),
+			"huaweicloud_gaussdb_nosql_flavors":                gaussdb.DataSourceGaussDBNoSQLFlavors(),
 			"huaweicloud_gaussdb_cassandra_instance":           dataSourceGeminiDBInstance(),
 			"huaweicloud_gaussdb_cassandra_instances":          dataSourceGeminiDBInstances(),
 			"huaweicloud_gaussdb_opengauss_instance":           dataSourceOpenGaussInstance(),

--- a/huaweicloud/resource_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_redis_instance_test.go
@@ -33,8 +33,7 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "password", password),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "3"),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "80"),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "geminidb.redis.large.4"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 				),
 			},
@@ -46,7 +45,6 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", newPassword),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "4"),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "geminidb.redis.xlarge.4"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 				),
 			},
@@ -118,11 +116,17 @@ data "huaweicloud_networking_secgroup" "test" {
   name = "default"
 }
 
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
 resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%s"
   password    = "%s"
-  flavor      = "geminidb.redis.large.4"
-  volume_size = 80
+  flavor      = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  volume_size = 50
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id
   node_num    = 3
@@ -153,10 +157,16 @@ data "huaweicloud_networking_secgroup" "test" {
   name = "default"
 }
 
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 4
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
 resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%s-update"
   password    = "%s"
-  flavor      = "geminidb.redis.xlarge.4"
+  flavor      = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
   volume_size = 100
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
@@ -1,0 +1,230 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBNoSQLFlavors_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_default(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.engine", "cassandra"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+			{
+				Config: testAccGaussDBNoSQLFlavors_cassandra(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "cassandra"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_mongodb(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_mongodb(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "mongodb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_influxdb(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_influxdb(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "influxdb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_redis(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_redis(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "redis"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_vcpus(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_vcpus(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.vcpus", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_memory(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_memory(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.memory", "8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_az(t *testing.T) {
+	dataSourceName := "data.huaweicloud_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_az(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.availability_zones.0", acceptance.HW_AVAILABILITY_ZONE),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDBNoSQLFlavors_default() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_cassandra() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  engine = "cassandra"
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_mongodb() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  engine = "mongodb"
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_influxdb() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  engine = "influxdb"
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_redis() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  engine = "redis"
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_vcpus() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus = 4
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_memory() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  memory = 8
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_az() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  availability_zone = "%s"
+}
+`, acceptance.HW_AVAILABILITY_ZONE)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors.go
@@ -1,0 +1,164 @@
+package gaussdb
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/chnsz/golangsdk/openstack/geminidb/v3/flavors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceGaussDBNoSQLFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaussDBFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"cassandra", "mongodb", "influxdb", "redis",
+				}, false),
+				Default: "cassandra",
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vcpus": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"memory": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zones": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// This method is used to filter all available gaussdb flavors by ram, vcpus, engine version and availability zone.
+func filterAvailableFlavors(d *schema.ResourceData, flavorList []flavors.Flavor) ([]map[string]interface{}, []string, error) {
+	var names []string
+	result := make([]map[string]interface{}, 0)
+
+	// build filter by ram, vcpus and engine version
+	filter := map[string]interface{}{
+		"EngineVersion": d.Get("engine_version").(string),
+	}
+	if ram, ok := d.GetOk("memory"); ok {
+		filter["Ram"] = strconv.Itoa(ram.(int))
+	}
+	if vcpus, ok := d.GetOk("vcpus"); ok {
+		filter["Vcpus"] = strconv.Itoa(vcpus.(int))
+	}
+
+	filterFlavors, err := utils.FilterSliceWithField(flavorList, filter)
+	if err != nil {
+		return nil, nil, err
+	}
+	logp.Printf("[DEBUG] The filter is %v and the result is %v", filter, filterFlavors)
+
+	// filter by availability zone
+	az := d.Get("availability_zone").(string)
+	for _, item := range filterFlavors {
+		flavor := item.(flavors.Flavor)
+
+		var azList []string
+		for k, v := range flavor.AzStatus {
+			if v == "normal" && (az == "" || (az != "" && az == k)) {
+				azList = append(azList, k)
+			}
+		}
+		result = append(result, map[string]interface{}{
+			"name":               flavor.SpecCode,
+			"vcpus":              flavor.Vcpus,
+			"memory":             flavor.Ram,
+			"engine":             flavor.EngineName,
+			"engine_version":     flavor.EngineVersion,
+			"availability_zones": azList,
+		})
+		names = append(names, flavor.SpecCode)
+	}
+
+	logp.Printf("[DEBUG] After filtering, the NoSQL flavors is %v", result)
+	return result, names, nil
+}
+
+func dataSourceGaussDBFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.GeminiDBV31Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud GaussDB client: %s", err)
+	}
+
+	opt := flavors.ListFlavorOpts{
+		EngineName: d.Get("engine").(string),
+	}
+	pages, err := flavors.List(client, opt).AllPages()
+	if err != nil {
+		return fmtp.DiagErrorf(err.Error())
+	}
+	flavorsResp, err := flavors.ExtractFlavors(pages)
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve GuassDB NoSQL flavors: %s", err)
+	}
+
+	result, names, err := filterAvailableFlavors(d, flavorsResp.Flavors)
+	if err != nil {
+		return fmtp.DiagErrorf("An error occurred while filtering the GaussDB NoSQL flavors: %s", err)
+	}
+	d.SetId(hashcode.Strings(names))
+
+	d.Set("flavors", result)
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- The acc test of `huaweicloud_gaussdb_redis_instance` has a problem: the flavor is invalid.
- Currently we support the data source `huaweicloud_gaussdb_cassandra_flavors` to obtain the specifications of cassandra, but the specifications of redis cannot be obtained.

Add a new data source to support all NoSQL flavors obtain: `huaweicloud_gaussdb_nosql_flavors` to replace the `huaweicloud_gaussdb_cassandra_flavors` and support four kinds of engine type flavors obtain.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1861

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to obtain flavors of GaussDB (for NoSQL).
2. update acceptance test of gaussdb redis.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccOpenGaussInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccOpenGaussInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceDataSource_basic
=== PAUSE TestAccOpenGaussInstanceDataSource_basic
=== CONT  TestAccOpenGaussInstanceDataSource_basic
--- PASS: TestAccOpenGaussInstanceDataSource_basic (1578.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1579.046s
```

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb' TESTARGS='-run=TestAccGaussDBNoSQLFlavors'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run=TestAccGaussDBNoSQLFlavors -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_basic
=== PAUSE TestAccGaussDBNoSQLFlavors_basic
=== RUN   TestAccGaussDBNoSQLFlavors_mongodb
=== PAUSE TestAccGaussDBNoSQLFlavors_mongodb
=== RUN   TestAccGaussDBNoSQLFlavors_influxdb
=== PAUSE TestAccGaussDBNoSQLFlavors_influxdb
=== RUN   TestAccGaussDBNoSQLFlavors_redis
=== PAUSE TestAccGaussDBNoSQLFlavors_redis
=== CONT  TestAccGaussDBNoSQLFlavors_basic
=== CONT  TestAccGaussDBNoSQLFlavors_redis
=== CONT  TestAccGaussDBNoSQLFlavors_influxdb
=== CONT  TestAccGaussDBNoSQLFlavors_mongodb
--- PASS: TestAccGaussDBNoSQLFlavors_basic (78.57s)
--- PASS: TestAccGaussDBNoSQLFlavors_redis (79.65s)
--- PASS: TestAccGaussDBNoSQLFlavors_influxdb (89.43s)
--- PASS: TestAccGaussDBNoSQLFlavors_mongodb (90.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   91.856s
```
