### PR TITLE
feat: add port_id attribute into compute eip associate resource

### DIFF
--- a/docs/resources/compute_eip_associate.md
+++ b/docs/resources/compute_eip_associate.md
@@ -85,17 +85,24 @@ resource "huaweicloud_compute_eip_associate" "associated" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the associated resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
 * `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate.
+  Changing this creates a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the instance to associte the EIP with.
+* `instance_id` - (Required, String, ForceNew) Specifies the ECS instance to associate the EIP with.
+  Changing this creates a new resource.
 
-* `fixed_ip` - (Optional, String, ForceNew) Specifies the IP address to direct traffic to.
+* `fixed_ip` - (Optional, String, ForceNew) Specifies the private IP address to direct traffic to.
+  Changing this creates a new resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - The resource ID in UUID format.
+* `port_id` - The port ID of the ECS instance that associated the EIP with.
 
 ## Import
 

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -14,6 +12,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccComputeV2EIPAssociate_basic(t *testing.T) {
@@ -34,6 +33,7 @@ func TestAccComputeV2EIPAssociate_basic(t *testing.T) {
 					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
 					testAccCheckComputeV2EIPAssociateAssociated(&eip, &instance, 1),
+					resource.TestCheckResourceAttrSet(resourceName, "port_id"),
 				),
 			},
 			{
@@ -63,6 +63,7 @@ func TestAccComputeV2EIPAssociate_fixedIP(t *testing.T) {
 					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
 					testAccCheckComputeV2EIPAssociateAssociated(&eip, &instance, 1),
+					resource.TestCheckResourceAttrSet(resourceName, "port_id"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* add `port_id` attribute into compute eip associate resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2EIPAssociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2EIPAssociate -timeout 360m -parallel 4
=== RUN   TestAccComputeV2EIPAssociate_basic
=== PAUSE TestAccComputeV2EIPAssociate_basic
=== RUN   TestAccComputeV2EIPAssociate_fixedIP
=== PAUSE TestAccComputeV2EIPAssociate_fixedIP
=== CONT  TestAccComputeV2EIPAssociate_basic
=== CONT  TestAccComputeV2EIPAssociate_fixedIP
--- PASS: TestAccComputeV2EIPAssociate_fixedIP (191.82s)
--- PASS: TestAccComputeV2EIPAssociate_basic (196.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       196.931s
```
