### PR TITLE
feat(lb/certificate): support enterprise project id in lb certificate

### DIFF
--- a/docs/resources/lb_certificate.md
+++ b/docs/resources/lb_certificate.md
@@ -94,6 +94,9 @@ The following arguments are supported:
 * `domain` - (Optional, String) The domain of the Certificate. The value contains a maximum of 100 characters. This
   parameter is valid only when `type` is set to "server".
 
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of the certificate. Changing this
+  creates a new certificate.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/resource_huaweicloud_lb_certificate.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate.go
@@ -77,6 +77,13 @@ func ResourceCertificateV2() *schema.Resource {
 				Sensitive:        true,
 			},
 
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
 			"update_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -98,10 +105,11 @@ func resourceCertificateV2Create(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	createOpts := certificates.CreateOpts{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Type:        d.Get("type").(string),
-		Domain:      d.Get("domain").(string),
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		Type:                d.Get("type").(string),
+		Domain:              d.Get("domain").(string),
+		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
 	}
 
 	logp.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/huaweicloud/resource_huaweicloud_lb_certificate_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate_test.go
@@ -64,6 +64,29 @@ func TestAccLBV2Certificate_client(t *testing.T) {
 	})
 }
 
+func TestAccLBV2Certificate_withEpsId(t *testing.T) {
+	var c certificates.Certificate
+	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_lb_certificate.certificate_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEpsID(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2CertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBV2CertificateConfig_withEpsId(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2CertificateExists(resourceName, &c),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "server"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckLBV2CertificateDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
 	elbClient, err := config.LoadBalancerClient(HW_REGION_NAME)
@@ -291,4 +314,75 @@ i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
 EOT
 }
 `, name)
+}
+
+func testAccLBV2CertificateConfig_withEpsId(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lb_certificate" "certificate_1" {
+  name                  = "%s"
+  description           = "terraform test certificate"
+  domain                = "www.elb.com"
+  enterprise_project_id = "%s"
+  private_key           = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----
+EOT
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----
+EOT
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+`, name, HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/resource_huaweicloud_lb_certificate_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_certificate_test.go
@@ -377,12 +377,6 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, name, HW_ENTERPRISE_PROJECT_ID_TEST)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support enterprise project id in lb certificate

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support enterprise project id in lb certificate
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Certificate_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Certificate_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccLBV2Certificate_withEpsId
=== PAUSE TestAccLBV2Certificate_withEpsId
=== CONT  TestAccLBV2Certificate_withEpsId
--- PASS: TestAccLBV2Certificate_withEpsId (61.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       61.939s
```
