### PR TITLE
fix: fix URL splicing error when specifying endpoint for service without version number

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -501,7 +501,11 @@ func (c *Config) newServiceClientByEndpoint(client *golangsdk.ProviderClient, sr
 		ProviderClient: client,
 		Endpoint:       endpoint,
 	}
-	sc.ResourceBase = sc.Endpoint + catalog.Version + "/"
+
+	sc.ResourceBase = sc.Endpoint
+	if catalog.Version != "" {
+		sc.ResourceBase = sc.ResourceBase + catalog.Version + "/"
+	}
 	if !catalog.WithOutProjectID {
 		sc.ResourceBase = sc.ResourceBase + client.ProjectID + "/"
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

A service without a version number will have a URL splicing error under the specified endpoint.

e.g.
specify the endpoint in the provider, as follows
```
provider "huaweicloud" {

  endpoints = {
    iam_no_version = "https://iam.myhuaweicloud.com"
  }

}
```
the URL will be spliced to https://iam.myhuaweicloud.com//v3/, the service will return an api does not exist error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1867

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```

```
