### PR TITLE
refactor: vpc bandwidth resource and data source with sdk v2

### DIFF
--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_bandwidth_test.go
@@ -35,8 +35,8 @@ func TestAccBandWidthDataSource_basic(t *testing.T) {
 func testAccBandWidthDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc_bandwidth" "test" {
-	name = "%s"
-	size = 10
+  name = "%s"
+  size = 10
 }
 
 data "huaweicloud_vpc_bandwidth" "test" {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_bandwidth.go
@@ -1,17 +1,23 @@
 package vpc
 
 import (
-	"github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceBandWidth() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceBandWidthRead,
+		ReadContext: dataSourceBandWidthRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -52,11 +58,11 @@ func DataSourceBandWidth() *schema.Resource {
 	}
 }
 
-func dataSourceBandWidthRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceBandWidthRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud vpc client: %s", err)
+		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC client: %s", err)
 	}
 
 	listOpts := bandwidths.ListOpts{
@@ -68,49 +74,44 @@ func dataSourceBandWidthRead(d *schema.ResourceData, meta interface{}) error {
 
 	allBWs, err := bandwidths.List(vpcClient, listOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Unable to list huaweicloud bandwidths: %s", err)
+		return fmtp.DiagErrorf("Unable to list HuaweiCloud bandwidths: %s", err)
 	}
 	if len(allBWs) == 0 {
-		return fmtp.Errorf("No huaweicloud bandwidth was found")
+		return fmtp.DiagErrorf("No HuaweiCloud bandwidth was found")
 	}
 
-	// Filter bandwidths by "name"
-	var bandList []bandwidths.BandWidth
-	name := d.Get("name").(string)
-	for _, band := range allBWs {
-		if name == band.Name {
-			bandList = append(bandList, band)
-		}
+	filter := map[string]interface{}{
+		"Name": d.Get("name").(string),
 	}
-	if len(bandList) == 0 {
-		return fmtp.Errorf("No huaweicloud bandwidth was found by name: %s", name)
-	}
-
-	// Filter bandwidths by "size"
-	result := bandList[0]
 	if v, ok := d.GetOk("size"); ok {
-		var found bool
-		for _, band := range bandList {
-			if v.(int) == band.Size {
-				found = true
-				result = band
-				break
-			}
-		}
-		if !found {
-			return fmtp.Errorf("No huaweicloud bandwidth was found by size: %d", v.(int))
-		}
+		filter["Size"] = v
 	}
 
-	logp.Printf("[DEBUG] Retrieved huaweicloud bandwidth %s: %+v", result.ID, result)
-	d.SetId(result.ID)
-	d.Set("name", result.Name)
-	d.Set("size", result.Size)
-	d.Set("enterprise_project_id", result.EnterpriseProjectID)
+	filterBWs, err := utils.FilterSliceWithField(allBWs, filter)
+	if err != nil {
+		return fmtp.DiagErrorf("filter bandwidths failed: %s", err)
+	}
+	if len(filterBWs) == 0 {
+		return fmtp.DiagErrorf("No HuaweiCloud bandwidth was found by %+v", filter)
+	}
 
-	d.Set("share_type", result.ShareType)
-	d.Set("bandwidth_type", result.BandwidthType)
-	d.Set("charge_mode", result.ChargeMode)
-	d.Set("status", result.Status)
+	result := filterBWs[0].(bandwidths.BandWidth)
+	logp.Printf("[DEBUG] Retrieved HuaweiCloud bandwidth %s: %+v", result.ID, result)
+	d.SetId(result.ID)
+
+	mErr := multierror.Append(
+		d.Set("name", result.Name),
+		d.Set("size", result.Size),
+		d.Set("enterprise_project_id", result.EnterpriseProjectID),
+
+		d.Set("share_type", result.ShareType),
+		d.Set("bandwidth_type", result.BandwidthType),
+		d.Set("charge_mode", result.ChargeMode),
+		d.Set("status", result.Status),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmtp.DiagErrorf("Error setting bandwidth fields: %s", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcBandWidth_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcBandWidth_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== CONT  TestAccVpcBandWidth_basic
--- PASS: TestAccVpcBandWidth_basic (62.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       62.142s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccBandWidthDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccBandWidthDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== CONT  TestAccBandWidthDataSource_basic
--- PASS: TestAccBandWidthDataSource_basic (40.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       40.669s
```
