### PR TITLE
fix(kafak/topic): fixed an issue where the API returned an error when modifying part fields

### DIFF
--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
@@ -62,14 +62,24 @@ func TestAccDmsKafkaTopic_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDmsKafkaTopic_update(rName),
+				Config: testAccDmsKafkaTopic_update_part1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "partitions", "20"),
 					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
 					resource.TestCheckResourceAttr(resourceName, "aging_time", "72"),
-					resource.TestCheckResourceAttr(resourceName, "sync_replication", "false"),
+				),
+			},
+			{
+				Config: testAccDmsKafkaTopic_update_part2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "partitions", "20"),
+					resource.TestCheckResourceAttr(resourceName, "replicas", "3"),
+					resource.TestCheckResourceAttr(resourceName, "aging_time", "72"),
+					resource.TestCheckResourceAttr(resourceName, "sync_replication", "true"),
 					resource.TestCheckResourceAttr(resourceName, "sync_flushing", "true"),
 				),
 			},
@@ -112,16 +122,30 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
 `, testAccDmsKafkaInstance_basic(rName), rName)
 }
 
-func testAccDmsKafkaTopic_update(rName string) string {
+func testAccDmsKafkaTopic_update_part1(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "huaweicloud_dms_kafka_topic" "topic" {
-  instance_id   = huaweicloud_dms_kafka_instance.test.id
-  name          = "%s"
-  partitions    = 20
-  aging_time    = 72
-  sync_flushing = true
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%s"
+  partitions  = 20
+  aging_time  = 72
+}
+`, testAccDmsKafkaInstance_basic(rName), rName)
+}
+
+func testAccDmsKafkaTopic_update_part2(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_topic" "topic" {
+  instance_id      = huaweicloud_dms_kafka_instance.test.id
+  name             = "%s"
+  partitions       = 20
+  aging_time       = 72
+  sync_flushing    = true
+  sync_replication = true
 }
 `, testAccDmsKafkaInstance_basic(rName), rName)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_topic.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_topic.go
@@ -153,20 +153,30 @@ func resourceDmsKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, me
 		return fmtp.DiagErrorf("error creating HuaweiCloud DMS client: %s", err)
 	}
 
-	newPartition := d.Get("partitions").(int)
-	retentionTime := d.Get("aging_time").(int)
-	syncReplication := d.Get("sync_replication").(bool)
-	syncMessageFlush := d.Get("sync_flushing").(bool)
+	updateItem := topics.UpdateItem{
+		Name: d.Get("name").(string),
+	}
+	// Set value if it changed.
+	if d.HasChange("partitions") {
+		newPartition := d.Get("partitions").(int)
+		updateItem.Partition = &newPartition
+	}
+	if d.HasChange("aging_time") {
+		retentionTime := d.Get("aging_time").(int)
+		updateItem.RetentionTime = &retentionTime
+	}
+	if d.HasChange("sync_replication") {
+		syncReplication := d.Get("sync_replication").(bool)
+		updateItem.SyncReplication = &syncReplication
+	}
+	if d.HasChange("sync_flushing") {
+		syncMessageFlush := d.Get("sync_flushing").(bool)
+		updateItem.SyncMessageFlush = &syncMessageFlush
+	}
 
 	updateOpts := topics.UpdateOpts{
 		Topics: []topics.UpdateItem{
-			{
-				Name:             d.Get("name").(string),
-				Partition:        &newPartition,
-				RetentionTime:    &retentionTime,
-				SyncMessageFlush: &syncMessageFlush,
-				SyncReplication:  &syncReplication,
-			},
+			updateItem,
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When I changed `sync_flushing` or `sync_replication` it caused an error.

```
huaweicloud_dms_kafka_topic.topic: Modifying... [id=topic_1]

Error: error updating HuaweiCloud DMS kafka topic: Expected HTTP response code [204] when accessing [PUT https://dms.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c
60ae115/instances/9b1a4aae-0262-4cba-bad0-153e8fba9e90/topics], but got 206 instead
{"failed_topics":[{"id":"topic_1","success":false,"error_msg":"AlterTopics Failed! instance:9b1a4aae-0262-4cba-bad0-153e8fba9e90, topic:topic_1, add partition failed. excepti
on:Topic already has 21 partitions."}]}
```

Reason: Unmodified fields can not be passed to the modifition API, passed on demand.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1872

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
 make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsKafkaTopic_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaTopic_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaTopic_basic
=== PAUSE TestAccDmsKafkaTopic_basic
=== CONT  TestAccDmsKafkaTopic_basic
--- PASS: TestAccDmsKafkaTopic_basic (821.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       821.125s
```
