### PR TITLE
refactor(lb/monitor): update lb monitor with v2 api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
-	github.com/chnsz/golangsdk v0.0.0-20220117022437-0e893fadb50c
+	github.com/chnsz/golangsdk v0.0.0-20220117022449-9f7387ed5f3b
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220117022437-0e893fadb50c h1:9h7fApSPt8qo+Q0Ev+xVe4mdU9dYzf/iP6lq8SdIFgA=
-github.com/chnsz/golangsdk v0.0.0-20220117022437-0e893fadb50c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220117022449-9f7387ed5f3b h1:YBwWD3cRJKsQxAQ7ZKfQgEdNdNStBgB6rsoR+MJyMZA=
+github.com/chnsz/golangsdk v0.0.0-20220117022449-9f7387ed5f3b/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/resource_huaweicloud_lb_monitor_test.go
+++ b/huaweicloud/resource_huaweicloud_lb_monitor_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/monitors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -104,7 +104,7 @@ func TestAccLBV2Monitor_http(t *testing.T) {
 
 func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
-	elbClient, err := config.ElbV2Client(HW_REGION_NAME)
+	elbClient, err := config.LoadBalancerClient(HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
 	}
@@ -135,7 +135,7 @@ func testAccCheckLBV2MonitorExists(n string, monitor *monitors.Monitor) resource
 		}
 
 		config := testAccProvider.Meta().(*config.Config)
-		elbClient, err := config.ElbV2Client(HW_REGION_NAME)
+		elbClient, err := config.LoadBalancerClient(HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/monitors/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/monitors/requests.go
@@ -1,0 +1,267 @@
+package monitors
+
+import (
+	"fmt"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToMonitorListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Monitor attributes you want to see returned. SortKey allows you to
+// sort by a particular Monitor attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID            string `q:"id"`
+	Name          string `q:"name"`
+	TenantID      string `q:"tenant_id"`
+	ProjectID     string `q:"project_id"`
+	PoolID        string `q:"pool_id"`
+	Type          string `q:"type"`
+	Delay         int    `q:"delay"`
+	Timeout       int    `q:"timeout"`
+	MaxRetries    int    `q:"max_retries"`
+	DomainName    string `q:"domain_name"`
+	HTTPMethod    string `q:"http_method"`
+	URLPath       string `q:"url_path"`
+	MonitorPort   string `q:"monitor_port"`
+	ExpectedCodes string `q:"expected_codes"`
+	AdminStateUp  *bool  `q:"admin_state_up"`
+	Status        string `q:"status"`
+	Limit         int    `q:"limit"`
+	PageReverse   *bool  `q:"page_reverse"`
+	Marker        string `q:"marker"`
+	SortKey       string `q:"sort_key"`
+	SortDir       string `q:"sort_dir"`
+}
+
+// ToMonitorListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToMonitorListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// health monitors. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those health monitors that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(c)
+	if opts != nil {
+		query, err := opts.ToMonitorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return MonitorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Constants that represent approved monitoring types.
+const (
+	TypePING  = "PING"
+	TypeTCP   = "TCP"
+	TypeHTTP  = "HTTP"
+	TypeHTTPS = "HTTPS"
+)
+
+var (
+	errDelayMustGETimeout = fmt.Errorf("Delay must be greater than or equal to timeout")
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type CreateOptsBuilder interface {
+	ToMonitorCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// The Pool to Monitor.
+	PoolID string `json:"pool_id" required:"true"`
+
+	// Specifies the health check protocol.
+	// The value can be TCP, UDP_CONNECT, or HTTP.
+	Type string `json:"type" required:"true"`
+
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay" required:"true"`
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
+	// before it times out. The value must be less than the delay value.
+	Timeout int `json:"timeout" required:"true"`
+
+	// Number of permissible ping failures before changing the member's
+	// status to INACTIVE. Must be a number between 1 and 10.
+	MaxRetries int `json:"max_retries" required:"true"`
+
+	// Specifies the domain name of HTTP requests during the health check.
+	// This parameter takes effect only when the value of type is set to HTTP.
+	DomainName string `json:"domain_name,omitempty"`
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
+	URLPath string `json:"url_path,omitempty"`
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET".
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202".
+	ExpectedCodes string `json:"expected_codes,omitempty"`
+
+	// TenantID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The Port of the Monitor.
+	MonitorPort int `json:"monitor_port,omitempty"`
+}
+
+// ToMonitorCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
+	if opts.Type == TypeHTTP || opts.Type == TypeHTTPS {
+		if opts.URLPath == "" {
+			return nil, fmt.Errorf("url_path must be provided for HTTP and HTTPS")
+		}
+	}
+
+	b, err := golangsdk.BuildRequestBody(opts, "healthmonitor")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+/*
+ Create is an operation which provisions a new Health Monitor. There are
+ different types of Monitor you can provision: PING, TCP or HTTP(S). Below
+ are examples of how to create each one.
+
+ Here is an example config struct to use when creating a PING or TCP Monitor:
+
+ CreateOpts{Type: TypePING, Delay: 20, Timeout: 10, MaxRetries: 3}
+ CreateOpts{Type: TypeTCP, Delay: 20, Timeout: 10, MaxRetries: 3}
+
+ Here is an example config struct to use when creating a HTTP(S) Monitor:
+
+ CreateOpts{Type: TypeHTTP, Delay: 20, Timeout: 10, MaxRetries: 3,
+ HttpMethod: "HEAD", ExpectedCodes: "200", PoolID: "2c946bfc-1804-43ab-a2ff-58f6a762b505"}
+*/
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToMonitorCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Health Monitor based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToMonitorUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay,omitempty"`
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
+	// before it times out. The value must be less than the delay value.
+	Timeout int `json:"timeout,omitempty"`
+
+	// Number of permissible ping failures before changing the member's
+	// status to INACTIVE. Must be a number between 1 and 10.
+	MaxRetries int `json:"max_retries,omitempty"`
+
+	// Specifies the health check protocol.
+	// The value can be TCP, UDP_CONNECT, or HTTP.
+	Type string `json:"type" required:"true"`
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
+	URLPath string `json:"url_path,omitempty"`
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET". Required for HTTP(S) types.
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202". Required for HTTP(S)
+	// types.
+	ExpectedCodes string `json:"expected_codes,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The Port of the Monitor.
+	MonitorPort int `json:"monitor_port,omitempty"`
+}
+
+// ToMonitorUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToMonitorUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "healthmonitor")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// Monitor.
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToMonitorUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete will permanently delete a particular Monitor based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/monitors/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/monitors/results.go
@@ -1,0 +1,164 @@
+package monitors
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+type PoolID struct {
+	ID string `json:"id"`
+}
+
+// Monitor represents a load balancer health monitor. A health monitor is used
+// to determine whether or not back-end members of the VIP's pool are usable
+// for processing a request. A pool can have several health monitors associated
+// with it. There are different types of health monitors supported:
+//
+// PING: used to ping the members using ICMP.
+// TCP: used to connect to the members using TCP.
+// HTTP: used to send an HTTP request to the member.
+// HTTPS: used to send a secure HTTP request to the member.
+//
+// When a pool has several monitors associated with it, each member of the pool
+// is monitored by all these monitors. If any monitor declares the member as
+// unhealthy, then the member status is changed to INACTIVE and the member
+// won't participate in its pool's load balancing. In other words, ALL monitors
+// must declare the member to be healthy for it to stay ACTIVE.
+type Monitor struct {
+	// The unique ID for the Monitor.
+	ID string `json:"id"`
+
+	// The Name of the Monitor.
+	Name string `json:"name"`
+
+	// TenantID is the owner of the Monitor.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Specifies the health check protocol.
+	// The value can be TCP, UDP_CONNECT, or HTTP.
+	Type string `json:"type"`
+
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay"`
+
+	// The maximum number of seconds for a monitor to wait for a connection to be
+	// established before it times out. This value must be less than the delay
+	// value.
+	Timeout int `json:"timeout"`
+
+	// Number of allowed connection failures before changing the status of the
+	// member to INACTIVE. A valid value is from 1 to 10.
+	MaxRetries int `json:"max_retries"`
+
+	// The HTTP method that the monitor uses for requests.
+	HTTPMethod string `json:"http_method"`
+
+	// Specifies the domain name of HTTP requests during the health check.
+	// This parameter takes effect only when the value of type is set to HTTP.
+	DomainName string `json:"domain_name,omitempty"`
+
+	// The HTTP path of the request sent by the monitor to test the health of a
+	// member. Must be a string beginning with a forward slash (/).
+	URLPath string `json:"url_path" `
+
+	// Expected HTTP codes for a passing HTTP(S) monitor.
+	ExpectedCodes string `json:"expected_codes"`
+
+	// The administrative state of the health monitor, which is up (true) or
+	// down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// The Port of the Monitor.
+	MonitorPort int `json:"monitor_port"`
+
+	// The status of the health monitor. Indicates whether the health monitor is
+	// operational.
+	Status string `json:"status"`
+
+	// List of pools that are associated with the health monitor.
+	Pools []PoolID `json:"pools"`
+
+	// The provisioning status of the monitor.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+}
+
+// MonitorPage is the page returned by a pager when traversing over a
+// collection of health monitors.
+type MonitorPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of monitors has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r MonitorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"healthmonitors_links"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a MonitorPage struct is empty.
+func (r MonitorPage) IsEmpty() (bool, error) {
+	is, err := ExtractMonitors(r)
+	return len(is) == 0, err
+}
+
+// ExtractMonitors accepts a Page struct, specifically a MonitorPage struct,
+// and extracts the elements into a slice of Monitor structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractMonitors(r pagination.Page) ([]Monitor, error) {
+	var s struct {
+		Monitors []Monitor `json:"healthmonitors"`
+	}
+	err := (r.(MonitorPage)).ExtractInto(&s)
+	return s.Monitors, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a monitor.
+func (r commonResult) Extract() (*Monitor, error) {
+	var s struct {
+		Monitor *Monitor `json:"healthmonitor"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Monitor, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Monitor.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Monitor.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Monitor.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the result succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/monitors/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/monitors/urls.go
@@ -1,0 +1,16 @@
+package monitors
+
+import "github.com/chnsz/golangsdk"
+
+const (
+	rootPath     = "elb"
+	resourcePath = "healthmonitors"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220117022437-0e893fadb50c
+# github.com/chnsz/golangsdk v0.0.0-20220117022449-9f7387ed5f3b
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -117,6 +117,7 @@ github.com/chnsz/golangsdk/openstack/elb/v2/certificates
 github.com/chnsz/golangsdk/openstack/elb/v2/l7policies
 github.com/chnsz/golangsdk/openstack/elb/v2/listeners
 github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers
+github.com/chnsz/golangsdk/openstack/elb/v2/monitors
 github.com/chnsz/golangsdk/openstack/elb/v2/pools
 github.com/chnsz/golangsdk/openstack/elb/v3/certificates
 github.com/chnsz/golangsdk/openstack/elb/v3/flavors


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

update lb monitor with v2 api

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update lb monitor with v2 api
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLBV2Monitor'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLBV2Monitor -timeout 360m -parallel 4
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== RUN   TestAccLBV2Monitor_udp
=== PAUSE TestAccLBV2Monitor_udp
=== RUN   TestAccLBV2Monitor_http
=== PAUSE TestAccLBV2Monitor_http
=== CONT  TestAccLBV2Monitor_basic
=== CONT  TestAccLBV2Monitor_http
=== CONT  TestAccLBV2Monitor_udp
--- PASS: TestAccLBV2Monitor_udp (210.93s)
--- PASS: TestAccLBV2Monitor_http (214.49s)
--- PASS: TestAccLBV2Monitor_basic (269.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       269.698s
```
