### PR TITLE
chore: move eip and bandwidth out of vpc directory

### DIFF
--- a/huaweicloud/data_source_huaweicloud_iec_eips.go
+++ b/huaweicloud/data_source_huaweicloud_iec_eips.go
@@ -1,7 +1,7 @@
 package huaweicloud
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -114,7 +114,7 @@ func dataSourceIECNetworkEipsRead(d *schema.ResourceData, meta interface{}) erro
 			"public_ip":            item.PublicIpAddress,
 			"private_ip":           item.PrivateIpAddress,
 			"port_id":              item.PortID,
-			"status":               vpc.NormalizeEIPStatus(item.Status),
+			"status":               eip.NormalizeEIPStatus(item.Status),
 			"ip_version":           item.IPVersion,
 			"bandwidth_id":         item.BandwidthID,
 			"bandwidth_name":       item.BandwidthName,

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/evs"
@@ -355,11 +356,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_file_system":                      DataSourceSFSFileSystemV2(),
 			"huaweicloud_vbs_backup_policy":                    dataSourceVBSBackupPolicyV2(),
 			"huaweicloud_vbs_backup":                           dataSourceVBSBackupV2(),
+			"huaweicloud_vpc_bandwidth":                        eip.DataSourceBandWidth(),
+			"huaweicloud_vpc_eip":                              eip.DataSourceVpcEip(),
+			"huaweicloud_vpc_eips":                             eip.DataSourceVpcEips(),
 			"huaweicloud_vpc":                                  vpc.DataSourceVpcV1(),
 			"huaweicloud_vpcs":                                 vpc.DataSourceVpcs(),
-			"huaweicloud_vpc_bandwidth":                        vpc.DataSourceBandWidth(),
-			"huaweicloud_vpc_eip":                              vpc.DataSourceVpcEip(),
-			"huaweicloud_vpc_eips":                             vpc.DataSourceVpcEips(),
 			"huaweicloud_vpc_ids":                              vpc.DataSourceVpcIdsV1(),
 			"huaweicloud_vpc_peering_connection":               vpc.DataSourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_route_table":                      vpc.DataSourceVPCRouteTable(),
@@ -580,12 +581,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_repository_sharing":          swr.ResourceSWRRepositorySharing(),
 			"huaweicloud_vbs_backup":                      resourceVBSBackupV2(),
 			"huaweicloud_vbs_backup_policy":               resourceVBSBackupPolicyV2(),
-			"huaweicloud_vpc":                             vpc.ResourceVirtualPrivateCloudV1(),
-			"huaweicloud_vpc_bandwidth":                   vpc.ResourceVpcBandWidthV2(),
-			"huaweicloud_vpc_eip":                         vpc.ResourceVpcEIPV1(),
+			"huaweicloud_vpc_bandwidth":                   eip.ResourceVpcBandWidthV2(),
+			"huaweicloud_vpc_eip":                         eip.ResourceVpcEIPV1(),
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"huaweicloud_vpc_route_table":                 vpc.ResourceVPCRouteTable(),
+			"huaweicloud_vpc":                             vpc.ResourceVirtualPrivateCloudV1(),
 			"huaweicloud_vpc_route":                       vpc.ResourceVPCRouteTableRoute(),
 			"huaweicloud_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
 			"huaweicloud_vpcep_approval":                  ResourceVPCEndpointApproval(),
@@ -649,12 +650,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_file_system_v2":                 ResourceSFSFileSystemV2(),
 			"huaweicloud_iam_agency":                         iam.ResourceIAMAgencyV3(),
 			"huaweicloud_iam_agency_v3":                      iam.ResourceIAMAgencyV3(),
-			"huaweicloud_vpc_v1":                             vpc.ResourceVirtualPrivateCloudV1(),
-			"huaweicloud_vpc_bandwidth_v2":                   vpc.ResourceVpcBandWidthV2(),
-			"huaweicloud_vpc_eip_v1":                         vpc.ResourceVpcEIPV1(),
+			"huaweicloud_vpc_bandwidth_v2":                   eip.ResourceVpcBandWidthV2(),
+			"huaweicloud_vpc_eip_v1":                         eip.ResourceVpcEIPV1(),
 			"huaweicloud_vpc_peering_connection_v2":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter_v2": vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"huaweicloud_vpc_route_v2":                       vpc.ResourceVPCRouteV2(),
+			"huaweicloud_vpc_v1":                             vpc.ResourceVirtualPrivateCloudV1(),
 			"huaweicloud_vpc_subnet_v1":                      vpc.ResourceVpcSubnetV1(),
 			"huaweicloud_cce_cluster_v3":                     ResourceCCEClusterV3(),
 			"huaweicloud_cce_node_v3":                        ResourceCCENodeV3(),

--- a/huaweicloud/resource_huaweicloud_iec_eip.go
+++ b/huaweicloud/resource_huaweicloud_iec_eip.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -183,7 +183,7 @@ func resourceIecEipV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bandwidth_size", n.BandwidthSize)
 	d.Set("bandwidth_share_type", n.BandwidthShareType)
 	d.Set("site_info", n.SiteInfo)
-	d.Set("status", vpc.NormalizeEIPStatus(n.Status))
+	d.Set("status", eip.NormalizeEIPStatus(n.Status))
 
 	return nil
 }

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_bandwidth_test.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"fmt"

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_test.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"fmt"

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"fmt"
@@ -28,8 +28,8 @@ func TestAccVpcEipsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
-					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "eips.0.id",
-						"${huaweicloud_vpc_eip.test.id}"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
+						"huaweicloud_vpc_eip.test", "id"),
 				),
 			},
 		},
@@ -65,8 +65,8 @@ func TestAccVpcEipsDataSource_byTag(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
-					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "eips.0.id",
-						"${huaweicloud_vpc_eip.test.id}"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
+						"huaweicloud_vpc_eip.test", "id"),
 				),
 			},
 		},

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_test.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"fmt"

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"fmt"

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidth.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"context"

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"context"

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"context"

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -1,4 +1,4 @@
-package vpc
+package eip
 
 import (
 	"time"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

move eip and bandwidth out of vpc directory, related resource and data source:
+ huaweicloud_vpc_bandwidth
+ huaweicloud_vpc_eip
+ data.huaweicloud_vpc_bandwidth
+ data.huaweicloud_vpc_eip
+ data.huaweicloud_vpc_eips

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v  -timeout 360m -parallel 4
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== RUN   TestAccVpcEipsDataSource_byTag
=== PAUSE TestAccVpcEipsDataSource_byTag
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== RUN   TestAccVpcBandWidth_WithEpsId
=== PAUSE TestAccVpcBandWidth_WithEpsId
=== RUN   TestAccVpcEIP_basic
=== PAUSE TestAccVpcEIP_basic
=== RUN   TestAccVpcEIP_share
=== PAUSE TestAccVpcEIP_share
=== RUN   TestAccVpcEIP_WithEpsId
=== PAUSE TestAccVpcEIP_WithEpsId
=== RUN   TestAccVpcEIP_prePaid
=== PAUSE TestAccVpcEIP_prePaid
=== RUN   TestAccVpcEIP_ipv6
=== PAUSE TestAccVpcEIP_ipv6
=== CONT  TestAccBandWidthDataSource_basic
=== CONT  TestAccVpcEIP_basic
=== CONT  TestAccVpcEIP_prePaid
=== CONT  TestAccVpcEIP_WithEpsId
=== CONT  TestAccVpcEIP_prePaid
    acceptance.go:419: This environment does not support prepaid tests
--- SKIP: TestAccVpcEIP_prePaid (0.00s)
=== CONT  TestAccVpcEIP_ipv6
=== CONT  TestAccVpcEIP_WithEpsId
    acceptance.go:346: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccVpcEIP_WithEpsId (0.00s)
=== CONT  TestAccVpcEIP_share
--- PASS: TestAccBandWidthDataSource_basic (113.14s)
=== CONT  TestAccVpcBandWidth_WithEpsId
    acceptance.go:346: This environment does not support Enterprise Project ID tests
--- SKIP: TestAccVpcBandWidth_WithEpsId (0.00s)
=== CONT  TestAccVpcBandWidth_basic
--- PASS: TestAccVpcEIP_ipv6 (116.89s)
=== CONT  TestAccVpcEipsDataSource_byTag
--- PASS: TestAccVpcEIP_share (125.01s)
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEIP_basic (170.61s)
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (78.35s)
--- PASS: TestAccVpcEipsDataSource_byTag (88.96s)
--- PASS: TestAccVpcBandWidth_basic (108.45s)
--- PASS: TestAccVpcEipDataSource_basic (65.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       236.664s
```
