### PR TITLE
feat: add vpc_eip_associate resource and hide networking_eip_associate resource

### DIFF
--- a/docs/resources/vpc_eip_associate.md
+++ b/docs/resources/vpc_eip_associate.md
@@ -1,11 +1,10 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Elastic IP (EIP)"
 ---
 
-# huaweicloud_networking_eip_associate
+# huaweicloud_vpc_eip_associate
 
-Associates an EIP to a port. This can be used instead of the
-`huaweicloud_networking_floatingip_associate_v2` resource.
+Associates an EIP to a specified port.
 
 ## Example Usage
 
@@ -27,7 +26,7 @@ resource "huaweicloud_vpc_eip" "myeip" {
   }
 }
 
-resource "huaweicloud_networking_eip_associate" "associated" {
+resource "huaweicloud_vpc_eip_associate" "associated" {
   public_ip = huaweicloud_vpc_eip.myeip.address
   port_id   = data.huaweicloud_networking_port.myport.id
 }
@@ -52,5 +51,5 @@ In addition to all arguments above, the following attributes are exported:
 EIP associations can be imported using the `id` of the EIP, e.g.
 
 ```
-$ terraform import huaweicloud_networking_eip_associate.eip 2c7f39f3-702b-48d1-940c-b50384177ee1
+$ terraform import huaweicloud_vpc_eip_associate.eip 2c7f39f3-702b-48d1-940c-b50384177ee1
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -585,6 +585,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vbs_backup_policy":               resourceVBSBackupPolicyV2(),
 			"huaweicloud_vpc_bandwidth":                   eip.ResourceVpcBandWidthV2(),
 			"huaweicloud_vpc_eip":                         eip.ResourceVpcEIPV1(),
+			"huaweicloud_vpc_eip_associate":               eip.ResourceEIPAssociate(),
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"huaweicloud_vpc_route_table":                 vpc.ResourceVPCRouteTable(),
@@ -694,6 +695,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_vip_associate_v2":        resourceNetworkingVIPAssociateV2(),
 			"huaweicloud_fgs_function_v2":                    fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_cdn_domain_v1":                      resourceCdnDomainV1(),
+
 			// Deprecated
 			"huaweicloud_blockstorage_volume_v2":             resourceBlockStorageVolumeV2(),
 			"huaweicloud_networking_network_v2":              resourceNetworkingNetworkV2(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -560,7 +560,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_snat_rule":                   ResourceNatSnatRuleV2(),
 			"huaweicloud_network_acl":                     ResourceNetworkACL(),
 			"huaweicloud_network_acl_rule":                ResourceNetworkACLRule(),
-			"huaweicloud_networking_eip_associate":        ResourceNetworkingFloatingIPAssociateV2(),
 			"huaweicloud_networking_port":                 ResourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":             ResourceNetworkingSecGroupV2(),
 			"huaweicloud_networking_secgroup_rule":        ResourceNetworkingSecGroupRuleV2(),
@@ -614,6 +613,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_reference_table":             waf.ResourceWafReferenceTableV1(),
 
 			// Legacy
+			"huaweicloud_networking_eip_associate":           eip.ResourceEIPAssociate(),
 			"huaweicloud_compute_instance_v2":                ResourceComputeInstanceV2(),
 			"huaweicloud_compute_interface_attach_v2":        ResourceComputeInterfaceAttachV2(),
 			"huaweicloud_compute_keypair_v2":                 ResourceComputeKeypairV2(),

--- a/huaweicloud/resource_huaweicloud_networking_eip_associate.go
+++ b/huaweicloud/resource_huaweicloud_networking_eip_associate.go
@@ -10,6 +10,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
+// ResourceNetworkingFloatingIPAssociateV2 is not uesd in huaweicloud,
+// but it is used by other Joint-Operation cloud providers, so keep it.
 func ResourceNetworkingFloatingIPAssociateV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNetworkingFloatingIPAssociateV2Create,

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
@@ -49,7 +49,45 @@ func TestAccEIPAssociate_basic(t *testing.T) {
 	})
 }
 
-func testAccEIPAssociate_basic(rName string) string {
+func TestAccEIPAssociate_compatible(t *testing.T) {
+	var eip eips.PublicIp
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	associateName := "huaweicloud_networking_eip_associate.test"
+	resourceName := "huaweicloud_vpc_eip.test"
+
+	// huaweicloud_networking_eip_associate and huaweicloud_vpc_eip have the same ID
+	// and call the same API to get resource
+	rc := acceptance.InitResourceCheck(
+		associateName,
+		&eip,
+		getEipResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPAssociate_compatible(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPtr(
+						associateName, "port_id", &eip.PortID),
+					resource.TestCheckResourceAttrPair(
+						associateName, "public_ip", resourceName, "address"),
+				),
+			},
+			{
+				ResourceName:      associateName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEIPAssociate_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "vpc_1" {
   name = "%s"
@@ -79,10 +117,27 @@ resource "huaweicloud_vpc_eip" "test" {
     charge_mode = "traffic"
   }
 }
+`, rName, rName, rName, rName)
+}
+
+func testAccEIPAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "huaweicloud_vpc_eip_associate" "test" {
   public_ip = huaweicloud_vpc_eip.test.address
   port_id   = huaweicloud_networking_vip.vip_1.id
 }
-`, rName, rName, rName, rName)
+`, testAccEIPAssociate_base(rName))
+}
+
+func testAccEIPAssociate_compatible(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_networking_eip_associate" "test" {
+  public_ip = huaweicloud_vpc_eip.test.address
+  port_id   = huaweicloud_networking_vip.vip_1.id
+}
+`, testAccEIPAssociate_base(rName))
 }

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
@@ -1,0 +1,88 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEIPAssociate_basic(t *testing.T) {
+	var eip eips.PublicIp
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	associateName := "huaweicloud_vpc_eip_associate.test"
+	resourceName := "huaweicloud_vpc_eip.test"
+
+	// huaweicloud_vpc_eip_associate and huaweicloud_vpc_eip have the same ID
+	// and call the same API to get resource
+	rc := acceptance.InitResourceCheck(
+		associateName,
+		&eip,
+		getEipResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPAssociate_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPtr(
+						associateName, "port_id", &eip.PortID),
+					resource.TestCheckResourceAttrPair(
+						associateName, "public_ip", resourceName, "address"),
+				),
+			},
+			{
+				ResourceName:      associateName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEIPAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "vpc_1" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "subnet_1" {
+  vpc_id     = huaweicloud_vpc.vpc_1.id
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+resource "huaweicloud_networking_vip" "vip_1" {
+  name       = "%s"
+  network_id = huaweicloud_vpc_subnet.subnet_1.id
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "%s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_vpc_eip_associate" "test" {
+  public_ip = huaweicloud_vpc_eip.test.address
+  port_id   = huaweicloud_networking_vip.vip_1.id
+}
+`, rName, rName, rName, rName)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_eip_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_eip_associate.go
@@ -1,0 +1,157 @@
+package eip
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+// ResourceEIPAssociate is the ipml for huaweicloud_vpc_eip_associate resource
+func ResourceEIPAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEIPAssociateCreate,
+		ReadContext:   resourceEIPAssociateRead,
+		DeleteContext: resourceEIPAssociateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"port_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"public_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceEIPAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC client: %s", err)
+	}
+
+	publicIP := d.Get("public_ip").(string)
+	publicID, err := getEIPByAddress(vpcClient, publicIP)
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to get ID of public IP %s: %s", publicIP, err)
+	}
+
+	portID := d.Get("port_id").(string)
+	err = bindPort(vpcClient, publicID, portID, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmtp.DiagErrorf("Error associating EIP %s to port %s: %s", publicID, portID, err)
+	}
+
+	d.SetId(publicID)
+	return resourceEIPAssociateRead(ctx, d, meta)
+}
+
+func resourceEIPAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	vpcClient, err := config.NetworkingV1Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC client: %s", err)
+	}
+
+	eIP, err := eips.Get(vpcClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "EIP")
+	}
+
+	d.Set("region", region)
+	d.Set("public_ip", eIP.PublicAddress)
+	d.Set("port_id", eIP.PortID)
+
+	return nil
+}
+
+func resourceEIPAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC client: %s", err)
+	}
+
+	portID := d.Get("port_id").(string)
+	err = unbindPort(vpcClient, d.Id(), portID, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return fmtp.DiagErrorf("Error disassociating EIP %s from port %s: %s",
+			d.Id(), portID, err)
+	}
+
+	return nil
+}
+
+func getEIPByAddress(client *golangsdk.ServiceClient, address string) (string, error) {
+	listOpts := eips.ListOpts{
+		PublicIp: []string{address},
+	}
+
+	pages, err := eips.List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+	allEips, err := eips.ExtractPublicIPs(pages)
+	if err != nil {
+		return "", fmtp.Errorf("Unable to retrieve EIPs: %s ", err)
+	}
+
+	if len(allEips) != 1 {
+		return "", fmtp.Errorf("unable to determine the ID of %s", address)
+	}
+
+	return allEips[0].ID, nil
+}
+
+func bindPort(client *golangsdk.ServiceClient, eipID, portID string, timeout time.Duration) error {
+	logp.Printf("[DEBUG] Bind EIP %s to port %s", eipID, portID)
+	return actionOnPort(client, eipID, portID, timeout)
+}
+
+func unbindPort(client *golangsdk.ServiceClient, eipID, portID string, timeout time.Duration) error {
+	logp.Printf("[DEBUG] Unbind EIP %s from port: %s", eipID, portID)
+	return actionOnPort(client, eipID, "", timeout)
+}
+
+func actionOnPort(client *golangsdk.ServiceClient, eipID, portID string, timeout time.Duration) error {
+	updateOpts := eips.UpdateOpts{
+		PortID: portID,
+	}
+	_, err := eips.Update(client, eipID, updateOpts).Extract()
+	if err != nil {
+		return err
+	}
+
+	return waitForEIPActive(client, eipID, timeout)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

+ add new resource **huaweicloud_vpc_eip_associate** with the same schema with **huaweicloud_networking_eip_associate**
+ change impl of **huaweicloud_networking_eip_associate**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccEIPAssociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccEIPAssociate -timeout 360m -parallel 4
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== RUN   TestAccEIPAssociate_compatible
=== PAUSE TestAccEIPAssociate_compatible
=== CONT  TestAccEIPAssociate_basic
=== CONT  TestAccEIPAssociate_compatible
--- PASS: TestAccEIPAssociate_basic (126.87s)
--- PASS: TestAccEIPAssociate_compatible (129.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       129.334s
```
