### PR TITLE
feat(cce/node): support password encryption in cce node, node_pool and node_attach

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -133,7 +133,8 @@ The following arguments are supported:
   This parameter and `password` are alternative. Changing this parameter will create a new resource.
 
 * `password` - (Optional, String, ForceNew) Specifies the root password when logging in to select the password mode.
-  This parameter must be salted and alternative to `key_pair`. Changing this parameter will create a new resource.
+  This parameter can be plain or salted and is alternative to `key_pair`.
+  Changing this parameter will create a new resource.
 
 * `root_volume` - (Required, List, ForceNew) Specifies the configuration of the system disk.
   Changing this parameter will create a new resource.

--- a/docs/resources/cce_node_attach.md
+++ b/docs/resources/cce_node_attach.md
@@ -44,7 +44,8 @@ The following arguments are supported:
   This parameter and `password` are alternative. Changing this parameter will reset the node.
 
 * `password` - (Optional, String) Specifies the root password when logging in to select the password mode.
-  This parameter must be salted and alternative to `key_pair`. Changing this parameter will reset the node.
+  This parameter can be plain or salted and is alternative to `key_pair`.
+  Changing this parameter will reset the node.
 
 * `max_pods` - (Optional, Int, ForceNew) Specifies the the maximum number of instances a node is allowed to create.
   Changing this parameter will create a new resource.

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -69,7 +69,8 @@ The following arguments are supported:
   This parameter and `password` are alternative. Changing this parameter will create a new resource.
 
 * `password` - (Optional, String, ForceNew) Specifies the root password when logging in to select the password mode.
-  This parameter must be salted and alternative to `key_pair`. Changing this parameter will create a new resource.
+  This parameter can be plain or salted and is alternative to `key_pair`.
+  Changing this parameter will create a new resource.
 
 * `subnet_id` - (Optional, String, ForceNew) Specifies the ID of the subnet to which the NIC belongs.
   Changing this parameter will create a new resource.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/huaweicloud/terraform-provider-huaweicloud
 go 1.14
 
 require (
+	github.com/amoghe/go-crypt v0.0.0-20191109212615-b2ff80594b7f
 	github.com/chnsz/golangsdk v0.0.0-20220120023609-36c388c02c1b
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/amoghe/go-crypt v0.0.0-20191109212615-b2ff80594b7f h1:JxPBJknH9/9Yp0BPLZII8Cn4vaWPNsFOdkmpIwPhO8A=
+github.com/amoghe/go-crypt v0.0.0-20191109212615-b2ff80594b7f/go.mod h1:eFiR01PwTcpbzXtdMces7zxg6utvFM5puiWHpWB8D/k=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=

--- a/huaweicloud/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_attach.go
@@ -61,7 +61,6 @@ func ResourceCCENodeAttachV3() *schema.Resource {
 			"password": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Sensitive:    true,
 				ExactlyOneOf: []string{"password", "key_pair"},
 			},
@@ -345,10 +344,14 @@ func resourceCCENodeAttachV3Create(ctx context.Context, d *schema.ResourceData, 
 			SshKey: d.Get("key_pair").(string),
 		}
 	} else {
+		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		loginSpec = nodes.LoginSpec{
 			UserPassword: nodes.UserPassword{
 				Username: "root",
-				Password: d.Get("password").(string),
+				Password: password,
 			},
 		}
 	}
@@ -418,10 +421,14 @@ func resourceCCENodeAttachV3Update(ctx context.Context, d *schema.ResourceData, 
 				SshKey: d.Get("key_pair").(string),
 			}
 		} else {
+			password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 			loginSpec = nodes.LoginSpec{
 				UserPassword: nodes.UserPassword{
 					Username: "root",
-					Password: d.Get("password").(string),
+					Password: password,
 				},
 			}
 		}
@@ -476,10 +483,14 @@ func resourceCCENodeAttachV3Delete(ctx context.Context, d *schema.ResourceData, 
 			SshKey: d.Get("key_pair").(string),
 		}
 	} else {
+		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		loginSpec = nodes.LoginSpec{
 			UserPassword: nodes.UserPassword{
 				Username: "root",
-				Password: d.Get("password").(string),
+				Password: password,
 			},
 		}
 	}

--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -346,10 +346,14 @@ func resourceCCENodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 			SshKey: d.Get("key_pair").(string),
 		}
 	} else if hasFilledOpt(d, "password") {
+		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		loginSpec = nodes.LoginSpec{
 			UserPassword: nodes.UserPassword{
 				Username: "root",
-				Password: d.Get("password").(string),
+				Password: password,
 			},
 		}
 	}
@@ -483,10 +487,14 @@ func resourceCCENodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if hasFilledOpt(d, "key_pair") {
 		loginSpec = nodes.LoginSpec{SshKey: d.Get("key_pair").(string)}
 	} else if hasFilledOpt(d, "password") {
+		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		loginSpec = nodes.LoginSpec{
 			UserPassword: nodes.UserPassword{
 				Username: "root",
-				Password: d.Get("password").(string),
+				Password: password,
 			},
 		}
 	}

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -604,10 +604,14 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 			SshKey: d.Get("key_pair").(string),
 		}
 	} else if hasFilledOpt(d, "password") {
+		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		loginSpec = nodes.LoginSpec{
 			UserPassword: nodes.UserPassword{
 				Username: "root",
-				Password: d.Get("password").(string),
+				Password: password,
 			},
 		}
 	}
@@ -780,10 +784,14 @@ func resourceCCENodeV3Delete(ctx context.Context, d *schema.ResourceData, meta i
 				SshKey: d.Get("key_pair").(string),
 			}
 		} else if hasFilledOpt(d, "password") {
+			password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 			loginSpec = nodes.LoginSpec{
 				UserPassword: nodes.UserPassword{
 					Username: "root",
-					Password: d.Get("password").(string),
+					Password: password,
 				},
 			}
 		}

--- a/huaweicloud/utils/password_encrypt.go
+++ b/huaweicloud/utils/password_encrypt.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	crypt "github.com/amoghe/go-crypt"
+)
+
+var letters = []byte("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ=_")
+
+// Salt generates a random salt according to given size
+func Salt(size int) ([]byte, error) {
+	salt := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, salt)
+	if err != nil {
+		return nil, fmt.Errorf("error generating salt: %s", err)
+	}
+
+	arc := uint8(0)
+	for i, x := range salt {
+		arc = x & 63
+		salt[i] = letters[arc]
+	}
+	return salt, nil
+}
+
+// PasswordEncrypt encrypts given password with sha512
+func PasswordEncrypt(password string) (string, error) {
+	saltBytes, err := Salt(16)
+	if err != nil {
+		return "", err
+	}
+	salt := "$6$" + string(saltBytes) + "$"
+
+	passwordEncrypted, err := crypt.Crypt(password, salt)
+	if err != nil {
+		return "", fmt.Errorf("error encrypting the password: %s", err)
+	}
+	return base64.StdEncoding.EncodeToString([]byte(passwordEncrypted)), nil
+}
+
+// TryPasswordEncrypt tries to encrypt given password if it's not encrypted
+func TryPasswordEncrypt(password string) (string, error) {
+	if _, err := base64.StdEncoding.DecodeString(password); err != nil {
+		return PasswordEncrypt(password)
+	}
+	return password, nil
+}

--- a/vendor/github.com/amoghe/go-crypt/.gitignore
+++ b/vendor/github.com/amoghe/go-crypt/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/amoghe/go-crypt/.travis.yml
+++ b/vendor/github.com/amoghe/go-crypt/.travis.yml
@@ -1,0 +1,5 @@
+sudo:     false
+language: go
+
+go:
+  - 1.4

--- a/vendor/github.com/amoghe/go-crypt/LICENSE
+++ b/vendor/github.com/amoghe/go-crypt/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Akshay Moghe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/amoghe/go-crypt/README.md
+++ b/vendor/github.com/amoghe/go-crypt/README.md
@@ -1,0 +1,108 @@
+go-crypt (`crypt`)
+==================
+
+[![Build Status](https://travis-ci.org/amoghe/go-crypt.svg)](https://travis-ci.org/amoghe/go-crypt)
+
+Package `crypt` provides go language wrappers around crypt(3). For further information on crypt see the
+[man page](http://man7.org/linux/man-pages/man3/crypt.3.html)
+
+If you have questions about how to use crypt (the C function), it is likely this is not the package you
+are looking for.
+
+**NOTE** Depending on the platform, this package provides a `Crypt` function that is backed by different
+flavors of the libc crypt. This is done by detecting the GOOS and trying to build using `crypt_r` (the GNU
+extension) when on linux, and wrapping around plain 'ol `crypt` (guarded by a global lock) otherwise.
+
+Example
+-------
+```go
+import (
+	"fmt"
+	"github.com/amoghe/go-crypt"
+)
+
+func main() {
+	md5, err := crypt.Crypt("password", "in")
+	if err != nil {
+		fmt.Errorf("error:", err)
+		return
+	}
+
+	sha512, err := crypt.Crypt("password", "$6$SomeSaltSomePepper$")
+	if err != nil {
+		fmt.Errorf("error:", err)
+		return
+	}
+
+	fmt.Println("MD5:", md5)
+	fmt.Println("SHA512:", sha512)
+}
+```
+
+A Note On "Salt"
+----------------
+
+You can find out more about salt [here](https://en.wikipedia.org/wiki/Salt_(cryptography))
+
+The hash algorithm can be selected via the salt string. Here is how to do it (relevant
+section from the man page):
+
+```
+   If salt is a character string starting with the characters
+   "$id$" followed by a string terminated by "$":
+
+       $id$salt$encrypted
+
+   then instead of using the DES machine, id identifies the
+   encryption method used and this then determines how the rest
+   of the password string is interpreted.  The following values
+   of id are supported:
+
+          ID  | Method
+          ─────────────────────────────────────────────────────────
+          1   | MD5
+          2a  | Blowfish (not in mainline glibc; added in some
+              | Linux distributions)
+          5   | SHA-256 (since glibc 2.7)
+          6   | SHA-512 (since glibc 2.7)
+
+   So $5$salt$encrypted is an SHA-256 encoded password and
+   $6$salt$encrypted is an SHA-512 encoded one.
+
+   "salt" stands for the up to 16 characters following "$id$" in
+   the salt.  The encrypted part of the password string is the
+   actual computed password.  The size of this string is fixed:
+
+   MD5     | 22 characters
+   SHA-256 | 43 characters
+   SHA-512 | 86 characters
+```
+
+Platforms
+---------
+
+This package has been tested on the following platforms:
+- ubuntu 14.04.2 (libc 2.19)
+- ubuntu 12.04.5 (libc 2.15)
+- centos         (libc 2.17)
+- fedora 22      (libc 2.21)
+
+All the platforms tested on have GNU libc (with extensions) so that the GOOS=linux always
+compiles the reentrant versions of the crypt function (`crypt_r`), and exposes it to go land.
+
+Other platforms (freebsd, netbsd) should also work (in theory) since their libc expose at least
+a posix compliant crypt function. On these platforms the fallback should compile and expose the
+'plain' (non reentrant, thus globally locked) crypt function.
+
+Unfortunately, I do not have access to machines that run anything other than Linux, hence the other
+platforms have not been tested, however I believe they should work just fine. If you can verify this
+(or provide a patch that fixes this), I would be grateful.
+
+TODO
+----
+* Find someone with access to *BSD system(s)
+
+License
+-------
+
+Released under the [MIT License](LICENSE)

--- a/vendor/github.com/amoghe/go-crypt/crypt.go
+++ b/vendor/github.com/amoghe/go-crypt/crypt.go
@@ -1,0 +1,49 @@
+// +build darwin freebsd netbsd
+
+// Package crypt provides wrappers around functions available in crypt.h
+//
+// It wraps around the GNU specific extension (crypt) when the reentrant version
+// (crypt_r) is unavailable. The non-reentrant version is guarded by a global lock
+// so as to be safely callable from concurrent goroutines.
+package crypt
+
+import (
+	"sync"
+	"unsafe"
+)
+
+/*
+#cgo LDFLAGS: -lcrypt
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <unistd.h>
+*/
+import "C"
+
+var (
+	mu sync.Mutex
+)
+
+// Crypt provides a wrapper around the glibc crypt() function.
+// For the meaning of the arguments, refer to the README.
+func Crypt(pass, salt string) (string, error) {
+	c_pass := C.CString(pass)
+	defer C.free(unsafe.Pointer(c_pass))
+
+	c_salt := C.CString(salt)
+	defer C.free(unsafe.Pointer(c_salt))
+
+	mu.Lock()
+	c_enc, err := C.crypt(c_pass, c_salt)
+	mu.Unlock()
+
+	if c_enc == nil {
+		return "", err
+	}
+	defer C.free(unsafe.Pointer(c_enc))
+
+	// Return nil error if the string is non-nil.
+	// As per the errno.h manpage, functions are allowed to set errno
+	// on success. Caller should ignore errno on success.
+	return C.GoString(c_enc), err
+}

--- a/vendor/github.com/amoghe/go-crypt/crypt_r.go
+++ b/vendor/github.com/amoghe/go-crypt/crypt_r.go
@@ -1,0 +1,62 @@
+// +build linux
+
+// Package crypt provides wrappers around functions available in crypt.h
+//
+// It wraps around the GNU specific extension (crypt_r) when it is available
+// (i.e. where GOOS=linux). This makes the go function reentrant (and thus
+// callable from concurrent goroutines).
+package crypt
+
+import (
+	"unsafe"
+)
+
+/*
+#cgo LDFLAGS: -lcrypt
+
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <string.h>
+#include <crypt.h>
+
+char *gnu_ext_crypt(char *pass, char *salt) {
+  char *enc = NULL;
+  char *ret = NULL;
+  struct crypt_data data;
+  data.initialized = 0;
+
+  enc = crypt_r(pass, salt, &data);
+  if(enc == NULL) {
+    return NULL;
+  }
+
+  ret = (char *)malloc(strlen(enc)+1); // for trailing null
+  strncpy(ret, enc, strlen(enc));
+  ret[strlen(enc)]= '\0'; // paranoid
+
+  return ret;
+}
+*/
+import "C"
+
+// Crypt provides a wrapper around the glibc crypt_r() function.
+// For the meaning of the arguments, refer to the package README.
+func Crypt(pass, salt string) (string, error) {
+	c_pass := C.CString(pass)
+	defer C.free(unsafe.Pointer(c_pass))
+
+	c_salt := C.CString(salt)
+	defer C.free(unsafe.Pointer(c_salt))
+
+	c_enc, err := C.gnu_ext_crypt(c_pass, c_salt)
+	if c_enc == nil {
+		return "", err
+	}
+	defer C.free(unsafe.Pointer(c_enc))
+
+	// Return nil error if the string is non-nil.
+	// As per the errno.h manpage, functions are allowed to set errno
+	// on success. Caller should ignore errno on success.
+	return C.GoString(c_enc), nil
+}

--- a/vendor/github.com/amoghe/go-crypt/version.go
+++ b/vendor/github.com/amoghe/go-crypt/version.go
@@ -1,0 +1,14 @@
+// +build linux
+
+package crypt
+
+/*
+#include <gnu/libc-version.h>
+*/
+import "C"
+
+// Returns version string from libc
+func LibCVersion() string {
+	c_ver := C.gnu_get_libc_version()
+	return C.GoString(c_ver)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,8 @@
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
+# github.com/amoghe/go-crypt v0.0.0-20191109212615-b2ff80594b7f
+## explicit
+github.com/amoghe/go-crypt
 # github.com/apparentlymart/go-cidr v1.0.1
 github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg v1.0.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support password encryption in cce node, node_pool and node_attach

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support password encryption in cce node, node_pool and node_attach
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_password'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_password -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_password
=== PAUSE TestAccCCENodeV3_password
=== CONT  TestAccCCENodeV3_password
--- PASS: TestAccCCENodeV3_password (822.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       823.035s
```
