### PR TITLE
feat(ecs): support to associate IPv6 address to a specified shared bandwidth

### DIFF
--- a/docs/resources/compute_eip_associate.md
+++ b/docs/resources/compute_eip_associate.md
@@ -4,7 +4,8 @@ subcategory: "Elastic Cloud Server (ECS)"
 
 # huaweicloud_compute_eip_associate
 
-Associate an EIP to a compute instance.
+* Associates the **IPv4** address of an ECS instance to a specified EIP.
+* Associates the **IPv6** address of an ECS instance to a specified **Shared** Bandwidth.
 
 ## Example Usage
 
@@ -12,12 +13,8 @@ Associate an EIP to a compute instance.
 
 ```hcl
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name = "instance"
+  ...
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -30,7 +27,7 @@ resource "huaweicloud_vpc_eip" "myeip" {
   }
   bandwidth {
     name        = "test"
-    size        = 8
+    size        = 5
     share_type  = "PER"
     charge_mode = "traffic"
   }
@@ -46,12 +43,8 @@ resource "huaweicloud_compute_eip_associate" "associated" {
 
 ```hcl
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name = "instance"
+  ...
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -68,7 +61,7 @@ resource "huaweicloud_vpc_eip" "myeip" {
   }
   bandwidth {
     name        = "test"
-    size        = 8
+    size        = 5
     share_type  = "PER"
     charge_mode = "traffic"
   }
@@ -81,6 +74,30 @@ resource "huaweicloud_compute_eip_associate" "associated" {
 }
 ```
 
+### Associate the IPv6 address to a specified Shared Bandwidth
+
+```hcl
+variable "subnet_id" {}
+variable "bandwidth_id" {}
+
+resource "huaweicloud_compute_instance" "myinstance" {
+  name      = "instance"
+  flavor_id = "c6.large.2"
+  ...
+
+  network {
+    uuid        = var.subnet_id
+    ipv6_enable = true
+  }
+}
+
+resource "huaweicloud_compute_eip_associate" "associated" {
+  bandwidth_id = var.bandwidth_id
+  instance_id  = huaweicloud_compute_instance.myinstance.id
+  fixed_ip     = huaweicloud_compute_instance.myinstance.network.0.fixed_ip_v6
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -88,26 +105,31 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the associated resource.
   If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate.
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of ECS instance to associated with.
   Changing this creates a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ECS instance to associate the EIP with.
+* `public_ip` - (Optional, String, ForceNew) Specifies the EIP address to associate. It's **mandatory**
+  when you want to associate the ECS instance with an EIP. Changing this creates a new resource.
+
+* `bandwidth_id` - (Optional, String, ForceNew) Specifies the **shared** bandwidth ID to associate.
+  It's **mandatory** when you want to associate the ECS instance with a specified shared bandwidth.
   Changing this creates a new resource.
 
-* `fixed_ip` - (Optional, String, ForceNew) Specifies the private IP address to direct traffic to.
+* `fixed_ip` - (Optional, String, ForceNew) Specifies the private IP address to direct traffic to. It's **mandatory**
+  and must be a valid IPv6 address when you want to associate the ECS instance with a specified shared bandwidth.
   Changing this creates a new resource.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID in UUID format.
-* `port_id` - The port ID of the ECS instance that associated the EIP with.
+* `id` - The resource ID in format of `<eip address or bandwidth_id>/<instance_id>/<fixed_ip>`.
+* `port_id` - The port ID of the ECS instance that associated with.
 
 ## Import
 
 This resource can be imported by specifying all three arguments, separated by a forward slash:
 
 ```
-$ terraform import huaweicloud_compute_eip_associate.eip_1 <eip>/<instance_id>/<fixed_ip>
+$ terraform import huaweicloud_compute_eip_associate.bind <eip address or bandwidth_id>/<instance_id>/<fixed_ip>
 ```

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate.go
@@ -63,12 +63,11 @@ func ResourceComputeFloatingIPAssociateV2() *schema.Resource {
 				RequiredWith: []string{"fixed_ip"},
 			},
 			"fixed_ip": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Computed:         true,
-				ValidateFunc:     validation.IsIPAddress,
-				DiffSuppressFunc: utils.SuppressComputedFixedWhenFloatingIp,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPAddress,
 			},
 			"port_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate.go
@@ -2,27 +2,34 @@ package huaweicloud
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	bandwidthsv1 "github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/chnsz/golangsdk/openstack/networking/v2/bandwidths"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
+const publicIPv6Type string = "5_dualStack"
+
 func ResourceComputeFloatingIPAssociateV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceComputeFloatingIPAssociateV2Create,
-		Read:   resourceComputeFloatingIPAssociateV2Read,
-		Delete: resourceComputeFloatingIPAssociateV2Delete,
+		Create: resourceComputeEIPAssociateCreate,
+		Read:   resourceComputeEIPAssociateRead,
+		Delete: resourceComputeEIPAssociateDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceComputeEIPAssociateImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -43,15 +50,24 @@ func ResourceComputeFloatingIPAssociateV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"public_ip": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPv4Address,
+				ExactlyOneOf: []string{"bandwidth_id"},
+			},
+			"bandwidth_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"fixed_ip"},
 			},
 			"fixed_ip": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
 				Computed:         true,
+				ValidateFunc:     validation.IsIPAddress,
 				DiffSuppressFunc: utils.SuppressComputedFixedWhenFloatingIp,
 			},
 			"port_id": {
@@ -62,126 +78,174 @@ func ResourceComputeFloatingIPAssociateV2() *schema.Resource {
 	}
 }
 
-func resourceComputeFloatingIPAssociateV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeEIPAssociateCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
-	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud VPC client: %s", err)
-	}
+	region := config.GetRegion(d)
 
-	floatingIP := d.Get("public_ip").(string)
+	var publicID string
 	instanceID := d.Get("instance_id").(string)
 	fixedIP := d.Get("fixed_ip").(string)
+
+	if _, ok := d.GetOk("bandwidth_id"); ok {
+		// fixed_ip must be a valid IPv6 address when combining with bandwidth_id
+		if utils.IsIPv4Address(fixedIP) {
+			return fmtp.Errorf("the fixed_ip must be a valid IPv6 address, got: %s", fixedIP)
+		}
+	}
 
 	// get port id
 	portID, privateIP, err := getComputeInstancePortIDbyFixedIP(d, config, instanceID, fixedIP)
 	if err != nil {
-		return fmtp.Errorf("Error get port id of compute instance: %s", err)
+		return fmtp.Errorf("Error getting port id of compute instance: %s", err)
 	}
 
-	// get EIP id
-	pAddress, err := getFloatingIPbyAddress(d, config, floatingIP)
-	if err != nil {
-		return fmtp.Errorf("Error get eip: %s", err)
-	}
-	floatingID := pAddress.ID
+	if v, ok := d.GetOk("public_ip"); ok {
+		vpcClient, err := config.NetworkingV1Client(region)
+		if err != nil {
+			return fmtp.Errorf("Error creating HuaweiCloud VPC client: %s", err)
+		}
 
-	// Associate EIP to compute instance
-	associateOpts := eips.UpdateOpts{
-		PortID: portID,
-	}
-	logp.Printf("[DEBUG] EIP Associate Options: %#v", associateOpts)
+		// get EIP id
+		eipAddr := v.(string)
+		publicID = eipAddr
+		pAddress, err := getFloatingIPbyAddress(vpcClient, eipAddr)
+		if err != nil {
+			return fmtp.Errorf("Error getting EIP: %s", err)
+		}
 
-	_, err = eips.Update(vpcClient, floatingID, associateOpts).Extract()
-	if err != nil {
-		return fmtp.Errorf("Error associating EIP: %s", err)
+		eipID := pAddress.ID
+		err = bindPortToEIP(vpcClient, eipID, portID)
+		if err != nil {
+			return fmtp.Errorf("Error associating port %s to EIP: %s", portID, err)
+		}
+	} else {
+		bwClient, err := config.NetworkingV2Client(region)
+		if err != nil {
+			return fmtp.Errorf("Error creating bandwidth v2.0 client: %s", err)
+		}
+
+		bwID := d.Get("bandwidth_id").(string)
+		publicID = bwID
+		err = insertPortToBandwidth(bwClient, bwID, portID)
+		if err != nil {
+			return fmtp.Errorf("Error associating IPv6 port %s to bandwidth: %s", portID, err)
+		}
 	}
 
-	id := fmt.Sprintf("%s/%s/%s", floatingIP, instanceID, privateIP)
+	id := fmt.Sprintf("%s/%s/%s", publicID, instanceID, privateIP)
 	d.SetId(id)
 
-	logp.Printf("[DEBUG] Waiting for eip associate to instance %s", id)
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{""},
-		Target:     []string{fmt.Sprintf("floating/%s", floatingIP)},
-		Refresh:    resourceComputeFloatingIPAssociateStateRefreshFunc(d, config, instanceID, floatingIP),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for eip associate to instance(%s): %s",
-			id, err)
-	}
-
-	return resourceComputeFloatingIPAssociateV2Read(d, meta)
+	return resourceComputeEIPAssociateRead(d, meta)
 }
 
-func resourceComputeFloatingIPAssociateV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeEIPAssociateRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-
-	floatingIP, instanceID, fixedIP, err := parseComputeFloatingIPAssociateId(d.Id())
+	region := config.GetRegion(d)
+	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return err
+		return fmtp.Errorf("Error creating VPC client: %s", err)
 	}
 
-	eipInfo, err := getFloatingIPbyAddress(d, config, floatingIP)
-	if err != nil {
-		return fmtp.Errorf("Error get eip: %s", err)
-	}
+	var associated bool
+	var publicID string
+	instanceID := d.Get("instance_id").(string)
+	fixedIP := d.Get("fixed_ip").(string)
 
 	// get port id of compute instance
 	portID, privateIP, err := getComputeInstancePortIDbyFixedIP(d, config, instanceID, fixedIP)
 	if err != nil {
-		return fmtp.Errorf("Error get port id of compute instance: %s", err)
+		return fmtp.Errorf("Error getting port id of compute instance: %s", err)
 	}
 
-	var associated bool
-	if eipInfo.PortID == portID {
-		associated = true
+	if v, ok := d.GetOk("public_ip"); ok {
+		eipAddr := v.(string)
+		publicID = eipAddr
+		eipInfo, err := getFloatingIPbyAddress(vpcClient, eipAddr)
+		if err != nil {
+			if eipInfo != nil {
+				logp.Printf("[WARN] can not find the EIP by %s", eipAddr)
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
+
+		if eipInfo.PortID == portID {
+			associated = true
+		}
+	} else {
+		bwID := d.Get("bandwidth_id").(string)
+		publicID = bwID
+		band, err := bandwidthsv1.Get(vpcClient, bwID).Extract()
+		if err != nil {
+			return common.CheckDeleted(d, err, "bandwidth")
+		}
+
+		for _, ipInfo := range band.PublicipInfo {
+			if ipInfo.PublicipId == portID {
+				associated = true
+				break
+			}
+		}
 	}
 
 	if !associated {
+		logp.Printf("[WARN] the resource is not associated with the specified EIP or bandwidth")
 		d.SetId("")
 	}
 
-	id := fmt.Sprintf("%s/%s/%s", floatingIP, instanceID, privateIP)
+	id := fmt.Sprintf("%s/%s/%s", publicID, instanceID, privateIP)
 	d.SetId(id)
 
 	// Set the attributes pulled from the composed resource ID
-	d.Set("public_ip", floatingIP)
 	d.Set("instance_id", instanceID)
 	d.Set("fixed_ip", privateIP)
 	d.Set("port_id", portID)
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", region)
 
 	return nil
 }
 
-func resourceComputeFloatingIPAssociateV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceComputeEIPAssociateDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	region := config.GetRegion(d)
+
+	instanceID := d.Get("instance_id").(string)
+	fixedIP := d.Get("fixed_ip").(string)
+
+	// get port id of compute instance
+	portID, _, err := getComputeInstancePortIDbyFixedIP(d, config, instanceID, fixedIP)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud VPC client: %s", err)
+		return fmtp.Errorf("Error getting port id of compute instance: %s", err)
 	}
 
-	// get EIP id
-	floatingIP := d.Get("public_ip").(string)
-	eipInfo, err := getFloatingIPbyAddress(d, config, floatingIP)
-	if err != nil {
-		return fmtp.Errorf("Error get eip: %s", err)
-	}
-	floatingID := eipInfo.ID
+	if v, ok := d.GetOk("public_ip"); ok {
+		vpcClient, err := config.NetworkingV1Client(region)
+		if err != nil {
+			return fmtp.Errorf("Error creating HuaweiCloud VPC client: %s", err)
+		}
 
-	disassociateOpts := eips.UpdateOpts{PortID: ""}
-	logp.Printf("[DEBUG] EIP Disssociate Options: %#v", disassociateOpts)
+		eipAddr := v.(string)
+		eipInfo, err := getFloatingIPbyAddress(vpcClient, eipAddr)
+		if err != nil {
+			return fmtp.Errorf("Error getting EIP: %s", err)
+		}
 
-	_, err = eips.Update(vpcClient, floatingID, disassociateOpts).Extract()
-	if err != nil {
-		return fmtp.Errorf("Error disassociating Floating IP: %s", err)
+		err = unbindPortFromEIP(vpcClient, eipInfo.ID, portID)
+		if err != nil {
+			return fmtp.Errorf("Error disassociating Floating IP: %s", err)
+		}
+	} else {
+		bwClient, err := config.NetworkingV2Client(region)
+		if err != nil {
+			return fmtp.Errorf("Error creating bandwidth v2.0 client: %s", err)
+		}
+
+		bwID := d.Get("bandwidth_id").(string)
+		err = removePortFromBandwidth(bwClient, bwID, portID)
+		if err != nil {
+			return fmtp.Errorf("Error associating IPv6 port %s to bandwidth: %s", portID, err)
+		}
 	}
 
 	return nil
@@ -222,64 +286,98 @@ func getComputeInstancePortIDbyFixedIP(d *schema.ResourceData, config *config.Co
 	return portID, privateIP, nil
 }
 
-func getFloatingIPbyAddress(d *schema.ResourceData, config *config.Config, floatingIP string) (eips.PublicIp, error) {
-	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
-	if err != nil {
-		return eips.PublicIp{}, fmtp.Errorf("Error creating VPC client: %s", err)
-	}
-
+func getFloatingIPbyAddress(client *golangsdk.ServiceClient, floatingIP string) (*eips.PublicIp, error) {
 	listOpts := &eips.ListOpts{
 		PublicIp: []string{floatingIP},
 	}
 
-	pages, err := eips.List(vpcClient, listOpts).AllPages()
+	pages, err := eips.List(client, listOpts).AllPages()
 	if err != nil {
-		return eips.PublicIp{}, err
+		return nil, err
 	}
 
 	allEips, err := eips.ExtractPublicIPs(pages)
 	if err != nil {
-		return eips.PublicIp{}, fmtp.Errorf("Unable to retrieve eips: %s ", err)
+		return nil, fmtp.Errorf("Unable to retrieve eips: %s ", err)
 	}
 
 	if len(allEips) != 1 {
-		return eips.PublicIp{}, fmtp.Errorf("can not find the EIP %s", floatingIP)
+		return &eips.PublicIp{}, fmtp.Errorf("can not find the EIP by %s", floatingIP)
 	}
 
-	return allEips[0], nil
+	return &allEips[0], nil
 }
 
-func resourceComputeFloatingIPAssociateStateRefreshFunc(d *schema.ResourceData, config *config.Config, instanceId, floatingIP string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		computeClient, err := config.ComputeV1Client(GetRegion(d, config))
-		if err != nil {
-			return computeClient, "", fmtp.Errorf("Error creating HuaweiCloud compute client: %s", err)
-		}
-
-		instance, err := cloudservers.Get(computeClient, instanceId).Extract()
-		if err != nil {
-			return instance, "", err
-		}
-
-		for _, networkAddresses := range instance.Addresses {
-			for _, address := range networkAddresses {
-				if address.Type == "floating" && address.Addr == floatingIP {
-					return instance, fmt.Sprintf("floating/%s", floatingIP), nil
-				}
-			}
-		}
-
-		return instance, "", nil
+func insertPortToBandwidth(client *golangsdk.ServiceClient, bwID, portID string) error {
+	insertOpts := bandwidths.BandWidthInsertOpts{
+		PublicipInfo: []bandwidths.PublicIpInfoID{
+			{
+				PublicIPID:   portID,
+				PublicIPType: publicIPv6Type,
+			},
+		},
 	}
+
+	logp.Printf("[DEBUG] Insert port %s to bandwidth %s", portID, bwID)
+	_, err := bandwidths.Insert(client, bwID, insertOpts).Extract()
+	if err != nil {
+		return fmtp.Errorf("Error inserting %s into bandwidth %s: %s", portID, bwID, err)
+	}
+	return nil
 }
 
-func parseComputeFloatingIPAssociateId(id string) (string, string, string, error) {
+func removePortFromBandwidth(client *golangsdk.ServiceClient, bwID, portID string) error {
+	removalChargeMode := "bandwidth"
+	removalSize := 5
+	removeOpts := bandwidths.BandWidthRemoveOpts{
+		ChargeMode: removalChargeMode,
+		Size:       &removalSize,
+		PublicipInfo: []bandwidths.PublicIpInfoID{
+			{
+				PublicIPID:   portID,
+				PublicIPType: publicIPv6Type,
+			},
+		},
+	}
+
+	logp.Printf("[DEBUG] Remove port %s from bandwidth %s", portID, bwID)
+	err := bandwidths.Remove(client, bwID, removeOpts).ExtractErr()
+	if err != nil {
+		return fmtp.Errorf("Error removing %s from bandwidth: %s", portID, err)
+	}
+	return nil
+}
+
+func bindPortToEIP(client *golangsdk.ServiceClient, eipID, portID string) error {
+	logp.Printf("[DEBUG] Bind port %s to EIP %s", portID, eipID)
+	return actionOnPort(client, eipID, portID)
+}
+
+func unbindPortFromEIP(client *golangsdk.ServiceClient, eipID, portID string) error {
+	logp.Printf("[DEBUG] Unbind port %s from EIP: %s", portID, eipID)
+	return actionOnPort(client, eipID, "")
+}
+
+func actionOnPort(client *golangsdk.ServiceClient, eipID, portID string) error {
+	updateOpts := eips.UpdateOpts{
+		PortID: portID,
+	}
+	_, err := eips.Update(client, eipID, updateOpts).Extract()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseComputeFloatingIPAssociateID(id string) (string, string, string, error) {
 	idParts := strings.Split(id, "/")
 	if len(idParts) != 3 && len(idParts) != 2 {
-		return "", "", "", fmtp.Errorf("Unable to parse the resource ID, must be <eip>/<instance_id>/<fixed_ip> format")
+		return "", "", "",
+			fmtp.Errorf("Unable to parse the resource ID, must be <eip address or bandwidth_id>/<instance_id>/<fixed_ip> format")
 	}
 
-	floatingIP := idParts[0]
+	publicID := idParts[0]
 	instanceID := idParts[1]
 
 	var fixedIP string
@@ -287,5 +385,23 @@ func parseComputeFloatingIPAssociateId(id string) (string, string, string, error
 		fixedIP = idParts[2]
 	}
 
-	return floatingIP, instanceID, fixedIP, nil
+	return publicID, instanceID, fixedIP, nil
+}
+
+func resourceComputeEIPAssociateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	publicID, instanceID, fixedIP, err := parseComputeFloatingIPAssociateID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("instance_id", instanceID)
+	d.Set("fixed_ip", fixedIP)
+	parsedIP := net.ParseIP(publicID)
+	if parsedIP != nil {
+		d.Set("public_ip", publicID)
+	} else {
+		d.Set("bandwidth_id", publicID)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	bandwidthsv1 "github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
-func TestAccComputeV2EIPAssociate_basic(t *testing.T) {
+func TestAccComputeEIPAssociate_basic(t *testing.T) {
 	var instance cloudservers.CloudServer
 	var eip eips.PublicIp
 
@@ -25,14 +26,14 @@ func TestAccComputeV2EIPAssociate_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2EIPAssociateDestroy,
+		CheckDestroy: testAccCheckComputeEIPAssociateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2EIPAssociate_basic(rName),
+				Config: testAccComputeEIPAssociate_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
-					testAccCheckComputeV2EIPAssociateAssociated(&eip, &instance, 1),
+					testAccCheckComputeEIPAssociateAssociated(&eip, &instance, 1),
 					resource.TestCheckResourceAttrSet(resourceName, "port_id"),
 				),
 			},
@@ -45,7 +46,7 @@ func TestAccComputeV2EIPAssociate_basic(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2EIPAssociate_fixedIP(t *testing.T) {
+func TestAccComputeEIPAssociate_fixedIP(t *testing.T) {
 	var instance cloudservers.CloudServer
 	var eip eips.PublicIp
 
@@ -55,14 +56,14 @@ func TestAccComputeV2EIPAssociate_fixedIP(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2EIPAssociateDestroy,
+		CheckDestroy: testAccCheckComputeEIPAssociateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2EIPAssociate_fixedIP(rName),
+				Config: testAccComputeEIPAssociate_fixedIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
-					testAccCheckComputeV2EIPAssociateAssociated(&eip, &instance, 1),
+					testAccCheckComputeEIPAssociateAssociated(&eip, &instance, 1),
 					resource.TestCheckResourceAttrSet(resourceName, "port_id"),
 				),
 			},
@@ -75,7 +76,7 @@ func TestAccComputeV2EIPAssociate_fixedIP(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeV2EIPAssociateDestroy(s *terraform.State) error {
+func testAccCheckComputeEIPAssociateDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV1Client(HW_REGION_NAME)
 	if err != nil {
@@ -87,7 +88,7 @@ func testAccCheckComputeV2EIPAssociateDestroy(s *terraform.State) error {
 			continue
 		}
 
-		floatingIP, instanceId, _, err := parseComputeFloatingIPAssociateId(rs.Primary.ID)
+		floatingIP, instanceId, _, err := parseComputeFloatingIPAssociateID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -116,7 +117,7 @@ func testAccCheckComputeV2EIPAssociateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeV2EIPAssociateAssociated(
+func testAccCheckComputeEIPAssociateAssociated(
 	eip *eips.PublicIp, instance *cloudservers.CloudServer, n int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*config.Config)
@@ -176,7 +177,7 @@ func testAccCheckVpcV1EIPExists(n string, eip *eips.PublicIp) resource.TestCheck
 	}
 }
 
-func testAccComputeV2EIPAssociate_Base(rName string) string {
+func testAccComputeEIPAssociate_Base(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -205,7 +206,7 @@ resource "huaweicloud_vpc_eip" "test" {
 `, testAccCompute_data, rName, rName)
 }
 
-func testAccComputeV2EIPAssociate_basic(rName string) string {
+func testAccComputeEIPAssociate_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -213,10 +214,10 @@ resource "huaweicloud_compute_eip_associate" "test" {
   public_ip   = huaweicloud_vpc_eip.test.address
   instance_id = huaweicloud_compute_instance.test.id
 }
-`, testAccComputeV2EIPAssociate_Base(rName))
+`, testAccComputeEIPAssociate_Base(rName))
 }
 
-func testAccComputeV2EIPAssociate_fixedIP(rName string) string {
+func testAccComputeEIPAssociate_fixedIP(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -225,5 +226,151 @@ resource "huaweicloud_compute_eip_associate" "test" {
   instance_id = huaweicloud_compute_instance.test.id
   fixed_ip    = huaweicloud_compute_instance.test.access_ip_v4
 }
-`, testAccComputeV2EIPAssociate_Base(rName))
+`, testAccComputeEIPAssociate_Base(rName))
+}
+
+func TestAccComputeEIPAssociate_bandwidth(t *testing.T) {
+	var portInfo bandwidthsv1.PublicIpinfo
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resourceName := "huaweicloud_compute_eip_associate.test"
+	bwResourceName := "huaweicloud_vpc_bandwidth.bandwidth_1"
+	ecsResourceName := "huaweicloud_compute_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBandWidthAssociateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeEIPAssociate_bandwidth(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBandWidthAssociateExists(resourceName, &portInfo),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", bwResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "port_id", ecsResourceName, "network.0.port"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckBandWidthAssociateDestroy(s *terraform.State) error {
+	conf := testAccProvider.Meta().(*config.Config)
+	client, err := conf.NetworkingV1Client(HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating HuaweiCloud VPC client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_compute_eip_associate" {
+			continue
+		}
+
+		bwID := rs.Primary.Attributes["bandwidth_id"]
+		ipv6PortID := rs.Primary.Attributes["port_id"]
+		band, err := bandwidthsv1.Get(client, bwID).Extract()
+		if err != nil {
+			// ignore 404 status code
+			if _, ok := err.(golangsdk.ErrDefault404); !ok {
+				return fmt.Errorf("error fetching bandwidth %s: %s", bwID, err)
+			}
+		} else {
+			for _, item := range band.PublicipInfo {
+				if item.PublicipId == ipv6PortID {
+					return fmt.Errorf("IPv6 port %s still exists in bandwidth %s", ipv6PortID, bwID)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBandWidthAssociateExists(n string, info *bandwidthsv1.PublicIpinfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Bandwidth Associate Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		conf := testAccProvider.Meta().(*config.Config)
+		client, err := conf.NetworkingV1Client(HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating HuaweiCloud VPC client: %s", err)
+		}
+
+		bwID := rs.Primary.Attributes["bandwidth_id"]
+		ipv6PortID := rs.Primary.Attributes["port_id"]
+		band, err := bandwidthsv1.Get(client, bwID).Extract()
+		if err != nil {
+			return fmt.Errorf("error fetching bandwidth %s: %s", bwID, err)
+		}
+
+		for _, item := range band.PublicipInfo {
+			if item.PublicipId == ipv6PortID {
+				*info = item
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Resource not found: IPv6 port %s does not exist in bandwidth %s",
+			ipv6PortID, bwID)
+	}
+}
+
+func testAccComputeEIPAssociate_bandwidth(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_images_image" "image_1" {
+  name        = "Ubuntu 20.04 server 64bit"
+  most_recent = true
+}
+
+resource "huaweicloud_vpc" "vpc_1" {
+  name = "%s"
+  cidr = "172.16.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "subnet_1" {
+  vpc_id      = huaweicloud_vpc.vpc_1.id
+  name        = "subnet-ipv6"
+  cidr        = "172.16.10.0/24"
+  gateway_ip  = "172.16.10.1"
+  ipv6_enable = true
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name              = "%s"
+  image_id          = data.huaweicloud_images_image.image_1.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id         = "c6.large.2"
+  security_groups   = ["default"]
+
+  network {
+    uuid        = huaweicloud_vpc_subnet.subnet_1.id
+    ipv6_enable = true
+  }
+}
+
+resource "huaweicloud_vpc_bandwidth" "bandwidth_1" {
+  name = "%s"
+  size = 5
+}
+
+resource "huaweicloud_compute_eip_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.bandwidth_1.id
+  instance_id  = huaweicloud_compute_instance.test.id
+  fixed_ip     = huaweicloud_compute_instance.test.access_ip_v6
+}
+`, rName, rName, rName)
 }

--- a/huaweicloud/utils/diff_suppress_funcs.go
+++ b/huaweicloud/utils/diff_suppress_funcs.go
@@ -37,14 +37,6 @@ func SuppressMinDisk(k, old, new string, d *schema.ResourceData) bool {
 	return new == "0" || old == new
 }
 
-// Suppress changes if we get a fixed ip when not expecting one, if we have a floating ip (generates fixed ip).
-func SuppressComputedFixedWhenFloatingIp(k, old, new string, d *schema.ResourceData) bool {
-	if v, ok := d.GetOk("floating_ip"); ok && v != "" {
-		return new == "" || old == new
-	}
-	return false
-}
-
 func SuppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
 	if len(old) != len(new) {
 		return false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to associate IPv6 address to a specified shared bandwidth
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeEIPAssociate_bandwidth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeEIPAssociate_bandwidth -timeout 360m -parallel 4
=== RUN   TestAccComputeEIPAssociate_bandwidth
=== PAUSE TestAccComputeEIPAssociate_bandwidth
=== CONT  TestAccComputeEIPAssociate_bandwidth
--- PASS: TestAccComputeEIPAssociate_bandwidth (236.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       236.139s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeEIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeEIPAssociate_basic
=== PAUSE TestAccComputeEIPAssociate_basic
=== CONT  TestAccComputeEIPAssociate_basic
--- PASS: TestAccComputeEIPAssociate_basic (177.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       177.152s
```
