### PR TITLE
feat(ModelArts): add a  data-source to get notebook images

### DIFF
--- a/docs/data-sources/modelarts_notebook_images.md
+++ b/docs/data-sources/modelarts_notebook_images.md
@@ -1,0 +1,58 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+---
+
+# huaweicloud_modelarts_notebook_images
+
+Use this data source to get a list of ModelArts notebook images.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_modelarts_notebook_images" "test" {
+  type = "BUILD_IN"
+}
+
+output "image_id" {
+  value = data.huaweicloud_modelarts_notebook_images.test.images[0].id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available images in the current region.
+ All images that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain images. If omitted, the provider-level region
+ will be used.
+
+* `name` - (Optional, String) Specifies the name of image.
+
+* `organization` - (Optional, String) Specifies the name of the organization (namespace) which image belongs to.
+
+* `type` - (Optional, String) Specifies the type of image. The options are:
+  + `BUILD_IN`: The system built-in image.
+  + `DEDICATED`: User-saved images.
+
+ The default value is `BUILD_IN`.
+
+* `cpu_arch` - (Optional, String) Specifies the CPU architecture of image. The value can be **x86_64** and **aarch64**.
+
+* `workspace_id` - (Optional, String) Specifies the workspace ID which image belongs to.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `images` - Indicates a list of all images found. Structure is documented below.
+
+The `images` block contains:
+
+* `id` - The ID of the image.
+* `name` - The name of the image.
+* `swr_path` - The path the image in HuaweiCloud SWR service (SoftWare Repository for Container).
+* `type` - The type of the image.
+* `cpu_arch` - The CPU architecture of the image. The value can be **x86_64** and **aarch64**.
+* `description` - The description of the image.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -353,6 +353,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_gateway":                          DataSourceNatGatewayV2(),
 			"huaweicloud_networking_port":                      DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":                  DataSourceNetworkingSecGroup(),
+			"huaweicloud_modelarts_notebook_images":            modelarts.DataSourceNotebookImages(),
 			"huaweicloud_obs_buckets":                          obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object":                    DataSourceObsBucketObject(),
 			"huaweicloud_rds_flavors":                          rds.DataSourceRdsFlavor(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
@@ -1,0 +1,57 @@
+package modelarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNotebookImages_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_modelarts_notebook_images.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceImages_basic("BUILD_IN", "x86_64"),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.type", "BUILD_IN"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.cpu_arch", "x86_64"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.swr_path"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.description"),
+				),
+			},
+			{
+				Config: testAccDataSourceImages_basic("BUILD_IN", "aarch64"),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.type", "BUILD_IN"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.cpu_arch", "aarch64"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.swr_path"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceImages_basic(imageType, cpuArch string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelarts_notebook_images" "test" {
+  type     = "%s"
+  cpu_arch = "%s"
+}
+`, imageType, cpuArch)
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebook_images.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebook_images.go
@@ -1,0 +1,154 @@
+package modelarts
+
+import (
+	"context"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceNotebookImages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNotebookImagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"organization": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "BUILD_IN",
+				ValidateFunc: validation.StringInSlice([]string{"BUILD_IN", "DEDICATED"}, false),
+			},
+			"cpu_arch": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"x86_64", "aarch64"}, false),
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"images": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"swr_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cpu_arch": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNotebookImagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ModelArtsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts v1 client, err=%s", err)
+	}
+
+	listOpts := notebook.ListImageOpts{
+		Name:        d.Get("name").(string),
+		Namespace:   d.Get("organization").(string),
+		Type:        d.Get("type").(string),
+		WorkspaceId: d.Get("workspace_id").(string),
+		Limit:       200,
+		Offset:      0,
+	}
+
+	page, err := notebook.ListImages(client, listOpts)
+	if err != nil {
+		return fmtp.DiagErrorf("Unable to retrieve ModelArts notebook images: %s ", err)
+	}
+
+	p, err := page.AllPages()
+	if err != nil {
+		return fmtp.DiagErrorf("error querying ModelArts notebook images: %s", err)
+	}
+	images, err := notebook.ExtractImages(p)
+	if err != nil {
+		return fmtp.DiagErrorf("error querying ModelArts notebook images: %s", err)
+	}
+
+	if len(images) == 0 {
+		return fmtp.DiagErrorf("No data found. Please change your search criteria and try again.")
+	}
+
+	filter := map[string]interface{}{
+		"Arch": d.Get("cpu_arch"),
+	}
+
+	filterImages, err := utils.FilterSliceWithField(images, filter)
+	if err != nil {
+		return fmtp.DiagErrorf("filter ModelArts notebook images failed: %s", err)
+	}
+	logp.Printf("[DEBUG] filter %d ModelArts notebook images from %d through options %v", len(filterImages), len(images), filter)
+
+	var rst []map[string]interface{}
+	var ids []string
+	for _, v := range filterImages {
+		img := v.(notebook.ImageDetail)
+		item := map[string]interface{}{
+			"id":          img.Id,
+			"name":        img.Name,
+			"type":        img.Type,
+			"swr_path":    img.SwrPath,
+			"description": img.Description,
+			"cpu_arch":    img.Arch,
+		}
+		rst = append(rst, item)
+		ids = append(ids, img.Id)
+	}
+
+	err = d.Set("images", rst)
+	if err != nil {
+		return fmtp.DiagErrorf("set images err:%s", err)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a  data-source to get notebook images

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1879 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccNotebookImages_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccNotebookImages_basic -timeout 360m -parallel 4
=== RUN   TestAccNotebookImages_basic
=== PAUSE TestAccNotebookImages_basic
=== CONT  TestAccNotebookImages_basic
--- PASS: TestAccNotebookImages_basic (15.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 16.033s
```
