### PR TITLE
feat(gaussdb/cassandra): add dedicated_resource_name support

### DIFF
--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -89,6 +89,9 @@ The following arguments are supported:
 * `dedicated_resource_id` - (Optional, String, ForceNew) Specifies the dedicated resource ID. Changing this parameter
   will create a new resource.
 
+* `dedicated_resource_name` - (Optional, String, ForceNew) Specifies the dedicated resource name. Changing this parameter
+  will create a new resource.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id, Only valid for users who
   have enabled the enterprise multi-project service. Changing this parameter will create a new resource.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1869

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccGeminiDBInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccGeminiDBInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstance_basic
=== PAUSE TestAccGeminiDBInstance_basic
=== CONT  TestAccGeminiDBInstance_basic
--- PASS: TestAccGeminiDBInstance_basic (1167.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1167.568s
```
