### PR TITLE
add new cce example

### DIFF
--- a/examples/cce/nat-writekubeconfig/README.md
+++ b/examples/cce/nat-writekubeconfig/README.md
@@ -1,10 +1,18 @@
 # nat-writekubeconfig
 
-This example is demo create a cce cluster,and this cluster will use nat to access internat,Node does not need to be assigned EIP.
+This example is demo create a cce cluster.
+Cluster will use nat to access internat.
+Node does not need to be assigned EIP.
 
-Use local_file provider to write local kuberconfig file.When cce cluster created succesfull,you cao use Kubectl to connect clusters,no need to manually write kubeconfig file.
+Use local_file provider to write local kuberconfig file.
+When cce cluster created succesfull,you cao use Kubectl to connect clusters.
+no need to manually write kubeconfig file.
 
-When use kubectl to connect CCE,You need to switch use-context depending on the network between your local and Apiserver.
+When use kubectl to connect CCE,You need to switch use-context.
+Depending on the network between your local and Apiserver.
+
+kubectl command example.
+
 ```bash
 kubectl config use-context internal
 kubectl config use-context external

--- a/examples/cce/nat-writekubeconfig/README.md
+++ b/examples/cce/nat-writekubeconfig/README.md
@@ -1,0 +1,11 @@
+# nat-writekubeconfig
+
+This example is demo create a cce cluster,and this cluster will use nat to access internat,Node does not need to be assigned EIP.
+
+Use local_file provider to write local kuberconfig file.When cce cluster created succesfull,you cao use Kubectl to connect clusters,no need to manually write kubeconfig file.
+
+When use kubectl to connect CCE,You need to switch use-context depending on the network between your local and Apiserver.
+```bash
+kubectl config use-context internal
+kubectl config use-context external
+```

--- a/examples/cce/nat-writekubeconfig/main.tf
+++ b/examples/cce/nat-writekubeconfig/main.tf
@@ -1,0 +1,115 @@
+data "huaweicloud_availability_zones" "myaz" {}
+
+data "huaweicloud_vpc" "myvpc" {
+  id = var.vpc_id
+}
+
+data "huaweicloud_vpc_subnet" "mysubnet" {
+  id = var.subnet_id
+}
+
+resource "huaweicloud_vpc_eip" "cce" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "cce-apiserver"
+    size        = 20
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_vpc_eip" "nat" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "NAT"
+    size        = 100
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_nat_gateway" "nat_1" {
+  name        = var.nat_name
+  spec        = "1"
+  vpc_id      = data.huaweicloud_vpc.myvpc.id
+  subnet_id   = data.huaweicloud_vpc_subnet.mysubnet.id
+}
+
+resource "huaweicloud_nat_snat_rule" "snat_1" {
+  nat_gateway_id = huaweicloud_nat_gateway.nat_1.id
+  floating_ip_id = huaweicloud_vpc_eip.nat.id
+  subnet_id      = data.huaweicloud_vpc_subnet.mysubnet.id
+}
+
+resource "huaweicloud_cce_cluster" "cluster" {
+  name                   = var.cce_name
+  cluster_type           = "VirtualMachine"
+  cluster_version        = "v1.19"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = data.huaweicloud_vpc.myvpc.id
+  subnet_id              = data.huaweicloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+  authentication_mode    = "rbac"
+  eip                    = huaweicloud_vpc_eip.cce.address
+  delete_all             = "true"
+}
+
+resource "huaweicloud_cce_node" "cce-node1" {
+  cluster_id        = huaweicloud_cce_cluster.cluster.id
+  name              = "node1"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  key_pair          = var.key_pair_name
+
+  root_volume {
+    size       = 80
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+
+resource "huaweicloud_cce_node" "cce-node2" {
+  cluster_id        = huaweicloud_cce_cluster.cluster.id
+  name              = "node2"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  key_pair          = var.key_pair_name
+
+  root_volume {
+    size       = 80
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+
+resource "huaweicloud_cce_node" "cce-node3" {
+  cluster_id        = huaweicloud_cce_cluster.cluster.id
+  name              = "node3"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  key_pair          = var.key_pair_name
+
+  root_volume {
+    size       = 80
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+
+resource "local_file" "kubeconfig" {
+    content     = huaweicloud_cce_cluster.cluster.kube_config_raw
+    filename    = "$Local kubeconfig file path"
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This example is demo create a cce cluster,and this cluster will use nat to access internat,Node does not need to be assigned EIP.

Use local_file provider to write local kuberconfig file.When cce cluster created succesfull,you cao use Kubectl to connect clusters,no need to manually write kubeconfig file.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
