### PR TITLE
feat(evs/volume): support prepaid resource creation

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -106,6 +106,29 @@ The following arguments are supported:
 * `cascade` - (Optional, Bool) Specifies the delete mode of snapshot. The default value is false. All snapshot
   associated with the disk will also be deleted when the parameter is set to true.
 
+  -> This parameter is only valid for pay-as-you-go resources, and the snapshots bound to the package period resources
+     will be removed while resources unsubscribed.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the disk.
+  The valid values are as follows:
+  + **prePaid**: the yearly/monthly billing mode.
+  + **postPaid**: the pay-per-use billing mode.
+    Changing this creates a new disk.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the disk.
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this creates a new disk.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the disk.
+  If `period_unit` is set to **month**, the value ranges from 1 to 9.
+  If `period_unit` is set to **year**, the valid value is 1.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this creates a new disk.
+
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+  Valid values are **true** and **false**.
+  Changing this creates a new disk.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -124,8 +147,8 @@ $ terraform import huaweicloud_evs_volume.volume_1 14a80bc7-c12c-4fe0-a38a-cb77e
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
-API response, security or some other reason. The missing attributes include: cascade.
-It is generally recommended running terraform plan after importing an disk.
+API response, security or some other reason. The missing attributes include: **cascade**, **period_unit**, **period**
+and **auto_renew**. It is generally recommended running terraform plan after importing an disk.
 You can then decide if changes should be applied to the disk, or the resource definition should be updated to align
 with the disk. Also you can ignore changes as below.
 

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -133,8 +133,8 @@ func WaitOrderComplete(ctx context.Context, d *schema.ResourceData, config *conf
 		return fmtp.Errorf("Error creating HuaweiCloud bss V2 client: %s", err)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"3"},
-		Target:       []string{"5"},
+		Pending:      []string{"3"}, // 3: Processing; 6: Pending payment.
+		Target:       []string{"5"}, // 5: Completed.
 		Refresh:      refreshOrderStatus(bssV2Client, orderNum),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
@@ -142,7 +142,7 @@ func WaitOrderComplete(ctx context.Context, d *schema.ResourceData, config *conf
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf("Error while waiting for the order(%s) to complete payment: %#v", d.Id(), err)
+		return fmtp.Errorf("Error while waiting for the order (%s) to complete payment: %#v", orderNum, err)
 	}
 	return nil
 }

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -826,10 +826,6 @@ func (c *Config) BmsV1Client(region string) (*golangsdk.ServiceClient, error) {
 }
 
 // ********** client for Storage **********
-func (c *Config) BlockStorageV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("evsv1", region)
-}
-
 func (c *Config) BlockStorageV21Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("evsv21", region)
 }

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -605,7 +605,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 }
 
 // TestAccServiceEndpoints_Storage test for the endpoints of the clients used in storage
-// include BlockStorageV1Client,blockStorageV2Client,BlockStorageV21Client,blockStorageV3Client,sfsV2Client
+// include blockStorageV2Client,BlockStorageV21Client,blockStorageV3Client,sfsV2Client
 // sfsV1Client,csbsV1Client and vbsV2Client
 func TestAccServiceEndpoints_Storage(t *testing.T) {
 
@@ -622,16 +622,6 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	var expectedURL, actualURL string
 	var serviceClient *golangsdk.ServiceClient
 	var err error
-
-	// test for blockStorageV1Client
-	serviceClient, err = nil, nil
-	serviceClient, err = config.BlockStorageV1Client(HW_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud blockStorage v1 client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://evs.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
-	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "blockStorage", "v1", t)
 
 	// test for blockStorageV2Client
 	serviceClient, err = nil, nil

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
@@ -125,7 +125,7 @@ type ExtendSizeOpts struct {
 
 // ExtendChargeOpts contains the charging parameters of the volume
 type ExtendChargeOpts struct {
-	IsAutoPay string `json:"is_auto_pay,omitempty"`
+	IsAutoPay string `json:"isAutoPay,omitempty"`
 }
 
 // ToVolumeExtendMap assembles a request body based on the contents of an
@@ -147,7 +147,7 @@ func ExtendSize(client *golangsdk.ServiceClient, id string, opts ExtendOptsBuild
 	baseURL := newClient.ResourceBaseURL()
 	newClient.ResourceBase = strings.Replace(baseURL, "/v2/", "/v2.1/", 1)
 
-	_, r.Err = newClient.Post(actionURL(&newClient, id), b, nil, &golangsdk.RequestOpts{
+	_, r.Err = newClient.Post(actionURL(&newClient, id), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,6 @@ github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers
 github.com/chnsz/golangsdk/openstack/elb/v3/monitors
 github.com/chnsz/golangsdk/openstack/elb/v3/pools
 github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects
-github.com/chnsz/golangsdk/openstack/evs/v1/jobs
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For EVS volumes, the API support prepaid resource creation.
new params:
- charging_mode
- period_unit
- period
- auto_renew

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1844 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add prepaid of charging mode support for EVS volume.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run=TestAccEvs
Volume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_basic
--- PASS: TestAccEvsVolume_basic (133.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs     133.337s
```

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run=TestAccEvsVolume_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolume_prePaid -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_prePaid
=== PAUSE TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolume_prePaid
--- PASS: TestAccEvsVolume_prePaid (152.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs 152.090s
```
