### PR TITLE
fix(evs/volume): fix the problem that client version does not match

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220125092117-e13751718b24 h1:cOCSHw8Ql7waXRcxROk+gihUTkupqjvONKOGi3+kMCs=
-github.com/chnsz/golangsdk v0.0.0-20220125092117-e13751718b24/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220211032246-40ea6636749f h1:QwmQtqrv3avhUyodx1Z+shfJa2iUuxZgoW9cv6AuvAo=
 github.com/chnsz/golangsdk v0.0.0-20220211032246-40ea6636749f/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -824,10 +824,6 @@ func (c *Config) BlockStorageV2Client(region string) (*golangsdk.ServiceClient, 
 	return c.NewServiceClient("volumev2", region)
 }
 
-func (c *Config) BlockStorageV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("evs", region)
-}
-
 func (c *Config) SfsV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("sfs", region)
 }

--- a/huaweicloud/data_source_huaweicloud_compute_instance.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance.go
@@ -7,9 +7,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/blockstorage/v2/volumes"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -223,7 +223,7 @@ func setEcsInstanceVolumeAttached(d *schema.ResourceData, ecsClient, evsClient *
 		bds := make([]map[string]interface{}, len(attached))
 		for i, b := range attached {
 			// retrieve volume `size` and `type`
-			volumeInfo, err := volumes.Get(evsClient, b.ID).Extract()
+			volumeInfo, err := cloudvolumes.Get(evsClient, b.ID).Extract()
 			if err != nil {
 				return err
 			}
@@ -259,7 +259,7 @@ func setEcsInstanceParams(d *schema.ResourceData, config *config.Config, ecsClie
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud networking v2 client: %s", err)
 	}
-	blockStorageClient, err := config.BlockStorageV3Client(GetRegion(d, config))
+	blockStorageClient, err := config.BlockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud EVS client: %s", err)
 	}

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -653,16 +653,6 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "blockStorage", "v2.1", t)
 
-	// test for blockStorageV3Client
-	serviceClient, err = nil, nil
-	serviceClient, err = config.BlockStorageV3Client(HW_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud blockStorage v3 client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://evs.%s.%s/v3/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
-	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "blockStorage", "v3", t)
-
 	// test for cbrV3Client
 	serviceClient, err = nil, nil
 	serviceClient, err = config.CbrV3Client(HW_REGION_NAME)

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/blockstorage/extensions/volumeactions"
-	"github.com/chnsz/golangsdk/openstack/blockstorage/v2/volumes"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/keypairs"
@@ -20,6 +19,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/powers"
+	"github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes"
 	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
@@ -698,7 +698,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	ecsClient, err := config.ComputeV1Client(GetRegion(d, config))
-	blockStorageClient, err := config.BlockStorageV3Client(GetRegion(d, config))
+	blockStorageClient, err := config.BlockStorageV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud client: %s", err)
 	}
@@ -804,7 +804,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 		bds := make([]map[string]interface{}, len(server.VolumeAttached))
 		for i, b := range server.VolumeAttached {
 			// retrieve volume `size` and `type`
-			volumeInfo, err := volumes.Get(blockStorageClient, b.ID).Extract()
+			volumeInfo, err := cloudvolumes.Get(blockStorageClient, b.ID).Extract()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a problem that the client version does not match the method.
The client version for the method should be v2, actually is v3.
The sdk package should use `evs/v2/cloudvolumes` sdk, not `blockstorage/v2/volumes` sdk.
- The openstack v2 API cannot obtain instance for EPS authorization.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1954 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the networking client version from v3 to v2.
2. update reference of `Get` method from `blockstorage/v2/volumes` to `evs/v2/cloudvolumes`.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (199.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       199.280s
```
