### PR TITLE
fix: do not update other fields when only tags was changed

### DIFF
--- a/huaweicloud/resource_huaweicloud_dns_zone_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2.go
@@ -324,35 +324,41 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	var updateOpts zones.UpdateOpts
-	if d.HasChange("email") {
-		updateOpts.Email = d.Get("email").(string)
-	}
-	if d.HasChange("ttl") {
-		updateOpts.TTL = d.Get("ttl").(int)
-	}
-	if d.HasChange("description") {
-		updateOpts.Description = d.Get("description").(string)
-	}
+	if d.HasChanges("description", "ttl", "email") {
+		var updateOpts zones.UpdateOpts
+		if d.HasChange("email") {
+			updateOpts.Email = d.Get("email").(string)
+		}
+		if d.HasChange("ttl") {
+			updateOpts.TTL = d.Get("ttl").(int)
+		}
+		if d.HasChange("description") {
+			updateOpts.Description = d.Get("description").(string)
+		}
 
-	logp.Printf("[DEBUG] Updating Zone %s with options: %#v", d.Id(), updateOpts)
+		logp.Printf("[DEBUG] Updating Zone %s with options: %#v", d.Id(), updateOpts)
+		_, err = zones.Update(dnsClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmtp.Errorf("Error updating HuaweiCloud DNS Zone: %s", err)
+		}
 
-	_, err = zones.Update(dnsClient, d.Id(), updateOpts).Extract()
-	if err != nil {
-		return fmtp.Errorf("Error updating HuaweiCloud DNS Zone: %s", err)
+		logp.Printf("[DEBUG] Waiting for DNS Zone (%s) to update", d.Id())
+		stateConf := &resource.StateChangeConf{
+			Target:     []string{"ACTIVE"},
+			Pending:    []string{"PENDING"},
+			Refresh:    waitForDNSZone(dnsClient, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      5 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmtp.Errorf(
+				"Error waiting for DNS Zone (%s) to become ACTIVE for update: %s",
+				d.Id(), err)
+		}
 	}
-
-	logp.Printf("[DEBUG] Waiting for DNS Zone (%s) to update", d.Id())
-	stateConf := &resource.StateChangeConf{
-		Target:     []string{"ACTIVE"},
-		Pending:    []string{"PENDING"},
-		Refresh:    waitForDNSZone(dnsClient, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err = stateConf.WaitForState()
 
 	if d.HasChange("router") {
 		// when updating private zone

--- a/huaweicloud/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/resource_huaweicloud_vpcep_service.go
@@ -297,24 +297,26 @@ func resourceVPCEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmtp.Errorf("Error creating Huaweicloud VPC endpoint client: %s", err)
 	}
 
-	updateOpts := services.UpdateOpts{
-		ServiceName: d.Get("name").(string),
-	}
+	if d.HasChanges("name", "approval", "port_id", "port_mapping") {
+		updateOpts := services.UpdateOpts{
+			ServiceName: d.Get("name").(string),
+		}
 
-	if d.HasChange("approval") {
-		approval := d.Get("approval").(bool)
-		updateOpts.Approval = &approval
-	}
-	if d.HasChange("port_id") {
-		updateOpts.PortID = d.Get("port_id").(string)
-	}
-	if d.HasChange("port_mapping") {
-		updateOpts.Ports = expandPortMappingOpts(d)
-	}
+		if d.HasChange("approval") {
+			approval := d.Get("approval").(bool)
+			updateOpts.Approval = &approval
+		}
+		if d.HasChange("port_id") {
+			updateOpts.PortID = d.Get("port_id").(string)
+		}
+		if d.HasChange("port_mapping") {
+			updateOpts.Ports = expandPortMappingOpts(d)
+		}
 
-	_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()
-	if err != nil {
-		return fmtp.Errorf("Error updating Huaweicloud VPC endpoint service: %s", err)
+		_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmtp.Errorf("Error updating Huaweicloud VPC endpoint service: %s", err)
+		}
 	}
 
 	//update tags

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
@@ -45,6 +45,7 @@ func TestAccVpcSubnetV1_basic(t *testing.T) {
 				Config: testAccVpcSubnetV1_update(rNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_updated"),
 				),
 			},

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
@@ -531,25 +531,27 @@ func resourceDdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 		opts = append(opts, opt)
 	}
 
-	r := instances.Update(client, d.Id(), opts)
-	if r.Err != nil {
-		return fmtp.DiagErrorf("Error updating instance from result: %s ", r.Err)
-	}
+	if len(opts) > 0 {
+		r := instances.Update(client, d.Id(), opts)
+		if r.Err != nil {
+			return fmtp.DiagErrorf("Error updating instance from result: %s ", r.Err)
+		}
 
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"updating"},
-		Target:     []string{"normal"},
-		Refresh:    DdsInstanceStateRefreshFunc(client, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      15 * time.Second,
-		MinTimeout: 10 * time.Second,
-	}
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"updating"},
+			Target:     []string{"normal"},
+			Refresh:    DdsInstanceStateRefreshFunc(client, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      15 * time.Second,
+			MinTimeout: 10 * time.Second,
+		}
 
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return fmtp.DiagErrorf(
-			"Error waiting for instance (%s) to become ready: %s ",
-			d.Id(), err)
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return fmtp.DiagErrorf(
+				"Error waiting for instance (%s) to become ready: %s ",
+				d.Id(), err)
+		}
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
do not update other fields when only tags was changed.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_basic (107.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       107.757s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVPCEPService_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVPCEPService_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (237.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       237.143s
```
