### PR TITLE
refactor(vpc/data_source): set enterprise_project_id to all_granted_eps if it's not specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220211032246-40ea6636749f
+	github.com/chnsz/golangsdk v0.0.0-20220214084518-736580d8a113
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220125092117-e13751718b24 h1:cOCSHw8Ql7waXRcxROk+gihUTkupqjvONKOGi3+kMCs=
-github.com/chnsz/golangsdk v0.0.0-20220125092117-e13751718b24/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20220211032246-40ea6636749f h1:QwmQtqrv3avhUyodx1Z+shfJa2iUuxZgoW9cv6AuvAo=
-github.com/chnsz/golangsdk v0.0.0-20220211032246-40ea6636749f/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220214084518-736580d8a113 h1:zZKglCql30kPWSY6WnhiKrDBKggwpgVmsoDLkESe1dU=
+github.com/chnsz/golangsdk v0.0.0-20220214084518-736580d8a113/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -733,6 +733,20 @@ func (c *Config) GetEnterpriseProjectID(d *schema.ResourceData) string {
 	return c.EnterpriseProjectID
 }
 
+// DataGetEnterpriseProjectID returns the enterprise_project_id that was specified in the data source.
+// If it was not set, the provider-level value is checked. The provider-level value can
+// either be set by the `enterprise_project_id` argument or by HW_ENTERPRISE_PROJECT_ID.
+// If the provider-level value is also not set, `all_granted_eps` will be returned.
+func (c *Config) DataGetEnterpriseProjectID(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		return v.(string)
+	}
+	if c.EnterpriseProjectID != "" {
+		return c.EnterpriseProjectID
+	}
+	return "all_granted_eps"
+}
+
 // ********** client for Global Service **********
 func (c *Config) IAMV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("iam", region)

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test.go
@@ -102,6 +102,10 @@ func testAccDataSourceVpc_basic(rName, cidr string) string {
 
 data "huaweicloud_vpc" "test" {
   id = huaweicloud_vpc.test.id
+
+  depends_on = [
+	huaweicloud_vpc.test
+  ]
 }
 `, testAccDataSourceVpc_base(rName, cidr))
 }
@@ -112,6 +116,10 @@ func testAccDataSourceVpc_byCidr(rName, cidr string) string {
 
 data "huaweicloud_vpc" "test" {
   cidr = huaweicloud_vpc.test.cidr
+
+  depends_on = [
+	huaweicloud_vpc.test
+  ]
 }
 `, testAccDataSourceVpc_base(rName, cidr))
 }
@@ -122,6 +130,10 @@ func testAccDataSourceVpc_byName(rName, cidr string) string {
 
 data "huaweicloud_vpc" "test" {
   name = huaweicloud_vpc.test.name
+
+  depends_on = [
+	huaweicloud_vpc.test
+  ]
 }
 `, testAccDataSourceVpc_base(rName, cidr))
 }

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
@@ -87,6 +87,10 @@ func testAccDataSourceVpcs_byCidr(rName, cidr string) string {
 
 data "huaweicloud_vpcs" "test" {
   cidr = huaweicloud_vpc.test.cidr
+
+  depends_on = [
+    huaweicloud_vpc.test
+  ]
 }
 `, testAccDataSourceVpcs_base(rName, cidr))
 }
@@ -125,6 +129,10 @@ func testAccDataSourceVpcs_byName(rName, cidr string) string {
 
 data "huaweicloud_vpcs" "test" {
   name = huaweicloud_vpc.test.name
+
+  depends_on = [
+    huaweicloud_vpc.test
+  ]
 }
 `, testAccDataSourceVpcs_base(rName, cidr))
 }
@@ -169,6 +177,10 @@ data "huaweicloud_vpcs" "test" {
   cidr                  = huaweicloud_vpc.test.cidr
   enterprise_project_id = "%s"
   status                = "OK"
+
+  depends_on = [
+    huaweicloud_vpc.test
+  ]
 }
 `, testAccDataSourceVpcs_base(rName, cidr), enterpriseProjectID)
 }

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
@@ -81,15 +81,11 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	listOpts := vpcs.ListOpts{
-		ID:     d.Get("id").(string),
-		Name:   d.Get("name").(string),
-		Status: d.Get("status").(string),
-		CIDR:   d.Get("cidr").(string),
-	}
-
-	epsID := config.GetEnterpriseProjectID(d)
-	if epsID != "" {
-		listOpts.EnterpriseProjectID = epsID
+		ID:                  d.Get("id").(string),
+		Name:                d.Get("name").(string),
+		Status:              d.Get("status").(string),
+		CIDR:                d.Get("cidr").(string),
+		EnterpriseProjectID: config.DataGetEnterpriseProjectID(d),
 	}
 
 	refinedVpcs, err := vpcs.List(vpcClient, listOpts)

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/results.go
@@ -129,26 +129,25 @@ type Volume struct {
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.
 type VolumePage struct {
-	pagination.LinkedPageBase
+	pagination.MarkerPageBase
+}
+
+// LastMarker returns the last route table ID in a ListResult
+func (b VolumePage) LastMarker() (string, error) {
+	volumes, err := ExtractVolumes(b)
+	if err != nil {
+		return "", err
+	}
+	if len(volumes) == 0 {
+		return "", nil
+	}
+	return volumes[len(volumes)-1].ID, nil
 }
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
-}
-
-// NextPageURL uses the response's embedded link reference to navigate to the
-// next page of results.
-func (r VolumePage) NextPageURL() (string, error) {
-	var s struct {
-		Links []golangsdk.Link `json:"volumes_links"`
-	}
-	err := r.ExtractInto(&s)
-	if err != nil {
-		return "", err
-	}
-	return golangsdk.ExtractNextURL(s.Links)
 }
 
 // ExtractVolumes extracts and returns Volumes. It is used while iterating over a cloudvolumes.List call.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220211032246-40ea6636749f
+# github.com/chnsz/golangsdk v0.0.0-20220214084518-736580d8a113
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

set enterprise_project_id to "all_granted_eps" if it's not specified to avoid error under EPS authorization

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. set enterprise_project_id to "all_granted_eps" if it's not specified to avoid error under EPS authorization
2. add a new function DataGetEnterpriseProjectID in config.go
3. add some "depends_on" in test cases to make sure they can run successfully
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc  TESTARGS='-run TestAccVpcIdsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcIdsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcIdsDataSource_basic
=== PAUSE TestAccVpcIdsDataSource_basic
=== CONT  TestAccVpcIdsDataSource_basic
--- PASS: TestAccVpcIdsDataSource_basic (29.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       29.647s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcDataSource -timeout 360m -parallel 4
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== RUN   TestAccVpcDataSource_byCidr
=== PAUSE TestAccVpcDataSource_byCidr
=== RUN   TestAccVpcDataSource_byName
=== PAUSE TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_basic
=== CONT  TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_byCidr
--- PASS: TestAccVpcDataSource_byCidr (33.38s)
--- PASS: TestAccVpcDataSource_basic (36.30s)
--- PASS: TestAccVpcDataSource_byName (38.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       38.531s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcsDataSource -timeout 360m -parallel 4
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== RUN   TestAccVpcsDataSource_byCidr
=== PAUSE TestAccVpcsDataSource_byCidr
=== RUN   TestAccVpcsDataSource_byName
=== PAUSE TestAccVpcsDataSource_byName
=== RUN   TestAccVpcsDataSource_byAll
=== PAUSE TestAccVpcsDataSource_byAll
=== RUN   TestAccVpcsDataSource_tags
=== PAUSE TestAccVpcsDataSource_tags
=== CONT  TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_byAll
=== CONT  TestAccVpcsDataSource_tags
=== CONT  TestAccVpcsDataSource_byName
--- PASS: TestAccVpcsDataSource_byName (31.84s)
=== CONT  TestAccVpcsDataSource_byCidr
--- PASS: TestAccVpcsDataSource_byAll (36.89s)
--- PASS: TestAccVpcsDataSource_basic (37.06s)
--- PASS: TestAccVpcsDataSource_tags (61.62s)
--- PASS: TestAccVpcsDataSource_byCidr (30.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       62.036s
```
