### PR TITLE
fix(util): fix regexp error for IsIPv4Address

### DIFF
--- a/huaweicloud/utils/testing/utils_test.go
+++ b/huaweicloud/utils/testing/utils_test.go
@@ -78,3 +78,32 @@ func TestHasMapContainsFunc_empty(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestIsIPv4Address(t *testing.T) {
+	var validAddresses = []string{
+		"10.250.4.192", "192.168.10.1", "192.168.10.255", "255.255.255.255", "0.0.0.0",
+	}
+	for _, addr := range validAddresses {
+		if !utils.IsIPv4Address(addr) {
+			t.Fatalf("%s should be a valid IPv4 address", addr)
+		}
+	}
+
+	var invalidAddresses = []string{
+		"258.255.255.300", "192.168.010.76", "a.b.c.def",
+	}
+	for _, addr := range invalidAddresses {
+		if utils.IsIPv4Address(addr) {
+			t.Fatalf("%s should not be a valid IPv4 address", addr)
+		}
+	}
+
+	var ipv6Addresses = []string{
+		"2407:c080:1200:e4e:49ad:b067:d81f:6467", "2407:c080:1200:e4e::1", "2002:0:0:0:0:0:9f8a:20c3",
+	}
+	for _, addr := range ipv6Addresses {
+		if utils.IsIPv4Address(addr) {
+			t.Fatalf("%s should be a valid IPv6 address", addr)
+		}
+	}
+}

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -209,7 +209,7 @@ func EncodeBase64IfNot(str string) string {
 
 // IsIPv4Address is used to check whether the addr string is IPv4 format
 func IsIPv4Address(addr string) bool {
-	pattern := "^(25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d)\\.){3}(25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d))$"
+	pattern := "^((25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d))\\.){3}(25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d))$"
 	matched, _ := regexp.MatchString(pattern, addr)
 	return matched
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1944

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


**before** this PR:
```
$ go test -v -run TestIsIPv4Address ./
=== RUN   TestIsIPv4Address
    utils_test.go:88: 10.250.4.192 should be a valid IPv4 address
--- FAIL: TestIsIPv4Address (0.00s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/testing 0.017s
FAIL
```

**apply** this PR:
```
$ go test -v -run TestIsIPv4Address ./
=== RUN   TestIsIPv4Address
--- PASS: TestIsIPv4Address (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/testing 0.014s
```
