### PR TITLE
feat: update all versions for a specified customizing service endpoint

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -810,11 +810,11 @@ func (c *Config) CciV1BetaClient(region string) (*golangsdk.ServiceClient, error
 }
 
 func (c *Config) CciV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("cciv1", region)
+	return c.NewServiceClient("cci", region)
 }
 
 func (c *Config) FgsV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("fgsv2", region)
+	return c.NewServiceClient("fgs", region)
 }
 
 func (c *Config) SwrV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -831,7 +831,7 @@ func (c *Config) BlockStorageV21Client(region string) (*golangsdk.ServiceClient,
 }
 
 func (c *Config) BlockStorageV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("volumev2", region)
+	return c.NewServiceClient("evs", region)
 }
 
 func (c *Config) SfsV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -963,7 +963,7 @@ func (c *Config) DwsV1Client(region string) (*golangsdk.ServiceClient, error) {
 }
 
 func (c *Config) DwsV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("dwsV2", region)
+	return c.NewServiceClient("dwsv2", region)
 }
 
 func (c *Config) DliV1Client(region string) (*golangsdk.ServiceClient, error) {
@@ -975,7 +975,7 @@ func (c *Config) DliV2Client(region string) (*golangsdk.ServiceClient, error) {
 }
 
 func (c *Config) DisV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("disv2", region)
+	return c.NewServiceClient("dis", region)
 }
 
 func (c *Config) DisV3Client(region string) (*golangsdk.ServiceClient, error) {
@@ -1012,7 +1012,7 @@ func (c *Config) ApiGatewayV1Client(region string) (*golangsdk.ServiceClient, er
 }
 
 func (c *Config) ApigV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("apig_v2", region)
+	return c.NewServiceClient("apigv2", region)
 }
 
 func (c *Config) BcsV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -1024,7 +1024,7 @@ func (c *Config) DcsV1Client(region string) (*golangsdk.ServiceClient, error) {
 }
 
 func (c *Config) DcsV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("dcsv2", region)
+	return c.NewServiceClient("dcs", region)
 }
 
 func (c *Config) DmsV1Client(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -12,6 +12,36 @@ type ServiceCatalog struct {
 	WithOutProjectID bool
 }
 
+// multiCatalogKeys is a map of primary and derived catalog keys for services with multiple clients.
+// If we add another version of a service client, don't forget to update it.
+var multiCatalogKeys = map[string][]string{
+	"iam":      {"identity", "iam_no_version"},
+	"bss":      {"bssv2"},
+	"ecs":      {"ecsv21", "ecsv11"},
+	"evs":      {"evsv21"},
+	"cce":      {"ccev1", "cce_addon"},
+	"cci":      {"cciv1_bata"},
+	"vpc":      {"networkv2", "vpcv3", "security_group", "fwv2"},
+	"elb":      {"elbv2", "elbv3"},
+	"dns":      {"dns_region"},
+	"kms":      {"kmsv1"},
+	"mrs":      {"mrsv2"},
+	"rds":      {"rdsv1"},
+	"waf":      {"waf-dedicated"},
+	"geminidb": {"geminidbv31"},
+	"dli":      {"dliv2"},
+	"dcs":      {"dcsv1"},
+	"dis":      {"disv3"},
+	"dms":      {"dmsv2"},
+	"dws":      {"dwsv2"},
+	"apig":     {"apigv2"},
+}
+
+// GetServiceDerivedCatalogKeys returns the derived catalog keys of a service.
+func GetServiceDerivedCatalogKeys(mainKey string) []string {
+	return multiCatalogKeys[mainKey]
+}
+
 var allServiceCatalog = map[string]ServiceCatalog{
 	// catalog for global service
 	// identity is used for openstack keystone APIs
@@ -135,10 +165,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"evsv21": {
 		Name:    "evs",
 		Version: "v2.1",
-	},
-	"evsv1": {
-		Name:    "evs",
-		Version: "v1",
 	},
 	"sfs": {
 		Name:    "sfs",

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -103,7 +103,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "aom",
 		Version: "svcstg/icmgr/v1",
 	},
-	"cciv1": {
+	"cci": {
 		Name:             "cci",
 		Version:          "api/v1",
 		WithOutProjectID: true,
@@ -113,7 +113,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "apis/networking.cci.io/v1beta1",
 		WithOutProjectID: true,
 	},
-	"fgsv2": {
+	"fgs": {
 		Name:    "functiongraph",
 		Version: "v2",
 	},
@@ -128,21 +128,17 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	},
 
 	// ******* catalog for storage ******
-	"evsv1": {
+	"evs": {
 		Name:    "evs",
-		Version: "v1",
+		Version: "v2",
 	},
 	"evsv21": {
 		Name:    "evs",
 		Version: "v2.1",
 	},
-	"volumev2": {
+	"evsv1": {
 		Name:    "evs",
-		Version: "v2",
-	},
-	"evs": {
-		Name:    "evs",
-		Version: "v3",
+		Version: "v1",
 	},
 	"sfs": {
 		Name:    "sfs",
@@ -313,7 +309,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dws",
 		Version: "v1.0",
 	},
-	"dwsV2": {
+	"dwsv2": {
 		Name:    "dws",
 		Version: "v2",
 	},
@@ -325,7 +321,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dli",
 		Version: "v2.0",
 	},
-	"disv2": {
+	"dis": {
 		Name:    "dis",
 		Version: "v2",
 	},
@@ -361,7 +357,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		ResourceBase:     "apigw",
 		WithOutProjectID: true,
 	},
-	"apig_v2": {
+	"apigv2": {
 		Name:         "apig",
 		Version:      "v2",
 		ResourceBase: "apigw",
@@ -374,7 +370,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dcs",
 		Version: "v1.0",
 	},
-	"dcsv2": {
+	"dcs": {
 		Name:    "dcs",
 		Version: "v2",
 	},

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -605,8 +605,8 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 }
 
 // TestAccServiceEndpoints_Storage test for the endpoints of the clients used in storage
-// include blockStorageV2Client,BlockStorageV21Client,blockStorageV3Client,sfsV2Client
-// sfsV1Client,csbsV1Client and vbsV2Client
+// include blockStorageV2Client, BlockStorageV21Client, sfsV2Client, sfsV1Client,
+// csbsV1Client, vbsV2Client and cbrV3Client
 func TestAccServiceEndpoints_Storage(t *testing.T) {
 
 	testAccPreCheckServiceEndpoints(t)

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -557,7 +557,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	serviceClient, err = nil, nil
 	serviceClient, err = config.CciV1Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud cci v1 beta1 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud cci v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://cci.%s.%s/api/v1/", HW_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
@@ -567,11 +567,11 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	serviceClient, err = nil, nil
 	serviceClient, err = config.CciV1BetaClient(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud cci v1 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud cci v1 beta client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://cci.%s.%s/apis/networking.cci.io/v1beta1/", HW_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "cci", "v1", t)
+	compareURL(expectedURL, actualURL, "cci", "v1 beta", t)
 
 	// test for FgsV2Client
 	serviceClient, err = nil, nil
@@ -657,41 +657,41 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	serviceClient, err = nil, nil
 	serviceClient, err = config.SfsV2Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud sfsV2 v2 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud sfs v2 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://sfs.%s.%s/v2/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "sfsV2", "v2", t)
+	compareURL(expectedURL, actualURL, "sfs", "v2", t)
 
 	// test for sfsV1Client
 	serviceClient, err = nil, nil
 	serviceClient, err = config.SfsV1Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud sfsV1 v1 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud sfs v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://sfs-turbo.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "sfsV1", "v1", t)
+	compareURL(expectedURL, actualURL, "sfs", "v1", t)
 
 	// test for csbsV1Client
 	serviceClient, err = nil, nil
 	serviceClient, err = config.CsbsV1Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud csbsV1 v1 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud csbs v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://csbs.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "csbsV1", "v1", t)
+	compareURL(expectedURL, actualURL, "csbs", "v1", t)
 
 	// test for vbsV2Client
 	serviceClient, err = nil, nil
 	serviceClient, err = config.VbsV2Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud vbsV2 v2 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud vbs v2 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://vbs.%s.%s/v2/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "vbsV2", "v2", t)
+	compareURL(expectedURL, actualURL, "vbs", "v2", t)
 }
 
 // TestAccServiceEndpoints_Network test for the endpoints of the clients used in network
@@ -711,14 +711,24 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	var serviceClient *golangsdk.ServiceClient
 	var err error
 
-	// test endpoint of network v1 service
+	// test endpoint of vpc v1 service
 	serviceClient, err = config.NetworkingV1Client(HW_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud networking v1 client: %s", err)
+		t.Fatalf("Error creating HuaweiCloud vpc v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/", HW_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "vpc", "v1", t)
+
+	// test endpoint of vpc v3
+	serviceClient, err = nil, nil
+	serviceClient, err = config.NetworkingV3Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud vpc v3 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v3/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	compareURL(expectedURL, actualURL, "vpc", "v3", t)
 
 	// test endpoint of network v2 service
 	serviceClient, err = nil, nil
@@ -749,16 +759,6 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "security group", "v1", t)
-
-	// test endpoint of secgroup v3
-	serviceClient, err = nil, nil
-	serviceClient, err = config.NetworkingV3Client(HW_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud security group v3 client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v3/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
-	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "security group", "v3", t)
 
 	// test endpoint of elb v2.0
 	serviceClient, err = nil, nil
@@ -994,9 +994,9 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	expectedURL = fmt.Sprintf("https://dws.%s.%s/v2/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
-		t.Fatalf("dws V2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+		t.Fatalf("dws v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
-	t.Logf("dws V2 endpoint:\t %s", actualURL)
+	t.Logf("dws v2 endpoint:\t %s", actualURL)
 
 	serviceClient, err = config.GesV1Client(HW_REGION_NAME)
 	if err != nil {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -894,26 +894,17 @@ func flattenProviderEndpoints(d *schema.ResourceData) (map[string]string, error)
 		epMap[key] = endpoint
 	}
 
-	// unify the endpoint which has multi types
-	if endpoint, ok := epMap["iam"]; ok {
-		epMap["identity"] = endpoint
-	}
-	if endpoint, ok := epMap["ecs"]; ok {
-		epMap["ecsv11"] = endpoint
-		epMap["ecsv21"] = endpoint
-	}
-	if endpoint, ok := epMap["cce"]; ok {
-		epMap["cce_addon"] = endpoint
-	}
-	if endpoint, ok := epMap["evs"]; ok {
-		epMap["volumev2"] = endpoint
-	}
-	if endpoint, ok := epMap["vpc"]; ok {
-		epMap["networkv2"] = endpoint
-		epMap["security_group"] = endpoint
-	}
-	if endpoint, ok := epMap["geminidb"]; ok {
-		epMap["geminidbv31"] = endpoint
+	// unify the endpoint which has multiple versions
+	for key := range endpoints {
+		ep, ok := epMap[key]
+		if !ok {
+			continue
+		}
+
+		multiKeys := config.GetServiceDerivedCatalogKeys(key)
+		for _, k := range multiKeys {
+			epMap[k] = ep
+		}
 	}
 
 	log.Printf("[DEBUG] customer endpoints: %+v", epMap)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

Some services have multiple API versions/clients. For VPC service, there are four clients: **NetworkingV1Client**, **NetworkingV2Client**, **NetworkingV3Client** and **SecurityGroupV1Client**.

If a user want to change the service endpoint, he must add all versions key of a service with the same URL.
This PR will help users to add a customizing service endpoint with just one key.

```
provider "huaweicloud" {
  region      = "cn-north-4"

  endpoints = {
    vpc = "https://vpc.cn-north-4.myhuaweicloud.com"
  }
}
```
the customer endpoints are as follows:
map[fwv2:https://vpc.cn-north-4.myhuaweicloud.com/ networkv2:https://vpc.cn-north-4.myhuaweicloud.com/ security_group:https://vpc.cn-north-4.myhuaweicloud.com/ vpc:https://vpc.cn-north-4.myhuaweicloud.com/ vpcv3:https://vpc.cn-north-4.myhuaweicloud.com/]

