### PR TITLE
refactor(eip): set enterprise_project_id to all_granted_eps if it's not specified

### DIFF
--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidth.go
@@ -67,10 +67,8 @@ func dataSourceBandWidthRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	listOpts := bandwidths.ListOpts{
-		ShareType: "WHOLE",
-	}
-	if v, ok := d.GetOk("enterprise_project_id"); ok {
-		listOpts.EnterpriseProjectID = v.(string)
+		ShareType:           "WHOLE",
+		EnterpriseProjectID: config.DataGetEnterpriseProjectID(d),
 	}
 
 	allBWs, err := bandwidths.List(vpcClient, listOpts).Extract()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

set enterprise_project_id to all_granted_eps if it's not specified to avoid error under eps authorization

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
set enterprise_project_id to all_granted_eps if it's not specified to avoid error under eps authorization
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccBandWidthDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccBandWidthDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== CONT  TestAccBandWidthDataSource_basic
--- PASS: TestAccBandWidthDataSource_basic (34.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       34.939s

make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccVpcEipDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEipDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEipDataSource_basic (30.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       30.303s

make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccVpcEipsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEipsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (27.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       27.826s

make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccVpcEipsDataSource_byTag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEipsDataSource_byTag -timeout 360m -parallel 4
=== RUN   TestAccVpcEipsDataSource_byTag
=== PAUSE TestAccVpcEipsDataSource_byTag
=== CONT  TestAccVpcEipsDataSource_byTag
--- PASS: TestAccVpcEipsDataSource_byTag (28.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       28.881s
```
