### PR TITLE
feat(cbr/retention): support long term retention settings for backup quantity

### DIFF
--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -81,6 +81,16 @@ The following arguments are supported:
 
 -> **NOTE:** If this `backup_quantity` and `time_period` are both left blank, the backups will be retained permanently.
 
+* `long_term_retention` - (Optional, List) Specifies the long-term retention rules, which is an advanced options of
+  the `backup_quantity`. The [object](#cbr_policy_long_term_retention) structure is documented below.
+
+-> The configuration of `long_term_retention` and `backup_quantity` will take effect together.
+  When the number of retained backups exceeds the preset value (number of `backup_quantity`), the system automatically
+  deletes the earliest backups. By default, the system automatically clears data every other day.
+
+* `time_zone` - (Optional, String) Specifies the UTC time zone, e.g.: `UTC+08:00`.
+  Required if `long_term_retention` is set.
+
 <a name="cbr_policy_backup_cycle"></a>
 The `backup_cycle` block supports:
 
@@ -94,6 +104,20 @@ The `backup_cycle` block supports:
 * `execution_times` - (Required, List) Specifies the backup time. Automated backups will be triggered at the backup
   time. The current time is in the UTC format (HH:MM). The minutes in the list must be set to **00** and the hours
   cannot be repeated. In the replication policy, you are advised to set one time point for one day.
+
+<a name="cbr_policy_long_term_retention"></a>
+The `long_term_retention` block supports:
+
+* `daily` - (Optional, Int) - Specifies the latest backup of each day is saved in the long term.
+
+* `weekly` - (Optional, Int) - Specifies the latest backup of each week is saved in the long term.
+
+* `monthly` - (Optional, Int) - Specifies the latest backup of each month is saved in the long term.
+
+* `yearly` - (Optional, Int) - Specifies the latest backup of each year is saved in the long term.
+
+-> A maximum of 10 backups are retained for failed periodic backup tasks. They are retained for one month and can be
+  manually deleted on the web console.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
@@ -70,6 +70,66 @@ func TestAccCBRV3Policy_basic(t *testing.T) {
 	})
 }
 
+func TestAccCBRV3Policy_retention(t *testing.T) {
+	var asPolicy policies.Policy
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_cbr_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&asPolicy,
+		getResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_retention(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "15"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.daily", "10"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.weekly", "10"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.monthly", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				Config: testCBRV3Policy_retention_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "35"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.daily", "20"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.weekly", "20"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.monthly", "6"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.yearly", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCBRV3Policy_replication(t *testing.T) {
 	var asPolicy policies.Policy
 	randName := acceptance.RandomAccResourceName()
@@ -134,6 +194,51 @@ resource "huaweicloud_cbr_policy" "test" {
   name            = "%s-update"
   type            = "backup"
   backup_quantity = 5
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_retention(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_policy" "test" {
+  name            = "%s"
+  type            = "backup"
+  backup_quantity = 15
+
+  time_zone       = "UTC+08:00"
+  long_term_retention {
+    daily   = 10
+    weekly  = 10
+    monthly = 1
+  }
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_retention_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_policy" "test" {
+  name            = "%s"
+  type            = "backup"
+  backup_quantity = 35
+
+  time_zone       = "UTC+08:00"
+  long_term_retention {
+    daily   = 20
+    weekly  = 20
+    monthly = 6
+    yearly  = 1
+  }
 
   backup_cycle {
     days            = "SA,SU"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
On the basis of backup quantity, HuaweiCloud provides an additional configuration, namely `Long-term retention`, which provides four backup modes: Daily, Weekly, Monthly and Yearly.
- Daily: The latest backup of each day is saved in the long term.
- Weekly: The latest backup of each week is saved in the long term.
- Monthly : The latest backup of each month is saved in the long term.
- Yearly: The latest backup of each year is saved in the long term.

Quantity-based retention rules and advanced options (Long-term retention) do not conflict. They will both be applied.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1971

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support support long term retention settings for extra configurations of backup quantity.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCBRV3Policy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCBRV3Policy_basic -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== CONT  TestAccCBRV3Policy_basic
--- PASS: TestAccCBRV3Policy_basic (75.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       75.590s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCBRV3Policy_retention'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCBRV3Policy_retention -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Policy_retention
=== PAUSE TestAccCBRV3Policy_retention
=== CONT  TestAccCBRV3Policy_retention
--- PASS: TestAccCBRV3Policy_retention (73.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       73.545s
```
