### PR TITLE
refactor(lb/loadbalancer): update client to get port

### DIFF
--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -169,7 +169,7 @@ func resourceLoadBalancerV2Create(ctx context.Context, d *schema.ResourceData, m
 	// Once the loadbalancer has been created, apply any requested security groups
 	// to the port that was created behind the scenes.
 	if lb.VipPortID != "" {
-		networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+		networkingClient, err := config.SecurityGroupV1Client(config.GetRegion(d))
 		if err != nil {
 			return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 		}
@@ -227,7 +227,7 @@ func resourceLoadBalancerV2Read(_ context.Context, d *schema.ResourceData, meta 
 
 	// Get any security groups on the VIP Port
 	if lb.VipPortID != "" {
-		networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+		networkingClient, err := config.SecurityGroupV1Client(config.GetRegion(d))
 		if err != nil {
 			return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 		}
@@ -304,7 +304,7 @@ func resourceLoadBalancerV2Update(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange("security_group_ids") {
 		vipPortID := d.Get("vip_port_id").(string)
 		if vipPortID != "" {
-			networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+			networkingClient, err := config.SecurityGroupV1Client(config.GetRegion(d))
 			if err != nil {
 				return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

update the client used to get port to avoid error under eps authorization

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update the client used to get port to avoid error under eps authorization
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lb' TESTARGS='-run TestAccLBV2LoadBalancer_secGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run TestAccLBV2LoadBalancer_secGroup -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_secGroup
=== PAUSE TestAccLBV2LoadBalancer_secGroup
=== CONT  TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_secGroup (97.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        97.368s
```
