### PR TITLE
feat(as/configuration): set EnterpriseProjectID to all_granted_eps in func getASGroupsByConfiguration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220228081826-d12082c45894
+	github.com/chnsz/golangsdk v0.0.0-20220302084230-8bf8e974ecd6
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220228081826-d12082c45894 h1:XpbcW1HXskgYraoxBFI1qcYKbkAy0CrURkX9PuIN09I=
-github.com/chnsz/golangsdk v0.0.0-20220228081826-d12082c45894/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220302084230-8bf8e974ecd6 h1:dyVeAZgvIubl6c+eQIdgKbVQk45eJyvmwHN7Xjee7PE=
+github.com/chnsz/golangsdk v0.0.0-20220302084230-8bf8e974ecd6/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/bms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
@@ -441,10 +442,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_response":                    apig.ResourceApigResponseV2(),
 			"huaweicloud_apig_throttling_policy":           apig.ResourceApigThrottlingPolicyV2(),
 			"huaweicloud_apig_vpc_channel":                 apig.ResourceApigVpcChannelV2(),
-			"huaweicloud_as_configuration":                 ResourceASConfiguration(),
-			"huaweicloud_as_group":                         ResourceASGroup(),
-			"huaweicloud_as_lifecycle_hook":                ResourceASLifecycleHook(),
-			"huaweicloud_as_policy":                        ResourceASPolicy(),
+			"huaweicloud_as_configuration":                 as.ResourceASConfiguration(),
+			"huaweicloud_as_group":                         as.ResourceASGroup(),
+			"huaweicloud_as_lifecycle_hook":                as.ResourceASLifecycleHook(),
+			"huaweicloud_as_policy":                        as.ResourceASPolicy(),
 			"huaweicloud_bms_instance":                     bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance":                     resourceBCSInstanceV2(),
 			"huaweicloud_cbr_policy":                       cbr.ResourceCBRPolicyV3(),
@@ -670,9 +671,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnet_v1":                      vpc.ResourceVpcSubnetV1(),
 			"huaweicloud_cce_cluster_v3":                     ResourceCCEClusterV3(),
 			"huaweicloud_cce_node_v3":                        ResourceCCENodeV3(),
-			"huaweicloud_as_configuration_v1":                ResourceASConfiguration(),
-			"huaweicloud_as_group_v1":                        ResourceASGroup(),
-			"huaweicloud_as_policy_v1":                       ResourceASPolicy(),
+			"huaweicloud_as_configuration_v1":                as.ResourceASConfiguration(),
+			"huaweicloud_as_group_v1":                        as.ResourceASGroup(),
+			"huaweicloud_as_policy_v1":                       as.ResourceASPolicy(),
 			"huaweicloud_csbs_backup_v1":                     resourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy_v1":              resourceCSBSBackupPolicyV1(),
 			"huaweicloud_vbs_backup_policy_v2":               resourceVBSBackupPolicyV2(),

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_v1_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_v1_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package as
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -20,9 +21,9 @@ func TestAccASV1Configuration_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASV1ConfigurationDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckASV1ConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccASV1Configuration_basic(rName),
@@ -35,8 +36,8 @@ func TestAccASV1Configuration_basic(t *testing.T) {
 }
 
 func testAccCheckASV1ConfigurationDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 	}
@@ -68,8 +69,8 @@ func testAccCheckASV1ConfigurationExists(n string, configuration *configurations
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_v1_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_v1_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package as
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -21,9 +22,9 @@ func TestAccASV1Group_basic(t *testing.T) {
 	resourceName := "huaweicloud_as_group.hth_as_group"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASV1GroupDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckASV1GroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testASV1Group_basic(rName),
@@ -66,15 +67,15 @@ func TestAccASV1Group_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_as_group.hth_as_group"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASV1GroupDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckASV1GroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testASV1Group_withEpsId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1GroupExists(resourceName, &asGroup),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -82,8 +83,8 @@ func TestAccASV1Group_withEpsId(t *testing.T) {
 }
 
 func testAccCheckASV1GroupDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 	}
@@ -115,8 +116,8 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 		}
@@ -312,5 +313,5 @@ resource "huaweicloud_as_group" "hth_as_group"{
     key = "value"
   }
 }
-`, testASV1Group_Base(rName), rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testASV1Group_Base(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go
@@ -1,10 +1,11 @@
-package huaweicloud
+package as
 
 import (
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -23,9 +24,9 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 	resourceHookName := "huaweicloud_as_lifecycle_hook.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASLifecycleHookDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckASLifecycleHookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testASLifecycleHook_basic(rName),
@@ -37,7 +38,7 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceHookName, "timeout", "3600"),
 					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a test message"),
 					resource.TestMatchResourceAttr(resourceHookName, "notification_topic_urn",
-						regexp.MustCompile(fmt.Sprintf("^(urn:smn:%s:%s:%s)$", HW_REGION_NAME, HW_PROJECT_ID, rName))),
+						regexp.MustCompile(fmt.Sprintf("^(urn:smn:%s:%s:%s)$", acceptance.HW_REGION_NAME, acceptance.HW_PROJECT_ID, rName))),
 				),
 			},
 			{
@@ -52,7 +53,7 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 						"This is a update message"),
 					resource.TestMatchResourceAttr(resourceHookName, "notification_topic_urn",
 						regexp.MustCompile(fmt.Sprintf("^(urn:smn:%s:%s:%s-update)$",
-							HW_REGION_NAME, HW_PROJECT_ID, rName))),
+							acceptance.HW_REGION_NAME, acceptance.HW_PROJECT_ID, rName))),
 				),
 			},
 			{
@@ -66,8 +67,8 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 }
 
 func testAccCheckASLifecycleHookDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 	}
@@ -109,8 +110,8 @@ func testAccCheckASLifecycleHookExists(resGroup, resHook string, hook *lifecycle
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_v1_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_v1_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package as
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -20,9 +21,9 @@ func TestAccASV1Policy_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckASV1PolicyDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckASV1PolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testASV1Policy_basic(rName),
@@ -35,8 +36,8 @@ func TestAccASV1Policy_basic(t *testing.T) {
 }
 
 func testAccCheckASV1PolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 	}
@@ -68,8 +69,8 @@ func testAccCheckASV1PolicyExists(n string, policy *policies.Policy) resource.Te
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		asClient, err := config.AutoscalingV1Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating huaweicloud autoscaling client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_v1_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_v1_test.go
@@ -157,7 +157,7 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
     instance_number = 1
   }
   scheduled_policy {
-    launch_time = "2021-12-22T12:00Z"
+    launch_time = "2099-12-22T12:00Z"
   }
 }
 `, rName, rName, rName, rName, rName)

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration_v1.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration_v1.go
@@ -354,7 +354,8 @@ func resourceASConfigurationDelete(d *schema.ResourceData, meta interface{}) err
 func getASGroupsByConfiguration(asClient *golangsdk.ServiceClient, configurationID string) ([]groups.Group, error) {
 	var gs []groups.Group
 	listOpts := groups.ListOpts{
-		ConfigurationID: configurationID,
+		ConfigurationID:     configurationID,
+		EnterpriseProjectID: "all_granted_eps",
 	}
 	page, err := groups.List(asClient, listOpts).AllPages()
 	if err != nil {

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration_v1.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration_v1.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package as
 
 import (
 	"regexp"
@@ -8,6 +8,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -281,7 +282,7 @@ func getInstanceConfig(configDataMap map[string]interface{}) (configurations.Ins
 
 func resourceASConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
@@ -310,14 +311,14 @@ func resourceASConfigurationCreate(d *schema.ResourceData, meta interface{}) err
 
 func resourceASConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
 
 	asConfig, err := configurations.Get(asClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "AS Configuration")
+		return common.CheckDeleted(d, err, "AS Configuration")
 	}
 
 	logp.Printf("[DEBUG] Retrieved ASConfiguration %q: %+v", d.Id(), asConfig)
@@ -327,7 +328,7 @@ func resourceASConfigurationRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceASConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}

--- a/huaweicloud/services/as/resource_huaweicloud_as_group_v1.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group_v1.go
@@ -1,10 +1,11 @@
-package huaweicloud
+package as
 
 import (
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -176,7 +177,7 @@ func ResourceASGroup() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"tags": tagsSchema(),
+			"tags": common.TagsSchema(),
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -417,7 +418,7 @@ func checkASGroupInstancesRemoved(asClient *golangsdk.ServiceClient, groupID str
 
 func resourceASGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
@@ -471,7 +472,7 @@ func resourceASGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		InstanceTerminatePolicy:   d.Get("instance_terminate_policy").(string),
 		Notifications:             getAllNotifications(d),
 		IsDeletePublicip:          d.Get("delete_publicip").(bool),
-		EnterpriseProjectID:       GetEnterpriseProjectID(d, config),
+		EnterpriseProjectID:       common.GetEnterpriseProjectID(d, config),
 	}
 
 	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -513,14 +514,14 @@ func resourceASGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceASGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
 
 	asg, err := groups.Get(asClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "AS group")
+		return common.CheckDeleted(d, err, "AS group")
 	}
 	logp.Printf("[DEBUG] Retrieved ASGroup %q: %+v", d.Id(), asg)
 	logp.Printf("[DEBUG] Retrieved ASGroup %q notifications: %+v", d.Id(), asg.Notifications)
@@ -592,7 +593,7 @@ func resourceASGroupRead(d *schema.ResourceData, meta interface{}) error {
 	allIDs := getInstancesIDs(allIns)
 	d.Set("instances", allIDs)
 
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", config.GetRegion(d))
 
 	// save group tags
 	if resourceTags, err := tags.Get(asClient, d.Id()).Extract(); err == nil {
@@ -612,7 +613,7 @@ func resourceASGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
@@ -657,7 +658,7 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		InstanceTerminatePolicy:   d.Get("instance_terminate_policy").(string),
 		Notifications:             getAllNotifications(d),
 		IsDeletePublicip:          d.Get("delete_publicip").(bool),
-		EnterpriseProjectID:       GetEnterpriseProjectID(d, config),
+		EnterpriseProjectID:       common.GetEnterpriseProjectID(d, config),
 	}
 
 	logp.Printf("[DEBUG] AS Group update options: %#v", updateOpts)
@@ -708,7 +709,7 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceASGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}

--- a/huaweicloud/services/as/resource_huaweicloud_as_lifecycle_hook.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_lifecycle_hook.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package as
 
 import (
 	"regexp"
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
@@ -90,7 +91,7 @@ func ResourceASLifecycleHook() *schema.Resource {
 
 func resourceASLifecycleHookCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	client, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
 	}
@@ -119,7 +120,7 @@ func resourceASLifecycleHookCreate(d *schema.ResourceData, meta interface{}) err
 
 func resourceASLifecycleHookRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	region := GetRegion(d, config)
+	region := config.GetRegion(d)
 	client, err := config.AutoscalingV1Client(region)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
@@ -127,7 +128,7 @@ func resourceASLifecycleHookRead(d *schema.ResourceData, meta interface{}) error
 	groupId := d.Get("scaling_group_id").(string)
 	hook, err := lifecyclehooks.Get(client, groupId, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error getting the specifies lifecycle hook of the AutoScaling service")
+		return common.CheckDeleted(d, err, "Error getting the specifies lifecycle hook of the AutoScaling service")
 	}
 	d.Set("region", region)
 	if err = setASLifecycleHookToState(d, hook); err != nil {
@@ -138,7 +139,7 @@ func resourceASLifecycleHookRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceASLifecycleHookUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	client, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
 	}
@@ -174,7 +175,7 @@ func resourceASLifecycleHookUpdate(d *schema.ResourceData, meta interface{}) err
 
 func resourceASLifecycleHookDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	client, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud AutoScaling client: %s", err)
 	}

--- a/huaweicloud/services/as/resource_huaweicloud_as_policy_v1.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_policy_v1.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package as
 
 import (
 	"regexp"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -172,7 +173,7 @@ func getPolicyAction(rawPolicyAction map[string]interface{}) policies.ActionOpts
 
 func resourceASPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
@@ -213,14 +214,14 @@ func resourceASPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceASPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
 
 	asPolicy, err := policies.Get(asClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "AS Policy")
+		return common.CheckDeleted(d, err, "AS Policy")
 	}
 
 	logp.Printf("[DEBUG] Retrieved ASPolicy %q: %+v", d.Id(), asPolicy)
@@ -253,14 +254,14 @@ func resourceASPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("scheduled_policy", nil)
 	}
 
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", config.GetRegion(d))
 
 	return nil
 }
 
 func resourceASPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}
@@ -298,7 +299,7 @@ func resourceASPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceASPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(GetRegion(d, config))
+	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud autoscaling client: %s", err)
 	}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/requests.go
@@ -81,9 +81,10 @@ type ListOptsBuilder interface {
 }
 
 type ListOpts struct {
-	Name            string `q:"scaling_group_name"`
-	ConfigurationID string `q:"scaling_configuration_id"`
-	Status          string `q:"scaling_group_status"`
+	Name                string `q:"scaling_group_name"`
+	ConfigurationID     string `q:"scaling_configuration_id"`
+	Status              string `q:"scaling_group_status"`
+	EnterpriseProjectID string `q:"enterprise_project_id"`
 }
 
 // ToGroupListQuery formats a ListOpts into a query string.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220228081826-d12082c45894
+# github.com/chnsz/golangsdk v0.0.0-20220302084230-8bf8e974ecd6
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

set EnterpriseProjectID to all_granted_eps in func getASGroupsByConfiguration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. move AS resources to services path
2. set EnterpriseProjectID to all_granted_eps in func getASGroupsByConfiguration
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASV1Configuration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASV1Configuration_basic -timeout 360m -parallel 4
=== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== CONT  TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (26.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        26.308s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASV1Group_basic'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASV1Group_basic -timeout 360m -parallel 4
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (187.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        187.814s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASLifecycleHook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASLifecycleHook_basic -timeout 360m -parallel 4
=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (160.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        160.993s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASV1Policy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASV1Policy_basic -timeout 360m -parallel 4
=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (40.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        40.825s
```
