### PR TITLE
fix(cloudtable/test): fix the problems that caused the acc test to fail

### DIFF
--- a/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
+++ b/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
@@ -46,6 +46,7 @@ func TestAccCloudtableCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_type", "ULTRAHIGH"),
 					resource.TestCheckResourceAttr(resourceName, "storage_size", "10240"),
 					resource.TestCheckResourceAttr(resourceName, "rs_num", "4"),
+					resource.TestCheckResourceAttr(resourceName, "hbase_version", "1.0.6"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
@@ -65,24 +66,22 @@ func TestAccCloudtableCluster_basic(t *testing.T) {
 }
 
 func testAccCloudtableCluster_base(rName string) string {
-	randCidr, randGatewayIp := acceptance.RandomCidrAndGatewayIp()
-
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
   name = "%s"
-  cidr = "%s"
+  cidr = "192.168.0.0/16"
 }
 
 resource "huaweicloud_vpc_subnet" "test" {
   name       = "%s"
   vpc_id     = huaweicloud_vpc.test.id
-  cidr       = "%s"
-  gateway_ip = "%s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
 }
 
 resource "huaweicloud_networking_secgroup" "test" {
   name = "%s"
-}`, rName, randCidr, rName, randCidr, randGatewayIp, rName)
+}`, rName, rName, rName)
 }
 
 func testAccCloudtableCluster_basic(rName string) string {
@@ -96,6 +95,7 @@ resource "huaweicloud_cloudtable_cluster" "test" {
   vpc_id            = huaweicloud_vpc.test.id
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
+  hbase_version     = "1.0.6"
   rs_num            = 4
 }
 `, testAccCloudtableCluster_base(rName), acceptance.HW_AVAILABILITY_ZONE, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `hbase_version` parameter is missing in the cluster script configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add 'hbase_version' parameter configuration.
2. keeps the subnet CIDR different with the VPC CIDR.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

No warning about the definition not found: 'The argument "hbase_version" is required. but no definition was found.'
```
make testacc TEST='./huaweicloud/services/acceptance/cloudtable' TESTARGS='-run=TestAccCloudtableCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cloudtable -v -run=TestAccCloudtableCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudtableCluster_basic
=== PAUSE TestAccCloudtableCluster_basic
=== CONT  TestAccCloudtableCluster_basic
--- PASS: TestAccCloudtableCluster_basic (626.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cloudtable        627.001s
```
