### PR TITLE
fix(defer): adjust the posistion of the defer declaration

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_keypair.go
+++ b/huaweicloud/resource_huaweicloud_compute_keypair.go
@@ -95,11 +95,11 @@ func writeToPemFile(path, privateKey string) error {
 	// If the private key exists, give it write permission for editing (-rw-------) for root user.
 	if _, err = ioutil.ReadFile(path); err == nil {
 		os.Chmod(path, 0600)
+		defer os.Chmod(path, 0400) // read-only permission (-r--------).
 	}
 	if err = ioutil.WriteFile(path, []byte(privateKey), 0600); err != nil {
 		return err
 	}
-	os.Chmod(path, 0400) // read-only permission (-r--------).
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Declaring defer in the wrong place may cause the code of defer to not be executed due to the previous return logic.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Adjust the position of the defer declaration to make it in front of the return logic.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
