### PR TITLE
feat(vpc/data): support new data source of security groups

### DIFF
--- a/docs/data-sources/networking_secgroups.md
+++ b/docs/data-sources/networking_secgroups.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# huaweicloud_networking_secgroups
+
+Use this data source to get the list of the available HuaweiCloud security groups.
+
+## Example Usage
+
+### Filter the list of security groups by a description keyword
+
+```hcl
+variable "key_word" {}
+
+data "huaweicloud_networking_secgroups" "test" {
+  description = var.key_word
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the security group list.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the security group.
+
+* `description` - (Optional, String) Specifies the description of the security group. The security groups can be
+  filtered by keywords in the description.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the security group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `security_groups` - The list of security groups. The [object](#security_groups) is documented below.
+
+<a name="security_groups"></a>
+The `security_groups` block supports:
+
+* `id` - The security group ID.
+
+* `description`- The description of the security group.
+
+* `name` - The name of the security group.
+
+* `enterprise_project_id` - The enterprise project ID of the security group.
+
+* `created_at` - The creation time, in UTC format.
+
+* `updated_at` - The last update time, in UTC format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -356,6 +356,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_gateway":                          DataSourceNatGatewayV2(),
 			"huaweicloud_networking_port":                      DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":                  DataSourceNetworkingSecGroup(),
+			"huaweicloud_networking_secgroups":                 vpc.DataSourceNetworkingSecGroups(),
 			"huaweicloud_modelarts_notebook_images":            modelarts.DataSourceNotebookImages(),
 			"huaweicloud_obs_buckets":                          obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object":                    DataSourceObsBucketObject(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
@@ -1,0 +1,80 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccNetworkingSecGroupsDataSource_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_networking_secgroups.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupsDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingSecGroupsDataSource_description(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_networking_secgroups.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupsDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkingSecGroupsDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%s"
+  description = "[Acc Test] The security group created by Terraform."
+}
+`, rName)
+}
+
+func testAccNetworkingSecGroupsDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_networking_secgroups" "test" {
+  name = huaweicloud_networking_secgroup.test.name
+}
+`, testAccNetworkingSecGroupsDataSource_base(rName))
+}
+
+func testAccNetworkingSecGroupV3DataSource_description(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_networking_secgroups" "test" {
+  description = "[Acc Test]"
+}
+`, testAccNetworkingSecGroupsDataSource_base(rName))
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
@@ -1,0 +1,142 @@
+package vpc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v3/security/groups"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func DataSourceNetworkingSecGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNetworkingSecGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getSecGroupDetail(secGroup groups.SecurityGroup) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                    secGroup.ID,
+		"name":                  secGroup.Name,
+		"enterprise_project_id": secGroup.EnterpriseProjectId,
+		"description":           secGroup.Description,
+		"created_at":            secGroup.CreatedAt,
+		"updated_at":            secGroup.UpdatedAt,
+	}
+}
+
+func filterAvailableSecGroups(d *schema.ResourceData, secGroups []groups.SecurityGroup) ([]map[string]interface{},
+	[]string) {
+	secGroupCopy := secGroups
+
+	// build filter by description content.
+	if desc, ok := d.GetOk("description"); ok {
+		tmp := make([]groups.SecurityGroup, 0, len(secGroupCopy))
+		for _, secgroup := range secGroupCopy {
+			if strings.Contains(secgroup.Description, desc.(string)) {
+				// Filter all security groups with keywords in their description.
+				tmp = append(tmp, secgroup)
+			}
+		}
+		secGroupCopy = tmp
+	}
+
+	result := make([]map[string]interface{}, len(secGroupCopy))
+	ids := make([]string, len(secGroupCopy))
+	for i, secGroup := range secGroupCopy {
+		ids[i] = secGroup.ID
+		result[i] = getSecGroupDetail(secGroup)
+	}
+
+	return result, ids
+}
+
+func dataSourceNetworkingSecGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	networkingClient, err := config.NetworkingV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
+	}
+
+	// The List method currently does not support filtering by keyword in the description. Therefore, keyword filtering
+	// is implemented by manually filtering the description value of the List method return.
+	listOpts := groups.ListOpts{
+		Name:                d.Get("name").(string),
+		EnterpriseProjectId: config.DataGetEnterpriseProjectID(d),
+	}
+	allSecGroups, err := groups.List(networkingClient, listOpts)
+	if err != nil {
+		return fmtp.DiagErrorf("Error getting security groups: %s", err)
+	}
+	logp.Printf("[DEBUG] Retrieved Security Groups: %+v", allSecGroups)
+
+	resp, ids := filterAvailableSecGroups(d, allSecGroups)
+	d.SetId(hashcode.Strings(ids))
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("security_groups", resp),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, VPC services lack the resources to query multiple security groups

**Which issue this PR fixes**:
reference: #1976 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new data source of security groups
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccNetworkingSecGroupsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccNetworkingSecGroupsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupsDataSource_basic
=== PAUSE TestAccNetworkingSecGroupsDataSource_basic
=== CONT  TestAccNetworkingSecGroupsDataSource_basic
--- PASS: TestAccNetworkingSecGroupsDataSource_basic (52.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc     52.345s
```
```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccNetworkingSecGroupsDataSource_description'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccNetworkingSecGroupsDataSource_description -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupsDataSource_description
=== PAUSE TestAccNetworkingSecGroupsDataSource_description
=== CONT  TestAccNetworkingSecGroupsDataSource_description
--- PASS: TestAccNetworkingSecGroupsDataSource_description (45.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc     45.184s
```
