### PR TITLE
chore(workflow): add a shedule task to mirror to codehub

### DIFF
--- a/.github/workflows/mirror_to_codehub.yml
+++ b/.github/workflows/mirror_to_codehub.yml
@@ -1,0 +1,22 @@
+name: Mirror to HuaweiCloud codehub Repo
+on:
+  schedule:
+    # triggers the workflow every day at 3:30 UTC.
+    - cron:  '30 3 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  to_codehub:
+    runs-on: ubuntu-latest
+    steps:                                              # <-- must use actions/checkout before mirroring!
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url:
+            git@codehub.devcloud.cn-north-4.huaweicloud.com:3333300012/terraform-provider-huaweicloud.git
+          ssh_private_key:                              # <-- use 'secrets' to pass credential information.
+            ${{ secrets.TF_MIRROR_PRIVATE_KEY }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
mirror to  codehub of huaweiCloud.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

To find out how to create and add the TF_MIRROR_PRIVATE_KEY, follow the steps below:

1. Generate an SSH key pair
2. Add the public key to  codehub 
3. Add the private key as a secret to `Deploy keys` in github

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```

```
