### PR TITLE
refactor(evs/data_source_volumes): set enterprise_project_id to all_granted_eps if it's not specified

### DIFF
--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
@@ -145,10 +145,10 @@ func DataSourceEvsVolumesV2() *schema.Resource {
 	}
 }
 
-func buildQueryOpts(d *schema.ResourceData) cloudvolumes.ListOpts {
+func buildQueryOpts(d *schema.ResourceData, config *config.Config) cloudvolumes.ListOpts {
 	result := cloudvolumes.ListOpts{
 		AvailabilityZone:    d.Get("availability_zone").(string),
-		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
+		EnterpriseProjectID: config.DataGetEnterpriseProjectID(d),
 		ServerID:            d.Get("server_id").(string),
 		Status:              d.Get("status").(string),
 	}
@@ -214,7 +214,7 @@ func dataSourceEvsVolumesV2Read(_ context.Context, d *schema.ResourceData, meta 
 		return fmtp.DiagErrorf("Error creating HuaweiCloud EVS v2 client: %s", err)
 	}
 
-	pages, err := cloudvolumes.List(client, buildQueryOpts(d)).AllPages()
+	pages, err := cloudvolumes.List(client, buildQueryOpts(d, config)).AllPages()
 	if err != nil {
 		return fmtp.DiagErrorf("An error occurred while fetching the pages of the EVS disks: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

set enterprise_project_id to all_granted_eps if it's not specified

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
set enterprise_project_id to all_granted_eps if it's not specified
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolumesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolumesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolumesDataSource_basic
=== PAUSE TestAccEvsVolumesDataSource_basic
=== CONT  TestAccEvsVolumesDataSource_basic
--- PASS: TestAccEvsVolumesDataSource_basic (259.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       259.425s
```
