### PR TITLE
refactor(ecs/compute_instance): update computed_instance resource and data_source for eps authorization

### DIFF
--- a/huaweicloud/compute_instance_v2_networking.go
+++ b/huaweicloud/compute_instance_v2_networking.go
@@ -69,7 +69,7 @@ func expandInstanceNetworks(d *schema.ResourceData) ([]servers.Network, error) {
 // InstanceNIC list struct.
 func getInstanceAddresses(d *schema.ResourceData, meta interface{}, server *cloudservers.CloudServer) ([]InstanceNIC, error) {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := config.SecurityGroupV1Client(GetRegion(d, config))
 	if err != nil {
 		return nil, fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/data_source_huaweicloud_compute_instance.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance.go
@@ -171,7 +171,7 @@ func DataSourceComputeInstance() *schema.Resource {
 func buildListOptsWithoutStatus(d *schema.ResourceData, conf *config.Config) *cloudservers.ListOpts {
 	result := cloudservers.ListOpts{
 		Limit:               100,
-		EnterpriseProjectID: GetEnterpriseProjectID(d, conf),
+		EnterpriseProjectID: conf.DataGetEnterpriseProjectID(d),
 		Name:                d.Get("name").(string),
 		Flavor:              d.Get("flavor_id").(string),
 		IP:                  d.Get("fixed_ip_v4").(string),

--- a/huaweicloud/data_source_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance_test.go
@@ -72,6 +72,10 @@ resource "huaweicloud_compute_instance" "test" {
 
 data "huaweicloud_compute_instance" "this" {
   name = huaweicloud_compute_instance.test.name
+
+  depends_on = [
+    huaweicloud_compute_instance.test
+  ]
 }
 `, testAccCompute_data, rName)
 }

--- a/huaweicloud/data_source_huaweicloud_compute_instances.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances.go
@@ -149,7 +149,7 @@ func DataSourceComputeInstances() *schema.Resource {
 func buildListOptsWithoutIP(d *schema.ResourceData, conf *config.Config) *cloudservers.ListOpts {
 	result := cloudservers.ListOpts{
 		Limit:               100,
-		EnterpriseProjectID: GetEnterpriseProjectID(d, conf),
+		EnterpriseProjectID: conf.DataGetEnterpriseProjectID(d),
 		Name:                d.Get("name").(string),
 		Flavor:              d.Get("flavor_id").(string),
 		Status:              d.Get("status").(string),
@@ -213,10 +213,7 @@ func dataSourceComputeInstancesRead(_ context.Context, d *schema.ResourceData, m
 }
 
 func IsSystemVolume(index string) bool {
-	if index == "0" {
-		return true
-	}
-	return false
+	return index == "0"
 }
 
 func parseEcsInstanceSecurityGroupIds(groups []cloudservers.SecurityGroups) []string {

--- a/huaweicloud/data_source_huaweicloud_compute_instances_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances_test.go
@@ -81,6 +81,10 @@ resource "huaweicloud_compute_instance" "test" {
 
 data "huaweicloud_compute_instances" "test" {
   name = huaweicloud_compute_instance.test.name
+
+  depends_on = [
+    huaweicloud_compute_instance.test
+  ]
 }
 `, testAccCompute_data, rName)
 }

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -1326,9 +1326,10 @@ func resourceInstanceSchedulerHintsV2(d *schema.ResourceData, schedulerHintsRaw 
 
 func getImage(client *golangsdk.ServiceClient, id, name string) (*cloudimages.Image, error) {
 	listOpts := &cloudimages.ListOpts{
-		ID:    id,
-		Name:  name,
-		Limit: 1,
+		ID:                  id,
+		Name:                name,
+		Limit:               1,
+		EnterpriseProjectID: "all_granted_eps",
 	}
 	allPages, err := cloudimages.List(client, listOpts).AllPages()
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

update computed_instance resource and data_source for eps authorization

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. set default value of EnterpriseProjectID to 'all_granted_eps' in data_source compute_instance and compute_instances
2. replace client NetworkingV2Client with SecurityGroupV1Client in func getInstanceAddresses to avoid error under eps authorization
3. add 'EnterpriseProjectID: "all_granted_eps"' in ListOpts in func getImage to avoid error under eps authorization
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (158.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       158.336s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstancesDataSource_basic
=== PAUSE TestAccComputeInstancesDataSource_basic
=== CONT  TestAccComputeInstancesDataSource_basic
--- PASS: TestAccComputeInstancesDataSource_basic (151.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       151.708s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (154.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       154.328s
```
