### PR TITLE
fix(cluster/test): replace az environment with data source query

### DIFF
--- a/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
+++ b/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
@@ -41,7 +41,8 @@ func TestAccCloudtableCluster_basic(t *testing.T) {
 				Config: testAccCloudtableCluster_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", acceptance.HW_AVAILABILITY_ZONE),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "storage_type", "ULTRAHIGH"),
 					resource.TestCheckResourceAttr(resourceName, "storage_size", "10240"),
@@ -67,6 +68,8 @@ func TestAccCloudtableCluster_basic(t *testing.T) {
 
 func testAccCloudtableCluster_base(rName string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
 resource "huaweicloud_vpc" "test" {
   name = "%s"
   cidr = "192.168.0.0/16"
@@ -89,7 +92,7 @@ func testAccCloudtableCluster_basic(rName string) string {
 %s
 
 resource "huaweicloud_cloudtable_cluster" "test" {
-  availability_zone = "%s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
   name              = "%s"
   storage_type      = "ULTRAHIGH"
   vpc_id            = huaweicloud_vpc.test.id
@@ -98,5 +101,5 @@ resource "huaweicloud_cloudtable_cluster" "test" {
   hbase_version     = "1.0.6"
   rs_num            = 4
 }
-`, testAccCloudtableCluster_base(rName), acceptance.HW_AVAILABILITY_ZONE, rName)
+`, testAccCloudtableCluster_base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There are no HW_AVAILABILITY_ZONE environments in .yml files, therefore, replace the environment with data source querying.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace az environment with data source querying.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cloudtable' TESTARGS='-run=TestAccCloudtableCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cloudtable -v -run=TestAccCloudtableCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudtableCluster_basic
=== PAUSE TestAccCloudtableCluster_basic
=== CONT  TestAccCloudtableCluster_basic
--- PASS: TestAccCloudtableCluster_basic (641.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cloudtable        642.131s
```
