### PR TITLE
feat(cci/namespace): add new data source support for namespace list querying

### DIFF
--- a/docs/data-sources/cci_namespaces.md
+++ b/docs/data-sources/cci_namespaces.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+---
+
+# huaweicloud_cci_namespaces
+
+Use this data source to obtain CCI namespaces within HuaweiCloud.
+
+## Example Usage
+
+### Filter the list of namespaces by a name keyword
+
+```hcl
+variable "key_word" {}
+
+data "huaweicloud_cci_namespaces" "test" {
+  name = var.key_word
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the CCI namespace list.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the CCI namespace type.
+  The valid values are **general-computing** and **gpu-accelerated**.
+
+* `name` - (Optional, String) Specifies the unique name or keyword of the CCI namespace.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and hyphens.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID in UUID format.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Data source ID.
+
+* `namespaces` - All CCI namespaces that meet the query parameters.
+
+The `namespaces` block supports:
+
+* `id` - The CCI namespace ID in UUID format.
+
+* `type` - The CCI namespace type.
+
+* `name` - The CCI namespace name.
+
+* `auto_expend_enabled` - Whether elastic scheduling is enabled.
+
+* `enterprise_project_id` - The enterprise project ID in UUID format.
+
+* `warmup_pool_size` - The size of IP pool to warm-up.
+
+* `recycling_interval` - The IP address recycling interval in hour.
+  The idle IP resources from the elastic expansion of the IP resource pool can be recycled within this time.
+
+* `container_network_enabled` - Whether container network is enabled.
+
+* `rbac_enabled` - Whether Role-based access control is enabled.
+  After the RBAC permission is enabled, the user's use of resources under the namespace will be controlled by the RBAC
+  permission.
+
+* `created_at` - The time when the namespace was created in UTC format, such as **2021-09-27T01:30:39Z**.
+
+* `status` - The CCI namespace status.
+
+* `network` - The network information of the CCI namespace. The structure is documented below.
+
+The `network` block supports:
+
+* `name` - The CCI network name.
+
+* `security_group_id` - The default security group ID in UUID format.
+
+* `vpc` - The network information of the VPC under the CCI network. The structure is documented below.
+
+The `vpc` block supports:
+
+* `id` - The VPC ID in UUID format.
+
+* `subnet_id` - The VPC subnet ID in UUID format.
+
+* `subnet_cidr` - The subnet CIDR block.
+
+* `network_id` - The network ID of the VPC subnet in UUID format.

--- a/docs/data-sources/cci_namespaces.md
+++ b/docs/data-sources/cci_namespaces.md
@@ -8,13 +8,13 @@ Use this data source to obtain CCI namespaces within HuaweiCloud.
 
 ## Example Usage
 
-### Filter the list of namespaces by a name keyword
+### Get the specified namespace details
 
 ```hcl
-variable "key_word" {}
+variable "namespace_name" {}
 
 data "huaweicloud_cci_namespaces" "test" {
-  name = var.key_word
+  name = var.namespace_name
 }
 ```
 
@@ -28,8 +28,9 @@ The following arguments are supported:
 * `type` - (Optional, String) Specifies the CCI namespace type.
   The valid values are **general-computing** and **gpu-accelerated**.
 
-* `name` - (Optional, String) Specifies the unique name or keyword of the CCI namespace.
-  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and hyphens.
+* `name` - (Optional, String) Specifies th name of the specified CCI namespace.
+  This parameter can contain a maximum of 63 characters, which may consist of lowercase letters, digits and hyphens,
+  and must start and end with lowercase letters and digits.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID in UUID format.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220307123048-02b57a42292e
+	github.com/chnsz/golangsdk v0.0.0-20220308064310-f715737b3b03
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220307123048-02b57a42292e h1:pii8bhc6NhQMr/QoESHSoHfcKry6wZ9us0NxE5SuhrE=
-github.com/chnsz/golangsdk v0.0.0-20220307123048-02b57a42292e/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220308064310-f715737b3b03 h1:NicOWY+IQ1v7wcrVYOicSpxYw/mBJR4NwXSgMFmKO1k=
+github.com/chnsz/golangsdk v0.0.0-20220308064310-f715737b3b03/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -301,6 +301,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_node":                             DataSourceCCENodeV3(),
 			"huaweicloud_cce_nodes":                            cce.DataSourceCCENodes(),
 			"huaweicloud_cce_node_pool":                        DataSourceCCENodePoolV3(),
+			"huaweicloud_cci_namespaces":                       cci.DataSourceCciNamespaces(),
 			"huaweicloud_cdm_flavors":                          DataSourceCdmFlavorV1(),
 			"huaweicloud_compute_flavors":                      DataSourceEcsFlavors(),
 			"huaweicloud_compute_instance":                     DataSourceComputeInstance(),

--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
@@ -1,0 +1,126 @@
+package cci
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataCciNamespaces_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_cci_namespaces.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCciNamespaces_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.auto_expend_enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.container_network_enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.rbac_enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.status", "Active"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.type", "general-computing"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.recycling_interval"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespaces.0.warmup_pool_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.name",
+						"huaweicloud_cci_network.test", "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.security_group_id",
+						"huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.vpc.0.id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.vpc.0.subnet_id",
+						"huaweicloud_vpc_subnet.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.vpc.0.subnet_cidr",
+						"huaweicloud_vpc_subnet.test", "cidr"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.vpc.0.network_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataCciNamespaces_byKeyword(t *testing.T) {
+	dataSourceName := "data.huaweicloud_cci_namespaces.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCciNamespaces_byKeyword(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "namespaces.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCciNamespaces_base(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%s"
+}
+
+resource "huaweicloud_cci_namespace" "test" {
+  name = "%s"
+  type = "general-computing"
+}
+
+resource "huaweicloud_cci_network" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  namespace         = huaweicloud_cci_namespace.test.name
+  name              = "%s"
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+}
+`, rName, rName, rName, rName, rName)
+}
+
+func testAccDataCciNamespaces_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cci_namespaces" "test" {
+  depends_on = [huaweicloud_cci_network.test]
+
+  name = "%s"
+  type = "general-computing"
+}
+`, testAccDataCciNamespaces_base(rName), rName)
+}
+
+func testAccDataCciNamespaces_byKeyword(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cci_namespaces" "test" {
+  depends_on = [huaweicloud_cci_network.test]
+
+  name = "tf-acc-test"
+}  
+`, testAccDataCciNamespaces_base(rName))
+}

--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
@@ -2,7 +2,6 @@ package cci
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -41,24 +40,6 @@ func TestAccDataCciNamespaces_basic(t *testing.T) {
 						"huaweicloud_vpc_subnet.test", "cidr"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "namespaces.0.network.0.vpc.0.network_id",
 						"huaweicloud_vpc_subnet.test", "id"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccDataCciNamespaces_byKeyword(t *testing.T) {
-	dataSourceName := "data.huaweicloud_cci_namespaces.test"
-	rName := acceptance.RandomAccResourceNameWithDash()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataCciNamespaces_byKeyword(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(dataSourceName, "namespaces.#", regexp.MustCompile(`[1-9][0-9]*`)),
 				),
 			},
 		},
@@ -111,16 +92,4 @@ data "huaweicloud_cci_namespaces" "test" {
   type = "general-computing"
 }
 `, testAccDataCciNamespaces_base(rName), rName)
-}
-
-func testAccDataCciNamespaces_byKeyword(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_cci_namespaces" "test" {
-  depends_on = [huaweicloud_cci_network.test]
-
-  name = "tf-acc-test"
-}  
-`, testAccDataCciNamespaces_base(rName))
 }

--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_namespace_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_namespace_test.go
@@ -21,7 +21,7 @@ func getNamespaceResourceFunc(conf *config.Config, state *terraform.ResourceStat
 	return cci.GetCciNamespaceInfoById(c, state.Primary.ID)
 }
 
-func TestAccCciNamespaces_basic(t *testing.T) {
+func TestAccCciNamespace_basic(t *testing.T) {
 	var ns namespaces.Namespace
 	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_cci_namespace.test"
@@ -41,7 +41,7 @@ func TestAccCciNamespaces_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCciNamespaces_basic(rName),
+				Config: testAccCciNamespace_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -66,7 +66,7 @@ func TestAccCciNamespaces_basic(t *testing.T) {
 	})
 }
 
-func TestAccCciNamespaces_network(t *testing.T) {
+func TestAccCciNamespace_network(t *testing.T) {
 	var ns namespaces.Namespace
 	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_cci_namespace.test"
@@ -86,7 +86,7 @@ func TestAccCciNamespaces_network(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCciNamespaces_network(rName),
+				Config: testAccCciNamespace_network(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -121,7 +121,7 @@ func testAccCciNamespaceImportStateFunc(rName string) resource.ImportStateIdFunc
 	}
 }
 
-func testAccCciNamespaces_basic(rName string) string {
+func testAccCciNamespace_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cci_namespace" "test" {
   name                      = "%s"
@@ -134,7 +134,7 @@ resource "huaweicloud_cci_namespace" "test" {
 }
 
 // The container network of namespace is only supported in cn-north-4.
-func testAccCciNamespaces_network(rName string) string {
+func testAccCciNamespace_network(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cci_namespace" "test" {
   name                      = "%s"

--- a/huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go
+++ b/huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go
@@ -1,0 +1,251 @@
+package cci
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cci/v1/namespaces"
+	"github.com/chnsz/golangsdk/openstack/cci/v1/networks"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func DataSourceCciNamespaces() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCciNamespacesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"general-computing", "gpu-accelerated",
+				}, false),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					// Release head and tail restrictions on prefix and suffix matching.
+					validation.StringMatch(regexp.MustCompile(`^[-a-z0-9]*$`),
+						"The name can only consist of lowercase letters, numbers, and hyphens (-)"),
+					validation.StringLenBetween(1, 63),
+				),
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespaces": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auto_expend_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"warmup_pool_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"recycling_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"container_network_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"rbac_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"security_group_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"vpc": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"subnet_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"subnet_cidr": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"network_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func isNamespaceParamMatch(d *schema.ResourceData, ns namespaces.Namespace) bool {
+	if val, ok := d.GetOk("name"); ok {
+		if !strings.Contains(ns.Metadata.Name, val.(string)) {
+			return false
+		}
+	}
+	if val, ok := d.GetOk("type"); ok {
+		if val.(string) != ns.Metadata.Annotations.Flavor {
+			return false
+		}
+	}
+	if val, ok := d.GetOk("enterprise_project_id"); ok {
+		if val.(string) != ns.Metadata.Labels.EnterpriseProjectID {
+			return false
+		}
+	}
+	return true
+}
+
+func flattenVpcNetwork(network networks.Network) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":              network.Metadata.Name,
+			"security_group_id": network.Metadata.Annotations["network.alpha.kubernetes.io/default-security-group"],
+			"vpc": []map[string]interface{}{
+				{
+					"id":          network.Spec.AttachedVPC,
+					"subnet_id":   network.Spec.SubnetID,
+					"subnet_cidr": network.Spec.Cidr,
+					"network_id":  network.Spec.NetworkID,
+				},
+			},
+		},
+	}
+}
+
+func filterDataCciNamespaces(d *schema.ResourceData, client *golangsdk.ServiceClient,
+	nsList []namespaces.Namespace) ([]map[string]interface{}, []string, error) {
+	result := make([]map[string]interface{}, 0, len(nsList))
+	ids := make([]string, 0)
+	for _, ns := range nsList {
+		if isNamespaceParamMatch(d, ns) {
+			netList, err := networks.List(client, ns.Metadata.Name)
+			if err != nil {
+				return result, ids, err
+			}
+			nsParams := map[string]interface{}{
+				"id":                        ns.Metadata.UID,
+				"name":                      ns.Metadata.Name,
+				"type":                      ns.Metadata.Annotations.Flavor,
+				"enterprise_project_id":     ns.Metadata.Labels.EnterpriseProjectID,
+				"auto_expend_enabled":       ns.Metadata.Annotations.AutoExpend,
+				"warmup_pool_size":          ns.Metadata.Annotations.PoolSize,
+				"recycling_interval":        ns.Metadata.Annotations.RecyclingInterval,
+				"container_network_enabled": isContainNetworkEnabled(ns.Metadata.Annotations.NetworkEnable),
+				"rbac_enabled":              ns.Metadata.Labels.RbacEnable,
+				"created_at":                ns.Metadata.CreationTimestamp,
+				"status":                    ns.Status.Phase,
+				"network":                   flattenVpcNetwork(netList[0]),
+			}
+
+			result = append(result, nsParams)
+			ids = append(ids, ns.Metadata.UID)
+		}
+	}
+
+	return result, ids, nil
+}
+
+func dataSourceCciNamespacesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.CciV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud CCI v1 client: %s", err)
+	}
+	betaClient, err := config.CciV1BetaClient(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud CCI v1 beta1 client: %s", err)
+	}
+
+	pages, err := namespaces.List(client, namespaces.ListOpts{}).AllPages()
+	if err != nil {
+		return fmtp.DiagErrorf("Error finding the namespace list from the server: %s", err)
+	}
+	nsList, err := namespaces.ExtractNamespaces(pages)
+	if err != nil {
+		return fmtp.DiagErrorf("Error extracting HuaweiCloud CCI namespaces: %s", err)
+	}
+
+	resp, ids, err := filterDataCciNamespaces(d, betaClient, nsList)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(hashcode.Strings(ids))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("namespaces", resp),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return fmtp.DiagErrorf("Error saving the namespace's (%v) fields to state: %s", ids, mErr)
+	}
+	return nil
+}

--- a/huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go
@@ -177,13 +177,11 @@ func resourceCciNamespaceCreate(ctx context.Context, d *schema.ResourceData, met
 	return resourceCciNamespaceRead(ctx, d, meta)
 }
 
-func setCciNamespaceContainNetwork(d *schema.ResourceData, network string) error {
+func isContainNetworkEnabled(network string) bool {
 	if network == "vpc-network-ready" {
-		return d.Set("container_network_enabled", true)
-	} else if network == "" {
-		return d.Set("container_network_enabled", false)
+		return true
 	}
-	return fmtp.Errorf("Invalid container network return: %s.", network)
+	return false
 }
 
 func setCciNamespaceParams(d *schema.ResourceData, resp *namespaces.Namespace) error {
@@ -199,7 +197,7 @@ func setCciNamespaceParams(d *schema.ResourceData, resp *namespaces.Namespace) e
 		d.Set("status", &resp.Status.Phase),
 		d.Set("warmup_pool_size", metadata.Annotations.PoolSize),
 		d.Set("recycling_interval", metadata.Annotations.RecyclingInterval),
-		setCciNamespaceContainNetwork(d, metadata.Annotations.NetworkEnable),
+		d.Set("container_network_enabled", isContainNetworkEnabled(metadata.Annotations.NetworkEnable)),
 	)
 	if mErr.ErrorOrNil() != nil {
 		return mErr

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220307123048-02b57a42292e
+# github.com/chnsz/golangsdk v0.0.0-20220308064310-f715737b3b03
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1976 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source support for CCI namespace list querying.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc T'ST='./huaweicloud/services/acceptance/cci' TESTARGS='-run=TestAccDataCciNamespaces'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run=TestAccDataCciNamespaces -timeout 360m -parallel 4
=== RUN   TestAccDataCciNamespaces_basic
=== PAUSE TestAccDataCciNamespaces_basic
=== RUN   TestAccDataCciNamespaces_byKeyword
=== PAUSE TestAccDataCciNamespaces_byKeyword
=== CONT  TestAccDataCciNamespaces_basic
=== CONT  TestAccDataCciNamespaces_byKeyword
--- PASS: TestAccDataCciNamespaces_byKeyword (99.73s)
--- PASS: TestAccDataCciNamespaces_basic (100.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci    100.583s
```
