### PR TITLE
feat(tms/tag): add tms tag support

### DIFF
--- a/docs/resources/tms_tags.md
+++ b/docs/resources/tms_tags.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Tag Management Service (TMS)"
+---
+
+# huaweicloud_tms_tags
+
+Manages TMS tags resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_tms_tags" "test" {
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `tags` - (Required, List, ForceNew) Specifies an array of one or more predefined tags. The tags object
+  structure is documented below. Changing this will create a new resource.
+
+The `tags` block supports:
+
+* `key` - (Required, String, ForceNew) Specifies the tag key. The value can contain up to 36 characters.
+  Only letters, digits, hyphens (-), underscores (_), and Unicode characters from \u4e00 to \u9fff are allowed.
+  Changing this will create a new resource.
+
+* `value` - (Required, String, ForceNew) Specifies the tag value. The value can contain up to 43 characters.
+  Only letters, digits, periods (.), hyphens (-), and underscores (_), and Unicode characters from \u4e00 to \u9fff
+  are allowed. Changing this will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minute.
+* `delete` - Default is 3 minute.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.77
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.78
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.77 h1:D/30jOfM/01EE8aSLwYJjhcUiH6uGmVS5//pDVL6VLM=
-github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.77/go.mod h1:Z+vVu7nV/6xqti0P2evPEqhzh86ArBELsXTOU9zsnoM=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.78 h1:WG+SYlMaEiFU6SQLE+pBfuZxnmRdK8fjBT5g456x17c=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.78/go.mod h1:Z+vVu7nV/6xqti0P2evPEqhzh86ArBELsXTOU9zsnoM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -296,6 +296,12 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:      "v2",
 		ResourceBase: "notifications",
 	},
+	"tms": {
+		Name:             "tms",
+		Version:          "v1.0",
+		Scope:            "global",
+		WithOutProjectID: true,
+	},
 
 	// catalog for Security service
 	"anti-ddos": {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -43,6 +43,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
 )
@@ -587,6 +588,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_organization_permissions":     swr.ResourceSWROrganizationPermissions(),
 			"huaweicloud_swr_repository":                   swr.ResourceSWRRepository(),
 			"huaweicloud_swr_repository_sharing":           swr.ResourceSWRRepositorySharing(),
+			"huaweicloud_tms_tags":                         tms.ResourceTmsTag(),
 			"huaweicloud_vbs_backup":                       resourceVBSBackupV2(),
 			"huaweicloud_vbs_backup_policy":                resourceVBSBackupPolicyV2(),
 			"huaweicloud_vpc_bandwidth":                    eip.ResourceVpcBandWidthV2(),

--- a/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
+++ b/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
@@ -1,0 +1,98 @@
+package tms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTmsTag_basic(t *testing.T) {
+	resourceName := "huaweicloud_tms_tags.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckTmsTagDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testTmsTag_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTmsTagExists("foo", "bar"),
+					testAccCheckTmsTagExists("k", "v"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTmsTagDestroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.NewTmsClient(conf, acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating TMS client: %s", err)
+	}
+
+	tags := map[string]string{"foo": "bar", "k": "v"}
+	for key, value := range tags {
+		request := &model.ListPredefineTagsRequest{
+			Key:   &key,
+			Value: &value,
+		}
+
+		response, err := client.ListPredefineTags(request)
+		if err != nil {
+			return err
+		}
+		tagsFromResponse := *response.Tags
+		if len(tagsFromResponse) != 0 {
+			return fmt.Errorf("huaweicloud_tms_tags %s/%s still exists", key, value)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckTmsTagExists(key, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.NewTmsClient(conf, acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating TMS client: %s", err)
+		}
+
+		request := &model.ListPredefineTagsRequest{
+			Key:   &key,
+			Value: &value,
+		}
+
+		response, err := client.ListPredefineTags(request)
+		if err != nil {
+			return err
+		}
+		tags := *response.Tags
+		if len(tags) != 0 {
+			return nil
+		}
+
+		return fmt.Errorf("huaweicloud_tms_tags %s/%s does not exist", key, value)
+	}
+}
+
+const testTmsTag_basic = `
+resource "huaweicloud_tms_tags" "test" {
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+  tags {
+    key   = "k"
+    value = "v"
+  }
+}
+`

--- a/huaweicloud/services/tms/resource_huaweicloud_tms_tags.go
+++ b/huaweicloud/services/tms/resource_huaweicloud_tms_tags.go
@@ -1,0 +1,189 @@
+package tms
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+)
+
+func ResourceTmsTag() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTmsTagCreate,
+		DeleteContext: resourceTmsTagDelete,
+		ReadContext:   resourceTmsTagRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"tags": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fffA-Za-z0-9-_]+$"),
+									"The key can only consist of letters, digits, underscores (_) and hyphens (-)."),
+								validation.StringLenBetween(1, 36),
+							),
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fffA-Za-z0-9-_.]+$"),
+									"The key can only consist of letters, digits, periods (.)underscores (_) and hyphens (-)."),
+								validation.StringLenBetween(1, 43),
+							),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceTmsTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := config.NewTmsClient(c, "")
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
+	}
+
+	var tagIds []string
+	var predefineTags []model.PredefineTagRequest
+	tagsRaw := d.Get("tags").([]interface{})
+	for _, v := range tagsRaw {
+		tag := v.(map[string]interface{})
+		predefineTag := model.PredefineTagRequest{
+			Key:   tag["key"].(string),
+			Value: tag["value"].(string),
+		}
+		predefineTags = append(predefineTags, predefineTag)
+		tagId := fmt.Sprintf("%s:%s", tag["key"], tag["value"])
+		tagIds = append(tagIds, tagId)
+	}
+
+	createOpts := &model.CreatePredefineTagsRequest{
+		Body: &model.ReqCreatePredefineTag{
+			Tags:   predefineTags,
+			Action: model.GetReqCreatePredefineTagActionEnum().CREATE,
+		},
+	}
+
+	logp.Printf("[DEBUG] Create TMS tag options: %#v", createOpts)
+	_, err = client.CreatePredefineTags(createOpts)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating TMS tag: %s", err)
+	}
+
+	d.SetId(hashcode.Strings(tagIds))
+	return resourceTmsTagRead(ctx, d, meta)
+}
+
+func resourceTmsTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := config.NewTmsClient(c, "")
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
+	}
+
+	var marker *string
+	var tags []model.PredefineTag
+	// List all predefine tags
+	for {
+		request := &model.ListPredefineTagsRequest{
+			Marker: marker,
+		}
+
+		response, err := client.ListPredefineTags(request)
+		if err != nil {
+			return fmtp.DiagErrorf("Error listing TMS tags: %s", err)
+		}
+		tagsResp := *response.Tags
+		if len(tagsResp) == 0 {
+			break
+		} else {
+			marker = response.Marker
+			tags = append(tags, tagsResp...)
+		}
+	}
+
+	// Check if the requested tag is missing on cloud side
+	var tagList []map[string]interface{}
+	tagsRaw := d.Get("tags").([]interface{})
+	for _, v := range tagsRaw {
+		tag := v.(map[string]interface{})
+		key := tag["key"].(string)
+		value := tag["value"].(string)
+
+		for _, t := range tags {
+			if key == t.Key && value == t.Value {
+				tagFound := map[string]interface{}{
+					"key":   key,
+					"value": value,
+				}
+				tagList = append(tagList, tagFound)
+			}
+		}
+	}
+	d.Set("tags", tagList)
+
+	return nil
+}
+
+func resourceTmsTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := config.NewTmsClient(c, "")
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
+	}
+
+	var predefineTags []model.PredefineTagRequest
+	tagsRaw := d.Get("tags").([]interface{})
+	if len(tagsRaw) == 0 {
+		logp.Printf("[DEBUG] TMS tags are empty, no need to issue delete request")
+		return nil
+	}
+	for _, v := range tagsRaw {
+		tag := v.(map[string]interface{})
+		predefineTag := model.PredefineTagRequest{
+			Key:   tag["key"].(string),
+			Value: tag["value"].(string),
+		}
+		predefineTags = append(predefineTags, predefineTag)
+	}
+
+	deleteOpts := &model.DeletePredefineTagsRequest{
+		Body: &model.ReqDeletePredefineTag{
+			Tags:   predefineTags,
+			Action: model.GetReqDeletePredefineTagActionEnum().DELETE,
+		},
+	}
+
+	logp.Printf("[DEBUG] Delete TMS tag options: %#v", deleteOpts)
+	_, err = client.DeletePredefineTags(deleteOpts)
+	if err != nil {
+		return fmtp.DiagErrorf("Error deleting TMS tag: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_create_predefine_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_create_predefine_tags_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreatePredefineTagsRequest struct {
+	Body *ReqCreatePredefineTag `json:"body,omitempty"`
+}
+
+func (o CreatePredefineTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePredefineTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreatePredefineTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_create_predefine_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_create_predefine_tags_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreatePredefineTagsResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o CreatePredefineTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePredefineTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreatePredefineTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_delete_predefine_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_delete_predefine_tags_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeletePredefineTagsRequest struct {
+	Body *ReqDeletePredefineTag `json:"body,omitempty"`
+}
+
+func (o DeletePredefineTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeletePredefineTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeletePredefineTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_delete_predefine_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_delete_predefine_tags_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeletePredefineTagsResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DeletePredefineTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeletePredefineTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeletePredefineTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_link.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_link.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// API的URL地址。
+type Link struct {
+	// API的URL地址。
+
+	Href string `json:"href"`
+	// self
+
+	Rel string `json:"rel"`
+}
+
+func (o Link) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Link struct{}"
+	}
+
+	return strings.Join([]string{"Link", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_api_versions_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_api_versions_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListApiVersionsRequest struct {
+}
+
+func (o ListApiVersionsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListApiVersionsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListApiVersionsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_api_versions_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_api_versions_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListApiVersionsResponse struct {
+	// 版本列表
+
+	Versions       *[]VersionDetail `json:"versions,omitempty"`
+	HttpStatusCode int              `json:"-"`
+}
+
+func (o ListApiVersionsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListApiVersionsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListApiVersionsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_predefine_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_predefine_tags_request.go
@@ -1,0 +1,79 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Request Object
+type ListPredefineTagsRequest struct {
+	// 键，支持模糊查询，不区分大小写，如果包含“non-URL-safe”的字符，需要进行“urlencoded”。
+
+	Key *string `json:"key,omitempty"`
+	// 值，支持模糊查询，不区分大小写，如果包含“non-URL-safe”的字符，需要进行“urlencoded”。
+
+	Value *string `json:"value,omitempty"`
+	// 查询记录数。 最小为1，最大为1000，未输入时默认为10，为0时不限制查询数据条数。
+
+	Limit *int32 `json:"limit,omitempty"`
+	// 分页位置标识（索引）。 从marker指定索引的下一条数据开始查询。 说明： 查询第一页数据时，不需要传入此参数，查询后续页码数据时，将查询前一页数据响应体中marker值配入此参数，当返回的tags为空列表时表示查询到最后一页。
+
+	Marker *string `json:"marker,omitempty"`
+	// 排序字段： 可输入的值包含（区分大小写）：update_time（更新时间）、key（键）、value（值）。 只能选择以上排序字段中的一个，并按照排序方法字段order_method进行排序，如果不传则默认值为：update_time。 如以下： 若该字段为update_time，则剩余两个默认字段排序为key升序，value升序。 若该字段如为key，则剩余两个默认字段排序为update_time降序，value升序。 若该字段如为value，则剩余两个默认字段排序为update_time降序，key升序。 若该字段不传，默认字段为update_time，则剩余两个默认字段排序为key升序，value升序。
+
+	OrderField *string `json:"order_field,omitempty"`
+	// order_field字段的排序方法。 可输入的值包含（区分大小写）： asc（升序） desc（降序） 只能选择以上值的其中之一。 不传则默认值为：desc
+
+	OrderMethod *ListPredefineTagsRequestOrderMethod `json:"order_method,omitempty"`
+}
+
+func (o ListPredefineTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListPredefineTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListPredefineTagsRequest", string(data)}, " ")
+}
+
+type ListPredefineTagsRequestOrderMethod struct {
+	value string
+}
+
+type ListPredefineTagsRequestOrderMethodEnum struct {
+	ASC  ListPredefineTagsRequestOrderMethod
+	DESC ListPredefineTagsRequestOrderMethod
+}
+
+func GetListPredefineTagsRequestOrderMethodEnum() ListPredefineTagsRequestOrderMethodEnum {
+	return ListPredefineTagsRequestOrderMethodEnum{
+		ASC: ListPredefineTagsRequestOrderMethod{
+			value: "asc",
+		},
+		DESC: ListPredefineTagsRequestOrderMethod{
+			value: "desc",
+		},
+	}
+}
+
+func (c ListPredefineTagsRequestOrderMethod) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ListPredefineTagsRequestOrderMethod) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_predefine_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_list_predefine_tags_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListPredefineTagsResponse struct {
+	// 分页位置标识（索引）。
+
+	Marker *string `json:"marker,omitempty"`
+	// 查询到的标签总数
+
+	TotalCount *int32 `json:"total_count,omitempty"`
+	// 查询到的标签列表
+
+	Tags           *[]PredefineTag `json:"tags,omitempty"`
+	HttpStatusCode int             `json:"-"`
+}
+
+func (o ListPredefineTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListPredefineTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListPredefineTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_modify_prefine_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_modify_prefine_tag.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 修改预定义标签
+type ModifyPrefineTag struct {
+	NewTag *PredefineTagRequest `json:"new_tag"`
+
+	OldTag *PredefineTagRequest `json:"old_tag"`
+}
+
+func (o ModifyPrefineTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ModifyPrefineTag struct{}"
+	}
+
+	return strings.Join([]string{"ModifyPrefineTag", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_predefine_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_predefine_tag.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdktime"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+//  标签列表。
+type PredefineTag struct {
+	//   键。 最大长度36个字符。 字符集：A-Z，a-z ， 0-9，‘-’，‘_’，UNICODE字符（\\u4E00-\\u9FFF）。
+
+	Key string `json:"key"`
+	// 值。 每个值最大长度43个字符，可以为空字符串。 字符集：A-Z，a-z ， 0-9，‘.’，‘-’，‘_’，UNICODE字符（\\u4E00-\\u9FFF）。
+
+	Value string `json:"value"`
+	// 更新时间，采用UTC时间表示。2016-12-09T00:00:00Z
+
+	UpdateTime *sdktime.SdkTime `json:"update_time"`
+}
+
+func (o PredefineTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "PredefineTag struct{}"
+	}
+
+	return strings.Join([]string{"PredefineTag", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_predefine_tag_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_predefine_tag_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+//  标签详情。
+type PredefineTagRequest struct {
+	// 键。最大长度36个字符。字符集：A-Z，a-z ， 0-9，‘-’，‘_’，UNICODE字符（\\u4E00-\\u9FFF）。
+
+	Key string `json:"key"`
+	// 值。每个值最大长度43个字符，可以为空字符串。字符集：AZ，a-z ， 0-9，‘.’，‘-’，‘_’，UNICODE字符（\\u4E00-\\u9FFF）。
+
+	Value string `json:"value"`
+}
+
+func (o PredefineTagRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "PredefineTagRequest struct{}"
+	}
+
+	return strings.Join([]string{"PredefineTagRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_req_create_predefine_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_req_create_predefine_tag.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 创建预定义标签请求
+type ReqCreatePredefineTag struct {
+	// 操作标识（区分大小写）：create（创建）
+
+	Action ReqCreatePredefineTagAction `json:"action"`
+	// 标签列表
+
+	Tags []PredefineTagRequest `json:"tags"`
+}
+
+func (o ReqCreatePredefineTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ReqCreatePredefineTag struct{}"
+	}
+
+	return strings.Join([]string{"ReqCreatePredefineTag", string(data)}, " ")
+}
+
+type ReqCreatePredefineTagAction struct {
+	value string
+}
+
+type ReqCreatePredefineTagActionEnum struct {
+	CREATE ReqCreatePredefineTagAction
+}
+
+func GetReqCreatePredefineTagActionEnum() ReqCreatePredefineTagActionEnum {
+	return ReqCreatePredefineTagActionEnum{
+		CREATE: ReqCreatePredefineTagAction{
+			value: "create",
+		},
+	}
+}
+
+func (c ReqCreatePredefineTagAction) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ReqCreatePredefineTagAction) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_req_delete_predefine_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_req_delete_predefine_tag.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 删除预定义标签请求
+type ReqDeletePredefineTag struct {
+	// 操作标识（区分大小写）：delete（删除）
+
+	Action ReqDeletePredefineTagAction `json:"action"`
+	// 标签列表
+
+	Tags []PredefineTagRequest `json:"tags"`
+}
+
+func (o ReqDeletePredefineTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ReqDeletePredefineTag struct{}"
+	}
+
+	return strings.Join([]string{"ReqDeletePredefineTag", string(data)}, " ")
+}
+
+type ReqDeletePredefineTagAction struct {
+	value string
+}
+
+type ReqDeletePredefineTagActionEnum struct {
+	DELETE ReqDeletePredefineTagAction
+}
+
+func GetReqDeletePredefineTagActionEnum() ReqDeletePredefineTagActionEnum {
+	return ReqDeletePredefineTagActionEnum{
+		DELETE: ReqDeletePredefineTagAction{
+			value: "delete",
+		},
+	}
+}
+
+func (c ReqDeletePredefineTagAction) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ReqDeletePredefineTagAction) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_api_version_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_api_version_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowApiVersionRequest struct {
+	// API版本号。
+
+	ApiVersion string `json:"api_version"`
+}
+
+func (o ShowApiVersionRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowApiVersionRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowApiVersionRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_api_version_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_api_version_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowApiVersionResponse struct {
+	Version        *VersionDetail `json:"version,omitempty"`
+	HttpStatusCode int            `json:"-"`
+}
+
+func (o ShowApiVersionResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowApiVersionResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowApiVersionResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_tag_quota_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_tag_quota_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowTagQuotaRequest struct {
+}
+
+func (o ShowTagQuotaRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTagQuotaRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowTagQuotaRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_tag_quota_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_show_tag_quota_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowTagQuotaResponse struct {
+	// 配额列表
+
+	Quotas         *[]TagQuota `json:"quotas,omitempty"`
+	HttpStatusCode int         `json:"-"`
+}
+
+func (o ShowTagQuotaResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTagQuotaResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowTagQuotaResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_tag_quota.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_tag_quota.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 配额
+type TagQuota struct {
+	// 配额键
+
+	QuotaKey string `json:"quota_key"`
+	// 配额值
+
+	QuotaLimit int32 `json:"quota_limit"`
+	// 已使用
+
+	Used int32 `json:"used"`
+	// 单位
+
+	Unit string `json:"unit"`
+}
+
+func (o TagQuota) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TagQuota struct{}"
+	}
+
+	return strings.Join([]string{"TagQuota", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_update_predefine_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_update_predefine_tags_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdatePredefineTagsRequest struct {
+	Body *ModifyPrefineTag `json:"body,omitempty"`
+}
+
+func (o UpdatePredefineTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdatePredefineTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdatePredefineTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_update_predefine_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_update_predefine_tags_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdatePredefineTagsResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdatePredefineTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdatePredefineTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdatePredefineTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_version_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model/model_version_detail.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdktime"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+	"strings"
+)
+
+// 版本详情
+type VersionDetail struct {
+	// 版本ID（版本号），如v1.0。
+
+	Id string `json:"id"`
+	// API的URL地址。
+
+	Links []Link `json:"links"`
+	// 若该版本API支持微版本，则返回支持的最新微版本号，如果不支持微版本，则返回空。
+
+	Version string `json:"version"`
+	// 版本状态，为如下3种： CURRENT：表示该版本为主推版本。 SUPPORTED：表示为老版本，但是现在还继续支持。 DEPRECATED：表示为废弃版本，存在后续删除的可能。
+
+	Status VersionDetailStatus `json:"status"`
+	// 版本发布时间，采用UTC时间表示。如v1.0发布的时间2016-12-09T00:00:00Z。
+
+	Updated *sdktime.SdkTime `json:"updated"`
+	// 若该版本API 支持微版本，则返回支持的最早微版本号， 如果不支持微版本，则返回空。
+
+	MinVersion string `json:"min_version"`
+}
+
+func (o VersionDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "VersionDetail struct{}"
+	}
+
+	return strings.Join([]string{"VersionDetail", string(data)}, " ")
+}
+
+type VersionDetailStatus struct {
+	value string
+}
+
+type VersionDetailStatusEnum struct {
+	CURRENT    VersionDetailStatus
+	SUPPORTED  VersionDetailStatus
+	DEPRECATED VersionDetailStatus
+}
+
+func GetVersionDetailStatusEnum() VersionDetailStatusEnum {
+	return VersionDetailStatusEnum{
+		CURRENT: VersionDetailStatus{
+			value: "CURRENT",
+		},
+		SUPPORTED: VersionDetailStatus{
+			value: "SUPPORTED",
+		},
+		DEPRECATED: VersionDetailStatus{
+			value: "DEPRECATED",
+		},
+	}
+}
+
+func (c VersionDetailStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *VersionDetailStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/tms_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/tms_client.go
@@ -1,0 +1,97 @@
+package v1
+
+import (
+	http_client "github.com/huaweicloud/huaweicloud-sdk-go-v3/core"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model"
+)
+
+type TmsClient struct {
+	HcClient *http_client.HcHttpClient
+}
+
+func NewTmsClient(hcClient *http_client.HcHttpClient) *TmsClient {
+	return &TmsClient{HcClient: hcClient}
+}
+
+func TmsClientBuilder() *http_client.HcHttpClientBuilder {
+	builder := http_client.NewHcHttpClientBuilder().WithCredentialsType("global.Credentials")
+	return builder
+}
+
+//用于创建预定标签。用户创建预定义标签后，可以使用预定义标签来给资源创建标签。该接口支持幂等特性和处理批量数据。
+func (c *TmsClient) CreatePredefineTags(request *model.CreatePredefineTagsRequest) (*model.CreatePredefineTagsResponse, error) {
+	requestDef := GenReqDefForCreatePredefineTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreatePredefineTagsResponse), nil
+	}
+}
+
+//用于删除预定标签。
+func (c *TmsClient) DeletePredefineTags(request *model.DeletePredefineTagsRequest) (*model.DeletePredefineTagsResponse, error) {
+	requestDef := GenReqDefForDeletePredefineTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeletePredefineTagsResponse), nil
+	}
+}
+
+//查询标签管理服务的API版本列表。
+func (c *TmsClient) ListApiVersions(request *model.ListApiVersionsRequest) (*model.ListApiVersionsResponse, error) {
+	requestDef := GenReqDefForListApiVersions()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListApiVersionsResponse), nil
+	}
+}
+
+//用于查询预定义标签列表。
+func (c *TmsClient) ListPredefineTags(request *model.ListPredefineTagsRequest) (*model.ListPredefineTagsResponse, error) {
+	requestDef := GenReqDefForListPredefineTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListPredefineTagsResponse), nil
+	}
+}
+
+//查询指定的标签管理服务API版本号详情。
+func (c *TmsClient) ShowApiVersion(request *model.ShowApiVersionRequest) (*model.ShowApiVersionResponse, error) {
+	requestDef := GenReqDefForShowApiVersion()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowApiVersionResponse), nil
+	}
+}
+
+//查询标签的配额信息。
+func (c *TmsClient) ShowTagQuota(request *model.ShowTagQuotaRequest) (*model.ShowTagQuotaResponse, error) {
+	requestDef := GenReqDefForShowTagQuota()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowTagQuotaResponse), nil
+	}
+}
+
+//修改预定义标签。
+func (c *TmsClient) UpdatePredefineTags(request *model.UpdatePredefineTagsRequest) (*model.UpdatePredefineTagsResponse, error) {
+	requestDef := GenReqDefForUpdatePredefineTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdatePredefineTagsResponse), nil
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/tms_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/tms_meta.go
@@ -1,0 +1,127 @@
+package v1
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/def"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model"
+	"net/http"
+)
+
+func GenReqDefForCreatePredefineTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/predefine_tags/action").
+		WithResponse(new(model.CreatePredefineTagsResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeletePredefineTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/predefine_tags/action").
+		WithResponse(new(model.DeletePredefineTagsResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListApiVersions() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/").
+		WithResponse(new(model.ListApiVersionsResponse)).
+		WithContentType("application/json")
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListPredefineTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/predefine_tags").
+		WithResponse(new(model.ListPredefineTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Key").
+		WithJsonTag("key").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Value").
+		WithJsonTag("value").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Marker").
+		WithJsonTag("marker").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("OrderField").
+		WithJsonTag("order_field").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("OrderMethod").
+		WithJsonTag("order_method").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowApiVersion() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/{api_version}").
+		WithResponse(new(model.ShowApiVersionResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ApiVersion").
+		WithJsonTag("api_version").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowTagQuota() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/tms/quotas").
+		WithResponse(new(model.ShowTagQuotaResponse)).
+		WithContentType("application/json")
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdatePredefineTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.0/predefine_tags").
+		WithResponse(new(model.UpdatePredefineTagsResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -373,7 +373,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.77
+# github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.78
 ## explicit
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth
@@ -394,6 +394,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3/core/response
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdktime
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model
 # github.com/jen20/awspolicyequivalence v1.1.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new TMS predefined tag resource support.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2006 

**Special notes for your reviewer**:
1. This uses huaweicloud go sdk v3 instead of golangsdk.
2. Tms tag doesn't have a `id` attribute, use  key/value to indicates a tag.
3. Tms tag can use same key with others.
4. Create tag is an idempotent operation that has no additional effect if it is called more than once, there's no need to implement an update method.
5. Delete tag with non exist key/value will not return error, and request body should not be empty.
6. resource id are combined with all tags key/value with a hashcode value

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
7. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/tms/ TESTARGS='-run=TestAccTmsTag_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/tms/ -v -run=TestAccTmsTag_basic -timeout 360m -parallel 4
=== RUN   TestAccTmsTag_basic
--- PASS: TestAccTmsTag_basic (48.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/tms
```
