### PR TITLE
fix bugs on csbs and vbs

### DIFF
--- a/vendor/github.com/chnsz/golangsdk/openstack/csbs/v1/backup/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/csbs/v1/backup/results.go
@@ -106,7 +106,7 @@ type Backup struct {
 
 type ExtendInfo struct {
 	AutoTrigger          bool           `json:"auto_trigger"`
-	AverageSpeed         int            `json:"average_speed"`
+	AverageSpeed         int            `json:"-"`
 	CopyFrom             string         `json:"copy_from"`
 	CopyStatus           string         `json:"copy_status"`
 	FailCode             FailCode       `json:"fail_code"`
@@ -145,7 +145,7 @@ type FailCode struct {
 }
 
 type VolumeBackup struct {
-	AverageSpeed     int    `json:"average_speed"`
+	AverageSpeed     int    `json:"-"`
 	Bootable         bool   `json:"bootable"`
 	Id               string `json:"id"`
 	ImageType        string `json:"image_type"`


### PR DESCRIPTION
* csbs: API response has changed, should update golangsdk to f715737b3b03;
* vbs: update the Endpoint item to call job APIs

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- bug about VBS:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVBSBackupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVBSBackupV2_basic -timeout 360m -parallel 4
=== RUN   TestAccVBSBackupV2_basic
=== PAUSE TestAccVBSBackupV2_basic
=== CONT  TestAccVBSBackupV2_basic
    resource_huaweicloud_vbs_backup_v2_test.go:21: Step 1/2 error: Error running apply: exit status 1
        2022/03/08 10:25:35 [DEBUG] Using modified User-Agent: Terraform/0.12.28 HashiCorp-terraform-exec/0.15.0

        Error: Resource not found: [GET https://vbs.cn-north-4.myhuaweicloud.com/jobs/fb60ecac-ee4d-4098-bb64-f22a58cc0943], error message: {"error_msg":"The API does not exist or has not been published in the environment","error_code":"APIGW.0101","request_id":"06110fb86d21efd4f9139b30d7cded73"}


          on terraform_plugin_test.tf line 18, in resource "huaweicloud_vbs_backup" "backup_1":
          18: resource "huaweicloud_vbs_backup" "backup_1" {
```
should update the Endpoint item to call job APIs

- bug about CSBS
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCSBSBackupV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCSBSBackupV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCSBSBackupV1_basic
=== PAUSE TestAccCSBSBackupV1_basic
=== CONT  TestAccCSBSBackupV1_basic
    resource_huaweicloud_csbs_backup_v1_test.go:22: Step 1/2 error: Error running apply: exit status 1
        2022/03/08 11:14:29 [DEBUG] Using modified User-Agent: Terraform/0.12.28 HashiCorp-terraform-exec/0.15.0

        Error: Error waiting for Backup (68c97b86-d4c6-43c2-a5dd-8e361c9c87af) to become available: json: cannot unmarshal number 64.3 into Go struct field .checkpoint_item of type int

          on terraform_plugin_test.tf line 19, in resource "huaweicloud_csbs_backup" "csbs":
          19: resource "huaweicloud_csbs_backup" "csbs" {


    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        2022/03/08 11:20:56 [DEBUG] Using modified User-Agent: Terraform/0.12.28 HashiCorp-terraform-exec/0.15.0

        Error: Error deleting csbs backup: json: cannot unmarshal number 64.3 into Go struct field .checkpoint_item of type int


--- FAIL: TestAccCSBSBackupV1_basic (407.11s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       407.178s
FAIL
``` 
API response has changed, should update golangsdk to f715737b3b03

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCSBSBackupV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCSBSBackupV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCSBSBackupV1_basic
=== PAUSE TestAccCSBSBackupV1_basic
=== CONT  TestAccCSBSBackupV1_basic
--- PASS: TestAccCSBSBackupV1_basic (645.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       645.767s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccVBSBackupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccVBSBackupV2_basic -timeout 360m -parallel 4
=== RUN   TestAccVBSBackupV2_basic
=== PAUSE TestAccVBSBackupV2_basic
=== CONT  TestAccVBSBackupV2_basic
--- PASS: TestAccVBSBackupV2_basic (305.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       306.025s
```
