### PR TITLE
fix(dms/product): fix the problem of vm_specification parameter

### DIFF
--- a/docs/data-sources/dms_product.md
+++ b/docs/data-sources/dms_product.md
@@ -9,6 +9,8 @@ to `huaweicloud_dms_product_v1`
 
 ## Example Usage
 
+### Filter DMS kafka product list by I/O specification
+
 ```hcl
 data "huaweicloud_dms_product" "product1" {
   engine            = "kafka"
@@ -17,6 +19,17 @@ data "huaweicloud_dms_product" "product1" {
   partition_num     = 300
   storage           = 600
   storage_spec_code = "dms.physical.storage.high"
+}
+```
+
+### Filter DMS kafka product list by underlying VM specification
+
+```
+data "huaweicloud_dms_product" "product2" {
+  engine           = "kafka"
+  version          = "2.3.0"
+  instance_type    = "cluster"
+  vm_specification = "c6.large.2"
 }
 ```
 
@@ -33,7 +46,7 @@ data "huaweicloud_dms_product" "product1" {
 
 * `availability_zones` - (Optional, List) Indicates the list of availability zones with available resources.
 
-* `vm_specification` - (Optional, String) Indicates VM specifications.
+* `vm_specification` - (Optional, String) Indicates underlying VM specification, such as **c6.large.2**.
 
 * `storage` - (Optional, String) Indicates the storage capacity of the resource.
   The default value is the storage capacity of the product.

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_product_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_product_test.go
@@ -34,6 +34,28 @@ func TestAccDmsProductDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccDmsProductDataSource_kafkaVmSpec(t *testing.T) {
+	dataSourceName := "data.huaweicloud_dms_product.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsProductDataSource_kafkaVmSpec,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "kafka"),
+					resource.TestCheckResourceAttr(dataSourceName, "vm_specification", "c6.large.2"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "availability_zones.0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDmsProductDataSource_rabbitmqSingle(t *testing.T) {
 	dataSourceName := "data.huaweicloud_dms_product.product1"
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
@@ -91,6 +113,15 @@ data "huaweicloud_dms_product" "product1" {
   partition_num     = 300
   storage           = 600
   storage_spec_code = "dms.physical.storage.high"
+}
+`)
+
+var testAccDmsProductDataSource_kafkaVmSpec = fmt.Sprintf(`
+data "huaweicloud_dms_product" "test" {
+  instance_type    = "cluster"
+  version          = "2.3.0"
+  engine           = "kafka"
+  vm_specification = "c6.large.2"
 }
 `)
 

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
@@ -166,7 +166,9 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 				continue
 			}
 			for _, detail := range value.Details {
-				if vmSpecification != "" && detail.VMSpecification != vmSpecification {
+				// The vm_specification has been removed and the evs_flavor_id return is the same as the
+				// vm_specification.
+				if vmSpecification != "" && detail.EcsFlavorId != vmSpecification {
 					continue
 				}
 
@@ -244,7 +246,7 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 			storageSpecCodes = append(storageSpecCodes, v.StorageSpecCode)
 		}
 		mErr = multierror.Append(err,
-			d.Set("vm_specification", pd.VMSpecification),
+			d.Set("vm_specification", pd.EcsFlavorId),
 			d.Set("storage", pd.Storage),
 			d.Set("partition_num", pd.PartitionNum),
 			d.Set("bandwidth", pd.Bandwidth),
@@ -265,7 +267,7 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 			storageSpecCodes = append(storageSpecCodes, v.StorageSpecCode)
 		}
 		mErr = multierror.Append(err,
-			d.Set("vm_specification", pd.VMSpecification),
+			d.Set("vm_specification", pd.EcsFlavorId),
 			d.Set("storage", pdInfo.Storage),
 			d.Set("io_type", pdInfo.IOs[0].IOType),
 			d.Set("node_num", pdInfo.NodeNum),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The field referenced by `vm_specification` has been removed due to API changes at 2020. This parameter is currently unavailable. To fix this, change the field reference for this parameter from `VMSpecification` to `EcsFlavorId`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2005

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the field reference for this parameter from `VMSpecification` to `EcsFlavorId`.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acc
eptance/dms' TESTARGS='-run=TestAccDmsProductDataSource_kafkaVmSpec'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run=TestAccDmsProductDataSource_kafkaVmSpec -timeout 360m -parallel 4
=== RUN   TestAccDmsProductDataSource_kafkaVmSpec
=== PAUSE TestAccDmsProductDataSource_kafkaVmSpec
=== CONT  TestAccDmsProductDataSource_kafkaVmSpec
--- PASS: TestAccDmsProductDataSource_kafkaVmSpec (48.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms 48.763s
```
