### PR TITLE
feat(ModelArts): add new dataSource to get datasets

### DIFF
--- a/docs/data-sources/modelarts_datasets.md
+++ b/docs/data-sources/modelarts_datasets.md
@@ -1,0 +1,110 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+---
+
+# huaweicloud_modelarts_datasets
+
+Use this data source to get a list of ModelArts datasets.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_modelarts_datasets" "test" {
+  name = "your_dataset_name"
+  type = 1
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available datasets in the current region.
+ All datasets that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain datasets. If omitted, the provider-level region
+ will be used.
+
+* `name` - (Optional, String) Specifies the name of datasets.
+
+* `type` - (Optional, Int) Specifies the type of datasets. The options are:
+  + **0**: Image classification, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
+  + **1**: Object detection, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
+  + **3**: Image segmentation, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
+  + **100**: Text classification, supported formats: `.txt`, `.csv`.
+  + **200**: Sound classification, Supported formats: `.wav`.
+  + **400**: Table type, supported formats: Carbon type.
+  + **600**: Video, supported formats: `.mp4`
+  + **900**: Free format.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `datasets` - Indicates a list of all datasets found. Structure is documented below.
+
+The `datasets` block contains:
+
+* `id` - The ID of the dataset.
+
+* `name` - The name of the dataset.
+
+* `type` - The type of the dataset.
+
+* `description` - The description of the dataset.
+
+* `output_path` - The OBS path for storing output files such as labeled files.
+
+* `data_source` - The data sources which is used to imported the source data (such as pictures/files/audio, etc.) in
+ this directory and subdirectories to the dataset. Structure is documented below.
+
+* `schemas` - The schema information of source data when `type` is `400`(Table Type). Structure is documented below.
+
+* `labels` - The labels information. Structure is documented below.
+
+* `data_format` - The dataset format. Valid values include: `Default`, `CarbonData`: Carbon format(Supported only for
+ table type dataset.).
+
+* `created_at` - The dataset creation time.
+
+* `status` - Dataset status. Valid values are as follows:
+  + **0**: Creating.
+  + **1**: Completed.
+  + **2**: Deleting.
+  + **3**: Deleted.
+  + **4**: Exception.
+  + **5**: Syncing.
+  + **6**: Releasing.
+  + **7**: Version switching.
+  + **8**: Importing.
+
+The `data_source` block contains:
+
+* `data_type` - The type of data source. Valid values are as follows:
+  + *0*: OBS.
+  + *1*: GaussDB(DWS).
+  + *2*: DLI.
+  + *4*: MRS.
+  
+* `path` - The OBS path when `data_type` is `0`(OBS) or the HDFS path when `data_type` is `4`(MRS). All the file in this
+ directory and subdirectories will be which be imported to the dataset.
+
+* `with_column_header` - Whether the data contains table header when the type of dataset is `400`(Table type).
+
+The `schemas` block contains:
+
+* `type` - The field type. Valid values include: `String`, `Short`, `Int`, `Long`, `Double`, `Float`, `Byte`,
+ `Date`, `Timestamp`, `Bool`.
+
+* `name` - The field name.
+
+The `labels` block contains:
+
+* `name` - The name of label.
+
+* `property_color` - The color of label.
+
+* `property_shape` - The shape of label. Valid values include: `bndbox`, `polygon`, `circle`, `line`, `dashed`,
+ `point`, `polyline`.
+
+* `property_shortcut` - The shortcut of label.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -375,6 +375,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_secgroup":                  DataSourceNetworkingSecGroup(),
 			"huaweicloud_networking_secgroups":                 vpc.DataSourceNetworkingSecGroups(),
 			"huaweicloud_modelarts_notebook_images":            modelarts.DataSourceNotebookImages(),
+			"huaweicloud_modelarts_datasets":                   modelarts.DataSourceDatasets(),
 			"huaweicloud_obs_buckets":                          obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object":                    DataSourceObsBucketObject(),
 			"huaweicloud_rds_flavors":                          rds.DataSourceRdsFlavor(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
@@ -1,0 +1,59 @@
+package modelarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDatasets_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_modelarts_datasets.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	name := acceptance.RandomAccResourceName()
+	obsName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDatasets_basic(name, obsName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(dataSourceName, "datasets.0.id",
+						"huaweicloud_modelarts_dataset.test", "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.type", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "datasets.0.description",
+						"huaweicloud_modelarts_dataset.test", "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "datasets.0.output_path",
+						"huaweicloud_modelarts_dataset.test", "output_path"),
+					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.data_source.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.labels.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.schemas.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDatasets_basic(rName, obsName string) string {
+	datasets := testAccDateset_basic(rName, obsName)
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_modelarts_datasets" "test" {
+  name = "%s"
+  type = 1
+
+  depends_on = [
+    huaweicloud_modelarts_dataset.test
+  ]
+}
+`, datasets, rName)
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_datasets.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_datasets.go
@@ -1,0 +1,256 @@
+package modelarts
+
+import (
+	"context"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func DataSourceDatasets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDatasetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"type": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntInSlice([]int{0, 1, 3, 100, 101, 102, 200, 201, 202, 400, 600, 900}),
+			},
+
+			"datasets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"type": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"output_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"data_source": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"data_type": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+
+									"path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"with_column_header": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"schemas": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"labels": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"property_color": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"property_shape": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"property_shortcut": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"data_format": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDatasetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ModelArtsV2Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating ModelArts v2 client, err=%s", err)
+	}
+
+	opts := dataset.ListOpts{
+		WithLabels:    true,
+		SearchContent: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		dataType := v.(int)
+		opts.DatasetType = &dataType
+	}
+
+	page, err := dataset.List(client, opts)
+	if err != nil {
+		return fmtp.DiagErrorf("Error querying ModelArts datasets: %s ", err)
+	}
+
+	p, err := page.AllPages()
+	if err != nil {
+		return fmtp.DiagErrorf("Error querying ModelArts datasets: %s", err)
+	}
+
+	datasets, err := dataset.ExtractDatasets(p)
+	if err != nil {
+		return fmtp.DiagErrorf("Error querying ModelArts datasets: %s", err)
+	}
+
+	var rst []map[string]interface{}
+	var ids []string
+	for _, v := range datasets {
+		item := map[string]interface{}{
+			"id":          v.DatasetId,
+			"name":        v.DatasetName,
+			"type":        v.DatasetType,
+			"description": v.Description,
+			"output_path": v.WorkPath,
+			"created_at":  utils.FormatTimeStampUTC(int64(v.CreateTime) / 1000),
+			"status":      v.Status,
+			"data_format": v.DataFormat,
+			"data_source": parseDataSource(v.DataSources),
+			"schemas":     parseSchemas(v.Schema),
+			"labels":      parseLabels(v.Labels),
+		}
+		rst = append(rst, item)
+		ids = append(ids, v.DatasetId)
+	}
+
+	err = d.Set("datasets", rst)
+	if err != nil {
+		return fmtp.DiagErrorf("set datasets err:%s", err)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	return nil
+}
+
+func parseLabels(in []dataset.Label) []interface{} {
+	var result []interface{}
+	for _, v := range in {
+		item := map[string]interface{}{
+			"name":              v.Name,
+			"property_color":    v.Property.Color,
+			"property_shape":    v.Property.DefaultShape,
+			"property_shortcut": v.Property.Shortcut,
+		}
+
+		result = append(result, item)
+	}
+	return result
+}
+
+func parseDataSource(in []dataset.DataSource) []interface{} {
+	result := make([]interface{}, 1)
+	if len(in) >= 1 {
+		result[0] = map[string]interface{}{
+			"data_type":          in[0].DataType,
+			"path":               in[0].DataPath,
+			"with_column_header": in[0].WithColumnHeader,
+		}
+	}
+	return result
+}
+
+func parseSchemas(in []dataset.Field) []interface{} {
+	result := make([]interface{}, len(in))
+	for i, v := range in {
+		result[i] = map[string]interface{}{
+			"name": v.Name,
+			"type": v.Type,
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. add new dataSource to get datasets
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2016

**Special notes for your reviewer**:
1. ci build may be failed. it depends on  the endpoint  file in the PR  #2010 
2. Due to the limitation of the data returned by the API, there are fewer parameters than creating a dataset

**Release note**:
<!--  Steps to write your release note:  #2010 
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccDataSourceDatasets_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccDataSourceDatasets_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDatasets_basic
=== PAUSE TestAccDataSourceDatasets_basic
=== CONT  TestAccDataSourceDatasets_basic
--- PASS: TestAccDataSourceDatasets_basic (76.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 76.529s
```
