### PR TITLE
fix(dms/kafka): fix the force replacement problem

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -87,6 +87,8 @@ The following arguments are supported:
   Deploy to more availability zones, the better the reliability and SLA coverage.
   [Learn more](https://support.huaweicloud.com/en-us/kafka_faq/kafka-faq-200426002.html)
 
+  ~> The parameter behavior of `availability_zones` has been changed from `list` to `set`.
+
 * `manager_user` - (Required, String, ForceNew) Specifies the username for logging in to the Kafka Manager. The username
   consists of 4 to 64 characters and can contain letters, digits, hyphens (-), and underscores (_). Changing this
   creates a new instance resource.

--- a/docs/resources/dms_rabbitmq_instance.md
+++ b/docs/resources/dms_rabbitmq_instance.md
@@ -75,6 +75,8 @@ The following arguments are supported:
   The parameter value can not be left blank or an empty array.
   Changing this creates a new instance resource.
 
+  ~> The parameter behavior of `availability_zones` has been changed from `list` to `set`.
+
 * `access_user` - (Required, String, ForceNew) Specifies a username. A username consists of 4 to 64 characters and
   supports only letters, digits, and hyphens (-). Changing this creates a new instance resource.
 

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
@@ -84,11 +84,13 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"availability_zones": {
-				Type:     schema.TypeList,
+				// There is a problem with order of elements in Availability Zone list returned by Kafka API.
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 			"product_id": {
 				Type:     schema.TypeString,
@@ -325,8 +327,8 @@ func resourceDmsKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		availableZones = utils.ExpandToStringList(zoneIDs.([]interface{}))
 	} else {
 		// convert the codes of the availability zone into ids
-		azCodes := d.Get("availability_zones").([]interface{})
-		availableZones, err = getAvailableZoneIDByCode(config, region, azCodes)
+		azCodes := d.Get("availability_zones").(*schema.Set)
+		availableZones, err = getAvailableZoneIDByCode(config, region, azCodes.List())
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_instance.go
@@ -93,12 +93,14 @@ func ResourceDmsRabbitmqInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"availability_zones": {
-				Type:          schema.TypeList,
+				// There is a problem with order of elements in Availability Zone list returned by RabbitMQ API.
+				Type:          schema.TypeSet,
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"available_zones"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
 			},
 			"product_id": {
 				Type:     schema.TypeString,
@@ -204,8 +206,8 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		availableZones = utils.ExpandToStringList(zoneIDs.([]interface{}))
 	} else {
 		// convert the codes of the availability zone into ids
-		azCodes := d.Get("availability_zones").([]interface{})
-		availableZones, err = getAvailableZoneIDByCode(config, region, azCodes)
+		azCodes := d.Get("availability_zones").(*schema.Set)
+		availableZones, err = getAvailableZoneIDByCode(config, region, azCodes.List())
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix terraform resource re-creation due to wrong order of the availability zone list return from Kafka API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2009 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update AZ schema type from TypeList to TypeSet.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
