### PR TITLE
feat(auth): add shared config profile support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ supported, in this order, and explained below:
 
 * Static credentials
 * Environment variables
+* Shared configuration file
 * ECS Instance Metadata Service
 
 ### Static credentials
@@ -96,6 +97,23 @@ $ export HW_REGION_NAME="cn-north-4"
 $ terraform plan
 ```
 
+### Shared Configuration File
+
+You can use a
+[HuaweiCloud CLI configuration file](https://support.huaweicloud.com/intl/en-us/usermanual-hcli/hcli_03_002.html)
+to specify your credentials. You need to specify a location in the Terraform configuration by providing the
+`shared_configuration_file` argument or using the `HW_SHARED_CONFIGURATION_FILE` environment variable.
+This method also supports a `profile` configuration and matching `HW_PROFILE` environment variable:
+
+Usage:
+
+```terraform
+provider "huaweicloud" {
+  shared_configuration_file = "/home/tf_user/.hcloud/config.json"
+  profile                   = "customprofile"
+}
+```
+
 ### ECS Instance Metadata Service
 
 If you're running Terraform from an ECS instance with Agency configured, Terraform will just ask
@@ -110,14 +128,20 @@ which reduces the chance of leakage.
 
 The following arguments are supported:
 
-* `region` - (Required) This is the Huawei Cloud region. It must be provided, but it can also be sourced from
-  the `HW_REGION_NAME` environment variables.
+* `region` - (Optional) This is the Huawei Cloud region. It must be provided when using `static credentials`
+  authentication, but it can also be sourced from the `HW_REGION_NAME` environment variables.
 
 * `access_key` - (Optional) The access key of the HuaweiCloud to use. If omitted, the `HW_ACCESS_KEY` environment
   variable is used.
 
 * `secret_key` - (Optional) The secret key of the HuaweiCloud to use. If omitted, the `HW_SECRET_KEY` environment
   variable is used.
+
+* `shared_config_file` - (Optional) The path to the shared config file. If omitted, the `HW_SHARED_CONFIG_FILE` environment
+  variable is used.
+
+* `profile` - (Optional) The profile name as set in the shared config file. If omitted, the `HW_PROFILE` environment
+  variable is used. Defaults to the `current` profile in the shared config file.
 
 * `project_name` - (Optional) The Name of the project to login with. If omitted, the `HW_PROJECT_NAME` environment
   variable or `region` is used.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -58,7 +58,7 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Description:  descriptions["region"],
 				InputDefault: "cn-north-1",
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
@@ -272,6 +272,20 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: descriptions["endpoints"],
 				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"shared_config_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["shared_config_file"],
+				DefaultFunc: schema.EnvDefaultFunc("HW_SHARED_CONFIG_FILE", ""),
+			},
+
+			"profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["profile"],
+				DefaultFunc: schema.EnvDefaultFunc("HW_PROFILE", ""),
 			},
 
 			"enterprise_project_id": {
@@ -787,6 +801,10 @@ func init() {
 
 		"endpoints": "The custom endpoints used to override the default endpoint URL.",
 
+		"shared_config_file": "The path to the shared config file. If not set, the default is ~/.hcloud/config.json.",
+
+		"profile": "The profile name as set in the shared config file.",
+
 		"max_retries": "How many times HTTP connection should be retried until giving up.",
 
 		"enterprise_project_id": "enterprise project id",
@@ -858,6 +876,8 @@ func configureProvider(d *schema.ResourceData, terraformVersion string) (interfa
 		Cloud:               cloud,
 		MaxRetries:          d.Get("max_retries").(int),
 		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
+		SharedConfigFile:    d.Get("shared_config_file").(string),
+		Profile:             d.Get("profile").(string),
 		TerraformVersion:    terraformVersion,
 		RegionProjectIDMap:  make(map[string]string),
 		RPLock:              new(sync.Mutex),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add shared cofnig profiles support

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2024 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
