### PR TITLE
fix(dms/test): fix the problem of import state verification

### DIFF
--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
@@ -48,6 +48,14 @@ func TestAccDmsRabbitmqInstances_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+			{
 				Config: testAccDmsRabbitmqInstance_update(rName, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
@@ -57,14 +65,6 @@ func TestAccDmsRabbitmqInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"password",
-				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After the update is complete, `used_storage_space` will increase and be different from the original state. This will cause equivalence checks on the `ImportStateVerify` property to fail.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Relocated import check in acc test for RabbitMQ instance.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run=TestAccDmsRabbitmqInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run=TestAccDmsRabbitmqInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_basic
--- PASS: TestAccDmsRabbitmqInstances_basic (1084.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1084.929s
```
