### PR TITLE
feat(fgs/function): support param specified of functiongraph version

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -169,6 +169,10 @@ The following arguments are supported:
 * `code_type` - (Required, String) Specifies the function code type, which can be inline: inline code, zip: ZIP file,
   jar: JAR file or java functions, obs: function code stored in an OBS bucket.
 
+* `functiongraph_version` - (Optional, String, ForceNew) Specifies the FunctionGraph version, defaults to **v1**.
+  + **v1**: Hosts event-driven functions in a serverless context.
+  + **v2**: Next-generation function hosting service powered by Huawei YuanRong architecture.
+
 * `func_code` - (Optional, String) Specifies the function code. When code_type is set to inline, zip, or jar, this
   parameter is mandatory, and the code can be encoded using Base64 or just with the text code.
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -41,6 +41,7 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 				Config: testAccFgsV2Function_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -8,6 +8,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/fgs/v2/function"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -62,6 +63,15 @@ func ResourceFgsFunctionV2() *schema.Resource {
 			"timeout": {
 				Type:     schema.TypeInt,
 				Required: true,
+			},
+			"functiongraph_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"v1", "v2",
+				}, false), // The current default value is v1, which may be adjusted in the future.
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -223,6 +233,7 @@ func buildFgsFunctionV2Parameters(d *schema.ResourceData, config *config.Config)
 	}
 	result := function.CreateOpts{
 		FuncName:            d.Get("name").(string),
+		Type:                d.Get("functiongraph_version").(string),
 		Package:             pack_v,
 		CodeType:            d.Get("code_type").(string),
 		CodeUrl:             d.Get("code_url").(string),
@@ -367,6 +378,7 @@ func resourceFgsFunctionV2Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("initializer_handler", f.InitializerHandler),
 		d.Set("initializer_timeout", f.InitializerTimeout),
 		d.Set("enterprise_project_id", f.EnterpriseProjectID),
+		d.Set("functiongraph_version", f.Type),
 		setFgsFunctionApp(d, f.Package),
 		setFgsFunctionAgency(d, f.Xrole),
 		setFgsFunctionVpcAccess(d, f.FuncVpc),

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -37,6 +37,7 @@ type CreateOpts struct {
 	AppXrole            string           `json:"app_xrole,omitempty"`
 	FuncCode            FunctionCodeOpts `json:"func_code,omitempty"`
 	EnterpriseProjectID string           `json:"enterprise_project_id,omitempty"`
+	Type                string           `json:"type,omitempty"`
 }
 
 func (opts CreateOpts) ToCreateFunctionMap() (map[string]interface{}, error) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
@@ -45,6 +45,7 @@ type Function struct {
 	InitializerTimeout  int            `json:"initializer_timeout,omitempty"`
 	InitializerHandler  string         `json:"initializer_handler,omitempty"`
 	EnterpriseProjectID string         `json:"enterprise_project_id"`
+	Type                string         `json:"type"`
 }
 
 type FuncMount struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new parameter to specify the FunctionGraph version, and the current values include **v1** and **v2**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2042 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support param specified of functiongraph version.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_fgsVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_fgsVersion -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_fgsVersion
=== PAUSE TestAccFgsV2Function_fgsVersion
=== CONT  TestAccFgsV2Function_fgsVersion
--- PASS: TestAccFgsV2Function_fgsVersion (46.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       46.130s
```
