### PR TITLE
feat(ecs/eip): add auto_pay support

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -279,6 +279,10 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
   Valid values are "true" and "false". Changing this creates a new resource.
 
+* `auto_pay` - (Optional, Bool, ForceNew) Specifies whether auto pay is enabled.
+  Defaults to *true*. If you set this to *false*, you need to pay the order yourself in time,
+  be careful about the timeout of resource creation. Changing this creates a new resource.
+
 * `user_id` - (Optional, String, ForceNew) Specifies a user ID, required when using key_pair in prePaid charging mode.
   Changing this creates a new instance.
 

--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -76,6 +76,10 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are "true" and "
   false". Changing this creates a new resource.
 
+* `auto_pay` - (Optional, Bool, ForceNew) Specifies whether auto pay is enabled.
+  Defaults to *true*. If you set this to *false*, you need to pay the order yourself in time,
+  be careful about the timeout of resource creation. Changing this creates a new resource.
+
 The `publicip` block supports:
 
 * `type` - (Optional, String, ForceNew) Specifies the EIP type. Possible values are *5_bgp* (dynamic BGP)

--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -82,6 +82,18 @@ func SchemaAutoRenew(conflicts []string) *schema.Schema {
 	return &resourceSchema
 }
 
+func SchemaAutoPay(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		ForceNew:      true,
+		Default:       true,
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
 func ValidatePrePaidChargeInfo(d *schema.ResourceData) error {
 	if _, ok := d.GetOk("period_unit"); !ok {
 		return fmtp.Errorf("both of `period, period_unit` must be specified in prePaid charging mode")

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -283,11 +283,12 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				ConflictsWith: novaConflicts,
 			},
 
-			// charge info: charging_mode, period_unit, period, auto_renew
+			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
 			"charging_mode": schemeChargingMode(novaConflicts),
 			"period_unit":   schemaPeriodUnit(novaConflicts),
 			"period":        schemaPeriod(novaConflicts),
 			"auto_renew":    schemaAutoRenew(novaConflicts),
+			"auto_pay":      schemaAutoPay(novaConflicts),
 
 			"user_id": { // required if in prePaid charging mode with key_pair.
 				Type:     schema.TypeString,
@@ -505,8 +506,12 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 			extendParam.ChargingMode = d.Get("charging_mode").(string)
 			extendParam.PeriodType = d.Get("period_unit").(string)
 			extendParam.PeriodNum = d.Get("period").(int)
-			extendParam.IsAutoPay = "true"
 			extendParam.IsAutoRenew = d.Get("auto_renew").(string)
+			if d.Get("auto_pay").(bool) {
+				extendParam.IsAutoPay = "true"
+			} else {
+				extendParam.IsAutoPay = "false"
+			}
 		}
 
 		epsID := GetEnterpriseProjectID(d, config)

--- a/huaweicloud/resource_schema.go
+++ b/huaweicloud/resource_schema.go
@@ -82,6 +82,18 @@ func schemaAutoRenew(conflicts []string) *schema.Schema {
 	return &resourceSchema
 }
 
+func schemaAutoPay(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		ForceNew:      true,
+		Default:       true,
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
 func validatePrePaidChargeInfo(d *schema.ResourceData) error {
 	if _, ok := d.GetOk("period_unit"); !ok {
 		return fmtp.Errorf("both of `period, period_unit` must be specified in prePaid charging mode")

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -147,11 +147,12 @@ func ResourceVpcEIPV1() *schema.Resource {
 				Computed: true,
 			},
 
-			// charge info: charging_mode, period_unit, period, auto_renew
+			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
 			"charging_mode": common.SchemeChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit([]string{"publicip.0.ip_address"}),
 			"period":        common.SchemaPeriod([]string{"publicip.0.ip_address"}),
 			"auto_renew":    common.SchemaAutoRenew([]string{"publicip.0.ip_address"}),
+			"auto_pay":      common.SchemaAutoPay([]string{"publicip.0.ip_address"}),
 		},
 	}
 }
@@ -229,8 +230,12 @@ func resourceVpcEIPV1Create(d *schema.ResourceData, meta interface{}) error {
 			ChargeMode:  d.Get("charging_mode").(string),
 			PeriodType:  d.Get("period_unit").(string),
 			PeriodNum:   d.Get("period").(int),
-			IsAutoPay:   "true",
 			IsAutoRenew: d.Get("auto_renew").(string),
+		}
+		if d.Get("auto_pay").(bool) {
+			chargeInfo.IsAutoPay = "true"
+		} else {
+			chargeInfo.IsAutoPay = "false"
 		}
 		createOpts.ExtendParam = chargeInfo
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2034 

**Special notes for your reviewer**:
No tests add for this as it need to pay the order on Console.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccComputeV2Instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccComputeV2Instance -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== RUN   TestAccComputeV2Instance_disks
=== PAUSE TestAccComputeV2Instance_disks
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== RUN   TestAccComputeV2Instance_tags
=== PAUSE TestAccComputeV2Instance_tags
=== RUN   TestAccComputeV2Instance_powerAction
=== PAUSE TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_tags
=== CONT  TestAccComputeV2Instance_prePaid
=== CONT  TestAccComputeV2Instance_powerAction
--- PASS: TestAccComputeV2Instance_basic (224.99s)
=== CONT  TestAccComputeV2Instance_disks
--- PASS: TestAccComputeV2Instance_prePaid (246.79s)
--- PASS: TestAccComputeV2Instance_disks (229.88s)

--- PASS: TestAccComputeV2Instance_tags (471.99s)
--- PASS: TestAccComputeV2Instance_powerAction (693.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       693.667s
```
```
make testacc TEST=./huaweicloud/services/acceptance/eip/ TESTARGS='-run=TestAccEIPAssociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip/ -v -run=TestAccEIPAssociate -timeout 360m -parallel 4
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== RUN   TestAccEIPAssociate_compatible
=== PAUSE TestAccEIPAssociate_compatible
=== CONT  TestAccEIPAssociate_basic
=== CONT  TestAccEIPAssociate_compatible
--- PASS: TestAccEIPAssociate_compatible (115.01s)
--- PASS: TestAccEIPAssociate_basic (121.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       121.221s
```