### PR TITLE
chore: remove unused code

### DIFF
--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -68,12 +68,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccPrecheckCustomRegion(t *testing.T) {
-	if HW_CUSTOM_REGION_NAME == "" {
-		t.Skip("This environment does not support custom region tests")
-	}
-}
-
 func testAccPreCheckDeprecated(t *testing.T) {
 	if HW_DEPRECATED_ENVIRONMENT == "" {
 		t.Skip("This environment does not support deprecated tests")
@@ -92,12 +86,6 @@ func testAccPreCheckDNS(t *testing.T) {
 	}
 }
 
-func testAccPreCheckULB(t *testing.T) {
-	if HW_SUBNET_ID == "" {
-		t.Skip("HW_SUBNET_ID must be set for LB acceptance tests")
-	}
-}
-
 func testAccPreCheckMaas(t *testing.T) {
 	if HW_ACCESS_KEY == "" || HW_SECRET_KEY == "" || HW_SRC_ACCESS_KEY == "" || HW_SRC_SECRET_KEY == "" {
 		t.Skip("HW_ACCESS_KEY, HW_SECRET_KEY, HW_SRC_ACCESS_KEY, and HW_SRC_SECRET_KEY  must be set for MAAS acceptance tests")
@@ -110,27 +98,9 @@ func testAccPreCheckOBS(t *testing.T) {
 	}
 }
 
-func testAccPreCheckDws(t *testing.T) {
-	if HW_DWS_ENVIRONMENT == "" {
-		t.Skip("This environment does not support DWS tests")
-	}
-}
-
-func testAccPreCheckCloudTable(t *testing.T) {
-	if HW_CLOUDTABLE_AVAILABILITY_ZONE == "" {
-		t.Skip("HW_CLOUDTABLE_AVAILABILITY_ZONE must be set for CloudTable tests")
-	}
-}
-
 func testAccPreCheckMrs(t *testing.T) {
 	if HW_MRS_ENVIRONMENT == "" {
 		t.Skip("This environment does not support MRS tests")
-	}
-}
-
-func testAccPreCheckDms(t *testing.T) {
-	if HW_DMS_ENVIRONMENT == "" {
-		t.Skip("This environment does not support DMS tests")
 	}
 }
 
@@ -158,33 +128,15 @@ func testAccPreCheckCCI(t *testing.T) {
 	}
 }
 
-func testAccPreCheckDestProject(t *testing.T) {
-	if HW_DEST_REGION == "" || HW_DEST_PROJECT_ID == "" {
-		t.Skip("This environment does not support destination project tests")
-	}
-}
-
 func testAccPreCheckEpsID(t *testing.T) {
 	if HW_ENTERPRISE_PROJECT_ID_TEST == "" {
 		t.Skip("This environment does not support Enterprise Project ID tests")
 	}
 }
 
-func testAccPreCheckProject(t *testing.T) {
-	if HW_ENTERPRISE_PROJECT_ID_TEST != "" {
-		t.Skip("This environment does not support project tests")
-	}
-}
-
 func testAccPreCheckProjectID(t *testing.T) {
 	if HW_PROJECT_ID == "" {
 		t.Skip("HW_PROJECT_ID must be set for acceptance tests")
-	}
-}
-
-func testAccAsConfigPreCheck(t *testing.T) {
-	if HW_FLAVOR_ID == "" {
-		t.Skip("HW_FLAVOR_ID must be set for acceptance tests")
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_blockstorage_volume_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_blockstorage_volume_v2_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/blockstorage/v2/volumes"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -168,26 +167,6 @@ func testAccCheckBlockStorageV2VolumeExists(n string, volume *volumes.Volume) re
 		*volume = *found
 
 		return nil
-	}
-}
-
-func testAccCheckBlockStorageV2VolumeDoesNotExist(t *testing.T, n string, volume *volumes.Volume) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*config.Config)
-		blockStorageClient, err := config.BlockStorageV2Client(HW_REGION_NAME)
-		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud block storage client: %s", err)
-		}
-
-		_, err = volumes.Get(blockStorageClient, volume.ID).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil
-			}
-			return err
-		}
-
-		return fmtp.Errorf("Volume still exists")
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_compute_volume_attach_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_volume_attach_test.go
@@ -121,18 +121,6 @@ func testAccCheckComputeVolumeAttachExists(n string, va *block_devices.VolumeAtt
 	}
 }
 
-func testAccCheckComputeVolumeAttachDevice(
-	va *block_devices.VolumeAttachment, device string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if va.Device != device {
-			return fmtp.Errorf("Requested device of volume attachment (%s) does not match: %s",
-				device, va.Device)
-		}
-
-		return nil
-	}
-}
-
 func testAccComputeVolumeAttach_basic(rName string) string {
 	return fmt.Sprintf(`
 %s

--- a/huaweicloud/resource_huaweicloud_iec_network_acl_rule_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_network_acl_rule_test.go
@@ -45,27 +45,6 @@ func TestAccIecNetworkACLRuleResource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckIecNetworkACLRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	iecV1Client, err := config.IECV1Client(HW_REGION_NAME)
-	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud IEC client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_iec_network_acl" {
-			continue
-		}
-
-		_, err := firewalls.Get(iecV1Client, rs.Primary.ID).Extract()
-		if err == nil {
-			return fmtp.Errorf("IEC network acl still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckIecNetworkACLRuleExists(n, direction string, resource *firewalls.RespFirewallRulesEntity) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/huaweicloud/resource_huaweicloud_iec_security_group_test.go
+++ b/huaweicloud/resource_huaweicloud_iec_security_group_test.go
@@ -44,17 +44,6 @@ func TestAccIecSecurityGroupResource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckIecSecurityGroupV1RuleCount(group *groups.RespSecurityGroupEntity, count int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(group.SecurityGroupRules) == count {
-			return nil
-		}
-
-		return fmtp.Errorf("Unexpected number of rules in group %s. Expected %d, got %d",
-			group.ID, count, len(group.SecurityGroupRules))
-	}
-}
-
 func testAccCheckIecSecurityGroupV1Exists(n string, group *groups.RespSecurityGroupEntity) resource.TestCheckFunc {
 
 	return func(state *terraform.State) error {

--- a/huaweicloud/resource_huaweicloud_networking_floatingip_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_floatingip_v2_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -116,28 +115,6 @@ func testAccCheckNetworkingV2FloatingIPBoundToCorrectIP(fip *floatingips.Floatin
 		}
 
 		return nil
-	}
-}
-
-func testAccCheckNetworkingV2InstanceFloatingIPAttach(
-	instance *servers.Server, fip *floatingips.FloatingIP) resource.TestCheckFunc {
-
-	// When Neutron is used, the Instance sometimes does not know its floating IP until some time
-	// after the attachment happened. This can be anywhere from 2-20 seconds. Because of that delay,
-	// the test usually completes with failure.
-	// However, the Fixed IP is known on both sides immediately, so that can be used as a bridge
-	// to ensure the two are now related.
-	// I think a better option is to introduce some state changing config in the actual resource.
-	return func(s *terraform.State) error {
-		for _, networkAddresses := range instance.Addresses {
-			for _, element := range networkAddresses.([]interface{}) {
-				address := element.(map[string]interface{})
-				if address["OS-EXT-IPS:type"] == "fixed" && address["addr"] == fip.FixedIP {
-					return nil
-				}
-			}
-		}
-		return fmtp.Errorf("Floating IP %+v was not attached to instance %+v", fip, instance)
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_networking_port_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_port_v2_test.go
@@ -245,17 +245,6 @@ func testAccCheckNetworkingV2PortCountFixedIPs(port *ports.Port, expected int) r
 	}
 }
 
-func testAccCheckNetworkingV2PortCountAllowedAddressPairs(
-	port *ports.Port, expected int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(port.AllowedAddressPairs) != expected {
-			return fmtp.Errorf("Expected %d Allowed Address Pairs, got %d", expected, len(port.AllowedAddressPairs))
-		}
-
-		return nil
-	}
-}
-
 const testAccNetworkingV2Port_basic = `
 resource "huaweicloud_networking_network_v2" "network_1" {
   name = "network_1"
@@ -301,76 +290,6 @@ resource "huaweicloud_networking_port_v2" "port_1" {
 
   fixed_ip {
     subnet_id =  "${huaweicloud_networking_subnet_v2.subnet_1.id}"
-  }
-}
-`
-const testAccNetworkingV2Port_allowedAddressPairs = `
-resource "huaweicloud_networking_network_v2" "vrrp_network" {
-  name = "vrrp_network"
-  admin_state_up = "true"
-}
-
-resource "huaweicloud_networking_subnet_v2" "vrrp_subnet" {
-  name = "vrrp_subnet"
-  cidr = "10.0.0.0/24"
-  ip_version = 4
-  network_id = "${huaweicloud_networking_network_v2.vrrp_network.id}"
-
-  allocation_pools {
-    start = "10.0.0.2"
-    end = "10.0.0.200"
-  }
-}
-
-resource "huaweicloud_networking_secgroup_v2" "secgroup_1" {
-  name = "secgroup_1"
-  description = "terraform security group acceptance test"
-}
-
-resource "huaweicloud_networking_router_v2" "vrrp_router" {
-  name = "vrrp_router"
-}
-
-resource "huaweicloud_networking_router_interface_v2" "vrrp_interface" {
-  router_id = "${huaweicloud_networking_router_v2.vrrp_router.id}"
-  subnet_id = "${huaweicloud_networking_subnet_v2.vrrp_subnet.id}"
-}
-
-resource "huaweicloud_networking_port_v2" "vrrp_port_1" {
-  name = "vrrp_port_1"
-  admin_state_up = "true"
-  network_id = "${huaweicloud_networking_network_v2.vrrp_network.id}"
-
-  fixed_ip {
-    subnet_id =  "${huaweicloud_networking_subnet_v2.vrrp_subnet.id}"
-    ip_address = "10.0.0.202"
-  }
-}
-
-resource "huaweicloud_networking_port_v2" "vrrp_port_2" {
-  name = "vrrp_port_2"
-  admin_state_up = "true"
-  network_id = "${huaweicloud_networking_network_v2.vrrp_network.id}"
-
-  fixed_ip {
-    subnet_id =  "${huaweicloud_networking_subnet_v2.vrrp_subnet.id}"
-    ip_address = "10.0.0.201"
-  }
-}
-
-resource "huaweicloud_networking_port_v2" "instance_port" {
-  name = "instance_port"
-  admin_state_up = "true"
-  network_id = "${huaweicloud_networking_network_v2.vrrp_network.id}"
-
-  allowed_address_pairs {
-    ip_address = "${huaweicloud_networking_port_v2.vrrp_port_1.fixed_ip.0.ip_address}"
-    mac_address = "${huaweicloud_networking_port_v2.vrrp_port_1.mac_address}"
-  }
-
-  allowed_address_pairs {
-    ip_address = "${huaweicloud_networking_port_v2.vrrp_port_2.fixed_ip.0.ip_address}"
-    mac_address = "${huaweicloud_networking_port_v2.vrrp_port_2.mac_address}"
   }
 }
 `

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
@@ -52,26 +52,6 @@ func TestAccDliQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
 				),
 			},
-			//test scale_out
-			{
-				Config: testAccDliQueue_basic(rName, 2*dli.CU_16),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QUEUE_TYPE_SQL),
-					resource.TestCheckResourceAttr(resourceName, "cu_count", fmt.Sprintf("%d", 2*dli.CU_16)),
-				),
-			},
-			//test scale_in
-			{
-				Config: testAccDliQueue_basic(rName, dli.CU_16),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QUEUE_TYPE_SQL),
-					resource.TestCheckResourceAttr(resourceName, "cu_count", fmt.Sprintf("%d", dli.CU_16)),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
@@ -68,13 +68,3 @@ data "huaweicloud_networking_secgroups" "test" {
 }
 `, testAccNetworkingSecGroupsDataSource_base(rName))
 }
-
-func testAccNetworkingSecGroupV3DataSource_description(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_networking_secgroups" "test" {
-  description = "[Acc Test]"
-}
-`, testAccNetworkingSecGroupsDataSource_base(rName))
-}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_queue.go
@@ -27,7 +27,6 @@ const QUEUE_FEATURE_BASIC, QUEUE_FEATURE_AI = "basic", "ai"
 const QUEUE_PLATFORM_X86, QUEUE_platform_AARCH64 = "x86_64", "aarch64"
 
 const (
-	actionRestart  = "restart"
 	actionScaleOut = "scale_out"
 	actionScaleIn  = "scale_in"
 )

--- a/huaweicloud/utils/filter.go
+++ b/huaweicloud/utils/filter.go
@@ -7,12 +7,6 @@ import (
 	"strings"
 )
 
-const (
-	matchRuleByNumLt = -1 // number value match by : less than
-	matchRuleByNumEq = 0  // number value match by : equal to
-	matchRuleByNumGt = 1  // number value match by : greater than
-)
-
 // FilterSliceWithField can filter the slice all through a map filter.
 // If the field is a nested value, using dot(.) to split them, e.g. "SubBlock.SubField".
 // If value in the map is zero, it will be ignored.

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -85,24 +85,6 @@ func ExpandToStringListBySet(v *schema.Set) []string {
 	return s
 }
 
-// Takes list of pointers to strings. Expand to an array
-// of raw strings and returns a []interface{}
-func flattenToStringList(list []*string) []interface{} {
-	vs := make([]interface{}, 0, len(list))
-	for _, v := range list {
-		vs = append(vs, *v)
-	}
-	return vs
-}
-
-func pointersMapToStringList(pointers map[string]*string) map[string]interface{} {
-	list := make(map[string]interface{}, len(pointers))
-	for i, v := range pointers {
-		list[i] = *v
-	}
-	return list
-}
-
 // Takes a value containing JSON string and passes it through
 // the JSON parser to normalize it, returns either a parsing
 // error or normalized JSON string.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 remove unused code 
1. chore resource_huaweicloud_oms_task_v1: use the unused func: getSmnInfo 
2. delete the scale test in dli queue basic test, (The queue must have executed sql to perform scale_out)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccNetworkingSecGroupsDataSource'
--- PASS: TestAccNetworkingSecGroupsDataSource_basic (19.10s)
--- PASS: TestAccNetworkingSecGroupsDataSource_description (19.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       19.255s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccProvider'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccProvider -timeout 360m -parallel 4
=== RUN   TestAccProvider_caCertFile
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.090s
```

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccBlockStorageV2Volume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccBlockStorageV2Volume -timeout 360m -parallel 4
=== RUN   TestAccBlockStorageV2Volume_basic
=== PAUSE TestAccBlockStorageV2Volume_basic
=== RUN   TestAccBlockStorageV2Volume_online_resize
=== PAUSE TestAccBlockStorageV2Volume_online_resize
=== RUN   TestAccBlockStorageV2Volume_image
=== PAUSE TestAccBlockStorageV2Volume_image
=== RUN   TestAccBlockStorageV2Volume_timeout
=== PAUSE TestAccBlockStorageV2Volume_timeout
=== CONT  TestAccBlockStorageV2Volume_basic
=== CONT  TestAccBlockStorageV2Volume_image
=== CONT  TestAccBlockStorageV2Volume_online_resize
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.081s
```

```
 make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIecNetworkACLRuleResource'
=== RUN   TestAccIecNetworkACLRuleResource_basic
--- PASS: TestAccIecNetworkACLRuleResource_basic (32.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       32.598s
```
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccIecSecurityGroupResource'
=== RUN   TestAccIecSecurityGroupResource_basic
--- PASS: TestAccIecSecurityGroupResource_basic (22.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       22.331s
```

```
 make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2FloatingIP'
=== RUN   TestAccNetworkingV2FloatingIP_basic
=== RUN   TestAccNetworkingV2FloatingIP_fixedip_bind
--- SKIP: TestAccNetworkingV2FloatingIP_basic (0.00s)
--- SKIP: TestAccNetworkingV2FloatingIP_fixedip_bind (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.083s
```

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingV2Port'
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== RUN   TestAccNetworkingV2Port_createExtraDHCPOpts
=== RUN   TestAccNetworkingV2Port_updateExtraDHCPOpts
--- PASS: TestAccNetworkingV2PortDataSource_basic (12.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       13.094s
```

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeVolumeAttach'
=== RUN   TestAccComputeVolumeAttach_basic
=== RUN   TestAccComputeVolumeAttach_device
--- PASS: TestAccComputeVolumeAttach_device (200.70s)
--- PASS: TestAccComputeVolumeAttach_basic (205.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       205.779s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDliQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDliQueue -timeout 360m -parallel 4
=== RUN   TestAccDliQueue_basic
=== PAUSE TestAccDliQueue_basic
=== RUN   TestAccDliQueue_cidr
=== PAUSE TestAccDliQueue_cidr
=== CONT  TestAccDliQueue_basic
=== CONT  TestAccDliQueue_cidr
--- PASS: TestAccDliQueue_basic (260.11s)
--- PASS: TestAccDliQueue_cidr (268.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       268.542s
```