### PR TITLE
feat(gaussdb): add audit log switch for gaussdb mysql instance

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -143,6 +143,8 @@ The `backup_strategy` block supports:
   0 to 35. If this parameter is set to 0, the automated backup policy is not set. If this parameter is not transferred,
   the automated backup policy is enabled by default. Backup files are stored for seven days by default.
 
+* `audit_log_enabled` - (Optional, Bool) Specifies whether audit log is enabled. The default value is `false`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -29,6 +29,7 @@ var multiCatalogKeys = map[string][]string{
 	"rds":       {"rdsv1"},
 	"waf":       {"waf-dedicated"},
 	"geminidb":  {"geminidbv31"},
+	"gaussdb":   {"gaussdbv3"},
 	"dli":       {"dliv2"},
 	"dcs":       {"dcsv1"},
 	"dis":       {"disv3"},
@@ -265,6 +266,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"gaussdb": {
 		Name:    "gaussdb",
 		Version: "mysql/v3",
+	},
+	"gaussdbv3": {
+		Name:    "gaussdb",
+		Version: "v3",
 	},
 	"opengauss": {
 		Name:    "gaussdb-opengauss",

--- a/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_cassandra_instance_test.go
@@ -98,13 +98,17 @@ resource "huaweicloud_vpc" "test" {
 }
 
 resource "huaweicloud_vpc_subnet" "test" {
-  name          = "%s"
-  cidr          = "192.168.0.0/16"
-  gateway_ip    = "192.168.0.1"
+  name       = "%s"
+  cidr       = "192.168.0.0/16"
+  gateway_ip = "192.168.0.1"
 
   primary_dns   = "100.125.1.250"
   secondary_dns = "100.125.21.250"
   vpc_id        = huaweicloud_vpc.test.id
+
+  timeouts {
+    delete = "20m"
+  }
 }
 `, rName, rName)
 }

--- a/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -29,6 +29,15 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGaussDBInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "audit_log_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccGaussDBInstanceConfig_basicUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGaussDBInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "audit_log_enabled", "true"),
 				),
 			},
 		},
@@ -95,15 +104,39 @@ data "huaweicloud_networking_secgroup" "test" {
 }
 
 resource "huaweicloud_gaussdb_mysql_instance" "test" {
-  name        = "%s"
-  password    = "Test@123"
-  flavor      = "gaussdb.mysql.4xlarge.x86.4"
-  vpc_id      = huaweicloud_vpc.test.id
-  subnet_id   = huaweicloud_vpc_subnet.test.id
+  name      = "%s"
+  password  = "Test@123"
+  flavor    = "gaussdb.mysql.4xlarge.x86.4"
+  vpc_id    = huaweicloud_vpc.test.id
+  subnet_id = huaweicloud_vpc_subnet.test.id
 
   security_group_id = data.huaweicloud_networking_secgroup.test.id
 
   enterprise_project_id = "0"
+}
+`, testAccVpcConfig_Base(rName), rName)
+}
+
+func testAccGaussDBInstanceConfig_basicUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
+resource "huaweicloud_gaussdb_mysql_instance" "test" {
+  name      = "%s"
+  password  = "Test@123"
+  flavor    = "gaussdb.mysql.4xlarge.x86.4"
+  vpc_id    = huaweicloud_vpc.test.id
+  subnet_id = huaweicloud_vpc_subnet.test.id
+
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+
+  enterprise_project_id = "0"
+
+  audit_log_enabled = true
 }
 `, testAccVpcConfig_Base(rName), rName)
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/gaussDB_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/gaussDB_client.go
@@ -1,0 +1,427 @@
+package v3
+
+import (
+	http_client "github.com/huaweicloud/huaweicloud-sdk-go-v3/core"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model"
+)
+
+type GaussDBClient struct {
+	HcClient *http_client.HcHttpClient
+}
+
+func NewGaussDBClient(hcClient *http_client.HcHttpClient) *GaussDBClient {
+	return &GaussDBClient{HcClient: hcClient}
+}
+
+func GaussDBClientBuilder() *http_client.HcHttpClientBuilder {
+	builder := http_client.NewHcHttpClientBuilder()
+	return builder
+}
+
+//批量添加或删除指定实例的标签。
+func (c *GaussDBClient) BatchTagAction(request *model.BatchTagActionRequest) (*model.BatchTagActionResponse, error) {
+	requestDef := GenReqDefForBatchTagAction()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchTagActionResponse), nil
+	}
+}
+
+//变更数据库实例的规格。
+func (c *GaussDBClient) ChangeGaussMySqlInstanceSpecification(request *model.ChangeGaussMySqlInstanceSpecificationRequest) (*model.ChangeGaussMySqlInstanceSpecificationResponse, error) {
+	requestDef := GenReqDefForChangeGaussMySqlInstanceSpecification()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ChangeGaussMySqlInstanceSpecificationResponse), nil
+	}
+}
+
+//创建手动备份
+func (c *GaussDBClient) CreateGaussMySqlBackup(request *model.CreateGaussMySqlBackupRequest) (*model.CreateGaussMySqlBackupResponse, error) {
+	requestDef := GenReqDefForCreateGaussMySqlBackup()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateGaussMySqlBackupResponse), nil
+	}
+}
+
+//创建云数据库 GaussDB(for MySQL)实例。
+func (c *GaussDBClient) CreateGaussMySqlInstance(request *model.CreateGaussMySqlInstanceRequest) (*model.CreateGaussMySqlInstanceResponse, error) {
+	requestDef := GenReqDefForCreateGaussMySqlInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateGaussMySqlInstanceResponse), nil
+	}
+}
+
+//开启数据库代理，只支持ELB模式。
+func (c *GaussDBClient) CreateGaussMySqlProxy(request *model.CreateGaussMySqlProxyRequest) (*model.CreateGaussMySqlProxyResponse, error) {
+	requestDef := GenReqDefForCreateGaussMySqlProxy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateGaussMySqlProxyResponse), nil
+	}
+}
+
+//创建只读节点。
+func (c *GaussDBClient) CreateGaussMySqlReadonlyNode(request *model.CreateGaussMySqlReadonlyNodeRequest) (*model.CreateGaussMySqlReadonlyNodeResponse, error) {
+	requestDef := GenReqDefForCreateGaussMySqlReadonlyNode()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateGaussMySqlReadonlyNodeResponse), nil
+	}
+}
+
+//删除数据库实例，不支持删除包周期实例。
+func (c *GaussDBClient) DeleteGaussMySqlInstance(request *model.DeleteGaussMySqlInstanceRequest) (*model.DeleteGaussMySqlInstanceResponse, error) {
+	requestDef := GenReqDefForDeleteGaussMySqlInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteGaussMySqlInstanceResponse), nil
+	}
+}
+
+//关闭数据库代理。
+func (c *GaussDBClient) DeleteGaussMySqlProxy(request *model.DeleteGaussMySqlProxyRequest) (*model.DeleteGaussMySqlProxyResponse, error) {
+	requestDef := GenReqDefForDeleteGaussMySqlProxy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteGaussMySqlProxyResponse), nil
+	}
+}
+
+//删除实例的只读节点。多可用区模式删除只读节点时，要保证删除后，剩余的只读节点和主节点在不同的可用区中，否则无法删除该只读节点。
+func (c *GaussDBClient) DeleteGaussMySqlReadonlyNode(request *model.DeleteGaussMySqlReadonlyNodeRequest) (*model.DeleteGaussMySqlReadonlyNodeResponse, error) {
+	requestDef := GenReqDefForDeleteGaussMySqlReadonlyNode()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteGaussMySqlReadonlyNodeResponse), nil
+	}
+}
+
+//包周期存储扩容
+func (c *GaussDBClient) ExpandGaussMySqlInstanceVolume(request *model.ExpandGaussMySqlInstanceVolumeRequest) (*model.ExpandGaussMySqlInstanceVolumeResponse, error) {
+	requestDef := GenReqDefForExpandGaussMySqlInstanceVolume()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ExpandGaussMySqlInstanceVolumeResponse), nil
+	}
+}
+
+//扩容数据库代理节点的数量。 DeC专属云账号暂不支持数据库代理。
+func (c *GaussDBClient) ExpandGaussMySqlProxy(request *model.ExpandGaussMySqlProxyRequest) (*model.ExpandGaussMySqlProxyResponse, error) {
+	requestDef := GenReqDefForExpandGaussMySqlProxy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ExpandGaussMySqlProxyResponse), nil
+	}
+}
+
+//获取参数模板列表，包括所有数据库的默认参数模板和用户创建的参数模板。
+func (c *GaussDBClient) ListGaussMySqlConfigurations(request *model.ListGaussMySqlConfigurationsRequest) (*model.ListGaussMySqlConfigurationsResponse, error) {
+	requestDef := GenReqDefForListGaussMySqlConfigurations()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListGaussMySqlConfigurationsResponse), nil
+	}
+}
+
+//获取专属资源池列表，包括用户开通的所有专属资源池信息。
+func (c *GaussDBClient) ListGaussMySqlDedicatedResources(request *model.ListGaussMySqlDedicatedResourcesRequest) (*model.ListGaussMySqlDedicatedResourcesResponse, error) {
+	requestDef := GenReqDefForListGaussMySqlDedicatedResources()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListGaussMySqlDedicatedResourcesResponse), nil
+	}
+}
+
+//查询数据库错误日志。
+func (c *GaussDBClient) ListGaussMySqlErrorLog(request *model.ListGaussMySqlErrorLogRequest) (*model.ListGaussMySqlErrorLogResponse, error) {
+	requestDef := GenReqDefForListGaussMySqlErrorLog()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListGaussMySqlErrorLogResponse), nil
+	}
+}
+
+//根据指定条件查询实例列表。
+func (c *GaussDBClient) ListGaussMySqlInstances(request *model.ListGaussMySqlInstancesRequest) (*model.ListGaussMySqlInstancesResponse, error) {
+	requestDef := GenReqDefForListGaussMySqlInstances()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListGaussMySqlInstancesResponse), nil
+	}
+}
+
+//查询数据库慢日志
+func (c *GaussDBClient) ListGaussMySqlSlowLog(request *model.ListGaussMySqlSlowLogRequest) (*model.ListGaussMySqlSlowLogResponse, error) {
+	requestDef := GenReqDefForListGaussMySqlSlowLog()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListGaussMySqlSlowLogResponse), nil
+	}
+}
+
+//查询指定实例的标签信息。
+func (c *GaussDBClient) ListInstanceTags(request *model.ListInstanceTagsRequest) (*model.ListInstanceTagsResponse, error) {
+	requestDef := GenReqDefForListInstanceTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListInstanceTagsResponse), nil
+	}
+}
+
+//查询指定project ID下实例的所有标签集合。
+func (c *GaussDBClient) ListProjectTags(request *model.ListProjectTagsRequest) (*model.ListProjectTagsResponse, error) {
+	requestDef := GenReqDefForListProjectTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListProjectTagsResponse), nil
+	}
+}
+
+//重置数据库密码
+func (c *GaussDBClient) ResetGaussMySqlPassword(request *model.ResetGaussMySqlPasswordRequest) (*model.ResetGaussMySqlPasswordResponse, error) {
+	requestDef := GenReqDefForResetGaussMySqlPassword()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResetGaussMySqlPasswordResponse), nil
+	}
+}
+
+//设置指定企业项目的资源配额。
+func (c *GaussDBClient) SetGaussMySqlQuotas(request *model.SetGaussMySqlQuotasRequest) (*model.SetGaussMySqlQuotasResponse, error) {
+	requestDef := GenReqDefForSetGaussMySqlQuotas()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.SetGaussMySqlQuotasResponse), nil
+	}
+}
+
+//查询审计日志开关状态
+func (c *GaussDBClient) ShowAuditLog(request *model.ShowAuditLogRequest) (*model.ShowAuditLogResponse, error) {
+	requestDef := GenReqDefForShowAuditLog()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowAuditLogResponse), nil
+	}
+}
+
+//查询备份列表
+func (c *GaussDBClient) ShowGaussMySqlBackupList(request *model.ShowGaussMySqlBackupListRequest) (*model.ShowGaussMySqlBackupListResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlBackupList()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlBackupListResponse), nil
+	}
+}
+
+//查询自动备份策略。
+func (c *GaussDBClient) ShowGaussMySqlBackupPolicy(request *model.ShowGaussMySqlBackupPolicyRequest) (*model.ShowGaussMySqlBackupPolicyResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlBackupPolicy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlBackupPolicyResponse), nil
+	}
+}
+
+//获取指定数据库引擎对应的数据库版本信息。
+func (c *GaussDBClient) ShowGaussMySqlEngineVersion(request *model.ShowGaussMySqlEngineVersionRequest) (*model.ShowGaussMySqlEngineVersionResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlEngineVersion()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlEngineVersionResponse), nil
+	}
+}
+
+//获取指定数据库引擎版本对应的规格信息。
+func (c *GaussDBClient) ShowGaussMySqlFlavors(request *model.ShowGaussMySqlFlavorsRequest) (*model.ShowGaussMySqlFlavorsResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlFlavors()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlFlavorsResponse), nil
+	}
+}
+
+//查询实例详情信息
+func (c *GaussDBClient) ShowGaussMySqlInstanceInfo(request *model.ShowGaussMySqlInstanceInfoRequest) (*model.ShowGaussMySqlInstanceInfoResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlInstanceInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlInstanceInfoResponse), nil
+	}
+}
+
+//获取指定ID的任务信息。
+func (c *GaussDBClient) ShowGaussMySqlJobInfo(request *model.ShowGaussMySqlJobInfoRequest) (*model.ShowGaussMySqlJobInfoResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlJobInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlJobInfoResponse), nil
+	}
+}
+
+//获取指定租户的资源配额。
+func (c *GaussDBClient) ShowGaussMySqlProjectQuotas(request *model.ShowGaussMySqlProjectQuotasRequest) (*model.ShowGaussMySqlProjectQuotasResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlProjectQuotas()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlProjectQuotasResponse), nil
+	}
+}
+
+//查询数据库代理信息。
+func (c *GaussDBClient) ShowGaussMySqlProxy(request *model.ShowGaussMySqlProxyRequest) (*model.ShowGaussMySqlProxyResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlProxy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlProxyResponse), nil
+	}
+}
+
+//查询数据库代理规格信息。
+func (c *GaussDBClient) ShowGaussMySqlProxyFlavors(request *model.ShowGaussMySqlProxyFlavorsRequest) (*model.ShowGaussMySqlProxyFlavorsResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlProxyFlavors()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlProxyFlavorsResponse), nil
+	}
+}
+
+//获取指定企业项目的资源配额。
+func (c *GaussDBClient) ShowGaussMySqlQuotas(request *model.ShowGaussMySqlQuotasRequest) (*model.ShowGaussMySqlQuotasResponse, error) {
+	requestDef := GenReqDefForShowGaussMySqlQuotas()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGaussMySqlQuotasResponse), nil
+	}
+}
+
+//查询实例秒级监控频率。
+func (c *GaussDBClient) ShowInstanceMonitorExtend(request *model.ShowInstanceMonitorExtendRequest) (*model.ShowInstanceMonitorExtendResponse, error) {
+	requestDef := GenReqDefForShowInstanceMonitorExtend()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowInstanceMonitorExtendResponse), nil
+	}
+}
+
+//开启或者关闭审计日志
+func (c *GaussDBClient) UpdateAuditLog(request *model.UpdateAuditLogRequest) (*model.UpdateAuditLogResponse, error) {
+	requestDef := GenReqDefForUpdateAuditLog()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateAuditLogResponse), nil
+	}
+}
+
+//修改备份策略
+func (c *GaussDBClient) UpdateGaussMySqlBackupPolicy(request *model.UpdateGaussMySqlBackupPolicyRequest) (*model.UpdateGaussMySqlBackupPolicyResponse, error) {
+	requestDef := GenReqDefForUpdateGaussMySqlBackupPolicy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateGaussMySqlBackupPolicyResponse), nil
+	}
+}
+
+//修改实例名称
+func (c *GaussDBClient) UpdateGaussMySqlInstanceName(request *model.UpdateGaussMySqlInstanceNameRequest) (*model.UpdateGaussMySqlInstanceNameResponse, error) {
+	requestDef := GenReqDefForUpdateGaussMySqlInstanceName()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateGaussMySqlInstanceNameResponse), nil
+	}
+}
+
+//修改指定企业项目的资源配额。
+func (c *GaussDBClient) UpdateGaussMySqlQuotas(request *model.UpdateGaussMySqlQuotasRequest) (*model.UpdateGaussMySqlQuotasResponse, error) {
+	requestDef := GenReqDefForUpdateGaussMySqlQuotas()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateGaussMySqlQuotasResponse), nil
+	}
+}
+
+//打开/关闭/修改实例秒级监控。
+func (c *GaussDBClient) UpdateInstanceMonitor(request *model.UpdateInstanceMonitorRequest) (*model.UpdateInstanceMonitorResponse, error) {
+	requestDef := GenReqDefForUpdateInstanceMonitor()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateInstanceMonitorResponse), nil
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/gaussDB_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/gaussDB_meta.go
@@ -1,0 +1,981 @@
+package v3
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/def"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model"
+	"net/http"
+)
+
+func GenReqDefForBatchTagAction() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/tags/action").
+		WithResponse(new(model.BatchTagActionResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForChangeGaussMySqlInstanceSpecification() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/action").
+		WithResponse(new(model.ChangeGaussMySqlInstanceSpecificationResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateGaussMySqlBackup() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/backups/create").
+		WithResponse(new(model.CreateGaussMySqlBackupResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateGaussMySqlInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances").
+		WithResponse(new(model.CreateGaussMySqlInstanceResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateGaussMySqlProxy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/proxy").
+		WithResponse(new(model.CreateGaussMySqlProxyResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateGaussMySqlReadonlyNode() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/nodes/enlarge").
+		WithResponse(new(model.CreateGaussMySqlReadonlyNodeResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteGaussMySqlInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v3/{project_id}/instances/{instance_id}").
+		WithResponse(new(model.DeleteGaussMySqlInstanceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteGaussMySqlProxy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v3/{project_id}/instances/{instance_id}/proxy").
+		WithResponse(new(model.DeleteGaussMySqlProxyResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteGaussMySqlReadonlyNode() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v3/{project_id}/instances/{instance_id}/nodes/{node_id}").
+		WithResponse(new(model.DeleteGaussMySqlReadonlyNodeResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("NodeId").
+		WithJsonTag("node_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForExpandGaussMySqlInstanceVolume() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/volume/extend").
+		WithResponse(new(model.ExpandGaussMySqlInstanceVolumeResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForExpandGaussMySqlProxy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/proxy/enlarge").
+		WithResponse(new(model.ExpandGaussMySqlProxyResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListGaussMySqlConfigurations() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/configurations").
+		WithResponse(new(model.ListGaussMySqlConfigurationsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListGaussMySqlDedicatedResources() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/dedicated-resources").
+		WithResponse(new(model.ListGaussMySqlDedicatedResourcesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListGaussMySqlErrorLog() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/errorlog").
+		WithResponse(new(model.ListGaussMySqlErrorLogResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartDate").
+		WithJsonTag("start_date").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndDate").
+		WithJsonTag("end_date").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Level").
+		WithJsonTag("level").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("NodeId").
+		WithJsonTag("node_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListGaussMySqlInstances() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances").
+		WithResponse(new(model.ListGaussMySqlInstancesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Id").
+		WithJsonTag("id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Name").
+		WithJsonTag("name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Type").
+		WithJsonTag("type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DatastoreType").
+		WithJsonTag("datastore_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("VpcId").
+		WithJsonTag("vpc_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("SubnetId").
+		WithJsonTag("subnet_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PrivateIp").
+		WithJsonTag("private_ip").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Tags").
+		WithJsonTag("tags").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListGaussMySqlSlowLog() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/slowlog").
+		WithResponse(new(model.ListGaussMySqlSlowLogResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartDate").
+		WithJsonTag("start_date").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndDate").
+		WithJsonTag("end_date").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Type").
+		WithJsonTag("type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("NodeId").
+		WithJsonTag("node_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListInstanceTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/tags").
+		WithResponse(new(model.ListInstanceTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListProjectTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/tags").
+		WithResponse(new(model.ListProjectTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResetGaussMySqlPassword() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/password").
+		WithResponse(new(model.ResetGaussMySqlPasswordResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForSetGaussMySqlQuotas() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/quotas").
+		WithResponse(new(model.SetGaussMySqlQuotasResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowAuditLog() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instance/{instance_id}/audit-log/switch-status").
+		WithResponse(new(model.ShowAuditLogResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlBackupList() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/backups").
+		WithResponse(new(model.ShowGaussMySqlBackupListResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BackupId").
+		WithJsonTag("backup_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BackupType").
+		WithJsonTag("backup_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BeginTime").
+		WithJsonTag("begin_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlBackupPolicy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/backups/policy").
+		WithResponse(new(model.ShowGaussMySqlBackupPolicyResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlEngineVersion() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/datastores/{database_name}").
+		WithResponse(new(model.ShowGaussMySqlEngineVersionResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DatabaseName").
+		WithJsonTag("database_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlFlavors() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/flavors/{database_name}").
+		WithResponse(new(model.ShowGaussMySqlFlavorsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DatabaseName").
+		WithJsonTag("database_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("VersionName").
+		WithJsonTag("version_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("AvailabilityZoneMode").
+		WithJsonTag("availability_zone_mode").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("SpecCode").
+		WithJsonTag("spec_code").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlInstanceInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}").
+		WithResponse(new(model.ShowGaussMySqlInstanceInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlJobInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/jobs").
+		WithResponse(new(model.ShowGaussMySqlJobInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Id").
+		WithJsonTag("id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlProjectQuotas() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/project-quotas").
+		WithResponse(new(model.ShowGaussMySqlProjectQuotasResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Type").
+		WithJsonTag("type").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlProxy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/proxy").
+		WithResponse(new(model.ShowGaussMySqlProxyResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlProxyFlavors() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/proxy/flavors").
+		WithResponse(new(model.ShowGaussMySqlProxyFlavorsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGaussMySqlQuotas() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/quotas").
+		WithResponse(new(model.ShowGaussMySqlQuotasResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectName").
+		WithJsonTag("enterprise_project_name").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowInstanceMonitorExtend() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/instances/{instance_id}/monitor-policy").
+		WithResponse(new(model.ShowInstanceMonitorExtendResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateAuditLog() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instance/{instance_id}/audit-log/switch").
+		WithResponse(new(model.UpdateAuditLogResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateGaussMySqlBackupPolicy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v3/{project_id}/instances/{instance_id}/backups/policy/update").
+		WithResponse(new(model.UpdateGaussMySqlBackupPolicyResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateGaussMySqlInstanceName() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v3/{project_id}/instances/{instance_id}/name").
+		WithResponse(new(model.UpdateGaussMySqlInstanceNameResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateGaussMySqlQuotas() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v3/{project_id}/quotas").
+		WithResponse(new(model.UpdateGaussMySqlQuotasResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateInstanceMonitor() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v3/{project_id}/instances/{instance_id}/monitor-policy").
+		WithResponse(new(model.UpdateInstanceMonitorResponse)).
+		WithContentType("application/json;charset=UTF-8")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_backup.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_backup.go
@@ -1,0 +1,123 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type Backup struct {
+	// 备份ID
+
+	Id *string `json:"id,omitempty"`
+	// 备份名称。
+
+	Name *string `json:"name,omitempty"`
+	// 备份描述。
+
+	Descriprion *string `json:"descriprion,omitempty"`
+	// 备份开始时间，格式为“yyyy-mm-ddThh:mm:ssZ”，其中T指时间字段的开始；Z指时区偏移量。
+
+	BeginTime *string `json:"begin_time,omitempty"`
+	// 备份状态
+
+	Status *BackupStatus `json:"status,omitempty"`
+	// 备份类型，取值：
+
+	Type *BackupType `json:"type,omitempty"`
+	// 实例ID。
+
+	InstanceId *string `json:"instance_id,omitempty"`
+}
+
+func (o Backup) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Backup struct{}"
+	}
+
+	return strings.Join([]string{"Backup", string(data)}, " ")
+}
+
+type BackupStatus struct {
+	value string
+}
+
+type BackupStatusEnum struct {
+	BUILDING  BackupStatus
+	COMPLETED BackupStatus
+	FAILED    BackupStatus
+	AVAILABLE BackupStatus
+}
+
+func GetBackupStatusEnum() BackupStatusEnum {
+	return BackupStatusEnum{
+		BUILDING: BackupStatus{
+			value: "BUILDING：备份中。",
+		},
+		COMPLETED: BackupStatus{
+			value: "COMPLETED：备份完成。",
+		},
+		FAILED: BackupStatus{
+			value: "FAILED：备份失败。",
+		},
+		AVAILABLE: BackupStatus{
+			value: "AVAILABLE：备份可用。",
+		},
+	}
+}
+
+func (c BackupStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BackupStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type BackupType struct {
+	value string
+}
+
+type BackupTypeEnum struct {
+	MANUAL BackupType
+}
+
+func GetBackupTypeEnum() BackupTypeEnum {
+	return BackupTypeEnum{
+		MANUAL: BackupType{
+			value: "manual：手动全量备份。",
+		},
+	}
+}
+
+func (c BackupType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BackupType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_backup_policy.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_backup_policy.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 备份策略信息。
+type BackupPolicy struct {
+	// 指定已生成的备份文件可以保存的天数。取值范围：1～732。
+
+	KeepDays int32 `json:"keep_days"`
+	// 备份时间段。自动备份将在该时间段内触发。 取值范围：格式必须为hh:mm-HH:MM且有效，当前时间指UTC时间。
+
+	StartTime *string `json:"start_time,omitempty"`
+	// 备份周期配置。自动备份将在每星期指定的天进行。 取值范围：格式为逗号隔开的数字，数字代表星期。
+
+	Period *string `json:"period,omitempty"`
+	// 1级备份保留数量。当一级备份开关开启时，返回此参数。
+
+	RetentionNumBackupLevel1 *int32 `json:"retention_num_backup_level1,omitempty"`
+}
+
+func (o BackupPolicy) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BackupPolicy struct{}"
+	}
+
+	return strings.Join([]string{"BackupPolicy", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_backups.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_backups.go
@@ -1,0 +1,183 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type Backups struct {
+	// 备份ID。
+
+	Id *string `json:"id,omitempty"`
+	// 备份名称。
+
+	Name *string `json:"name,omitempty"`
+	// 备份开始时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	BeginTime *string `json:"begin_time,omitempty"`
+	// 备份结束时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	EndTime *string `json:"end_time,omitempty"`
+	// 备份状态
+
+	Status *BackupsStatus `json:"status,omitempty"`
+	// 备份花费时间(单位：minutes)
+
+	TakeUpTime *int32 `json:"take_up_time,omitempty"`
+	// 备份类型
+
+	Type *BackupsType `json:"type,omitempty"`
+	// 备份大小，(单位：MB)
+
+	Size *int64 `json:"size,omitempty"`
+
+	Datastore *MysqlDatastore `json:"datastore,omitempty"`
+	// 实例ID。
+
+	InstanceId *string `json:"instance_id,omitempty"`
+	// 备份级别。当开启一级备份开关时，返回该参数。
+
+	BackupLevel *BackupsBackupLevel `json:"backup_level,omitempty"`
+	// 备份文件描述信息
+
+	Description *string `json:"description,omitempty"`
+}
+
+func (o Backups) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Backups struct{}"
+	}
+
+	return strings.Join([]string{"Backups", string(data)}, " ")
+}
+
+type BackupsStatus struct {
+	value string
+}
+
+type BackupsStatusEnum struct {
+	BUILDING  BackupsStatus
+	COMPLETED BackupsStatus
+	FAILED    BackupsStatus
+	AVAILABLE BackupsStatus
+}
+
+func GetBackupsStatusEnum() BackupsStatusEnum {
+	return BackupsStatusEnum{
+		BUILDING: BackupsStatus{
+			value: "BUILDING：备份中。",
+		},
+		COMPLETED: BackupsStatus{
+			value: "COMPLETED：备份完成。",
+		},
+		FAILED: BackupsStatus{
+			value: "FAILED：备份失败。",
+		},
+		AVAILABLE: BackupsStatus{
+			value: "AVAILABLE：备份可用。",
+		},
+	}
+}
+
+func (c BackupsStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BackupsStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type BackupsType struct {
+	value string
+}
+
+type BackupsTypeEnum struct {
+	AUTO   BackupsType
+	MANUAL BackupsType
+}
+
+func GetBackupsTypeEnum() BackupsTypeEnum {
+	return BackupsTypeEnum{
+		AUTO: BackupsType{
+			value: "auto：自动全量备份。",
+		},
+		MANUAL: BackupsType{
+			value: "manual：手动全量备份。",
+		},
+	}
+}
+
+func (c BackupsType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BackupsType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type BackupsBackupLevel struct {
+	value string
+}
+
+type BackupsBackupLevelEnum struct {
+	E_0 BackupsBackupLevel
+	E_1 BackupsBackupLevel
+	E_2 BackupsBackupLevel
+}
+
+func GetBackupsBackupLevelEnum() BackupsBackupLevelEnum {
+	return BackupsBackupLevelEnum{
+		E_0: BackupsBackupLevel{
+			value: "0：备份正在创建中或者备份失败。",
+		},
+		E_1: BackupsBackupLevel{
+			value: "1：一级备份。",
+		},
+		E_2: BackupsBackupLevel{
+			value: "2：二级备份。",
+		},
+	}
+}
+
+func (c BackupsBackupLevel) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BackupsBackupLevel) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_batch_operate_instance_tag_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_batch_operate_instance_tag_request_body.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchOperateInstanceTagRequestBody struct {
+	// 操作标识，取值： - create，表示添加标签。 - delete，表示删除标签。
+
+	Action string `json:"action"`
+	// 标签列表。
+
+	Tags []TagItem `json:"tags"`
+}
+
+func (o BatchOperateInstanceTagRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchOperateInstanceTagRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"BatchOperateInstanceTagRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_batch_tag_action_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_batch_tag_action_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type BatchTagActionRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+
+	Body *BatchOperateInstanceTagRequestBody `json:"body,omitempty"`
+}
+
+func (o BatchTagActionRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchTagActionRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchTagActionRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_batch_tag_action_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_batch_tag_action_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type BatchTagActionResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o BatchTagActionResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchTagActionResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchTagActionResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_change_gauss_my_sql_instance_specification_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_change_gauss_my_sql_instance_specification_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ChangeGaussMySqlInstanceSpecificationRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *MysqlChangeSpecificationRequest `json:"body,omitempty"`
+}
+
+func (o ChangeGaussMySqlInstanceSpecificationRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ChangeGaussMySqlInstanceSpecificationRequest struct{}"
+	}
+
+	return strings.Join([]string{"ChangeGaussMySqlInstanceSpecificationRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_change_gauss_my_sql_instance_specification_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_change_gauss_my_sql_instance_specification_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ChangeGaussMySqlInstanceSpecificationResponse struct {
+	// 规格变更的任务id，仅变更按需实例时会返回该参数
+
+	JobId *string `json:"job_id,omitempty"`
+	// 订单id，仅变更包周期实例时会返回该参数
+
+	OrderId        *string `json:"order_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ChangeGaussMySqlInstanceSpecificationResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ChangeGaussMySqlInstanceSpecificationResponse struct{}"
+	}
+
+	return strings.Join([]string{"ChangeGaussMySqlInstanceSpecificationResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_configuration_summary.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_configuration_summary.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 参数模板信息。
+type ConfigurationSummary struct {
+	// 参数组ID。
+
+	Id string `json:"id"`
+	// 参数组名称。
+
+	Name string `json:"name"`
+	// 参数组描述。
+
+	Description *string `json:"description,omitempty"`
+	// 引擎版本。
+
+	DatastoreVersionName string `json:"datastore_version_name"`
+	// 引擎名。
+
+	DatastoreName string `json:"datastore_name"`
+	// 创建时间，格式为\"yyyy-MM-ddTHH:mm:ssZ\"。  其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	Created string `json:"created"`
+	// 更新时间，格式为\"yyyy-MM-ddTHH:mm:ssZ\"。  其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	Updated string `json:"updated"`
+	// 是否是用户自定义参数模板：  - false，表示为系统默认参数模板。 - true，表示为用户自定义参数模板。
+
+	UserDefined bool `json:"user_defined"`
+}
+
+func (o ConfigurationSummary) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ConfigurationSummary struct{}"
+	}
+
+	return strings.Join([]string{"ConfigurationSummary", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_backup_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_backup_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateGaussMySqlBackupRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+
+	Body *MysqlCreateBackupRequest `json:"body,omitempty"`
+}
+
+func (o CreateGaussMySqlBackupRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlBackupRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlBackupRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_backup_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_backup_response.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateGaussMySqlBackupResponse struct {
+	Backup *Backup `json:"backup,omitempty"`
+	// 任务ID。
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateGaussMySqlBackupResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlBackupResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlBackupResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_instance_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateGaussMySqlInstanceRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+
+	Body *MysqlInstanceRequest `json:"body,omitempty"`
+}
+
+func (o CreateGaussMySqlInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_instance_response.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateGaussMySqlInstanceResponse struct {
+	Instance *MysqlInstanceResponse `json:"instance,omitempty"`
+	// 实例创建的任务id。  仅创建按需实例时会返回该参数。
+
+	JobId *string `json:"job_id,omitempty"`
+	// 订单号，创建包年包月时返回该参数。
+
+	OrderId        *string `json:"order_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateGaussMySqlInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_proxy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_proxy_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateGaussMySqlProxyRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+
+	Body *OpenMysqlProxyRequestBody `json:"body,omitempty"`
+}
+
+func (o CreateGaussMySqlProxyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlProxyRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlProxyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_proxy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_proxy_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateGaussMySqlProxyResponse struct {
+	// 任务ID。
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateGaussMySqlProxyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlProxyResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlProxyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_readonly_node_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_readonly_node_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateGaussMySqlReadonlyNodeRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *MysqlCreateReadonlyNodeRequest `json:"body,omitempty"`
+}
+
+func (o CreateGaussMySqlReadonlyNodeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlReadonlyNodeRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlReadonlyNodeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_readonly_node_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_create_gauss_my_sql_readonly_node_response.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateGaussMySqlReadonlyNodeResponse struct {
+	// 实例ID。
+
+	InstanceId *string `json:"instance_id,omitempty"`
+	// 节点名称列表。
+
+	NodeNames *[]string `json:"node_names,omitempty"`
+	// 实例创建的任务id。  仅创建按需实例时会返回该参数。
+
+	JobId *string `json:"job_id,omitempty"`
+	// 订单号，创建包年包月时返回该参数。
+
+	OrderId        *string `json:"order_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateGaussMySqlReadonlyNodeResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateGaussMySqlReadonlyNodeResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateGaussMySqlReadonlyNodeResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_dedicated_resource.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_dedicated_resource.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 专属资源池信息。
+type DedicatedResource struct {
+	// 专属资源池ID。
+
+	Id *string `json:"id,omitempty"`
+	// 专属资源池名称
+
+	ResourceName *string `json:"resource_name,omitempty"`
+	// 数据库引擎名称
+
+	EngineName *string `json:"engine_name,omitempty"`
+	// CPU架构
+
+	Architecture *string `json:"architecture,omitempty"`
+	// 专属资源池状态
+
+	Status *DedicatedResourceStatus `json:"status,omitempty"`
+
+	Capacity *DedicatedResourceCapacity `json:"capacity,omitempty"`
+	// 专属资源池可用区信息。
+
+	AvailabilityZone *[]string `json:"availability_zone,omitempty"`
+}
+
+func (o DedicatedResource) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DedicatedResource struct{}"
+	}
+
+	return strings.Join([]string{"DedicatedResource", string(data)}, " ")
+}
+
+type DedicatedResourceStatus struct {
+	value string
+}
+
+type DedicatedResourceStatusEnum struct {
+	NORMAL    DedicatedResourceStatus
+	BUILDING  DedicatedResourceStatus
+	EXTENDING DedicatedResourceStatus
+	DELETED   DedicatedResourceStatus
+}
+
+func GetDedicatedResourceStatusEnum() DedicatedResourceStatusEnum {
+	return DedicatedResourceStatusEnum{
+		NORMAL: DedicatedResourceStatus{
+			value: "NORMAL",
+		},
+		BUILDING: DedicatedResourceStatus{
+			value: "BUILDING",
+		},
+		EXTENDING: DedicatedResourceStatus{
+			value: "EXTENDING",
+		},
+		DELETED: DedicatedResourceStatus{
+			value: "DELETED",
+		},
+	}
+}
+
+func (c DedicatedResourceStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DedicatedResourceStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_dedicated_resource_capacity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_dedicated_resource_capacity.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type DedicatedResourceCapacity struct {
+	// 内存大小，单位GB
+
+	Ram *int32 `json:"ram,omitempty"`
+	// 磁盘容量，单位GB
+
+	Volume *int64 `json:"volume,omitempty"`
+	// cpu核数
+
+	Vcpus *int32 `json:"vcpus,omitempty"`
+}
+
+func (o DedicatedResourceCapacity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DedicatedResourceCapacity struct{}"
+	}
+
+	return strings.Join([]string{"DedicatedResourceCapacity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_instance_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeleteGaussMySqlInstanceRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o DeleteGaussMySqlInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteGaussMySqlInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteGaussMySqlInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_instance_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeleteGaussMySqlInstanceResponse struct {
+	// 任务ID。
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o DeleteGaussMySqlInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteGaussMySqlInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteGaussMySqlInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_proxy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_proxy_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeleteGaussMySqlProxyRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o DeleteGaussMySqlProxyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteGaussMySqlProxyRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteGaussMySqlProxyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_proxy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_proxy_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeleteGaussMySqlProxyResponse struct {
+	// 任务ID。
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o DeleteGaussMySqlProxyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteGaussMySqlProxyResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteGaussMySqlProxyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_readonly_node_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_readonly_node_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeleteGaussMySqlReadonlyNodeRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+	// 节点ID，严格匹配UUID规则。
+
+	NodeId string `json:"node_id"`
+}
+
+func (o DeleteGaussMySqlReadonlyNodeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteGaussMySqlReadonlyNodeRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteGaussMySqlReadonlyNodeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_readonly_node_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_delete_gauss_my_sql_readonly_node_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeleteGaussMySqlReadonlyNodeResponse struct {
+	// 任务ID。
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o DeleteGaussMySqlReadonlyNodeResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteGaussMySqlReadonlyNodeResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteGaussMySqlReadonlyNodeResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_enlarge_proxy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_enlarge_proxy_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// proxy节点扩容信息
+type EnlargeProxyRequest struct {
+	// proxy节点扩容操作需要扩容的节点数。本次扩容的节点数的取值范围：1~30之间的整数。 限制条件：该实例的proxy节点的总数量小于等于32。
+
+	NodeNum int32 `json:"node_num"`
+}
+
+func (o EnlargeProxyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "EnlargeProxyRequest struct{}"
+	}
+
+	return strings.Join([]string{"EnlargeProxyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_instance_volume_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_instance_volume_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ExpandGaussMySqlInstanceVolumeRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *MysqlExtendInstanceVolumeRequest `json:"body,omitempty"`
+}
+
+func (o ExpandGaussMySqlInstanceVolumeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ExpandGaussMySqlInstanceVolumeRequest struct{}"
+	}
+
+	return strings.Join([]string{"ExpandGaussMySqlInstanceVolumeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_instance_volume_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_instance_volume_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ExpandGaussMySqlInstanceVolumeResponse struct {
+	// 扩容后容量。
+
+	Size *int32 `json:"size,omitempty"`
+	// 订单号。
+
+	OrderId        *string `json:"order_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ExpandGaussMySqlInstanceVolumeResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ExpandGaussMySqlInstanceVolumeResponse struct{}"
+	}
+
+	return strings.Join([]string{"ExpandGaussMySqlInstanceVolumeResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_proxy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_proxy_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ExpandGaussMySqlProxyRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *EnlargeProxyRequest `json:"body,omitempty"`
+}
+
+func (o ExpandGaussMySqlProxyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ExpandGaussMySqlProxyRequest struct{}"
+	}
+
+	return strings.Join([]string{"ExpandGaussMySqlProxyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_proxy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_expand_gauss_my_sql_proxy_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ExpandGaussMySqlProxyResponse struct {
+	// 任务ID。
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ExpandGaussMySqlProxyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ExpandGaussMySqlProxyResponse struct{}"
+	}
+
+	return strings.Join([]string{"ExpandGaussMySqlProxyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_get_job_entities_info_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_get_job_entities_info_detail.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 根据不同的任务，显示不同的内容。
+type GetJobEntitiesInfoDetail struct {
+}
+
+func (o GetJobEntitiesInfoDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "GetJobEntitiesInfoDetail struct{}"
+	}
+
+	return strings.Join([]string{"GetJobEntitiesInfoDetail", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_get_job_info_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_get_job_info_detail.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 任务信息。
+type GetJobInfoDetail struct {
+	// 任务ID。
+
+	Id string `json:"id"`
+	// 任务名称。
+
+	Name string `json:"name"`
+	// 任务执行状态。  取值： - 值为“Running”，表示任务正在执行。 - 值为“Completed”，表示任务执行成功。 - 值为“Failed”，表示任务执行失败。
+
+	Status GetJobInfoDetailStatus `json:"status"`
+	// 创建时间，格式为\"yyyy-mm-ddThh:mm:ssZ\"。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为   +0800 说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Created string `json:"created"`
+	// 结束时间，格式为\"yyyy-mm-ddThh:mm:ssZ\"。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为   +0800 说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Ended *string `json:"ended,omitempty"`
+	// 任务执行进度。执行中状态才返回执行进度，例如60%，否则返回\"\"。
+
+	Process *string `json:"process,omitempty"`
+
+	Instance *GetJobInstanceInfoDetail `json:"instance"`
+
+	Entities *GetJobEntitiesInfoDetail `json:"entities,omitempty"`
+	// 任务执行失败时的错误信息。
+
+	FailReason *string `json:"fail_reason,omitempty"`
+}
+
+func (o GetJobInfoDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "GetJobInfoDetail struct{}"
+	}
+
+	return strings.Join([]string{"GetJobInfoDetail", string(data)}, " ")
+}
+
+type GetJobInfoDetailStatus struct {
+	value string
+}
+
+type GetJobInfoDetailStatusEnum struct {
+	RUNNING   GetJobInfoDetailStatus
+	COMPLETED GetJobInfoDetailStatus
+	FAILED    GetJobInfoDetailStatus
+}
+
+func GetGetJobInfoDetailStatusEnum() GetJobInfoDetailStatusEnum {
+	return GetJobInfoDetailStatusEnum{
+		RUNNING: GetJobInfoDetailStatus{
+			value: "Running",
+		},
+		COMPLETED: GetJobInfoDetailStatus{
+			value: "Completed",
+		},
+		FAILED: GetJobInfoDetailStatus{
+			value: "Failed",
+		},
+	}
+}
+
+func (c GetJobInfoDetailStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *GetJobInfoDetailStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_get_job_instance_info_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_get_job_instance_info_detail.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 指定ID任务的实例信息。
+type GetJobInstanceInfoDetail struct {
+	// 实例ID。
+
+	Id string `json:"id"`
+	// 实例名称。
+
+	Name string `json:"name"`
+}
+
+func (o GetJobInstanceInfoDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "GetJobInstanceInfoDetail struct{}"
+	}
+
+	return strings.Join([]string{"GetJobInstanceInfoDetail", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_instance_tag_item.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_instance_tag_item.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type InstanceTagItem struct {
+	// 标签键。
+
+	Key string `json:"key"`
+	// 标签值。
+
+	Value string `json:"value"`
+}
+
+func (o InstanceTagItem) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "InstanceTagItem struct{}"
+	}
+
+	return strings.Join([]string{"InstanceTagItem", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_configurations_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_configurations_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListGaussMySqlConfigurationsRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100。
+
+	Limit *int32 `json:"limit,omitempty"`
+}
+
+func (o ListGaussMySqlConfigurationsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlConfigurationsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlConfigurationsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_configurations_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_configurations_response.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListGaussMySqlConfigurationsResponse struct {
+	Configurations *[]ConfigurationSummary `json:"configurations,omitempty"`
+	// 参数模板的总数。
+
+	TotalCount     *int32 `json:"total_count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListGaussMySqlConfigurationsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlConfigurationsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlConfigurationsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_dedicated_resources_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_dedicated_resources_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListGaussMySqlDedicatedResourcesRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100。
+
+	Limit *int32 `json:"limit,omitempty"`
+}
+
+func (o ListGaussMySqlDedicatedResourcesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlDedicatedResourcesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlDedicatedResourcesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_dedicated_resources_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_dedicated_resources_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListGaussMySqlDedicatedResourcesResponse struct {
+	// 专属资源池信息
+
+	Resources *[]DedicatedResource `json:"resources,omitempty"`
+	// 专属资源池数量
+
+	TotalCount     *int32 `json:"total_count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListGaussMySqlDedicatedResourcesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlDedicatedResourcesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlDedicatedResourcesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_error_log_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_error_log_request.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListGaussMySqlErrorLogRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+	// 开始时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	StartDate string `json:"start_date"`
+	// 结束时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	EndDate string `json:"end_date"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100
+
+	Limit *int32 `json:"limit,omitempty"`
+	// 日志级别
+
+	Level *string `json:"level,omitempty"`
+	// 节点ID
+
+	NodeId *string `json:"node_id,omitempty"`
+}
+
+func (o ListGaussMySqlErrorLogRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlErrorLogRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlErrorLogRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_error_log_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_error_log_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListGaussMySqlErrorLogResponse struct {
+	// 错误日志具体信息。
+
+	ErrorLogList *[]MysqlErrorLogList `json:"error_log_list,omitempty"`
+	// 总记录数。
+
+	TotalRecord    *int32 `json:"total_record,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListGaussMySqlErrorLogResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlErrorLogResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlErrorLogResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_instances_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_instances_request.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListGaussMySqlInstancesRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID。 “*”为系统保留字符，如果id是以 “*”起始，表示按照 “*”后面的值模糊匹配，否则，按照id精确匹配查询。不能只传入 “*”。
+
+	Id *string `json:"id,omitempty"`
+	// 实例名称。  “*”为系统保留字符，如果name是以 “*”起始，表示按照 “*”后面的值模糊匹配，否则，按照name精确匹配查询。不能只传入 “*”。
+
+	Name *string `json:"name,omitempty"`
+	// 按照实例类型查询。目前仅支持Cluster。
+
+	Type *string `json:"type,omitempty"`
+	// 数据库类型，现在只支持gaussdb-mysql。
+
+	DatastoreType *string `json:"datastore_type,omitempty"`
+	// 虚拟私有云ID。
+
+	VpcId *string `json:"vpc_id,omitempty"`
+	// 子网的网络ID信息。
+
+	SubnetId *string `json:"subnet_id,omitempty"`
+	// 读写内网IP。
+
+	PrivateIp *string `json:"private_ip,omitempty"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100。
+
+	Limit *int32 `json:"limit,omitempty"`
+	// 根据实例标签键值对进行查询。{key}表示标签键，{value}表示标签值。如果同时使用多个标签键值对进行查询，中间使用逗号分隔开，表示查询同时包含指定标签键值对的实例。key不能重复，key之间是与的关系。
+
+	Tags *string `json:"tags,omitempty"`
+}
+
+func (o ListGaussMySqlInstancesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlInstancesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlInstancesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_instances_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_instances_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListGaussMySqlInstancesResponse struct {
+	// 实例列表信息。
+
+	Instances *[]MysqlInstanceListInfo `json:"instances,omitempty"`
+	// 总记录数。
+
+	TotalCount     *int32 `json:"total_count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListGaussMySqlInstancesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlInstancesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlInstancesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_slow_log_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_slow_log_request.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListGaussMySqlSlowLogRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+	// 开始时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	StartDate string `json:"start_date"`
+	// 结束时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	EndDate string `json:"end_date"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100
+
+	Limit *int32 `json:"limit,omitempty"`
+	// 语句类型，取空值，表示查询所有语句类型，也可指定如下日志类型：INSERT、UPDATE、SELECT、DELETE和CREATE
+
+	Type *string `json:"type,omitempty"`
+	// 节点ID
+
+	NodeId string `json:"node_id"`
+}
+
+func (o ListGaussMySqlSlowLogRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlSlowLogRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlSlowLogRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_slow_log_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_gauss_my_sql_slow_log_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListGaussMySqlSlowLogResponse struct {
+	// 错误日志具体信息。
+
+	SlowLogList *[]MysqlSlowLogList `json:"slow_log_list,omitempty"`
+	// 慢日志阈值。
+
+	LongQueryTime *string `json:"long_query_time,omitempty"`
+	// 总记录数。
+
+	TotalRecord    *int32 `json:"total_record,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListGaussMySqlSlowLogResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListGaussMySqlSlowLogResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListGaussMySqlSlowLogResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_instance_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_instance_tags_request.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListInstanceTagsRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100。
+
+	Limit *int32 `json:"limit,omitempty"`
+}
+
+func (o ListInstanceTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListInstanceTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListInstanceTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_instance_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_instance_tags_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListInstanceTagsResponse struct {
+	// 总记录数。
+
+	TotalCount *int32 `json:"total_count,omitempty"`
+	// 标签列表。
+
+	Tags           *[]ResourceTagItem `json:"tags,omitempty"`
+	HttpStatusCode int                `json:"-"`
+}
+
+func (o ListInstanceTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListInstanceTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListInstanceTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_project_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_project_tags_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListProjectTagsRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。
+
+	Offset *int32 `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100。
+
+	Limit *int32 `json:"limit,omitempty"`
+}
+
+func (o ListProjectTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProjectTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListProjectTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_project_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_list_project_tags_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListProjectTagsResponse struct {
+	// 总记录数。
+
+	TotalCount *int32 `json:"total_count,omitempty"`
+	// 标签列表。
+
+	Tags           *[]ProjectTagItem `json:"tags,omitempty"`
+	HttpStatusCode int               `json:"-"`
+}
+
+func (o ListProjectTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProjectTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListProjectTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_backup_policy.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_backup_policy.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlBackupPolicy struct {
+	// 备份时间段。自动备份将在该时间段内触发。取值范围：非空，格式必须为hh:mm-HH:MM且有效，当前时间指UTC时间。HH取值必须比hh大1。mm和MM取值必须相同，且取值必须为00。取值示例：21:00-22:00
+
+	StartTime string `json:"start_time"`
+	// 备份文件的保留天数。
+
+	KeepDays int32 `json:"keep_days"`
+	// 备份周期配置。自动备份将在每星期指定的天进行。取值范围：格式为逗号隔开的数字，数字代表星期。取值示例：1,2,3,4则表示备份周期配置为星期一、星期二、星期三和星期四。
+
+	Period string `json:"period"`
+	// 1级备份保留数量，默认值为0。当一级备份开关开启时，该参数值有效。取值：0或1
+
+	RetentionNumBackupLevel1 *int32 `json:"retention_num_backup_level1,omitempty"`
+}
+
+func (o MysqlBackupPolicy) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlBackupPolicy struct{}"
+	}
+
+	return strings.Join([]string{"MysqlBackupPolicy", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_backup_strategy.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_backup_strategy.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 自动备份策略
+type MysqlBackupStrategy struct {
+	// 自动备份开始时间段。自动备份将在该时间一个小时内触发。  取值范围：非空，格式必须为hh:mm-HH:MM且有效，当前时间指UTC时间。  1. HH取值必须比hh大1。 2. mm和MM取值必须相同，且取值必须为00。
+
+	StartTime string `json:"start_time"`
+	// 自动备份保留天数，取值范围：1-732
+
+	KeepDays *string `json:"keep_days,omitempty"`
+}
+
+func (o MysqlBackupStrategy) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlBackupStrategy struct{}"
+	}
+
+	return strings.Join([]string{"MysqlBackupStrategy", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_change_specification_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_change_specification_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlChangeSpecificationRequest struct {
+	ResizeFlavor *MysqlResizeFlavor `json:"resize_flavor"`
+	// 变更包周期实例规格时可指定，表示是否自动从客户的账户中支付。true，为自动支付，默认该方式。false，为手动支付。
+
+	IsAutoPay *string `json:"is_auto_pay,omitempty"`
+}
+
+func (o MysqlChangeSpecificationRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlChangeSpecificationRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlChangeSpecificationRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_charge_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_charge_info.go
@@ -1,0 +1,114 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 计费类型信息，支持包年包月和按需，默认为按需。
+type MysqlChargeInfo struct {
+	// 计费模式。  取值范围：  - prePaid：预付费，即包年/包月。 - postPaid：后付费，即按需付费。
+
+	ChargeMode MysqlChargeInfoChargeMode `json:"charge_mode"`
+	// 订购周期类型。  取值范围：  - month：包月。 - year：包年。  说明：“charge_mode”为“prePaid”时生效，且为必选值。
+
+	PeriodType *MysqlChargeInfoPeriodType `json:"period_type,omitempty"`
+	// “charge_mode”为“prePaid”时生效，且为必选值，指定订购的时间。  取值范围：  当“period_type”为“month”时，取值为1~9。 当“period_type”为“year”时，取值为1~3。
+
+	PeriodNum *int32 `json:"period_num,omitempty"`
+	// 创建包周期实例时可指定，表示是否自动续订，续订的周期和原周期相同，且续订时会自动支付。  - true，为自动续订。 - false，为不自动续订，默认该方式。
+
+	IsAutoRenew *string `json:"is_auto_renew,omitempty"`
+	// 创建包周期时可指定，表示是否自动从客户的账户中支付，此字段不影响自动续订的支付方式。  - true，为自动支付，默认该方式。 - false，为手动支付。
+
+	IsAutoPay *string `json:"is_auto_pay,omitempty"`
+}
+
+func (o MysqlChargeInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlChargeInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlChargeInfo", string(data)}, " ")
+}
+
+type MysqlChargeInfoChargeMode struct {
+	value string
+}
+
+type MysqlChargeInfoChargeModeEnum struct {
+	PRE_PAID  MysqlChargeInfoChargeMode
+	POST_PAID MysqlChargeInfoChargeMode
+}
+
+func GetMysqlChargeInfoChargeModeEnum() MysqlChargeInfoChargeModeEnum {
+	return MysqlChargeInfoChargeModeEnum{
+		PRE_PAID: MysqlChargeInfoChargeMode{
+			value: "prePaid",
+		},
+		POST_PAID: MysqlChargeInfoChargeMode{
+			value: "postPaid",
+		},
+	}
+}
+
+func (c MysqlChargeInfoChargeMode) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *MysqlChargeInfoChargeMode) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type MysqlChargeInfoPeriodType struct {
+	value string
+}
+
+type MysqlChargeInfoPeriodTypeEnum struct {
+	MONTH MysqlChargeInfoPeriodType
+	YEAR  MysqlChargeInfoPeriodType
+}
+
+func GetMysqlChargeInfoPeriodTypeEnum() MysqlChargeInfoPeriodTypeEnum {
+	return MysqlChargeInfoPeriodTypeEnum{
+		MONTH: MysqlChargeInfoPeriodType{
+			value: "month",
+		},
+		YEAR: MysqlChargeInfoPeriodType{
+			value: "year",
+		},
+	}
+}
+
+func (c MysqlChargeInfoPeriodType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *MysqlChargeInfoPeriodType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_create_backup_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_create_backup_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlCreateBackupRequest struct {
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+	// 备份名称。 取值范围：4~64个字符之间，必须以字母开头，区分大小写，可以包含字母、数字、中划线或者下划线，不能包含其他的特殊字符。
+
+	Name string `json:"name"`
+	// 备份描述，不能包含>!<\"&'=特殊字符，不大于256个字符。
+
+	Description *string `json:"description,omitempty"`
+}
+
+func (o MysqlCreateBackupRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlCreateBackupRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlCreateBackupRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_create_readonly_node_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_create_readonly_node_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 只读节点信息
+type MysqlCreateReadonlyNodeRequest struct {
+	// 指定创建的只读节点故障倒换优先级。倒换优先级列表个数即为只读节点格式。 故障倒换优先级的取值范围为1~16，数字越小，优先级越大，即故障倒换时，主节点会优先倒换到优先级高的备节点上，优先级相同的备节点选为主节点的概率相同。
+
+	Priorities []int32 `json:"priorities"`
+	// 创建包周期时可指定，表示是否自动从客户的账户中支付，此字段不影响自动续订的支付方式。  - true，为自动支付，默认该方式。 - false，为手动支付。
+
+	IsAutoPay *string `json:"is_auto_pay,omitempty"`
+}
+
+func (o MysqlCreateReadonlyNodeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlCreateReadonlyNodeRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlCreateReadonlyNodeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_datastore.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_datastore.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 数据库信息。
+type MysqlDatastore struct {
+	// 数据库引擎，现在只支持gaussdb-mysql
+
+	Type string `json:"type"`
+	// 数据库版本。  数据库支持的详细版本信息，可调用查询数据库引擎的版本接口获取。
+
+	Version string `json:"version"`
+}
+
+func (o MysqlDatastore) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlDatastore struct{}"
+	}
+
+	return strings.Join([]string{"MysqlDatastore", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_engine_version_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_engine_version_info.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlEngineVersionInfo struct {
+	// 数据库版本ID，该字段不会有重复
+
+	Id string `json:"id"`
+	// 数据库版本号，只返回两位数的大版本号
+
+	Name string `json:"name"`
+}
+
+func (o MysqlEngineVersionInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlEngineVersionInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlEngineVersionInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_error_log_list.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_error_log_list.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlErrorLogList struct {
+	// 节点ID。
+
+	NodeId *string `json:"node_id,omitempty"`
+	// 日期时间UTC时间。
+
+	Time *string `json:"time,omitempty"`
+	// 日志级别。
+
+	Level *string `json:"level,omitempty"`
+	// 错误日志内容。
+
+	Content *string `json:"content,omitempty"`
+}
+
+func (o MysqlErrorLogList) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlErrorLogList struct{}"
+	}
+
+	return strings.Join([]string{"MysqlErrorLogList", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_extend_instance_volume_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_extend_instance_volume_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 扩容信息
+type MysqlExtendInstanceVolumeRequest struct {
+	// 扩容后的容量，每次扩容最小容量为10GB，实例所选容量大小必须为10的整数倍
+
+	Size int32 `json:"size"`
+	// 表示是否自动从客户的账户中支付。  - true，为自动支付，默认该方式。 - false，为手动支付。
+
+	IsAutoPay *string `json:"is_auto_pay,omitempty"`
+}
+
+func (o MysqlExtendInstanceVolumeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlExtendInstanceVolumeRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlExtendInstanceVolumeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_flavor_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_flavor_info.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// flavor规格信息。
+type MysqlFlavorInfo struct {
+	// CPU核数。
+
+	Vcpus string `json:"vcpus"`
+	// 内存大小，单位GB。
+
+	Ram string `json:"ram"`
+}
+
+func (o MysqlFlavorInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlFlavorInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlFlavorInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_flavors_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_flavors_info.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlFlavorsInfo struct {
+	// CPU大小。例如：1表示1U。
+
+	Vcpus string `json:"vcpus"`
+	// 内存大小，单位为GB。
+
+	Ram string `json:"ram"`
+	// 规格类型，取值为arm和x86。
+
+	Type string `json:"type"`
+	// 规格ID，该字段唯一
+
+	Id string `json:"id"`
+	// 资源规格编码，同创建指定的flavor_ref。例如：gaussdb.mysql.xlarge.x86.4。
+
+	SpecCode string `json:"spec_code"`
+	// 数据库版本号。
+
+	VersionName string `json:"version_name"`
+	// 实例类型。目前仅支持Cluster。
+
+	InstanceMode string `json:"instance_mode"`
+	// 规格所在az的状态，包含以下状态： - normal，在售 - unsupported，暂不支持该规格 - sellout，售罄。
+
+	AzStatus map[string]string `json:"az_status"`
+}
+
+func (o MysqlFlavorsInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlFlavorsInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlFlavorsInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_info_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_info_detail.go
@@ -1,0 +1,100 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlInstanceInfoDetail struct {
+	// 实例ID。
+
+	Id string `json:"id"`
+	// 创建的实例名称。
+
+	Name string `json:"name"`
+	// 租户在某一region下的project ID。
+
+	ProjectId string `json:"project_id"`
+	// 实例状态。 取值： 值为“BUILD”，表示实例正在创建。 值为“ACTIVE”，表示实例正常。 值为“FAILED”，表示实例异常。 值为“FROZEN”，表示实例冻结。 值为“MODIFYING”，表示实例正在扩容。 值为“REBOOTING”，表示实例正在重启。 值为“RESTORING”，表示实例正在恢复。 值为“MODIFYING INSTANCE TYPE”，表示实例正在转主备。 值为“SWITCHOVER”，表示实例正在主备切换。 值为“MIGRATING”，表示实例正在迁移。 值为“BACKING UP”，表示实例正在进行备份。 值为“MODIFYING DATABASE PORT”，表示实例正在修改数据库端口。值为“STORAGE FULL”，表示实例磁盘空间满。
+
+	Status *string `json:"status,omitempty"`
+	// 数据库端口号。
+
+	Port *string `json:"port,omitempty"`
+	// 实例备注
+
+	Alias *string `json:"alias,omitempty"`
+	// 实例类型，取值为“Cluster”。
+
+	Type *string `json:"type,omitempty"`
+	// 节点个数。
+
+	NodeCount *int32 `json:"node_count,omitempty"`
+
+	Datastore *MysqlDatastore `json:"datastore,omitempty"`
+	// 备份空间使用大小，单位为GB。
+
+	BackupUsedSpace *int64 `json:"backup_used_space,omitempty"`
+	// 创建时间，格式为\"yyyy-mm-ddThh:mm:ssZ\"。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Created *string `json:"created,omitempty"`
+	// 更新时间，格式与\"created\"字段对应格式完全相同。说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Updated *string `json:"updated,omitempty"`
+	// 实例的写内网IP。
+
+	PrivateWriteIps *[]string `json:"private_write_ips,omitempty"`
+	// 实例的公网IP。
+
+	PublicIps *string `json:"public_ips,omitempty"`
+	// 默认用户名。
+
+	DbUserName *string `json:"db_user_name,omitempty"`
+	// 虚拟私有云ID。
+
+	VpcId *string `json:"vpc_id,omitempty"`
+	// 子网的网络ID信息。
+
+	SubnetId *string `json:"subnet_id,omitempty"`
+	// 安全组ID。
+
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+	// 实例创建的模板ID，或者应用到实例的最新参数组模板ID。
+
+	ConfigurationId *string `json:"configuration_id,omitempty"`
+
+	BackupStrategy *MysqlBackupStrategy `json:"backup_strategy,omitempty"`
+
+	Nodes *[]MysqlInstanceNodeInfo `json:"nodes,omitempty"`
+	// 企业项目ID。
+
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+	// 时区。
+
+	TimeZone *string `json:"time_zone,omitempty"`
+	// 可用区模式，单可用区single或多可用区multi。
+
+	AzMode *string `json:"az_mode,omitempty"`
+	// 主可用区。
+
+	MasterAzCode *string `json:"master_az_code,omitempty"`
+	// 可维护时间窗，为UTC时间。
+
+	MaintenanceWindow *string `json:"maintenance_window,omitempty"`
+	// 实例标签。
+
+	Tags *[]MysqlTags `json:"tags,omitempty"`
+	// 专属资源池ID，只有数据库实例属于专属资源池才会返回该参数。
+
+	DedicatedResourceId *string `json:"dedicated_resource_id,omitempty"`
+}
+
+func (o MysqlInstanceInfoDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlInstanceInfoDetail struct{}"
+	}
+
+	return strings.Join([]string{"MysqlInstanceInfoDetail", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_list_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_list_info.go
@@ -1,0 +1,86 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlInstanceListInfo struct {
+	// 实例ID。
+
+	Id string `json:"id"`
+	// 创建的实例名称。
+
+	Name string `json:"name"`
+	// 实例状态。
+
+	Status *string `json:"status,omitempty"`
+	// 实例写内网IP地址列表。弹性云服务器创建成功后该值存在，其他情况下为空字符串。
+
+	PrivateIps *[]string `json:"private_ips,omitempty"`
+	// 实例外网IP地址列表。
+
+	PublicIps *[]string `json:"public_ips,omitempty"`
+	// 数据库端口号。
+
+	Port *string `json:"port,omitempty"`
+	// 实例类型，取值为“Cluster”。
+
+	Type *string `json:"type,omitempty"`
+	// 实例所在区域。
+
+	Region *string `json:"region,omitempty"`
+
+	Datastore *MysqlDatastore `json:"datastore,omitempty"`
+	// 创建时间，格式为\"yyyy-mm-ddThh:mm:ssZ\"。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Created *string `json:"created,omitempty"`
+	// 更新时间，格式与\"created\"字段对应格式完全相同。说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Updated *string `json:"updated,omitempty"`
+	// 默认用户名。
+
+	DbUserName *string `json:"db_user_name,omitempty"`
+	// 虚拟私有云ID。
+
+	VpcId *string `json:"vpc_id,omitempty"`
+	// 子网的网络ID信息。
+
+	SubnetId *string `json:"subnet_id,omitempty"`
+	// 安全组ID。
+
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+	// 规格码。
+
+	FlavorRef *string `json:"flavor_ref,omitempty"`
+
+	FlavorInfo *MysqlFlavorInfo `json:"flavor_info,omitempty"`
+
+	Volume *MysqlVolumeInfo `json:"volume,omitempty"`
+
+	BackupStrategy *MysqlBackupStrategy `json:"backup_strategy,omitempty"`
+	// 企业项目ID。
+
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+	// 时区。
+
+	TimeZone *string `json:"time_zone,omitempty"`
+
+	ChargeInfo *MysqlChargeInfo `json:"charge_info,omitempty"`
+	// 专属资源池ID，只有数据库实例属于专属资源池才会返回该参数。
+
+	DedicatedResourceId *string `json:"dedicated_resource_id,omitempty"`
+	// 标签列表。
+
+	Tags *[]InstanceTagItem `json:"tags,omitempty"`
+}
+
+func (o MysqlInstanceListInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlInstanceListInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlInstanceListInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_node_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_node_info.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 节点信息。
+type MysqlInstanceNodeInfo struct {
+	// 实例ID。
+
+	Id string `json:"id"`
+	// 节点名称。
+
+	Name string `json:"name"`
+	// 节点类型，master或slave。
+
+	Type *string `json:"type,omitempty"`
+	// 节点状态。
+
+	Status *string `json:"status,omitempty"`
+	// 数据库端口号。
+
+	Port *int32 `json:"port,omitempty"`
+	// 节点的读内网地址。
+
+	PrivateReadIps *[]string `json:"private_read_ips,omitempty"`
+
+	Volume *MysqlInstanceNodeVolumeInfo `json:"volume,omitempty"`
+	// 可用区。
+
+	AzCode *string `json:"az_code,omitempty"`
+	// 实例所在的区域。
+
+	RegionCode *string `json:"region_code,omitempty"`
+	// 创建时间，格式为\"yyyy-mm-ddThh:mm:ssZ\"。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Created *string `json:"created,omitempty"`
+	// 更新时间，格式与\"created\"字段对应格式完全相同。说明：创建时返回值为空，数据库实例创建成功后该值不为空。
+
+	Updated *string `json:"updated,omitempty"`
+	// 规格码。
+
+	FlavorRef *string `json:"flavor_ref,omitempty"`
+	// 允许的最大连接数。
+
+	MaxConnections *string `json:"max_connections,omitempty"`
+	// CPU核数。
+
+	Vcpus *string `json:"vcpus,omitempty"`
+	// 内存大小，单位为GB。
+
+	Ram *string `json:"ram,omitempty"`
+	// 是否需要重启使修改的参数生效。
+
+	NeedRestart *bool `json:"need_restart,omitempty"`
+	// 主备倒换优先级。
+
+	Priotiry *int32 `json:"priotiry,omitempty"`
+}
+
+func (o MysqlInstanceNodeInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlInstanceNodeInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlInstanceNodeInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_node_volume_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_node_volume_info.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 存储盘信息。
+type MysqlInstanceNodeVolumeInfo struct {
+	// 磁盘类型。
+
+	Type string `json:"type"`
+	// 已使用磁盘大小，单位GB。
+
+	Used string `json:"used"`
+	// 包周期购买的存储空间大小，单位GB。
+
+	Size int64 `json:"size"`
+}
+
+func (o MysqlInstanceNodeVolumeInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlInstanceNodeVolumeInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlInstanceNodeVolumeInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_request.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 实例信息
+type MysqlInstanceRequest struct {
+	ChargeInfo *MysqlChargeInfo `json:"charge_info,omitempty"`
+	// 区域ID。
+
+	Region string `json:"region"`
+	// 实例名称。 用于表示实例的名称，同一租户下，同类型的实例名可重名。 取值范围：4~64个字符之间，必须以字母开头，区分大小写，可以包含字母、数字、中划线或者下划线，不能包含其他的特殊字符。
+
+	Name string `json:"name"`
+
+	Datastore *MysqlDatastore `json:"datastore"`
+	// 实例类型，目前仅支持Cluster。
+
+	Mode string `json:"mode"`
+	// 规格码。
+
+	FlavorRef string `json:"flavor_ref"`
+	// 虚拟私有云ID。
+
+	VpcId string `json:"vpc_id"`
+	// 子网的网络ID。
+
+	SubnetId string `json:"subnet_id"`
+	// 安全组ID。如果实例所选用的子网开启网络ACL进行访问控制，则该参数非必选。如果未开启ACL进行访问控制，则该参数必选。
+
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+	// 参数模板ID。
+
+	ConfigurationId *string `json:"configuration_id,omitempty"`
+	// 数据库密码。 取值范围：至少包含以下字符的三种：大小写字母、数字和特殊符号~!@#$%^*-_=+?,()&，长度8~32个字符。 建议您输入高强度密码，以提高安全性，防止出现密码被暴力破解等安全风险。如果您输入弱密码，系统会自动判定密码非法。
+
+	Password string `json:"password"`
+
+	BackupStrategy *MysqlBackupStrategy `json:"backup_strategy,omitempty"`
+	// 时区。默认时区为UTC。
+
+	TimeZone *string `json:"time_zone,omitempty"`
+	// 可用区类型,单可用区Single或多可用区multi。
+
+	AvailabilityZoneMode string `json:"availability_zone_mode"`
+	// 主可用区。
+
+	MasterAvailabilityZone *string `json:"master_availability_zone,omitempty"`
+	// 备节点个数。单次接口调用最多支持创建9个备节点。
+
+	SlaveCount int32 `json:"slave_count"`
+
+	Volume *MysqlVolume `json:"volume,omitempty"`
+
+	Tags *[]MysqlTags `json:"tags,omitempty"`
+	// 企业项目ID。如果账户开通企业项目服务则该参数必选，未开启该参数不可选。
+
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+	// 专属资源池ID，只有开通专属资源池后才可以下发此参数。
+
+	DedicatedResourceId *string `json:"dedicated_resource_id,omitempty"`
+}
+
+func (o MysqlInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_instance_response.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlInstanceResponse struct {
+	// 实例ID。
+
+	Id string `json:"id"`
+	// 实例名称。用于表示实例的名称，同一租户下，同类型的实例名称可相同。 取值范围：4~64个字符之间，必须以字母开头，不区分大小写，可以包含字母、数字、中划线或者下划线, 不能包含其它的特殊字符。
+
+	Name string `json:"name"`
+	// 实例状态。
+
+	Status *string `json:"status,omitempty"`
+
+	Datastore *MysqlDatastore `json:"datastore,omitempty"`
+	// 实例类型，仅支持Cluster。
+
+	Mode *string `json:"mode,omitempty"`
+	// 参数组ID。
+
+	ConfigurationId *string `json:"configuration_id,omitempty"`
+	// 数据库端口信息。
+
+	Port *string `json:"port,omitempty"`
+
+	BackupStrategy *MysqlBackupStrategy `json:"backup_strategy,omitempty"`
+	// 企业项目ID。
+
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+	// 区域ID，与请求参数相同。
+
+	Region *string `json:"region,omitempty"`
+	// 可用区模式，与请求参数相同。
+
+	AvailabilityZoneMode *string `json:"availability_zone_mode,omitempty"`
+	// 主可用区ID。
+
+	MasterAvailabilityZone *string `json:"master_availability_zone,omitempty"`
+	// 虚拟私有云ID，与请求参数相同。
+
+	VpcId *string `json:"vpc_id,omitempty"`
+	// 安全组ID，与请求参数相同。
+
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+	// 子网ID，与请求参数相同。
+
+	SubnetId *string `json:"subnet_id,omitempty"`
+	// 规格码，与请求参数相同。
+
+	FlavorRef *string `json:"flavor_ref,omitempty"`
+
+	ChargeInfo *MysqlChargeInfo `json:"charge_info,omitempty"`
+}
+
+func (o MysqlInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"MysqlInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlProxy struct {
+	// Proxy实例id。
+
+	PoolId *string `json:"pool_id,omitempty"`
+	// Proxy实例开启状态。  取值范围：closed、open、frozen、opening、closing、enlarging、freezing和unfreezin。
+
+	Status *string `json:"status,omitempty"`
+	// Proxy读写分离地址。
+
+	Address *string `json:"address,omitempty"`
+	// Proxy端口信息。
+
+	Port *int32 `json:"port,omitempty"`
+	// Proxy实例状态。 取值范围：abnormal、normal、creating和deleted。
+
+	PoolStatus *string `json:"pool_status,omitempty"`
+	// 延时阈值，单位：秒。
+
+	DelayThresholdInSeconds *int32 `json:"delay_threshold_in_seconds,omitempty"`
+	// Elb模式的虚拟ip信息。
+
+	ElbVip *string `json:"elb_vip,omitempty"`
+	// 弹性公网IP信息。
+
+	Eip *string `json:"eip,omitempty"`
+	// Proxy实例规格的CPU数量。
+
+	Vcpus *string `json:"vcpus,omitempty"`
+	// Proxy实例规格的内存数量。
+
+	Ram *string `json:"ram,omitempty"`
+	// Proxy节点个数。
+
+	NodeNum *int32 `json:"node_num,omitempty"`
+	// Proxy主备模式，取值范围：Cluster。
+
+	Mode *string `json:"mode,omitempty"`
+	// Proxy节点信息。
+
+	Nodes *[]MysqlProxyNodes `json:"nodes,omitempty"`
+	// Proxy规格信息。
+
+	FlavorRef *string `json:"flavor_ref,omitempty"`
+}
+
+func (o MysqlProxy) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlProxy struct{}"
+	}
+
+	return strings.Join([]string{"MysqlProxy", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_available.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_available.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlProxyAvailable struct {
+	// 可用区编码。
+
+	Code *string `json:"code,omitempty"`
+	// 可用区描述。
+
+	Description *string `json:"description,omitempty"`
+}
+
+func (o MysqlProxyAvailable) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlProxyAvailable struct{}"
+	}
+
+	return strings.Join([]string{"MysqlProxyAvailable", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_compute_flavor.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_compute_flavor.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlProxyComputeFlavor struct {
+	// CPU大小。例如：1表示1U。
+
+	Vcpus string `json:"vcpus"`
+	// 内存大小，单位为GB。
+
+	Ram string `json:"ram"`
+	// 数据库类型。
+
+	DbType string `json:"db_type"`
+	// Proxy规格id。
+
+	Id string `json:"id"`
+	// Proxy规格码。
+
+	SpecCode string `json:"spec_code"`
+	// 其中key是可用区编号，value是规格所在az的状态。
+
+	AzStatus *interface{} `json:"az_status"`
+}
+
+func (o MysqlProxyComputeFlavor) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlProxyComputeFlavor struct{}"
+	}
+
+	return strings.Join([]string{"MysqlProxyComputeFlavor", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_flavor_groups.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_flavor_groups.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlProxyFlavorGroups struct {
+	// 规格组类型,如x86，arm。
+
+	GroupType *string `json:"group_type,omitempty"`
+	// 规格信息。
+
+	ProxyFlavors *[]MysqlProxyComputeFlavor `json:"proxy_flavors,omitempty"`
+}
+
+func (o MysqlProxyFlavorGroups) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlProxyFlavorGroups struct{}"
+	}
+
+	return strings.Join([]string{"MysqlProxyFlavorGroups", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_node.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_node.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlProxyNode struct {
+	// 节点id。
+
+	Id *string `json:"id,omitempty"`
+	// 实例id。
+
+	InstanceId *string `json:"instance_id,omitempty"`
+	// 节点状态。
+
+	Status *string `json:"status,omitempty"`
+	// 节点名称。
+
+	Name *string `json:"name,omitempty"`
+	// 节点读写分离权重。
+
+	Weight *int32 `json:"weight,omitempty"`
+	// 可用区信息。
+
+	AvailableZones *[]MysqlProxyAvailable `json:"available_zones,omitempty"`
+}
+
+func (o MysqlProxyNode) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlProxyNode struct{}"
+	}
+
+	return strings.Join([]string{"MysqlProxyNode", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_nodes.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_proxy_nodes.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlProxyNodes struct {
+	// Proxy节点id。
+
+	Id *string `json:"id,omitempty"`
+	// Proxy节点状态。 取值范围：normal、abnormal、creating和deleted。
+
+	Status *string `json:"status,omitempty"`
+	// Proxy节点名称。
+
+	Name *string `json:"name,omitempty"`
+	// Proxy节点角色：master和slave。
+
+	Role *string `json:"role,omitempty"`
+	// 可用区。
+
+	AzCode *string `json:"az_code,omitempty"`
+	// Proxy节点是否被冻结：0-未冻结；1-冻结；2-冻结删除。
+
+	FrozenFlag *int32 `json:"frozen_flag,omitempty"`
+}
+
+func (o MysqlProxyNodes) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlProxyNodes struct{}"
+	}
+
+	return strings.Join([]string{"MysqlProxyNodes", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_reset_password_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_reset_password_request.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlResetPasswordRequest struct {
+	// 数据库密码。取值范围：至少包含以下字符的三种：大小写字母、数字和特殊符号~!@#$%^*-_=+?,()&，长度8~32个字符。建议您输入高强度密码，以提高安全性，防止出现密码被暴力破解等安全风险。如果您输入弱密码，系统会自动判定密码非法。
+
+	Password string `json:"password"`
+}
+
+func (o MysqlResetPasswordRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlResetPasswordRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlResetPasswordRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_resize_flavor.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_resize_flavor.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlResizeFlavor struct {
+	// 规格码
+
+	SpecCode string `json:"spec_code"`
+}
+
+func (o MysqlResizeFlavor) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlResizeFlavor struct{}"
+	}
+
+	return strings.Join([]string{"MysqlResizeFlavor", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_slow_log_list.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_slow_log_list.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlSlowLogList struct {
+	// 节点ID。
+
+	NodeId *string `json:"node_id,omitempty"`
+	// 执行次数。
+
+	Count *string `json:"count,omitempty"`
+	// 执行时间。
+
+	Time *string `json:"time,omitempty"`
+	// 等待锁时间。
+
+	LockTime *string `json:"lock_time,omitempty"`
+	// 结果行数量。
+
+	RowsSent *string `json:"rows_sent,omitempty"`
+	// 扫描的行数量。
+
+	RowsExamined *string `json:"rows_examined,omitempty"`
+	// 所属数据库。
+
+	Database *string `json:"database,omitempty"`
+	// 账号。
+
+	Users *string `json:"users,omitempty"`
+	// 执行语法。
+
+	QuerySample *string `json:"query_sample,omitempty"`
+	// 语句类型。
+
+	Type *string `json:"type,omitempty"`
+	// 发生时间,UTC时间
+
+	StartTime *string `json:"start_time,omitempty"`
+	// IP地址。
+
+	ClientIp *string `json:"client_ip,omitempty"`
+}
+
+func (o MysqlSlowLogList) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlSlowLogList struct{}"
+	}
+
+	return strings.Join([]string{"MysqlSlowLogList", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_tags.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_tags.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 标签列表，根据标签键值对创建实例。 - {key}表示标签键，不可以为空或重复。 - {value}表示标签值，可以为空。  如果创建实例时同时使用多个标签键值对，中间使用逗号分隔开，最多包含10组。
+type MysqlTags struct {
+	// 标签键。最大长度36个unicode字符。 key不能为空或者空字符串，不能为空格。 字符集：A-Z，a-z ，0-9，‘-’，‘_’，UNICODE字符（\\u4E00-\\u9FFF）。
+
+	Key string `json:"key"`
+	// 标签值。最大长度43个unicode字符。 可以为空字符串。 字符集：A-Z，a-z ，0-9，‘.’，‘-’，‘_’，UNICODE字符（\\u4E00-\\u9FFF）。
+
+	Value string `json:"value"`
+}
+
+func (o MysqlTags) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlTags struct{}"
+	}
+
+	return strings.Join([]string{"MysqlTags", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_update_backup_policy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_update_backup_policy_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 修改备份策略信息
+type MysqlUpdateBackupPolicyRequest struct {
+	BackupPolicy *MysqlBackupPolicy `json:"backup_policy"`
+}
+
+func (o MysqlUpdateBackupPolicyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlUpdateBackupPolicyRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlUpdateBackupPolicyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_update_instance_name_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_update_instance_name_request.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlUpdateInstanceNameRequest struct {
+	// 实例名称。 用于表示实例的名称，同一租户下，同类型的实例名可重名。取值范围：4~64个字符之间，必须以字母开头，区分大小写，可以包含字母、数字、中划线或者下划线，不能包含其他的特殊字符。
+
+	Name string `json:"name"`
+}
+
+func (o MysqlUpdateInstanceNameRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlUpdateInstanceNameRequest struct{}"
+	}
+
+	return strings.Join([]string{"MysqlUpdateInstanceNameRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_volume.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_volume.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MysqlVolume struct {
+	// 磁盘大小。默认值为40，单位GB。 取值范围：40~128000，必须为10的整数倍。
+
+	Size string `json:"size"`
+}
+
+func (o MysqlVolume) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlVolume struct{}"
+	}
+
+	return strings.Join([]string{"MysqlVolume", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_volume_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_mysql_volume_info.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 存储盘信息。
+type MysqlVolumeInfo struct {
+	// 磁盘类型。
+
+	Type string `json:"type"`
+	// 已使用磁盘大小，单位GB。
+
+	Size string `json:"size"`
+}
+
+func (o MysqlVolumeInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MysqlVolumeInfo struct{}"
+	}
+
+	return strings.Join([]string{"MysqlVolumeInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_open_mysql_proxy_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_open_mysql_proxy_request_body.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type OpenMysqlProxyRequestBody struct {
+	// 代理规格码。
+
+	FlavorRef *string `json:"flavor_ref,omitempty"`
+	// 代理实例节点数，取值整数2-32。
+
+	NodeNum *int32 `json:"node_num,omitempty"`
+}
+
+func (o OpenMysqlProxyRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "OpenMysqlProxyRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"OpenMysqlProxyRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_operate_audit_log_request_v3_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_operate_audit_log_request_v3_body.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 开启/关闭审计日志参数体
+type OperateAuditLogRequestV3Body struct {
+	// 审计日志开关状态。取值：ON|OFF
+
+	SwitchStatus string `json:"switch_status"`
+}
+
+func (o OperateAuditLogRequestV3Body) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "OperateAuditLogRequestV3Body struct{}"
+	}
+
+	return strings.Join([]string{"OperateAuditLogRequestV3Body", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_project_quotas.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_project_quotas.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ProjectQuotas struct {
+	// 资源列表对象。
+
+	Resources []Resource `json:"resources"`
+}
+
+func (o ProjectQuotas) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ProjectQuotas struct{}"
+	}
+
+	return strings.Join([]string{"ProjectQuotas", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_project_tag_item.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_project_tag_item.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ProjectTagItem struct {
+	// 标签键。
+
+	Key string `json:"key"`
+	// 标签值。
+
+	Values []string `json:"values"`
+}
+
+func (o ProjectTagItem) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ProjectTagItem struct{}"
+	}
+
+	return strings.Join([]string{"ProjectTagItem", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_quota.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_quota.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type Quota struct {
+	// 企业项目ID。
+
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// 企业项目名称。
+
+	EnterpriseProjectName string `json:"enterprise_project_name"`
+	// 实例个数配额。
+
+	InstanceQuota int32 `json:"instance_quota"`
+	// CPU核数配额。
+
+	VcpusQuota int32 `json:"vcpus_quota"`
+	// 内存使用配额，单位为GB。
+
+	RamQuota int32 `json:"ram_quota"`
+	// 实例剩余配额。
+
+	AvailabilityInstanceQuota int32 `json:"availability_instance_quota"`
+	// CPU核数剩余配额。
+
+	AvailabilityVcpusQuota *int32 `json:"availability_vcpus_quota,omitempty"`
+	// 内存剩余配额。
+
+	AvailabilityRamQuota int32 `json:"availability_ram_quota"`
+}
+
+func (o Quota) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Quota struct{}"
+	}
+
+	return strings.Join([]string{"Quota", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_reset_gauss_my_sql_password_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_reset_gauss_my_sql_password_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ResetGaussMySqlPasswordRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *MysqlResetPasswordRequest `json:"body,omitempty"`
+}
+
+func (o ResetGaussMySqlPasswordRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetGaussMySqlPasswordRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResetGaussMySqlPasswordRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_reset_gauss_my_sql_password_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_reset_gauss_my_sql_password_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ResetGaussMySqlPasswordResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o ResetGaussMySqlPasswordResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetGaussMySqlPasswordResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResetGaussMySqlPasswordResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_resource.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_resource.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type Resource struct {
+	// 指定类型的配额。 - instance: 表示实例的配额
+
+	Type ResourceType `json:"type"`
+	// 已创建的资源个数。
+
+	Used int32 `json:"used"`
+	// 资源最大的配额数。
+
+	Quota int32 `json:"quota"`
+}
+
+func (o Resource) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Resource struct{}"
+	}
+
+	return strings.Join([]string{"Resource", string(data)}, " ")
+}
+
+type ResourceType struct {
+	value string
+}
+
+type ResourceTypeEnum struct {
+	INSTANCE ResourceType
+}
+
+func GetResourceTypeEnum() ResourceTypeEnum {
+	return ResourceTypeEnum{
+		INSTANCE: ResourceType{
+			value: "instance",
+		},
+	}
+}
+
+func (c ResourceType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ResourceType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_resource_tag_item.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_resource_tag_item.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResourceTagItem struct {
+	// 标签键。
+
+	Key string `json:"key"`
+	// 标签值。
+
+	Value string `json:"value"`
+}
+
+func (o ResourceTagItem) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResourceTagItem struct{}"
+	}
+
+	return strings.Join([]string{"ResourceTagItem", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_gauss_my_sql_quotas_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_gauss_my_sql_quotas_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type SetGaussMySqlQuotasRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+
+	Body *SetQuotasRequestBody `json:"body,omitempty"`
+}
+
+func (o SetGaussMySqlQuotasRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetGaussMySqlQuotasRequest struct{}"
+	}
+
+	return strings.Join([]string{"SetGaussMySqlQuotasRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_gauss_my_sql_quotas_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_gauss_my_sql_quotas_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type SetGaussMySqlQuotasResponse struct {
+	// 资源列表对象。
+
+	QuotaList      *[]SetQuota `json:"quota_list,omitempty"`
+	HttpStatusCode int         `json:"-"`
+}
+
+func (o SetGaussMySqlQuotasResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetGaussMySqlQuotasResponse struct{}"
+	}
+
+	return strings.Join([]string{"SetGaussMySqlQuotasResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_quota.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_quota.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type SetQuota struct {
+	// 企业项目ID。
+
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// 实例个数配额。取值范围0~1000。(如果已经存在实例，应该大于已经存在的实例个数)
+
+	InstanceQuota int32 `json:"instance_quota"`
+	// CPU核数配额。取值范围0~3600000。(如果已经存在实例，应该大于已经占用的cpu个数)
+
+	VcpusQuota int32 `json:"vcpus_quota"`
+	// 内存使用配额，单位为GB。取值范围0~19200000。(如果已经存在实例，应该大于已经占用的内存数)
+
+	RamQuota int32 `json:"ram_quota"`
+}
+
+func (o SetQuota) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetQuota struct{}"
+	}
+
+	return strings.Join([]string{"SetQuota", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_quotas_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_set_quotas_request_body.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type SetQuotasRequestBody struct {
+	// 资源列表对象。
+
+	QuotaList []SetQuota `json:"quota_list"`
+}
+
+func (o SetQuotasRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetQuotasRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"SetQuotasRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_audit_log_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_audit_log_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowAuditLogRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowAuditLogRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowAuditLogRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowAuditLogRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_audit_log_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_audit_log_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowAuditLogResponse struct {
+	// 审计日志开关状态。取值：ON|OFF
+
+	SwitchStatus   *string `json:"switch_status,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowAuditLogResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowAuditLogResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowAuditLogResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_list_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_list_request.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlBackupListRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID。
+
+	InstanceId *string `json:"instance_id,omitempty"`
+	// 备份ID。
+
+	BackupId *string `json:"backup_id,omitempty"`
+	// 备份类型，取值：   \"auto\"：自动全量备份   \"manual\"：手动全量备份
+
+	BackupType *string `json:"backup_type,omitempty"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。
+
+	Offset *string `json:"offset,omitempty"`
+	// 查询记录数。默认为100，不能为负数，最小值为1，最大值为100。
+
+	Limit *string `json:"limit,omitempty"`
+	// 查询开始时间，格式为“yyyy-mm-ddThh:mm:ssZ”。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	BeginTime *string `json:"begin_time,omitempty"`
+	// 查询结束时间，格式为“yyyy-mm-ddThh:mm:ssZ”，且大于查询开始时间。 其中，T指某个时间的开始；Z指时区偏移量，例如北京时间偏移显示为+0800。
+
+	EndTime *string `json:"end_time,omitempty"`
+}
+
+func (o ShowGaussMySqlBackupListRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlBackupListRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlBackupListRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_list_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_list_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlBackupListResponse struct {
+	// 备份信息。
+
+	Backups *[]Backups `json:"backups,omitempty"`
+	// 备份文件的总数。
+
+	TotalCount     *int64 `json:"total_count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowGaussMySqlBackupListResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlBackupListResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlBackupListResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_policy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_policy_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlBackupPolicyRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowGaussMySqlBackupPolicyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlBackupPolicyRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlBackupPolicyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_policy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_backup_policy_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlBackupPolicyResponse struct {
+	BackupPolicy   *BackupPolicy `json:"backup_policy,omitempty"`
+	HttpStatusCode int           `json:"-"`
+}
+
+func (o ShowGaussMySqlBackupPolicyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlBackupPolicyResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlBackupPolicyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_engine_version_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_engine_version_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlEngineVersionRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 数据库引擎。支持的引擎如下，不区分大小写：gaussdb-mysql
+
+	DatabaseName string `json:"database_name"`
+}
+
+func (o ShowGaussMySqlEngineVersionRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlEngineVersionRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlEngineVersionRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_engine_version_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_engine_version_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlEngineVersionResponse struct {
+	// 数据库版本信息列表
+
+	Datastores     *[]MysqlEngineVersionInfo `json:"datastores,omitempty"`
+	HttpStatusCode int                       `json:"-"`
+}
+
+func (o ShowGaussMySqlEngineVersionResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlEngineVersionResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlEngineVersionResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_flavors_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_flavors_request.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlFlavorsRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 数据库引擎名称。
+
+	DatabaseName string `json:"database_name"`
+	// 数据库版本号，目前仅支持兼容MySQL 8.0。
+
+	VersionName *string `json:"version_name,omitempty"`
+	// 规格的可用区模式，现在仅支持\"single\"、\"multi\"，不区分大小写。
+
+	AvailabilityZoneMode string `json:"availability_zone_mode"`
+	// 规格编码。
+
+	SpecCode *string `json:"spec_code,omitempty"`
+}
+
+func (o ShowGaussMySqlFlavorsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlFlavorsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlFlavorsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_flavors_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_flavors_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlFlavorsResponse struct {
+	// 实例规格信息列表
+
+	Flavors        *[]MysqlFlavorsInfo `json:"flavors,omitempty"`
+	HttpStatusCode int                 `json:"-"`
+}
+
+func (o ShowGaussMySqlFlavorsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlFlavorsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlFlavorsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_instance_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_instance_info_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlInstanceInfoRequest struct {
+	// 语言。
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID。
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowGaussMySqlInstanceInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlInstanceInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlInstanceInfoRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_instance_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_instance_info_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlInstanceInfoResponse struct {
+	Instance       *MysqlInstanceInfoDetail `json:"instance,omitempty"`
+	HttpStatusCode int                      `json:"-"`
+}
+
+func (o ShowGaussMySqlInstanceInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlInstanceInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlInstanceInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_job_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_job_info_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlJobInfoRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 任务ID。
+
+	Id string `json:"id"`
+}
+
+func (o ShowGaussMySqlJobInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlJobInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlJobInfoRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_job_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_job_info_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlJobInfoResponse struct {
+	Job            *GetJobInfoDetail `json:"job,omitempty"`
+	HttpStatusCode int               `json:"-"`
+}
+
+func (o ShowGaussMySqlJobInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlJobInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlJobInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_project_quotas_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_project_quotas_request.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlProjectQuotasRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// '功能说明：根据type过滤查询指定类型的配额' 取值范围：instance
+
+	Type *ShowGaussMySqlProjectQuotasRequestType `json:"type,omitempty"`
+}
+
+func (o ShowGaussMySqlProjectQuotasRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlProjectQuotasRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlProjectQuotasRequest", string(data)}, " ")
+}
+
+type ShowGaussMySqlProjectQuotasRequestType struct {
+	value string
+}
+
+type ShowGaussMySqlProjectQuotasRequestTypeEnum struct {
+	INSTANCE ShowGaussMySqlProjectQuotasRequestType
+}
+
+func GetShowGaussMySqlProjectQuotasRequestTypeEnum() ShowGaussMySqlProjectQuotasRequestTypeEnum {
+	return ShowGaussMySqlProjectQuotasRequestTypeEnum{
+		INSTANCE: ShowGaussMySqlProjectQuotasRequestType{
+			value: "instance",
+		},
+	}
+}
+
+func (c ShowGaussMySqlProjectQuotasRequestType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowGaussMySqlProjectQuotasRequestType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_project_quotas_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_project_quotas_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlProjectQuotasResponse struct {
+	Quotas         *ProjectQuotas `json:"quotas,omitempty"`
+	HttpStatusCode int            `json:"-"`
+}
+
+func (o ShowGaussMySqlProjectQuotasResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlProjectQuotasResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlProjectQuotasResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_flavors_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_flavors_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlProxyFlavorsRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowGaussMySqlProxyFlavorsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlProxyFlavorsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlProxyFlavorsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_flavors_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_flavors_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlProxyFlavorsResponse struct {
+	// 规格组信息。
+
+	ProxyFlavorGroups *[]MysqlProxyFlavorGroups `json:"proxy_flavor_groups,omitempty"`
+	HttpStatusCode    int                       `json:"-"`
+}
+
+func (o ShowGaussMySqlProxyFlavorsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlProxyFlavorsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlProxyFlavorsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlProxyRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowGaussMySqlProxyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlProxyRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlProxyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_proxy_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlProxyResponse struct {
+	Proxy *MysqlProxy `json:"proxy,omitempty"`
+
+	MasterNode *MysqlProxyNode `json:"master_node,omitempty"`
+	// 只读节点信息。
+
+	ReadonlyNodes  *[]MysqlProxyNode `json:"readonly_nodes,omitempty"`
+	HttpStatusCode int               `json:"-"`
+}
+
+func (o ShowGaussMySqlProxyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlProxyResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlProxyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_quotas_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_quotas_request.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGaussMySqlQuotasRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 索引位置，偏移量。从第一条数据偏移offset条数据后开始查询，默认为0（偏移0条数据，表示从第一条数据开始查询），必须为数字，不能为负数。 取值范围：0 - 10000
+
+	Offset *string `json:"offset,omitempty"`
+	// 查询记录数。默认为10，不能为负数，最小值为1，最大值为100。
+
+	Limit *string `json:"limit,omitempty"`
+	// 企业项目名称。
+
+	EnterpriseProjectName *string `json:"enterprise_project_name,omitempty"`
+}
+
+func (o ShowGaussMySqlQuotasRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlQuotasRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlQuotasRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_quotas_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_gauss_my_sql_quotas_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGaussMySqlQuotasResponse struct {
+	// 资源列表对象。
+
+	QuotaList *[]Quota `json:"quota_list,omitempty"`
+	// 配额记录的条数。
+
+	TotalCount     *int32 `json:"total_count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowGaussMySqlQuotasResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGaussMySqlQuotasResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGaussMySqlQuotasResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_instance_monitor_extend_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_instance_monitor_extend_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowInstanceMonitorExtendRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowInstanceMonitorExtendRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceMonitorExtendRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceMonitorExtendRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_instance_monitor_extend_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_show_instance_monitor_extend_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowInstanceMonitorExtendResponse struct {
+	// 实例秒级监控开关。为true时表示开启，为false时表示关闭。
+
+	MonitorSwitch *bool `json:"monitor_switch,omitempty"`
+	// 采集周期，仅在monitor_switch为true时返回。1：采集周期为1s； 5：采集周期为5s。
+
+	Period         *int32 `json:"period,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowInstanceMonitorExtendResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceMonitorExtendResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceMonitorExtendResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_tag_item.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_tag_item.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type TagItem struct {
+	// 标签键。最大长度36个unicode字符，不能为null或者空字符串，不能为空格。 字符集：0-9，A-Z，a-z，“_”，“-”，中文。
+
+	Key string `json:"key"`
+	// 标签值。最大长度43个unicode字符，可以为空字符串，不能为空格。 字符集：0-9，A-Z，a-z，“_”，“.”，“-”，中文。 - “action”值为“create”时，该参数必选。 - “action”值为“delete”时，如果value有值，按照key/value删除，如果value没值，则按照key删除。
+
+	Value *string `json:"value,omitempty"`
+}
+
+func (o TagItem) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TagItem struct{}"
+	}
+
+	return strings.Join([]string{"TagItem", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_taurus_modify_instance_monitor_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_taurus_modify_instance_monitor_request_body.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 秒级监控修改请求
+type TaurusModifyInstanceMonitorRequestBody struct {
+	// 实例秒级监控开关。为true时表示开启，为false时表示关闭。
+
+	MonitorSwitch bool `json:"monitor_switch"`
+	// 采集周期，仅在monitor_switch为true时生效。默认为5s。monitor_switch为false时，不传该参数。  取值： 1：采集周期为1s； 5：采集周期为5s。
+
+	Period *TaurusModifyInstanceMonitorRequestBodyPeriod `json:"period,omitempty"`
+}
+
+func (o TaurusModifyInstanceMonitorRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TaurusModifyInstanceMonitorRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"TaurusModifyInstanceMonitorRequestBody", string(data)}, " ")
+}
+
+type TaurusModifyInstanceMonitorRequestBodyPeriod struct {
+	value int32
+}
+
+type TaurusModifyInstanceMonitorRequestBodyPeriodEnum struct {
+	E_1 TaurusModifyInstanceMonitorRequestBodyPeriod
+	E_5 TaurusModifyInstanceMonitorRequestBodyPeriod
+}
+
+func GetTaurusModifyInstanceMonitorRequestBodyPeriodEnum() TaurusModifyInstanceMonitorRequestBodyPeriodEnum {
+	return TaurusModifyInstanceMonitorRequestBodyPeriodEnum{
+		E_1: TaurusModifyInstanceMonitorRequestBodyPeriod{
+			value: 1,
+		}, E_5: TaurusModifyInstanceMonitorRequestBodyPeriod{
+			value: 5,
+		},
+	}
+}
+
+func (c TaurusModifyInstanceMonitorRequestBodyPeriod) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *TaurusModifyInstanceMonitorRequestBodyPeriod) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("int32")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(int32)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to int32 error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_audit_log_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_audit_log_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateAuditLogRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+
+	Body *OperateAuditLogRequestV3Body `json:"body,omitempty"`
+}
+
+func (o UpdateAuditLogRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateAuditLogRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateAuditLogRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_audit_log_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_audit_log_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateAuditLogResponse struct {
+	// 开启/关闭审计日志操作结果。
+
+	Result         *string `json:"result,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateAuditLogResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateAuditLogResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateAuditLogResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_backup_policy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_backup_policy_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateGaussMySqlBackupPolicyRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *MysqlUpdateBackupPolicyRequest `json:"body,omitempty"`
+}
+
+func (o UpdateGaussMySqlBackupPolicyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateGaussMySqlBackupPolicyRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateGaussMySqlBackupPolicyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_backup_policy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_backup_policy_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateGaussMySqlBackupPolicyResponse struct {
+	// 状态信息
+
+	Status *string `json:"status,omitempty"`
+	// 实例ID
+
+	InstanceId *string `json:"instance_id,omitempty"`
+	// 实例名称
+
+	InstanceName   *string `json:"instance_name,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateGaussMySqlBackupPolicyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateGaussMySqlBackupPolicyResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateGaussMySqlBackupPolicyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_instance_name_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_instance_name_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateGaussMySqlInstanceNameRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID，严格匹配UUID规则。
+
+	InstanceId string `json:"instance_id"`
+
+	Body *MysqlUpdateInstanceNameRequest `json:"body,omitempty"`
+}
+
+func (o UpdateGaussMySqlInstanceNameRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateGaussMySqlInstanceNameRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateGaussMySqlInstanceNameRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_instance_name_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_instance_name_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateGaussMySqlInstanceNameResponse struct {
+	// 修改实例名称的任务id
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateGaussMySqlInstanceNameResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateGaussMySqlInstanceNameResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateGaussMySqlInstanceNameResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_quotas_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_quotas_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateGaussMySqlQuotasRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+
+	Body *SetQuotasRequestBody `json:"body,omitempty"`
+}
+
+func (o UpdateGaussMySqlQuotasRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateGaussMySqlQuotasRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateGaussMySqlQuotasRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_quotas_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_gauss_my_sql_quotas_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateGaussMySqlQuotasResponse struct {
+	// 资源列表对象。
+
+	QuotaList      *[]SetQuota `json:"quota_list,omitempty"`
+	HttpStatusCode int         `json:"-"`
+}
+
+func (o UpdateGaussMySqlQuotasResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateGaussMySqlQuotasResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateGaussMySqlQuotasResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_instance_monitor_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_instance_monitor_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateInstanceMonitorRequest struct {
+	// 语言
+
+	XLanguage *string `json:"X-Language,omitempty"`
+	// 实例ID
+
+	InstanceId string `json:"instance_id"`
+
+	Body *TaurusModifyInstanceMonitorRequestBody `json:"body,omitempty"`
+}
+
+func (o UpdateInstanceMonitorRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceMonitorRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceMonitorRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_instance_monitor_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model/model_update_instance_monitor_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateInstanceMonitorResponse struct {
+	// 修改秒级监控的任务流id
+
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateInstanceMonitorResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceMonitorResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceMonitorResponse", string(data)}, " ")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -400,6 +400,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3/model
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/gaussdb/v3/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/tms/v1/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. add audit log switch for gaussdb mysql instance
2. when MySQL is delete ,  subnet  port is not released, so set the delete timeouts of vpc_subnet to "20m".

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes  #1937 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccGaussDBInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccGaussDBInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_basic
--- PASS: TestAccGaussDBInstance_basic (1248.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1248.518s
```
