### PR TITLE
fix(config/logger): skip to parse empty body

### DIFF
--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -150,6 +150,10 @@ func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, contentType stri
 func formatJSON(raw []byte, maskBody bool) string {
 	var data map[string]interface{}
 
+	if len(raw) == 0 {
+		return ""
+	}
+
 	err := json.Unmarshal(raw, &data)
 	if err != nil {
 		log.Printf("[DEBUG] Unable to parse JSON: %s", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

when the API response body is **empty**, we will get the following message in log file:

```
2022/03/15 15:44:35 [DEBUG] Unable to parse JSON: unexpected end of JSON input
```

it looks like an error, so it's better to skip parsing empty body.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

