### PR TITLE
refactor(vpc/client): remove sercurity group client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220315024338-8b5a0e685be3
+	github.com/chnsz/golangsdk v0.0.0-20220326084319-c4df10cfffd8
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220315024338-8b5a0e685be3 h1:qLWiIJsijj5LWCVQ52SQPxyi9rJXi825RBfb0g/oiSE=
-github.com/chnsz/golangsdk v0.0.0-20220315024338-8b5a0e685be3/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220326084319-c4df10cfffd8 h1:79lxPrXSxp+1ilnbLKPbtxiR/wRJWAnelqDuX8MX3Iw=
+github.com/chnsz/golangsdk v0.0.0-20220326084319-c4df10cfffd8/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/compute_instance_v2_networking.go
+++ b/huaweicloud/compute_instance_v2_networking.go
@@ -69,7 +69,7 @@ func expandInstanceNetworks(d *schema.ResourceData) ([]servers.Network, error) {
 // InstanceNIC list struct.
 func getInstanceAddresses(d *schema.ResourceData, meta interface{}, server *cloudservers.CloudServer) ([]InstanceNIC, error) {
 	config := meta.(*config.Config)
-	networkingClient, err := config.SecurityGroupV1Client(GetRegion(d, config))
+	networkingClient, err := config.NetworkingV1Client(GetRegion(d, config))
 	if err != nil {
 		return nil, fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -559,10 +559,6 @@ func (c *Config) NetworkingV3Client(region string) (*golangsdk.ServiceClient, er
 	return c.NewServiceClient("vpcv3", region)
 }
 
-func (c *Config) SecurityGroupV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return c.NewServiceClient("security_group", region)
-}
-
 // VPCEPClient returns a ServiceClient for VPC Endpoint APIs
 // the endpoint likes: https://vpcep.{region}.myhuaweicloud.com/v1/{project_id}/
 func (c *Config) VPCEPClient(region string) (*golangsdk.ServiceClient, error) {

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -21,7 +21,7 @@ var multiCatalogKeys = map[string][]string{
 	"evs":       {"evsv21"},
 	"cce":       {"ccev1", "cce_addon"},
 	"cci":       {"cciv1_bata"},
-	"vpc":       {"networkv2", "vpcv3", "security_group", "fwv2"},
+	"vpc":       {"networkv2", "vpcv3", "fwv2"},
 	"elb":       {"elbv2", "elbv3"},
 	"dns":       {"dns_region"},
 	"kms":       {"kmsv1", "kmsv3"},
@@ -202,10 +202,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"vpcv3": {
 		Name:    "vpc",
 		Version: "v3",
-	},
-	"security_group": {
-		Name:    "vpc",
-		Version: "v1",
 	},
 	"nat": {
 		Name:    "nat",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -762,16 +762,6 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "nat", "v2", t)
 
-	// test endpoint of secgroup v1
-	serviceClient, err = nil, nil
-	serviceClient, err = config.SecurityGroupV1Client(HW_REGION_NAME)
-	if err != nil {
-		t.Fatalf("Error creating HuaweiCloud security_group v1 client: %s", err)
-	}
-	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
-	actualURL = serviceClient.ResourceBaseURL()
-	compareURL(expectedURL, actualURL, "security group", "v1", t)
-
 	// test endpoint of elb v2.0
 	serviceClient, err = nil, nil
 	serviceClient, err = config.ElbV2Client(HW_REGION_NAME)

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -169,7 +169,7 @@ func resourceLoadBalancerV2Create(ctx context.Context, d *schema.ResourceData, m
 	// Once the loadbalancer has been created, apply any requested security groups
 	// to the port that was created behind the scenes.
 	if lb.VipPortID != "" {
-		networkingClient, err := config.SecurityGroupV1Client(config.GetRegion(d))
+		networkingClient, err := config.NetworkingV1Client(config.GetRegion(d))
 		if err != nil {
 			return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 		}
@@ -227,7 +227,7 @@ func resourceLoadBalancerV2Read(_ context.Context, d *schema.ResourceData, meta 
 
 	// Get any security groups on the VIP Port
 	if lb.VipPortID != "" {
-		networkingClient, err := config.SecurityGroupV1Client(config.GetRegion(d))
+		networkingClient, err := config.NetworkingV1Client(config.GetRegion(d))
 		if err != nil {
 			return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 		}
@@ -304,7 +304,7 @@ func resourceLoadBalancerV2Update(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange("security_group_ids") {
 		vipPortID := d.Get("vip_port_id").(string)
 		if vipPortID != "" {
-			networkingClient, err := config.SecurityGroupV1Client(config.GetRegion(d))
+			networkingClient, err := config.NetworkingV1Client(config.GetRegion(d))
 			if err != nil {
 				return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 			}

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/ports/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/ports/urls.go
@@ -3,9 +3,9 @@ package ports
 import "github.com/chnsz/golangsdk"
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL("ports")
+	return c.ServiceURL(c.ProjectID, "ports")
 }
 
 func resourceURL(c *golangsdk.ServiceClient, portId string) string {
-	return c.ServiceURL("ports", portId)
+	return c.ServiceURL(c.ProjectID, "ports", portId)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220315024338-8b5a0e685be3
+# github.com/chnsz/golangsdk v0.0.0-20220326084319-c4df10cfffd8
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The SercurityGroupV1Client() method is unnecessary, so remove it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove the SercurityGroupV1Client() method.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/lb' TESTARGS='-run=TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run=TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (126.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        127.778
```
