### PR TITLE
fix(ecs/eip): update auto_pay parameter to string

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -277,11 +277,11 @@ The following arguments are supported:
   new resource.
 
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
-  Valid values are "true" and "false". Changing this creates a new resource.
+  Valid values are *true* and *false*. Defaults to *false*. Changing this creates a new resource.
 
-* `auto_pay` - (Optional, Bool, ForceNew) Specifies whether auto pay is enabled.
-  Defaults to *true*. If you set this to *false*, you need to pay the order yourself in time,
-  be careful about the timeout of resource creation. Changing this creates a new resource.
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this creates a new resource.
 
 * `user_id` - (Optional, String, ForceNew) Specifies a user ID, required when using key_pair in prePaid charging mode.
   Changing this creates a new instance.

--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -73,12 +73,12 @@ The following arguments are supported:
   *month*, the value ranges from 1 to 9. If `period_unit` is set to *year*, the value ranges from 1 to 3. This parameter
   is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new resource.
 
-* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are "true" and "
-  false". Changing this creates a new resource.
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+  Valid values are *true* and *false*. Defaults to *false*. Changing this creates a new resource.
 
-* `auto_pay` - (Optional, Bool, ForceNew) Specifies whether auto pay is enabled.
-  Defaults to *true*. If you set this to *false*, you need to pay the order yourself in time,
-  be careful about the timeout of resource creation. Changing this creates a new resource.
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this creates a new resource.
 
 The `publicip` block supports:
 

--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -84,10 +84,12 @@ func SchemaAutoRenew(conflicts []string) *schema.Schema {
 
 func SchemaAutoPay(conflicts []string) *schema.Schema {
 	resourceSchema := schema.Schema{
-		Type:          schema.TypeBool,
-		Optional:      true,
-		ForceNew:      true,
-		Default:       true,
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"true", "false",
+		}, false),
 		ConflictsWith: conflicts,
 	}
 

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -507,10 +507,10 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 			extendParam.PeriodType = d.Get("period_unit").(string)
 			extendParam.PeriodNum = d.Get("period").(int)
 			extendParam.IsAutoRenew = d.Get("auto_renew").(string)
-			if d.Get("auto_pay").(bool) {
-				extendParam.IsAutoPay = "true"
-			} else {
+			if d.Get("auto_pay").(string) == "false" {
 				extendParam.IsAutoPay = "false"
+			} else {
+				extendParam.IsAutoPay = "true"
 			}
 		}
 

--- a/huaweicloud/resource_schema.go
+++ b/huaweicloud/resource_schema.go
@@ -84,10 +84,12 @@ func schemaAutoRenew(conflicts []string) *schema.Schema {
 
 func schemaAutoPay(conflicts []string) *schema.Schema {
 	resourceSchema := schema.Schema{
-		Type:          schema.TypeBool,
-		Optional:      true,
-		ForceNew:      true,
-		Default:       true,
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"true", "false",
+		}, false),
 		ConflictsWith: conflicts,
 	}
 

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -232,10 +232,10 @@ func resourceVpcEIPV1Create(d *schema.ResourceData, meta interface{}) error {
 			PeriodNum:   d.Get("period").(int),
 			IsAutoRenew: d.Get("auto_renew").(string),
 		}
-		if d.Get("auto_pay").(bool) {
-			chargeInfo.IsAutoPay = "true"
-		} else {
+		if d.Get("auto_pay").(string) == "false" {
 			chargeInfo.IsAutoPay = "false"
+		} else {
+			chargeInfo.IsAutoPay = "true"
 		}
 		createOpts.ExtendParam = chargeInfo
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
this updates the type of auto_pay to string as bool value with default true will cause import issue.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccComputeV2Instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccComputeV2Instance -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== RUN   TestAccComputeV2Instance_disks
=== PAUSE TestAccComputeV2Instance_disks
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== RUN   TestAccComputeV2Instance_tags
=== PAUSE TestAccComputeV2Instance_tags
=== RUN   TestAccComputeV2Instance_powerAction
=== PAUSE TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_tags
=== CONT  TestAccComputeV2Instance_prePaid
--- PASS: TestAccComputeV2Instance_basic (230.40s)
=== CONT  TestAccComputeV2Instance_disks
--- PASS: TestAccComputeV2Instance_prePaid (231.89s)
--- PASS: TestAccComputeV2Instance_disks (242.35s)
--- PASS: TestAccComputeV2Instance_tags (500.52s)
--- PASS: TestAccComputeV2Instance_powerAction (783.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       783.995s
```
```
make testacc TEST=./huaweicloud/services/acceptance/eip/ TESTARGS='-run=TestAccVpcEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip/ -v -run=TestAccVpcEIP -timeout 360m -parallel 4
=== RUN   TestAccVpcEIP_basic
=== PAUSE TestAccVpcEIP_basic
=== RUN   TestAccVpcEIP_share
=== PAUSE TestAccVpcEIP_share
=== RUN   TestAccVpcEIP_WithEpsId
=== PAUSE TestAccVpcEIP_WithEpsId
=== RUN   TestAccVpcEIP_prePaid
=== PAUSE TestAccVpcEIP_prePaid
=== RUN   TestAccVpcEIP_ipv6
=== PAUSE TestAccVpcEIP_ipv6
=== RUN   TestAccVpcEIP_port
=== PAUSE TestAccVpcEIP_port
=== CONT  TestAccVpcEIP_basic
=== CONT  TestAccVpcEIP_prePaid
=== CONT  TestAccVpcEIP_port
=== CONT  TestAccVpcEIP_ipv6
--- PASS: TestAccVpcEIP_ipv6 (71.44s)
=== CONT  TestAccVpcEIP_WithEpsId
--- PASS: TestAccVpcEIP_basic (108.05s)
=== CONT  TestAccVpcEIP_share
--- PASS: TestAccVpcEIP_WithEpsId (63.99s)
--- PASS: TestAccVpcEIP_port (149.11s)
--- PASS: TestAccVpcEIP_prePaid (165.29s)
--- PASS: TestAccVpcEIP_share (86.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       194.687s
```