### PR TITLE
fix(ecs/eip): fix update non auto_pay resource issue

### DIFF
--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -25,7 +25,7 @@ func TagsForceNewSchema() *schema.Schema {
 	}
 }
 
-func SchemeChargingMode(conflicts []string) *schema.Schema {
+func SchemaChargingMode(conflicts []string) *schema.Schema {
 	resourceSchema := schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -221,7 +221,7 @@ func ResourceCCEClusterV3() *schema.Resource {
 			"tags": tagsForceNewSchema(),
 
 			// charge info: charging_mode, period_unit, period, auto_renew
-			"charging_mode": schemeChargingMode(nil),
+			"charging_mode": schemaChargingMode(nil),
 			"period_unit":   schemaPeriodUnit(nil),
 			"period":        schemaPeriod(nil),
 			"auto_renew":    schemaAutoRenew(nil),

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -398,7 +398,7 @@ func ResourceCCENodeV3() *schema.Resource {
 			},
 
 			// charge info: charging_mode, period_unit, period, auto_renew
-			"charging_mode": schemeChargingMode(nil),
+			"charging_mode": schemaChargingMode(nil),
 			"period_unit":   schemaPeriodUnit(nil),
 			"period":        schemaPeriod(nil),
 			"auto_renew":    schemaAutoRenew(nil),

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -284,7 +284,7 @@ func ResourceComputeInstanceV2() *schema.Resource {
 			},
 
 			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
-			"charging_mode": schemeChargingMode(novaConflicts),
+			"charging_mode": schemaChargingMode(novaConflicts),
 			"period_unit":   schemaPeriodUnit(novaConflicts),
 			"period":        schemaPeriod(novaConflicts),
 			"auto_renew":    schemaAutoRenew(novaConflicts),
@@ -983,6 +983,9 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 
 		extendParam := &cloudservers.ResizeExtendParam{
 			AutoPay: "true",
+		}
+		if d.Get("auto_pay").(string) == "false" {
+			extendParam.AutoPay = "false"
 		}
 		resizeOpts := &cloudservers.ResizeOpts{
 			FlavorRef:   newFlavorId,

--- a/huaweicloud/resource_huaweicloud_rds_instance_v3.go
+++ b/huaweicloud/resource_huaweicloud_rds_instance_v3.go
@@ -256,7 +256,7 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			},
 
 			// charge info: charging_mode, period_unit, period, auto_renew
-			"charging_mode": schemeChargingMode(nil),
+			"charging_mode": schemaChargingMode(nil),
 			"period_unit":   schemaPeriodUnit(nil),
 			"period":        schemaPeriod(nil),
 			"auto_renew":    schemaAutoRenew(nil),

--- a/huaweicloud/resource_schema.go
+++ b/huaweicloud/resource_schema.go
@@ -25,7 +25,7 @@ func tagsForceNewSchema() *schema.Schema {
 	}
 }
 
-func schemeChargingMode(conflicts []string) *schema.Schema {
+func schemaChargingMode(conflicts []string) *schema.Schema {
 	resourceSchema := schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -228,7 +228,7 @@ func ResourceBmsInstance() *schema.Resource {
 					},
 				},
 			},
-			"charging_mode": common.SchemeChargingMode([]string{}),
+			"charging_mode": common.SchemaChargingMode([]string{}),
 			"period_unit":   common.SchemaPeriodUnit([]string{}),
 			"period":        common.SchemaPeriod([]string{}),
 			"auto_renew":    common.SchemaAutoRenew([]string{}),

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -232,7 +232,7 @@ func ResourceDcsInstance() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
-			"charging_mode": common.SchemeChargingMode(nil),
+			"charging_mode": common.SchemaChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenew(nil),

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -166,7 +166,7 @@ func ResourceLoadBalancerV3() *schema.Resource {
 			"tags": common.TagsSchema(),
 
 			// charge info: charging_mode, period_unit, period, auto_renew
-			"charging_mode": common.SchemeChargingMode(nil),
+			"charging_mode": common.SchemaChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenew(nil),

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -109,7 +109,7 @@ func ResourceEvsVolume() *schema.Resource {
 				ForceNew: true,
 				Default:  false,
 			},
-			"charging_mode": common.SchemeChargingMode(nil),
+			"charging_mode": common.SchemaChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenew(nil),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. add non auto_pay support for updating flavor of ECS instance.
2. add prepaid support for updating eip bandwith.
3. fix typo of SchemaChargingMode func name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2060 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccComputeV2Instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccComputeV2Instance -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== RUN   TestAccComputeV2Instance_disks
=== PAUSE TestAccComputeV2Instance_disks
=== RUN   TestAccComputeV2Instance_prePaid
=== PAUSE TestAccComputeV2Instance_prePaid
=== RUN   TestAccComputeV2Instance_tags
=== PAUSE TestAccComputeV2Instance_tags
=== RUN   TestAccComputeV2Instance_powerAction
=== PAUSE TestAccComputeV2Instance_powerAction
=== CONT  TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_tags
=== CONT  TestAccComputeV2Instance_prePaid
=== CONT  TestAccComputeV2Instance_powerAction
--- PASS: TestAccComputeV2Instance_basic (226.99s)
=== CONT  TestAccComputeV2Instance_disks
--- PASS: TestAccComputeV2Instance_prePaid (274.99s)
--- PASS: TestAccComputeV2Instance_disks (251.12s)
--- PASS: TestAccComputeV2Instance_tags (515.03s)
--- PASS: TestAccComputeV2Instance_powerAction (780.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       780.925s
```
```
make testacc TEST=./huaweicloud/services/acceptance/eip/ TESTARGS='-run=TestAccVpcEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip/ -v -run=TestAccVpcEIP -timeout 360m -parallel 4
=== RUN   TestAccVpcEIP_basic
=== PAUSE TestAccVpcEIP_basic
=== RUN   TestAccVpcEIP_share
=== PAUSE TestAccVpcEIP_share
=== RUN   TestAccVpcEIP_WithEpsId
=== PAUSE TestAccVpcEIP_WithEpsId
=== RUN   TestAccVpcEIP_prePaid
=== PAUSE TestAccVpcEIP_prePaid
=== RUN   TestAccVpcEIP_ipv6
=== PAUSE TestAccVpcEIP_ipv6
=== RUN   TestAccVpcEIP_port
=== PAUSE TestAccVpcEIP_port
=== CONT  TestAccVpcEIP_basic
=== CONT  TestAccVpcEIP_prePaid
=== CONT  TestAccVpcEIP_ipv6
=== CONT  TestAccVpcEIP_port
--- PASS: TestAccVpcEIP_ipv6 (72.81s)
=== CONT  TestAccVpcEIP_WithEpsId
--- PASS: TestAccVpcEIP_basic (113.74s)
=== CONT  TestAccVpcEIP_share
--- PASS: TestAccVpcEIP_WithEpsId (58.09s)
--- PASS: TestAccVpcEIP_port (149.04s)
--- PASS: TestAccVpcEIP_share (82.51s)
--- PASS: TestAccVpcEIP_prePaid (206.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       206.955s
```