### PR TITLE
chore: rename hc client function,fix bug

### DIFF
--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -349,7 +349,7 @@ func buildClientByPassword(c *Config) error {
 }
 
 func buildClientByAgency(c *Config) error {
-	client, err := NewIamClient(c, "")
+	client, err := c.HcIamV3Client()
 	if err != nil {
 		return fmt.Errorf("Error creating Huaweicloud IAM client: %s", err)
 	}

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -24,12 +24,11 @@ var multiCatalogKeys = map[string][]string{
 	"vpc":       {"networkv2", "vpcv3", "fwv2"},
 	"elb":       {"elbv2", "elbv3"},
 	"dns":       {"dns_region"},
-	"kms":       {"kmsv1", "kmsv3"},
+	"kms":       {"kmsv1"},
 	"mrs":       {"mrsv2"},
 	"rds":       {"rdsv1"},
 	"waf":       {"waf-dedicated"},
 	"geminidb":  {"geminidbv31"},
-	"gaussdb":   {"gaussdbv3"},
 	"dli":       {"dliv2"},
 	"dcs":       {"dcsv1"},
 	"dis":       {"disv3"},
@@ -267,10 +266,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "gaussdb",
 		Version: "mysql/v3",
 	},
-	"gaussdbv3": {
-		Name:    "gaussdb",
-		Version: "v3",
-	},
 	"opengauss": {
 		Name:    "gaussdb-opengauss",
 		Version: "v3",
@@ -318,10 +313,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"kmsv1": {
 		Name:    "kms",
 		Version: "v1",
-	},
-	"kmsv3": {
-		Name:    "kms",
-		Version: "v3",
 	},
 	"waf": {
 		Name:         "waf",

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getKpsKeypairResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.NewKmsClient(conf, acceptance.HW_REGION_NAME)
+	client, err := conf.HcKmsV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating KMS v3 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
+++ b/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
@@ -33,7 +33,7 @@ func TestAccTmsTag_basic(t *testing.T) {
 
 func testAccCheckTmsTagDestroy(s *terraform.State) error {
 	conf := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.NewTmsClient(conf, acceptance.HW_REGION_NAME)
+	client, err := conf.HcTmsV1Client()
 	if err != nil {
 		return fmt.Errorf("Error creating TMS client: %s", err)
 	}
@@ -61,7 +61,7 @@ func testAccCheckTmsTagDestroy(s *terraform.State) error {
 func testAccCheckTmsTagExists(key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conf := acceptance.TestAccProvider.Meta().(*config.Config)
-		client, err := config.NewTmsClient(conf, acceptance.HW_REGION_NAME)
+		client, err := conf.HcTmsV1Client()
 		if err != nil {
 			return fmt.Errorf("Error creating TMS client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_address_group_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_address_group_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func getVpcAddressGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.NewVpcClient(conf, acceptance.HW_REGION_NAME)
+	client, err := conf.HcVpcV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Huaweicloud VPC client: %s", err)
 	}

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
@@ -127,7 +127,7 @@ func ResourceKeypair() *schema.Resource {
 func resourceKeypairCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := config.NewKmsClient(c, region)
+	client, err := c.HcKmsV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating KMS v3 client: %s", err)
 	}
@@ -168,7 +168,7 @@ func resourceKeypairCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceKeypairRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := config.NewKmsClient(c, region)
+	client, err := c.HcKmsV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating KMS v3 client: %s", err)
 	}
@@ -209,7 +209,7 @@ func resourceKeypairRead(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceKeypairUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := config.NewKmsClient(c, region)
+	client, err := c.HcKmsV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating KMS v3 client: %s", err)
 	}
@@ -226,7 +226,7 @@ func resourceKeypairUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceKeypairDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := config.NewKmsClient(c, region)
+	client, err := c.HcKmsV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating KMS v3 client: %s", err)
 	}

--- a/huaweicloud/services/tms/resource_huaweicloud_tms_tags.go
+++ b/huaweicloud/services/tms/resource_huaweicloud_tms_tags.go
@@ -63,7 +63,7 @@ func ResourceTmsTag() *schema.Resource {
 
 func resourceTmsTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := config.NewTmsClient(c, "")
+	client, err := c.HcTmsV1Client()
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
 	}
@@ -101,7 +101,7 @@ func resourceTmsTagCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceTmsTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := config.NewTmsClient(c, "")
+	client, err := c.HcTmsV1Client()
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
 	}
@@ -152,7 +152,7 @@ func resourceTmsTagRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourceTmsTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := config.NewTmsClient(c, "")
+	client, err := c.HcTmsV1Client()
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
 	}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -63,7 +63,7 @@ func ResourceVpcAddressGroup() *schema.Resource {
 func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := config.NewVpcClient(c, region)
+	client, err := c.HcVpcV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
 	}
@@ -103,7 +103,7 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := config.NewVpcClient(c, region)
+	client, err := c.HcVpcV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
 	}
@@ -134,7 +134,7 @@ func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, me
 
 func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := config.NewVpcClient(c, c.GetRegion(d))
+	client, err := c.HcVpcV3Client(c.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
 	}
@@ -177,7 +177,8 @@ func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceVpcAddressGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := config.NewVpcClient(c, c.GetRegion(d))
+	region := c.GetRegion(d)
+	client, err := c.HcVpcV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. fix bug of NewHcClient
2. rename the function name of hcXXXClient
3. remove Gaussdb config from endpoint.go

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/tms' TESTARGS='-run=TestAccTmsTag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/tms -v -run=TestAccTmsTag -timeout 360m -parallel 4
=== RUN   TestAccTmsTag_basic
--- PASS: TestAccTmsTag_basic (11.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/tms       11.604s
```
```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run=TestAccKpsKeypair'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run=TestAccKpsKeypair -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_basic
--- PASS: TestAccKpsKeypair_basic (23.62s)
=== RUN   TestAccKpsKeypair_domain
--- PASS: TestAccKpsKeypair_domain (23.05s)
=== RUN   TestAccKpsKeypair_publicKey
--- PASS: TestAccKpsKeypair_publicKey (19.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       66.036s
```
```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcAddressGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcAddressGroup -timeout 360m -parallel 4
=== RUN   TestAccVpcAddressGroup_basic
--- PASS: TestAccVpcAddressGroup_basic (18.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       18.812s
```
```
 make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccGaussDBInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccGaussDBInstance -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_basic
--- PASS: TestAccGaussDBInstance_basic (1255.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1255.825
```