### PR TITLE
fix(dns/zone): add computed behavior to email parameter

### DIFF
--- a/huaweicloud/resource_huaweicloud_dns_zone_v2.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2.go
@@ -47,6 +47,7 @@ func ResourceDNSZoneV2() *schema.Resource {
 			"email": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"zone_type": {
 				Type:         schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_dns_zone_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_dns_zone_v2_test.go
@@ -32,10 +32,10 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", zoneName),
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "description", "a zone"),
-					resource.TestCheckResourceAttr(resourceName, "email", "email1@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "300"),
 					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "email"),
 				),
 			},
 			{
@@ -47,10 +47,10 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 				Config: testAccDNSV2Zone_update(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "an updated zone"),
-					resource.TestCheckResourceAttr(resourceName, "email", "email2@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "600"),
 					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
+					resource.TestCheckResourceAttrSet(resourceName, "email"),
 				),
 			},
 		},
@@ -185,7 +185,6 @@ func testAccDNSV2Zone_basic(zoneName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_zone" "zone_1" {
   name        = "%s"
-  email       = "email1@example.com"
   description = "a zone"
   ttl         = 300
 
@@ -201,7 +200,6 @@ func testAccDNSV2Zone_update(zoneName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dns_zone" "zone_1" {
   name        = "%s"
-  email       = "email2@example.com"
   description = "an updated zone"
   ttl         = 600
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resources wil always changed because of the email parameter is not computed behavior and we setting in the Read method.
Fix the problem of resource changes:
- add `Computed` behavior to email parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2067 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add computed behavior to email parameter
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
