### PR TITLE
feat(config): add NatV2Client for Joint-Operation cloud

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -795,3 +795,10 @@ func (c *Config) MlsV1Client(region string) (*golangsdk.ServiceClient, error) {
 func (c *Config) ScmV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("scm", region)
 }
+
+// the following clients are used for Joint-Operation Cloud only
+
+// NatV2Client has the endpoint: https://nat.{{region}}/{{cloud}}/v2.0/
+func (c *Config) NatV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("natv2", region)
+}

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -456,4 +456,12 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v3",
 		WithOutProjectID: true,
 	},
+
+	// catalog for Joint-Operation Cloud only
+	// no need to put the key into allServiceCatalog
+	"natv2": {
+		Name:             "nat",
+		Version:          "v2.0",
+		WithOutProjectID: true,
+	},
 }

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -762,6 +762,16 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	actualURL = serviceClient.ResourceBaseURL()
 	compareURL(expectedURL, actualURL, "nat", "v2", t)
 
+	// test endpoint of nat gateway v2.0
+	serviceClient, err = nil, nil
+	serviceClient, err = config.NatV2Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud nat gateway v2.0 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://nat.%s.%s/v2.0/", HW_REGION_NAME, config.Cloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	compareURL(expectedURL, actualURL, "nat", "v2.0", t)
+
 	// test endpoint of elb v2.0
 	serviceClient, err = nil, nil
 	serviceClient, err = config.ElbV2Client(HW_REGION_NAME)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccServiceEndpoints_Network'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_Network -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_Network
2022/03/31 15:33:52 [DEBUG] customer endpoints: map[]
2022/03/31 15:33:52 [DEBUG] init region and project map: map[string]string{"cn-north-4":"{{project_id}}"}
    endpoints_test.go:1130: vpc v1 endpoint:     https://vpc.cn-north-4.myhuaweicloud.com/v1/
    endpoints_test.go:1130: vpc v3 endpoint:     https://vpc.cn-north-4.myhuaweicloud.com/v3/{{project_id}}/
    endpoints_test.go:1130: networking v2.0 endpoint:    https://vpc.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:1130: nat v2 endpoint:     https://nat.cn-north-4.myhuaweicloud.com/v2/{{project_id}}/
    endpoints_test.go:1130: nat v2.0 endpoint:   https://nat.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:1130: elb v2.0 endpoint:   https://elb.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:1130: elb v3 endpoint:     https://elb.cn-north-4.myhuaweicloud.com/v3/{{project_id}}/
    endpoints_test.go:1130: elb v2 endpoint:     https://elb.cn-north-4.myhuaweicloud.com/v2/{{project_id}}/
    endpoints_test.go:1130: fw v2.0 endpoint:    https://vpc.cn-north-4.myhuaweicloud.com/v2.0/
    endpoints_test.go:824: DNS endpoint:         https://dns.myhuaweicloud.com/v2/
    endpoints_test.go:836: DNS region endpoint:  https://dns.cn-north-4.myhuaweicloud.com/v2/
    endpoints_test.go:848: VPCEP endpoint:       https://vpcep.cn-north-4.myhuaweicloud.com/v1/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Network (0.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.973s
```
