### PR TITLE
docs(dcs/instance): fix the wrong special characters

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -140,7 +140,7 @@ The following arguments are supported:
   The password of a DCS instance must meet the following complexity requirements:
   + Must be a string of 8 to 32 bits in length.
   + Must contain three combinations of the following four characters: Lower case letters, uppercase letter, digital,
-    Special characters include (`~!@#$%^&*()-_=+|[{}]:'",<.>/?).
+    Special characters include (`~!@#$^&*()-_=+\\|{}:,<.>/?).
   + The new password cannot be the same as the old password.
     Redis instance defaults to 6379. Memcached instance does not use this argument.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The description of the special characters is wrong, `%[]'"` are not support.
![image](https://user-images.githubusercontent.com/74246744/161059625-fbbd9c2d-c86e-4ced-9f9a-028403214718.png)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong special characters.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
