### PR TITLE
fix(iam and tms): update iam and tms client

### DIFF
--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -349,7 +349,7 @@ func buildClientByPassword(c *Config) error {
 }
 
 func buildClientByAgency(c *Config) error {
-	client, err := c.HcIamV3Client()
+	client, err := c.HcIamV3Client(c.Region)
 	if err != nil {
 		return fmt.Errorf("Error creating Huaweicloud IAM client: %s", err)
 	}

--- a/huaweicloud/config/hc_config.go
+++ b/huaweicloud/config/hc_config.go
@@ -146,8 +146,8 @@ func (c *Config) HcVpcV3Client(region string) (*vpcv3.VpcClient, error) {
 }
 
 // HcTmsV1Client is the TMS service client using huaweicloud-sdk-go-v3 package
-func (c *Config) HcTmsV1Client() (*tmsv1.TmsClient, error) {
-	hcClient, err := NewHcClient(c, "", "tms", true)
+func (c *Config) HcTmsV1Client(region string) (*tmsv1.TmsClient, error) {
+	hcClient, err := NewHcClient(c, region, "tms", true)
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +164,8 @@ func (c *Config) HcKmsV3Client(region string) (*kpsv3.KpsClient, error) {
 }
 
 // HcIamV3Client is the IAM service client using huaweicloud-sdk-go-v3 package
-func (c *Config) HcIamV3Client() (*iamv3.IamClient, error) {
-	hcClient, err := NewHcClient(c, "", "iam", true)
+func (c *Config) HcIamV3Client(region string) (*iamv3.IamClient, error) {
+	hcClient, err := NewHcClient(c, region, "iam", true)
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
+++ b/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_tags_test.go
@@ -33,7 +33,7 @@ func TestAccTmsTag_basic(t *testing.T) {
 
 func testAccCheckTmsTagDestroy(s *terraform.State) error {
 	conf := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := conf.HcTmsV1Client()
+	client, err := conf.HcTmsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating TMS client: %s", err)
 	}
@@ -61,7 +61,7 @@ func testAccCheckTmsTagDestroy(s *terraform.State) error {
 func testAccCheckTmsTagExists(key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conf := acceptance.TestAccProvider.Meta().(*config.Config)
-		client, err := conf.HcTmsV1Client()
+		client, err := conf.HcTmsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating TMS client: %s", err)
 		}

--- a/huaweicloud/services/tms/resource_huaweicloud_tms_tags.go
+++ b/huaweicloud/services/tms/resource_huaweicloud_tms_tags.go
@@ -63,7 +63,7 @@ func ResourceTmsTag() *schema.Resource {
 
 func resourceTmsTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := c.HcTmsV1Client()
+	client, err := c.HcTmsV1Client(c.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
 	}
@@ -101,7 +101,7 @@ func resourceTmsTagCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceTmsTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := c.HcTmsV1Client()
+	client, err := c.HcTmsV1Client(c.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
 	}
@@ -152,7 +152,7 @@ func resourceTmsTagRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourceTmsTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
-	client, err := c.HcTmsV1Client()
+	client, err := c.HcTmsV1Client(c.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating Huaweicloud TMS client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The endpoints of global services are different between hauweicloud (tms.myhuaweicloud.com) and joint-operation cloud (tms.ae-ad-1.g42cloud.com), we need to make the provider compatible.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update iam and tms client to make the provider compatible with  joint-operation cloud 
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccIdentityV3User_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./g42cloud -v -run TestAccIdentityV3User_basic -timeout 360m -parallel=4
=== RUN   TestAccIdentityV3User_basic
=== PAUSE TestAccIdentityV3User_basic
=== CONT  TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (27.02s)
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      27.163s
```
