### PR TITLE
feat(servicestage): add new authorization resource support

### DIFF
--- a/docs/resources/servicestage_repo_password_authorization.md
+++ b/docs/resources/servicestage_repo_password_authorization.md
@@ -1,0 +1,65 @@
+---
+subcategory: "ServiceStage"
+---
+
+# huaweicloud_servicestage_repo_password_authorization
+
+This resource is used for the ServiceStage service to establish the authorization relationship through username
+and password with various types of the Open-Source repository.
+
+## Example Usage
+
+```hcl
+variable "authorization_name"
+variable "domain_name"
+variable "tenant_name"
+variable "password"
+
+resource "huaweicloud_servicestage_repo_password_authorization" "test" {
+  type      = "devcloud"
+  name      = var.authorization_name
+  user_name = format("%s/%s", var.domain_name, var.tenant_name)
+  password  = var.password
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specified the region in which to create the repository authorization.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new authorization.
+
+* `name` - (Required, String, ForceNew) Specified the authorization name. The name can contain of 4 to 63 characters,
+  only letters, digits, underscores (_), hyphens (-) and dots (.) are allowed.
+  Changing this parameter will create a new authorization.
+
+* `type` - (Required, String, ForceNew) Specified the repository type. The valid values are as follows:
+  + **devcloud**
+  + **bitbucket**
+
+  Changing this parameter will create a new authorization.
+
+* `user_name` - (Required, String, ForceNew) Specified the user name of the repository.
+  The format for each type is as follows:
+  + **devcloud**: `{domain name}/{tenant name}`
+  + **bitbucket**: `{account name}`
+
+  Changing this parameter will create a new authorization.
+
+* `password` - (Required, String, ForceNew) Specified the repository password.
+  Changing this parameter will create a new authorization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+Authorizations can be imported using their `id` or `name`, e.g.:
+
+```
+$ terraform import huaweicloud_servicestage_repo_password_authorization.test terraform-test
+```

--- a/docs/resources/servicestage_repo_token_authorization.md
+++ b/docs/resources/servicestage_repo_token_authorization.md
@@ -1,0 +1,61 @@
+---
+subcategory: "ServiceStage"
+---
+
+# huaweicloud_servicestage_repo_token_authorization
+
+This resource is used for the ServiceStage service to establish the authorization relationship through personal access
+token with various types of the Open-Source repository.
+
+## Example Usage
+
+```hcl
+variable "authorization_name"
+variable "repository_host"
+variable "personal_access_token"
+
+resource "huaweicloud_servicestage_repo_token_authorization" "test" {
+  type  = "github"
+  name  = var.authorization_name
+  host  = var.repository_host
+  token = var.personal_access_token
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specified the region in which to create the repository authorization.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new authorization.
+
+* `name` - (Required, String, ForceNew) Specified the authorization name. The name can contain of 4 to 63 characters,
+  only letters, digits, underscores (_), hyphens (-) and dots (.) are allowed.
+  Changing this parameter will create a new authorization.
+
+* `type` - (Required, String, ForceNew) Specified the repository type. The valid values are as follows:
+  + **github**
+  + **gitlab**
+  + **gitee**
+
+  Changing this parameter will create a new authorization.
+
+* `host` - (Required, String, ForceNew) Specified the host name of the repository.
+  Changing this parameter will create a new authorization.
+
+* `token` - (Required, String, ForceNew) Specified the personal access token of the repository.
+  Changing this parameter will create a new authorization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+Authorizations can be imported using their `id` or `name`, e.g.:
+
+```
+$ terraform import huaweicloud_servicestage_repo_token_authorization.test terraform-test
+```

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -735,6 +735,10 @@ func (c *Config) DmsV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dmsv2", region)
 }
 
+func (c *Config) ServiceStageV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("servicestage", region)
+}
+
 // ********** client for Database **********
 func (c *Config) RdsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("rdsv1", region)

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -504,6 +504,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		WithOutProjectID: true,
 		Product:          "DMS",
 	},
+	"servicestage": {
+		Name:    "servicestage",
+		Version: "v1",
+		Product: "ServiceStage",
+	},
 
 	// catalog for IEC which is a global service
 	"iec": {

--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -242,7 +242,7 @@ func isSecurityFields(field string) bool {
 	// "adminPass" is apply to the ecs/bms instance request JSON body
 	// "adminPwd" is apply to the css cluster request JSON body
 	// 'encrypted_user_data' is apply to the function request JSON body of FunctionGraph
-	securityFields := []string{"adminPass", "adminPwd", "encrypted_user_data"}
+	securityFields := []string{"adminPass", "adminPwd", "encrypted_user_data", "token"}
 	for _, key := range securityFields {
 		if key == field {
 			return true

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -475,6 +475,18 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 		t.Fatalf("DMS v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
 	t.Logf("DMS v2 endpoint:\t %s", actualURL)
+
+	// test the endpoint of ServiceStage V1 service
+	serviceClient, err = config.ServiceStageV1Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud ServiceStage v1 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://servicestage.%s.%s/v1/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("ServiceStage v1 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("ServiceStage v1 endpoint:\t %s", actualURL)
 }
 
 // TestAccServiceEndpoints_Compute test for endpoints of the clients used in ecs

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -47,6 +47,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
@@ -698,6 +699,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_instance":              ResourceRdsInstanceV3(),
 			"huaweicloud_rds_parametergroup":        ResourceRdsConfigurationV3(),
 			"huaweicloud_rds_read_replica_instance": ResourceRdsReadReplicaInstance(),
+
+			"huaweicloud_servicestage_repo_token_authorization": servicestage.ResourceRepoTokenAuth(),
 
 			"huaweicloud_sfs_access_rule": ResourceSFSAccessRuleV2(),
 			"huaweicloud_sfs_file_system": ResourceSFSFileSystemV2(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -700,7 +700,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_parametergroup":        ResourceRdsConfigurationV3(),
 			"huaweicloud_rds_read_replica_instance": ResourceRdsReadReplicaInstance(),
 
-			"huaweicloud_servicestage_repo_token_authorization": servicestage.ResourceRepoTokenAuth(),
+			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
+			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),
 
 			"huaweicloud_sfs_access_rule": ResourceSFSAccessRuleV2(),
 			"huaweicloud_sfs_file_system": ResourceSFSFileSystemV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -61,6 +61,9 @@ var (
 	HW_DMS_ENVIRONMENT              = os.Getenv("HW_DMS_ENVIRONMENT")
 
 	HW_DLI_FLINK_JAR_OBS_PATH = os.Getenv("HW_DLI_FLINK_JAR_OBS_PATH")
+
+	HW_GITHUB_REPO_HOST      = os.Getenv("HW_GITHUB_REPO_HOST")      // Repository host (Github, Gitlab, Gitee)
+	HW_GITHUB_PERSONAL_TOKEN = os.Getenv("HW_GITHUB_PERSONAL_TOKEN") // Personal access token (Github, Gitlab, Gitee)
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -458,5 +461,12 @@ func TestAccPreCheckDms(t *testing.T) {
 func TestAccPreCheckDliJarPath(t *testing.T) {
 	if HW_DLI_FLINK_JAR_OBS_PATH == "" {
 		t.Skip("HW_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckRepoTokenAuth(t *testing.T) {
+	if HW_GITHUB_REPO_HOST == "" || HW_GITHUB_PERSONAL_TOKEN == "" {
+		t.Skip("Repository configuration are not completed for acceptance test of personal access token authorization.")
 	}
 }

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -26,6 +26,7 @@ var (
 	HW_ACCESS_KEY                 = os.Getenv("HW_ACCESS_KEY")
 	HW_SECRET_KEY                 = os.Getenv("HW_SECRET_KEY")
 	HW_USER_ID                    = os.Getenv("HW_USER_ID")
+	HW_USER_NAME                  = os.Getenv("HW_USER_NAME")
 	HW_PROJECT_ID                 = os.Getenv("HW_PROJECT_ID")
 	HW_DOMAIN_ID                  = os.Getenv("HW_DOMAIN_ID")
 	HW_DOMAIN_NAME                = os.Getenv("HW_DOMAIN_NAME")
@@ -64,6 +65,7 @@ var (
 
 	HW_GITHUB_REPO_HOST      = os.Getenv("HW_GITHUB_REPO_HOST")      // Repository host (Github, Gitlab, Gitee)
 	HW_GITHUB_PERSONAL_TOKEN = os.Getenv("HW_GITHUB_PERSONAL_TOKEN") // Personal access token (Github, Gitlab, Gitee)
+	HW_GITHUB_REPO_PWD       = os.Getenv("HW_GITHUB_REPO_PWD")       // Repository password (DevCloud, BitBucket)
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -468,5 +470,12 @@ func TestAccPreCheckDliJarPath(t *testing.T) {
 func TestAccPreCheckRepoTokenAuth(t *testing.T) {
 	if HW_GITHUB_REPO_HOST == "" || HW_GITHUB_PERSONAL_TOKEN == "" {
 		t.Skip("Repository configuration are not completed for acceptance test of personal access token authorization.")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckRepoPwdAuth(t *testing.T) {
+	if HW_DOMAIN_NAME == "" || HW_USER_NAME == "" || HW_GITHUB_REPO_PWD == "" {
+		t.Skip("Repository configuration are not completed for acceptance test of password authorization.")
 	}
 }

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_repo_password_authorization_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_repo_password_authorization_test.go
@@ -1,0 +1,64 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRepoPwdAuth_basic(t *testing.T) {
+	var (
+		auth         repositories.Authorization
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_servicestage_repo_password_authorization.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&auth,
+		getAuthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRepoPwdAuth(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepoPwdAuth_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "type", "devcloud"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"user_name",
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func testAccRepoPwdAuth_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestage_repo_password_authorization" "test" {
+  type      = "devcloud"
+  name      = "%s"
+  user_name = "%s/%s"
+  password  = "%s"
+}
+`, rName, acceptance.HW_DOMAIN_NAME, acceptance.HW_USER_NAME, acceptance.HW_GITHUB_REPO_PWD)
+}

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_repo_token_authorization_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_repo_token_authorization_test.go
@@ -1,0 +1,84 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getAuthResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.ServiceStageV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage v1 client: %s", err)
+	}
+
+	resp, err := repositories.List(c)
+	if err != nil {
+		return resp, err
+	}
+	for _, v := range resp {
+		if v.Name == state.Primary.ID {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("error getting ServiceStage authorization (%s)", state.Primary.ID)
+}
+
+func TestAccRepoTokenAuth_basic(t *testing.T) {
+	var (
+		auth         repositories.Authorization
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_servicestage_repo_token_authorization.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&auth,
+		getAuthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRepoTokenAuth(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepoTokenAuth_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "type", "github"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"token",
+					"host",
+				},
+			},
+		},
+	})
+}
+
+func testAccRepoTokenAuth_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestage_repo_token_authorization" "test" {
+  type  = "github"
+  name  = "%s"
+  host  = "%s"
+  token = "%s"
+}
+`, rName, acceptance.HW_GITHUB_REPO_HOST, acceptance.HW_GITHUB_PERSONAL_TOKEN)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_password_authorization.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_password_authorization.go
@@ -1,0 +1,89 @@
+package servicestage
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceRepoPwdAuth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRepoPwdAuthCreate,
+		ReadContext:   resourceRepoAuthRead,
+		DeleteContext: resourceRepoAuthDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[\w.-]*$`),
+						"The name can only contain letters, digits, underscores (_), hyphens (-) and dots (.)."),
+					validation.StringLenBetween(4, 63),
+				),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"devcloud", "bitbucket",
+				}, false),
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceRepoPwdAuthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var err error
+	config := meta.(*config.Config)
+	client, err := config.ServiceStageV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("error creating ServiceStage v1 client: %s", err)
+	}
+
+	s := fmt.Sprintf("%s:%s", d.Get("user_name").(string), d.Get("password").(string))
+	opt := repositories.PwdAuthOpts{
+		Name:  d.Get("name").(string),
+		Token: base64.StdEncoding.EncodeToString([]byte(s)),
+	}
+	auth, err := repositories.CreatePwdAuth(client, d.Get("type").(string), opt)
+	if err != nil {
+		return diag.Errorf("error creating the ServiceStage password authorization: %s", err)
+	}
+
+	d.SetId(auth.Name)
+
+	return resourceRepoAuthRead(ctx, d, meta)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
@@ -1,0 +1,130 @@
+package servicestage
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func ResourceRepoTokenAuth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRepoTokenAuthCreate,
+		ReadContext:   resourceRepoAuthRead,
+		DeleteContext: resourceRepoAuthDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[\w.-]*$`),
+						"The name can only contain letters, digits, underscores (_), hyphens (-) and dots (.)."),
+					validation.StringLenBetween(4, 63),
+				),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"github", "gitlab", "gitee",
+				}, false),
+			},
+			"host": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceRepoTokenAuthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var err error
+	config := meta.(*config.Config)
+	client, err := config.ServiceStageV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("error creating ServiceStage v1 client: %s", err)
+	}
+
+	opt := repositories.PersonalAuthOpts{
+		Name:  d.Get("name").(string),
+		Host:  d.Get("host").(string),
+		Token: d.Get("token").(string),
+	}
+	auth, err := repositories.CreatePersonalAuth(client, d.Get("type").(string), opt)
+	if err != nil {
+		return diag.Errorf("error creating the ServiceStage repository token authorization: %s", err)
+	}
+
+	d.SetId(auth.Name)
+
+	return resourceRepoAuthRead(ctx, d, meta)
+}
+
+func resourceRepoAuthRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ServiceStageV1Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("error creating ServiceStage v1 client: %s", err)
+	}
+
+	resp, err := repositories.List(client)
+	if err == nil {
+		for _, v := range resp {
+			if v.Name != d.Id() {
+				continue
+			}
+			mErr := multierror.Append(nil,
+				d.Set("region", region),
+				d.Set("name", v.Name),
+				d.Set("type", v.RepoType),
+			)
+			return diag.FromErr(mErr.ErrorOrNil())
+		}
+	}
+
+	return common.CheckDeletedDiag(d, err, "error retrieving ServiceStage repository authorizations list")
+}
+
+func resourceRepoAuthDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ServiceStageV1Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("error creating ServiceStage v1 client: %s", err)
+	}
+
+	err = repositories.Delete(client, d.Id())
+	if err != nil {
+		return fmtp.DiagErrorf("error deleting ServiceStage repository authorization (%s): %s", d.Id(), err)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/requests.go
@@ -1,0 +1,75 @@
+package repositories
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// PwdAuthOpts is the structure required by the CreatePwdAuth method to create the authorization.
+type PwdAuthOpts struct {
+	// Specified the authorization name.
+	Name string `json:"name" required:"true"`
+	// Specified the base64 encoded token, before encoding, the format is '{account name}:{password}'.
+	Token string `json:"token" required:"true"`
+}
+
+// CreatePwdAuth is a method to create password authorization for a Git repository.
+func CreatePwdAuth(c *golangsdk.ServiceClient, rType string, opts PwdAuthOpts) (*Authorization, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(passwordURL(c, rType), b, &rst.Body, nil)
+	if err == nil {
+		var r Authorization
+		rst.ExtractIntoStructPtr(&r, "authorization")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// PersonalAuthOpts is the structure required by the CreatePersonalAuth method to create the authorization.
+type PersonalAuthOpts struct {
+	// Specified the authorization name.
+	Name string `json:"name" required:"true"`
+	// Specified the repository address.
+	Host string `json:"host" required:"true"`
+	// Specified the repository token.
+	Token string `json:"token" required:"true"`
+}
+
+// CreatePersonalAuth is a method to create the personal access token authorization.
+func CreatePersonalAuth(c *golangsdk.ServiceClient, rType string, opts PersonalAuthOpts) (*Authorization, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(personalURL(c, rType), b, &rst.Body, nil)
+	if err == nil {
+		var r Authorization
+		rst.ExtractIntoStructPtr(&r, "authorization")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// List is a method to obtain the authorization list of the repositories.
+func List(c *golangsdk.ServiceClient) ([]Authorization, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(rootURL(c), &rst.Body, nil)
+	if err == nil {
+		var r []Authorization
+		rst.ExtractIntoSlicePtr(&r, "authorizations")
+		return r, nil
+	}
+	return nil, err
+}
+
+// Delete is a method to delete an existing authorization.
+func Delete(c *golangsdk.ServiceClient, name string) error {
+	_, err := c.Delete(resourceURL(c, name), nil)
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/results.go
@@ -1,0 +1,26 @@
+package repositories
+
+// Authorization is the structure that represents the detail of the repository authorization.
+type Authorization struct {
+	// Specified the authorization name.
+	Name string `json:"name"`
+	// Specified the repository type
+	// The valid values are: devcloud, github, gitlab, gitee and bitbucket。
+	RepoType string `json:"repo_type"`
+	// Specified the repository address.
+	RepoHost string `json:"repo_host"`
+	// Specified the repository homepage.
+	RepoHome string `json:"repo_home"`
+	// Specified the repository username.
+	RepoUser string `json:"repo_user"`
+	// Specified the repository avatar.
+	Avartar string `json:"avartar"`
+	// Specified the authorization mode.
+	TokenType string `json:"token_type"`
+	// Specified the creation time.
+	CreateTime int `json:"create_time"`
+	// Specified the update time.
+	UpdateTime int `json:"update_time"`
+	// Specified the authorization status.
+	Status int `json:"status"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories/urls.go
@@ -1,0 +1,19 @@
+package repositories
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("git/auths")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, name string) string {
+	return c.ServiceURL("git/auths", name)
+}
+
+func passwordURL(c *golangsdk.ServiceClient, rType string) string {
+	return c.ServiceURL("git/auths", rType, "password")
+}
+
+func personalURL(c *golangsdk.ServiceClient, rType string) string {
+	return c.ServiceURL("git/auths", rType, "personal")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -236,6 +236,7 @@ github.com/chnsz/golangsdk/openstack/rds/v3/flavors
 github.com/chnsz/golangsdk/openstack/rds/v3/instances
 github.com/chnsz/golangsdk/openstack/rds/v3/securities
 github.com/chnsz/golangsdk/openstack/scm/v3/certificates
+github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories
 github.com/chnsz/golangsdk/openstack/sfs/v2/shares
 github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares
 github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Provides two resources for ServiceStage service to establish authorization relationships with various types of open source repositories:
- personal access token: creating authorization using host and token.
- password: creating authorization using user_name and password.

Which type of repository are support personal access token authorization creation:
- github
- gitlab
- gitee

Which type of repository are support password authorization  creation:
- devcloud
- bitbucket

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #2030 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Two resources of repository authorization have been supported:
    a. personal access token
    b. password
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccRepo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccRepo -timeout 360m -parallel 4
=== RUN   TestAccRepoPwdAuth_basic
=== PAUSE TestAccRepoPwdAuth_basic
=== RUN   TestAccRepoTokenAuth_basic
=== PAUSE TestAccRepoTokenAuth_basic
=== CONT  TestAccRepoPwdAuth_basic
=== CONT  TestAccRepoTokenAuth_basic
--- PASS: TestAccRepoPwdAuth_basic (54.58s)
--- PASS: TestAccRepoTokenAuth_basic (60.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      60.189s
```
