### PR TITLE
feat: support to forcibly delete an AS group

### DIFF
--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -179,6 +179,9 @@ The following arguments are supported:
 * `delete_instances` - (Optional, String) Whether to delete the instances in the AS group when deleting the AS group.
   The options are `yes` and `no`.
 
+* `force_delete` - (Optional, Bool) Whether to forcibly delete the AS group, remove the ECS instances and release them.
+  The default value is `false`.
+
 * `enable` - (Optional, Bool) Whether to enable the AS Group. The options are `true` and `false`. The default value
   is `true`.
 

--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -131,7 +131,7 @@ The following arguments are supported:
 * `scaling_group_name` - (Required, String) The name of the scaling group. The name can contain letters, digits,
   underscores(_), and hyphens(-),and cannot exceed 64 characters.
 
-* `scaling_configuration_id` - (Optional, String) The configuration ID which defines configurations of instances in the
+* `scaling_configuration_id` - (Required, String) The configuration ID which defines configurations of instances in the
   AS group.
 
 * `desire_instance_number` - (Optional, Int) The expected number of instances. The default value is the minimum number

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220407022843-88376a549c27
+	github.com/chnsz/golangsdk v0.0.0-20220409031514-b48169f0cea6
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220407022843-88376a549c27 h1:ziZlPkeznM/1eemyjAeEEQjD+Sc34x3/uRtmNuk6wLo=
 github.com/chnsz/golangsdk v0.0.0-20220407022843-88376a549c27/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220409031514-b48169f0cea6 h1:2fBpgeguAfh2VpQ8vVALABjLunwAuEOi5G91uO4kRl4=
+github.com/chnsz/golangsdk v0.0.0-20220409031514-b48169f0cea6/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
@@ -148,7 +148,7 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
     flavor = data.huaweicloud_compute_flavors.test.ids[0]
     disk {
       size        = 40
-      volume_type = "SATA"
+      volume_type = "SSD"
       disk_type   = "SYS"
     }
     key_name = huaweicloud_compute_keypair.acc_key.id

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
@@ -269,7 +269,7 @@ func getPublicIps(publicIpMeta map[string]interface{}) configurations.PublicIpOp
 	}
 
 	eipOpts := configurations.EipOpts{
-		IpType:    eipMap["ip_type"].(string),
+		Type:      eipMap["ip_type"].(string),
 		Bandwidth: bandWidthOpts,
 	}
 
@@ -293,7 +293,7 @@ func getInstanceConfig(configDataMap map[string]interface{}) (configurations.Ins
 	logp.Printf("[DEBUG] get personality: %#v", personalities)
 
 	instanceConfigOpts := configurations.InstanceConfigOpts{
-		ID:          configDataMap["instance_id"].(string),
+		InstanceID:  configDataMap["instance_id"].(string),
 		FlavorRef:   configDataMap["flavor"].(string),
 		ImageRef:    configDataMap["image"].(string),
 		SSHKey:      configDataMap["key_name"].(string),
@@ -309,7 +309,7 @@ func getInstanceConfig(configDataMap map[string]interface{}) (configurations.Ins
 	if len(pubicIpData) == 1 {
 		publicIpMap := pubicIpData[0].(map[string]interface{})
 		publicIps := getPublicIps(publicIpMap)
-		instanceConfigOpts.PubicIp = publicIps
+		instanceConfigOpts.PubicIP = &publicIps
 		logp.Printf("[DEBUG] get publicIps: %#v", publicIps)
 	}
 	logp.Printf("[DEBUG] get instanceConfig: %#v", instanceConfigOpts)

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -59,9 +59,10 @@ func ResourceASGroup() *schema.Resource {
 				),
 			},
 			"scaling_configuration_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "schema: Required",
 			},
 			"desire_instance_number": {
 				Type:     schema.TypeInt,

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -66,6 +66,7 @@ func ResourceASGroup() *schema.Resource {
 			"desire_instance_number": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"min_instance_number": {
 				Type:     schema.TypeInt,
@@ -267,7 +268,6 @@ func getAllAvailableZones(d *schema.ResourceData) []string {
 	for i, raw := range rawZones {
 		zones[i] = raw.(string)
 	}
-	logp.Printf("[DEBUG] getAvailableZones: %#v", zones)
 
 	return zones
 }
@@ -278,7 +278,6 @@ func getAllNotifications(d *schema.ResourceData) []string {
 	for i, raw := range rawNotifications {
 		notifications[i] = raw.(string)
 	}
-	logp.Printf("[DEBUG] getNotifications: %#v", notifications)
 
 	return notifications
 }
@@ -296,7 +295,6 @@ func getAllNetworks(d *schema.ResourceData, meta interface{}) []Network {
 		Networks = append(Networks, v)
 	}
 
-	logp.Printf("[DEBUG] getNetworks: %#v", Networks)
 	return Networks
 }
 
@@ -313,7 +311,6 @@ func getAllSecurityGroups(d *schema.ResourceData, meta interface{}) []Group {
 		Groups = append(Groups, v)
 	}
 
-	logp.Printf("[DEBUG] getGroups: %#v", Groups)
 	return Groups
 }
 
@@ -331,7 +328,6 @@ func getAllLBaaSListeners(d *schema.ResourceData, meta interface{}) []groups.LBa
 		aslisteners = append(aslisteners, s)
 	}
 
-	logp.Printf("[DEBUG] getAllLBaaSListeners: %#v", aslisteners)
 	return aslisteners
 }
 
@@ -339,11 +335,12 @@ func getInstancesInGroup(asClient *golangsdk.ServiceClient, groupID string, opts
 	var insList []instances.Instance
 	page, err := instances.List(asClient, groupID, opts).AllPages()
 	if err != nil {
-		return insList, fmtp.Errorf("Error getting instances in ASGroup %q: %s", groupID, err)
+		return insList, fmtp.Errorf("error getting instances in AS group %s: %s", groupID, err)
 	}
 	insList, err = page.(instances.InstancePage).Extract()
 	return insList, err
 }
+
 func getInstancesIDs(allIns []instances.Instance) []string {
 	var allIDs []string
 	for _, ins := range allIns {
@@ -354,7 +351,7 @@ func getInstancesIDs(allIns []instances.Instance) []string {
 			allIDs = append(allIDs, ins.ID)
 		}
 	}
-	logp.Printf("[DEBUG] Get instances in ASGroups: %#v", allIDs)
+
 	return allIDs
 }
 
@@ -363,7 +360,7 @@ func getInstancesLifeStates(allIns []instances.Instance) []string {
 	for _, ins := range allIns {
 		allLifeStates = append(allLifeStates, ins.LifeCycleStatus)
 	}
-	logp.Printf("[DEBUG] Get instances lifecycle status in ASGroups: %#v", allLifeStates)
+
 	return allLifeStates
 }
 
@@ -397,18 +394,18 @@ func refreshInstancesLifeStates(asClient *golangsdk.ServiceClient, groupID strin
 		if checkInService {
 			return allIns, "INSERVICE", err
 		}
-		logp.Printf("[DEBUG] Exit refreshInstancesLifeStates for %q!", groupID)
 		return allIns, "", err
 	}
 }
 
-func checkASGroupInstancesInService(ctx context.Context, asClient *golangsdk.ServiceClient, groupID string, insNum int, timeout time.Duration) error {
+func checkASGroupInstancesInService(ctx context.Context, client *golangsdk.ServiceClient, groupID string, insNum int, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"INSERVICE"}, //if there is no lifecyclestatus, meaning no instances in asg
-		Refresh: refreshInstancesLifeStates(asClient, groupID, insNum, true),
-		Timeout: timeout,
-		Delay:   10 * time.Second,
+		Pending:      []string{"PENDING"},
+		Target:       []string{"INSERVICE"}, //if there is no lifecyclestatus, meaning no instances in asg
+		Refresh:      refreshInstancesLifeStates(client, groupID, insNum, true),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -416,13 +413,14 @@ func checkASGroupInstancesInService(ctx context.Context, asClient *golangsdk.Ser
 	return err
 }
 
-func checkASGroupInstancesRemoved(ctx context.Context, asClient *golangsdk.ServiceClient, groupID string, timeout time.Duration) error {
+func checkASGroupInstancesRemoved(ctx context.Context, client *golangsdk.ServiceClient, groupID string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"REMOVING"},
-		Target:  []string{""}, //if there is no lifecyclestatus, meaning no instances in asg
-		Refresh: refreshInstancesLifeStates(asClient, groupID, 0, false),
-		Timeout: timeout,
-		Delay:   10 * time.Second,
+		Pending:      []string{"REMOVING"},
+		Target:       []string{""}, //if there is no lifecyclestatus, meaning no instances in asg
+		Refresh:      refreshInstancesLifeStates(client, groupID, 0, false),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -434,7 +432,7 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	config := meta.(*config.Config)
 	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating autoscaling client: %s", err)
+		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
 
 	minNum := d.Get("min_instance_number").(int)
@@ -445,19 +443,11 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	} else {
 		desireNum = minNum
 	}
-	logp.Printf("[DEBUG] Min instance number is: %#v", minNum)
-	logp.Printf("[DEBUG] Max instance number is: %#v", maxNum)
-	logp.Printf("[DEBUG] Desire instance number is: %#v", desireNum)
+	logp.Printf("[DEBUG] instance number options: min(%d), max(%d), desired(%d)", minNum, maxNum, desireNum)
 	if desireNum < minNum || desireNum > maxNum {
-		return diag.Errorf("Invalid parameters: it should be min_instance_number<=desire_instance_number<=max_instance_number")
+		return diag.Errorf("invalid parameters: it should be min_instance_number<=desire_instance_number<=max_instance_number")
 	}
-	var initNum int
-	if desireNum > 0 {
-		initNum = desireNum
-	} else {
-		initNum = minNum
-	}
-	logp.Printf("[DEBUG] Init instance number is: %#v", initNum)
+
 	networks := getAllNetworks(d, meta)
 	asgNetworks := expandNetworks(networks)
 
@@ -466,7 +456,6 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	asgLBaaSListeners := getAllLBaaSListeners(d, meta)
 
-	logp.Printf("[DEBUG] available_zones: %#v", d.Get("available_zones"))
 	createOpts := groups.CreateOpts{
 		Name:                      d.Get("scaling_group_name").(string),
 		ConfigurationID:           d.Get("scaling_configuration_id").(string),
@@ -491,7 +480,7 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
 	asgId, err := groups.Create(asClient, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error creating ASGroup: %s", err)
+		return diag.Errorf("error creating AS group: %s", err)
 	}
 
 	d.SetId(asgId)
@@ -501,7 +490,7 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if len(tagRaw) > 0 {
 		taglist := expandGroupsTags(tagRaw)
 		if tagErr := tags.Create(asClient, asgId, taglist).ExtractErr(); tagErr != nil {
-			return diag.Errorf("Error setting tags of ASGroup %q: %s", asgId, tagErr)
+			return diag.Errorf("error setting tags of AS group %s: %s", asgId, tagErr)
 		}
 	}
 
@@ -509,16 +498,16 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if d.Get("enable").(bool) {
 		enableResult := groups.Enable(asClient, asgId)
 		if enableResult.Err != nil {
-			return diag.Errorf("Error enabling ASGroup %q: %s", asgId, enableResult.Err)
+			return diag.Errorf("error enabling AS group %s: %s", asgId, enableResult.Err)
 		}
-		logp.Printf("[DEBUG] Enable ASGroup %q success!", asgId)
 	}
+
 	// check all instances are inservice
-	if initNum > 0 {
+	if desireNum > 0 {
 		timeout := d.Timeout(schema.TimeoutCreate)
-		err = checkASGroupInstancesInService(ctx, asClient, asgId, initNum, timeout)
+		err = checkASGroupInstancesInService(ctx, asClient, asgId, desireNum, timeout)
 		if err != nil {
-			return diag.Errorf("Error waiting for instances in the ASGroup %q to become inservice!!: %s", asgId, err)
+			return diag.Errorf("error waiting for instances in the AS group %s to become inservice: %s", asgId, err)
 		}
 	}
 
@@ -529,19 +518,14 @@ func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 	config := meta.(*config.Config)
 	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating autoscaling client: %s", err)
+		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
 
 	asg, err := groups.Get(asClient, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "AS group")
 	}
-	logp.Printf("[DEBUG] Retrieved ASGroup %q: %+v", d.Id(), asg)
-	logp.Printf("[DEBUG] Retrieved ASGroup %q notifications: %+v", d.Id(), asg.Notifications)
-	logp.Printf("[DEBUG] Retrieved ASGroup %q availablezones: %+v", d.Id(), asg.AvailableZones)
-	logp.Printf("[DEBUG] Retrieved ASGroup %q networks: %+v", d.Id(), asg.Networks)
-	logp.Printf("[DEBUG] Retrieved ASGroup %q secgroups: %+v", d.Id(), asg.SecurityGroups)
-	logp.Printf("[DEBUG] Retrieved ASGroup %q lbaaslisteners: %+v", d.Id(), asg.LBaaSListeners)
+	logp.Printf("[DEBUG] Retrieved AS group %s: %#v", d.Id(), asg)
 
 	// set properties based on the read info
 	d.Set("scaling_group_name", asg.Name)
@@ -601,7 +585,7 @@ func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 	var opts instances.ListOptsBuilder
 	allIns, err := getInstancesInGroup(asClient, d.Id(), opts)
 	if err != nil {
-		return diag.Errorf("Can not get the instances in ASGroup %q!!: %s", d.Id(), err)
+		return diag.Errorf("can not get the instances in AS Group %s: %s", d.Id(), err)
 	}
 	allIDs := getInstancesIDs(allIns)
 	d.Set("instances", allIDs)
@@ -615,10 +599,10 @@ func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 			tagmap[val.Key] = val.Value
 		}
 		if err := d.Set("tags", tagmap); err != nil {
-			return diag.Errorf("Error saving tags to state for ASGroup (%s): %s", d.Id(), err)
+			return diag.Errorf("error saving tags to state for AS group (%s): %s", d.Id(), err)
 		}
 	} else {
-		logp.Printf("[WARN] Error fetching tags of ASGroup (%s): %s", d.Id(), err)
+		logp.Printf("[WARN] Error fetching tags of AS group (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -628,7 +612,7 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	config := meta.(*config.Config)
 	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating autoscaling client: %s", err)
+		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
 
 	var desireNum int
@@ -640,11 +624,9 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		desireNum = minNum
 	}
 	if d.HasChanges("min_instance_number", "max_instance_number", "desire_instance_number") {
-		logp.Printf("[DEBUG] Min instance number is: %#v", minNum)
-		logp.Printf("[DEBUG] Max instance number is: %#v", maxNum)
-		logp.Printf("[DEBUG] Desire instance number is: %#v", desireNum)
+		logp.Printf("[DEBUG] instance number options: min(%d), max(%d), desired(%d)", minNum, maxNum, desireNum)
 		if desireNum < minNum || desireNum > maxNum {
-			return diag.Errorf("Invalid parameters: it should be min_instance_number<=desire_instance_number<=max_instance_number")
+			return diag.Errorf("invalid parameters: it should be min_instance_number<=desire_instance_number<=max_instance_number")
 		}
 	}
 
@@ -678,7 +660,7 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	logp.Printf("[DEBUG] AS Group update options: %#v", updateOpts)
 	asgID, err := groups.Update(asClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error updating ASGroup %q: %s", asgID, err)
+		return diag.Errorf("error updating AS group %s: %s", asgID, err)
 	}
 
 	//update tags
@@ -689,7 +671,7 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if len(oldRaw) > 0 {
 			taglist := expandGroupsTags(oldRaw)
 			if tagErr := tags.Delete(asClient, asgID, taglist).ExtractErr(); tagErr != nil {
-				return diag.Errorf("Error deleting tags of ASGroup %q: %s", asgID, tagErr)
+				return diag.Errorf("error deleting tags of AS group %s: %s", asgID, tagErr)
 			}
 		}
 
@@ -697,7 +679,7 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if len(newRaw) > 0 {
 			taglist := expandGroupsTags(newRaw)
 			if tagErr := tags.Create(asClient, asgID, taglist).ExtractErr(); tagErr != nil {
-				return diag.Errorf("Error setting tags of ASGroup %q: %s", asgID, tagErr)
+				return diag.Errorf("error setting tags of AS group %s: %s", asgID, tagErr)
 			}
 		}
 	}
@@ -706,15 +688,15 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if d.Get("enable").(bool) {
 			enableResult := groups.Enable(asClient, asgID)
 			if enableResult.Err != nil {
-				return diag.Errorf("Error enabling ASGroup %q: %s", asgID, enableResult.Err)
+				return diag.Errorf("error enabling AS group %s: %s", asgID, enableResult.Err)
 			}
-			logp.Printf("[DEBUG] Enable ASGroup %q success!", asgID)
+			logp.Printf("[DEBUG] Enable AS group %s success", asgID)
 		} else {
 			enableResult := groups.Disable(asClient, asgID)
 			if enableResult.Err != nil {
-				return diag.Errorf("Error disabling ASGroup %q: %s", asgID, enableResult.Err)
+				return diag.Errorf("error disabling AS group %s: %s", asgID, enableResult.Err)
 			}
-			logp.Printf("[DEBUG] Disable ASGroup %q success!", asgID)
+			logp.Printf("[DEBUG] Disable AS group %s success", asgID)
 		}
 	}
 
@@ -725,46 +707,48 @@ func resourceASGroupDelete(ctx context.Context, d *schema.ResourceData, meta int
 	config := meta.(*config.Config)
 	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating autoscaling client: %s", err)
+		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Begin to get instances of ASGroup %q", d.Id())
+	logp.Printf("[DEBUG] Begin to get instances of AS group %s", d.Id())
 	var listOpts instances.ListOptsBuilder
 	allIns, err := getInstancesInGroup(asClient, d.Id(), listOpts)
 	if err != nil {
-		return diag.Errorf("Error listing instances of asg: %s", err)
+		return diag.Errorf("error listing instances of AS group: %s", err)
 	}
 	allLifeStatus := getInstancesLifeStates(allIns)
 	for _, lifeCycleState := range allLifeStatus {
 		if lifeCycleState != "INSERVICE" {
-			return diag.Errorf("[DEBUG] Can't delete the ASGroup %q: There are some instances not in INSERVICE but in %s, try again latter.", d.Id(), lifeCycleState)
+			return diag.Errorf("can't delete the AS group %s: some instances are not in INSERVICE but in %s, "+
+				"please try again latter", d.Id(), lifeCycleState)
 		}
 	}
 	allIDs := getInstancesIDs(allIns)
-	logp.Printf("[DEBUG] InstanceIDs in ASGroup %q: %+v", d.Id(), allIDs)
-	logp.Printf("[DEBUG] There are %d instances in ASGroup %q", len(allIDs), d.Id())
+	logp.Printf("[DEBUG] Instances in AS group %s: %+v", d.Id(), allIDs)
 	if len(allLifeStatus) > 0 {
-		min_number := d.Get("min_instance_number").(int)
-		if min_number > 0 {
-			return diag.Errorf("[DEBUG] Can't delete the ASGroup %q: The instance number after the removal will less than the min number %d, modify the min number to zero first.", d.Id(), min_number)
+		minNumber := d.Get("min_instance_number").(int)
+		if minNumber > 0 {
+			return diag.Errorf("can't delete the AS group %s: The instance number after the removal will "+
+				"less than the min number %d, modify the min number to zero first", d.Id(), minNumber)
 		}
-		delete_ins := d.Get("delete_instances").(string)
-		logp.Printf("[DEBUG] The flag delete_instances in ASGroup is %s", delete_ins)
-		batchResult := instances.BatchDelete(asClient, d.Id(), allIDs, delete_ins)
+
+		deleteIns := d.Get("delete_instances").(string)
+		logp.Printf("[DEBUG] The flag delete_instances in AS group is %s", deleteIns)
+		batchResult := instances.BatchDelete(asClient, d.Id(), allIDs, deleteIns)
 		if batchResult.Err != nil {
-			return diag.Errorf("Error removing instancess of asg: %s", batchResult.Err)
+			return diag.Errorf("error removing instancess of AS group: %s", batchResult.Err)
 		}
-		logp.Printf("[DEBUG] Begin to remove instances of ASGroup %q", d.Id())
+
 		timeout := d.Timeout(schema.TimeoutDelete)
 		err = checkASGroupInstancesRemoved(ctx, asClient, d.Id(), timeout)
 		if err != nil {
-			return diag.Errorf("Error removing instances from ASGroup %q: %s", d.Id(), err)
+			return diag.Errorf("error removing instances from AS group %s: %s", d.Id(), err)
 		}
 	}
 
-	logp.Printf("[DEBUG] Begin to delete ASGroup %q", d.Id())
+	logp.Printf("[DEBUG] Begin to delete AS group %s", d.Id())
 	if delErr := groups.Delete(asClient, d.Id()).ExtractErr(); delErr != nil {
-		return diag.Errorf("Error deleting ASGroup: %s", delErr)
+		return diag.Errorf("error deleting AS group: %s", delErr)
 	}
 
 	return nil
@@ -776,6 +760,6 @@ func resourceASGroupValidateListenerId(v interface{}, k string) (ws []string, er
 	if len(split) <= 6 {
 		return
 	}
-	errors = append(errors, fmtp.Errorf("%q supports binding up to 6 ELB listeners which are separated by a comma.", k))
+	errors = append(errors, fmtp.Errorf("%s supports binding up to 6 ELB listeners which are separated by a comma.", k))
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/requests.go
@@ -22,38 +22,7 @@ func (opts CreateOpts) ToConfigurationCreateMap() (map[string]interface{}, error
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[DEBUG] ToConfigurationCreateMap b is: %#v", b)
-	log.Printf("[DEBUG] ToConfigurationCreateMap opts is: %#v", opts)
-	publicIp := opts.InstanceConfig.PubicIp
-	log.Printf("[DEBUG] ToConfigurationCreateMap publicIp is: %#v", publicIp)
 
-	if publicIp != (PublicIpOpts{}) {
-		public_ip := map[string]interface{}{}
-		eip := map[string]interface{}{}
-		bandwidth := map[string]interface{}{}
-		eip_raw := publicIp.Eip
-		log.Printf("[DEBUG] ToConfigurationCreateMap eip_raw is: %#v", eip_raw)
-		if eip_raw != (EipOpts{}) {
-			if eip_raw.IpType != "" {
-				eip["ip_type"] = eip_raw.IpType
-			}
-			bandWidth := eip_raw.Bandwidth
-			if bandWidth != (BandwidthOpts{}) {
-				if bandWidth.Size > 0 {
-					bandwidth["size"] = bandWidth.Size
-				}
-				if bandWidth.ChargingMode != "" {
-					bandwidth["charging_mode"] = bandWidth.ChargingMode
-				}
-				if bandWidth.ShareType != "" {
-					bandwidth["share_type"] = bandWidth.ShareType
-				}
-				eip["bandwidth"] = bandwidth
-			}
-			public_ip["eip"] = eip
-		}
-		b["instance_config"].(map[string]interface{})["public_ip"] = public_ip
-	}
 	if opts.InstanceConfig.UserData != nil {
 		var userData string
 		if _, err := base64.StdEncoding.DecodeString(string(opts.InstanceConfig.UserData)); err != nil {
@@ -69,13 +38,13 @@ func (opts CreateOpts) ToConfigurationCreateMap() (map[string]interface{}, error
 
 //InstanceConfigOpts is an inner struct of CreateOpts
 type InstanceConfigOpts struct {
-	ID          string            `json:"instance_id,omitempty"`
+	InstanceID  string            `json:"instance_id,omitempty"`
 	FlavorRef   string            `json:"flavorRef,omitempty"`
 	ImageRef    string            `json:"imageRef,omitempty"`
 	Disk        []DiskOpts        `json:"disk,omitempty"`
 	SSHKey      string            `json:"key_name,omitempty"`
 	Personality []PersonalityOpts `json:"personality,omitempty"`
-	PubicIp     PublicIpOpts      `json:"-"`
+	PubicIP     *PublicIpOpts     `json:"public_ip,omitempty"`
 	// UserData contains configuration information or scripts to use upon launch.
 	// Create will base64-encode it for you, if it isn't already.
 	UserData []byte                 `json:"-"`
@@ -96,18 +65,19 @@ type PersonalityOpts struct {
 }
 
 type PublicIpOpts struct {
-	Eip EipOpts `json:"-"`
+	Eip EipOpts `json:"eip" required:"true"`
 }
 
 type EipOpts struct {
-	IpType    string
-	Bandwidth BandwidthOpts `json:"-"`
+	Type      string        `json:"ip_type" required:"true"`
+	Bandwidth BandwidthOpts `json:"bandwidth" required:"true"`
 }
 
 type BandwidthOpts struct {
-	Size         int
-	ShareType    string
-	ChargingMode string
+	ShareType    string `json:"share_type" required:"true"`
+	Size         int    `json:"size,omitempty"`
+	ChargingMode string `json:"charging_mode,omitempty"`
+	ID           string `json:"id,omitempty"`
 }
 
 //Create is a method by which can be able to access to create a configuration

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/requests.go
@@ -5,12 +5,12 @@ import (
 	"github.com/chnsz/golangsdk/pagination"
 )
 
-//CreateGroupBuilder is an interface from which can build the request of creating group
+// CreateOptsBuilder is an interface from which can build the request of creating group
 type CreateOptsBuilder interface {
 	ToGroupCreateMap() (map[string]interface{}, error)
 }
 
-//CreateGroupOps is a struct contains the parameters of creating group
+// CreateOpts is a struct contains the parameters of creating group
 type CreateOpts struct {
 	Name                      string              `json:"scaling_group_name" required:"true"`
 	ConfigurationID           string              `json:"scaling_configuration_id,omitempty"`
@@ -51,7 +51,7 @@ func (opts CreateOpts) ToGroupCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-//CreateGroup is a method of creating group
+// Create is a method of creating group
 func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToGroupCreateMap()
 	if err != nil {
@@ -64,13 +64,19 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 	return
 }
 
-//DeleteGroup is a method of deleting a group by group id
+// Delete is a method of deleting a group by group id
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
-//GetGroup is a method of getting the detailed information of the group by id
+// ForceDelete is a method of force deleting a group by group id
+func ForceDelete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(forceDeleteURL(client, id), nil)
+	return
+}
+
+// Get is a method of getting the detailed information of the group by id
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
@@ -108,12 +114,12 @@ func List(client *golangsdk.ServiceClient, ops ListOptsBuilder) pagination.Pager
 	})
 }
 
-//UpdateOptsBuilder is an interface which can build the map paramter of update function
+// UpdateOptsBuilder is an interface which can build the map paramter of update function
 type UpdateOptsBuilder interface {
 	ToGroupUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the parameters of update function
+// UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	Name                      string              `json:"scaling_group_name,omitempty"`
 	DesireInstanceNumber      int                 `json:"desire_instance_number"`
@@ -139,8 +145,8 @@ func (opts UpdateOpts) ToGroupUpdateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-//Update is a method which can be able to update the group via accessing to the
-//autoscaling service with Put method and parameters
+// Update is a method which can be able to update the group via accessing to the
+// autoscaling service with Put method and parameters
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	body, err := opts.ToGroupUpdateMap()
 	if err != nil {
@@ -178,7 +184,7 @@ func doAction(client *golangsdk.ServiceClient, id string, opts ActionOptsBuilder
 	return
 }
 
-//Enable is an operation by which can make the group enable service
+// Enable is an operation by which can make the group enable service
 func Enable(client *golangsdk.ServiceClient, id string) (r ActionResult) {
 	opts := ActionOpts{
 		Action: "resume",
@@ -186,7 +192,7 @@ func Enable(client *golangsdk.ServiceClient, id string) (r ActionResult) {
 	return doAction(client, id, opts)
 }
 
-//Disable is an operation by which can be able to pause the group
+// Disable is an operation by which can be able to pause the group
 func Disable(client *golangsdk.ServiceClient, id string) (r ActionResult) {
 	opts := ActionOpts{
 		Action: "pause",

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/results.go
@@ -5,12 +5,12 @@ import (
 	"github.com/chnsz/golangsdk/pagination"
 )
 
-//CreateGroupResult is a struct retured by CreateGroup request
+// CreateResult is a struct retured by CreateGroup request
 type CreateResult struct {
 	golangsdk.Result
 }
 
-//Extract the create group result as a string type.
+// Extract the create group result as a string type.
 func (r CreateResult) Extract() (string, error) {
 	var a struct {
 		GroupID string `json:"scaling_group_id"`
@@ -19,24 +19,24 @@ func (r CreateResult) Extract() (string, error) {
 	return a.GroupID, err
 }
 
-//DeleteGroupResult contains the body of the deleting group request
+// DeleteResult contains the body of the deleting group request
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-//GetGroupResult contains the body of getting detailed group request
+// GetResult contains the body of getting detailed group request
 type GetResult struct {
 	golangsdk.Result
 }
 
-//Extract method will parse the result body into Group struct
+// Extract method will parse the result body into Group struct
 func (r GetResult) Extract() (Group, error) {
 	var g Group
 	err := r.Result.ExtractIntoStructPtr(&g, "scaling_group")
 	return g, err
 }
 
-//Group represents the struct of one autoscaling group
+// Group represents the struct of one autoscaling group
 type Group struct {
 	Name                      string          `json:"scaling_group_name"`
 	ID                        string          `json:"scaling_group_id"`
@@ -98,12 +98,12 @@ func (r GroupPage) Extract() ([]Group, error) {
 	return gs, err
 }
 
-//UpdateResult is a struct from which can get the result of udpate method
+// UpdateResult is a struct from which can get the result of udpate method
 type UpdateResult struct {
 	golangsdk.Result
 }
 
-//Extract will deserialize the result to group id with string
+// Extract will deserialize the result to group id with string
 func (r UpdateResult) Extract() (string, error) {
 	var a struct {
 		ID string `json:"scaling_group_id"`
@@ -112,7 +112,7 @@ func (r UpdateResult) Extract() (string, error) {
 	return a.ID, err
 }
 
-//this is the action result which is the result of enable or disable operations
+// ActionResult is the action result which is the result of enable or disable operations
 type ActionResult struct {
 	golangsdk.ErrResult
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/urls.go
@@ -1,7 +1,7 @@
 package groups
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/chnsz/golangsdk"
 )
@@ -9,17 +9,24 @@ import (
 const resourcePath = "scaling_group"
 
 func createURL(c *golangsdk.ServiceClient) string {
-	ur := c.ServiceURL(resourcePath)
-	log.Printf("[DEBUG] Create URL is: %#v", ur)
-	return ur
+	return c.ServiceURL(resourcePath)
+}
+
+func updateURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+func getURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
 }
 
 func deleteURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
-func getURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
+func forceDeleteURL(c *golangsdk.ServiceClient, id string) string {
+	url := c.ServiceURL(resourcePath, id)
+	return fmt.Sprintf("%s?force_delete=yes", url)
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
@@ -28,8 +35,4 @@ func listURL(c *golangsdk.ServiceClient) string {
 
 func enableURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id, "action")
-}
-
-func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220407022843-88376a549c27
+# github.com/chnsz/golangsdk v0.0.0-20220409031514-b48169f0cea6
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* support to forcibly delete an AS group
* make scaling_configuration_id be required
* delete useless debug message

If the AS group has no configurations, it will be failed when activating it.
```
POST https://as.cn-north-4.myhuaweicloud.com/autoscaling-api/v1/0970dd7a1300f5672ff2c003c60ae115/scaling_group/645a3a5b-237f-4410-9473-065f2e1daf4e/action], error message: {"error":{"code":"AS.2018","message":"No AS configuration is in the AS group."}
```
It's better to make `scaling_configuration_id` be required. To keep compatibility， we just marked it in docs and schema json.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (250.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        250.316s

$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_forceDelete'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_forceDelete -timeout 360m -parallel 4
=== RUN   TestAccASGroup_forceDelete
=== PAUSE TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_forceDelete
--- PASS: TestAccASGroup_forceDelete (199.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        199.315s

$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (52.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        52.944s
```
