### PR TITLE
refactor(esc/compute_instance): update the api version of extending system disk

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -148,8 +148,8 @@ func WaitOrderComplete(ctx context.Context, d *schema.ResourceData, config *conf
 		return fmtp.Errorf("Error creating HuaweiCloud bss V2 client: %s", err)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"3"}, // 3: Processing; 6: Pending payment.
-		Target:       []string{"5"}, // 5: Completed.
+		Pending:      []string{"3", "6"}, // 3: Processing; 6: Pending payment.
+		Target:       []string{"5"},      // 5: Completed.
 		Refresh:      refreshOrderStatus(bssV2Client, orderNum),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -1041,7 +1041,7 @@ func resourceCCENodeV3Delete(ctx context.Context, d *schema.ResourceData, meta i
 			pending := []string{"ACTIVE", "SHUTOFF"}
 			target := []string{"DELETED", "SOFT_DELETED"}
 			deleteTimeout := d.Timeout(schema.TimeoutDelete)
-			if err := waitForServerTargetState(computeClient, serverID, pending, target, deleteTimeout); err != nil {
+			if err := waitForServerTargetState(ctx, computeClient, serverID, pending, target, deleteTimeout); err != nil {
 				return fmtp.DiagErrorf("State waiting timeout: %s", err)
 			}
 

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -65,10 +65,19 @@ func TestAccComputeV2Instance_disks(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_disks(rName),
+				Config: testAccComputeV2Instance_disks(rName, 50),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "50"),
+				),
+			},
+			{
+				Config: testAccComputeV2Instance_disks(rName, 60),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "60"),
 				),
 			},
 		},
@@ -357,7 +366,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName)
 }
 
-func testAccComputeV2Instance_disks(rName string) string {
+func testAccComputeV2Instance_disks(rName string, systemDiskSize int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -370,7 +379,7 @@ resource "huaweicloud_compute_instance" "test" {
   delete_disks_on_termination = true
 
   system_disk_type = "SAS"
-  system_disk_size = 50
+  system_disk_size = %d
 
   data_disks {
     type = "SAS"
@@ -381,7 +390,7 @@ resource "huaweicloud_compute_instance" "test" {
     uuid = data.huaweicloud_vpc_subnet.test.id
   }
 }
-`, testAccCompute_data, rName)
+`, testAccCompute_data, rName, systemDiskSize)
 }
 
 func testAccComputeV2Instance_prePaid(rName string) string {

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -244,7 +244,7 @@ func resourceEvsVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating"},
 		Target:     []string{"available"},
-		Refresh:    cloudVolumeRefreshFunc(evsV2Client, d.Id()),
+		Refresh:    CloudVolumeRefreshFunc(evsV2Client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      3 * time.Second,
 		MinTimeout: 5 * time.Second,
@@ -387,7 +387,7 @@ func resourceEvsVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"extending"},
 			Target:     []string{"available", "in-use"},
-			Refresh:    cloudVolumeRefreshFunc(evsV2Client, d.Id()),
+			Refresh:    CloudVolumeRefreshFunc(evsV2Client, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,
@@ -478,7 +478,7 @@ func resourceEvsVolumeDelete(ctx context.Context, d *schema.ResourceData, meta i
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting", "downloading", "available"},
 		Target:     []string{"deleted"},
-		Refresh:    cloudVolumeRefreshFunc(evsV2Client, d.Id()),
+		Refresh:    CloudVolumeRefreshFunc(evsV2Client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -507,7 +507,7 @@ func AttachmentJobRefreshFunc(c *golangsdk.ServiceClient, jobId string) resource
 	}
 }
 
-func cloudVolumeRefreshFunc(c *golangsdk.ServiceClient, volumeId string) resource.StateRefreshFunc {
+func CloudVolumeRefreshFunc(c *golangsdk.ServiceClient, volumeId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		response, err := cloudvolumes.Get(c, volumeId).Extract()
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

update the api version of extending system disk to avoid erroe under eps authorization

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the api version of extending system disk
2. update resource compute_instance with context and diag
3. remove fmtp and update error message
4. rename cloudVolumeRefreshFunc to CloudVolumeRefreshFunc
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_disks'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_disks -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_disks
=== PAUSE TestAccComputeV2Instance_disks
=== CONT  TestAccComputeV2Instance_disks
--- PASS: TestAccComputeV2Instance_disks (212.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       212.368s
```
