### PR TITLE
feat: support to add a secondary CIDR into a VPC

### DIFF
--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -4,7 +4,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 # huaweicloud_vpc
 
-Manages a VPC resource within HuaweiCloud. This is an alternative to `huaweicloud_vpc_v1`
+Manages a VPC resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -49,6 +49,11 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies supplementary information about the VPC. The value is a string of
   no more than 255 characters and cannot contain angle brackets (< or >).
 
+* `secondary_cidr` - (Optional, String) Specifies the secondary CIDR block of the VPC.
+
+  -> The following secondary CIDR blocks cannot be added to a VPC: 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16.
+  [View the complete list of unsupported CIDR blocks](https://support.huaweicloud.com/intl/en-us/usermanual-vpc/vpc_vpc_0007.html).
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the VPC.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the VPC. Changing this
@@ -75,4 +80,17 @@ VPCs can be imported using the `id`, e.g.
 
 ```
 $ terraform import huaweicloud_vpc.vpc_v1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```
+
+Note that the imported state may not be identical to your resource definition when `secondary_cidr` was set.
+You you can ignore changes as below.
+
+```
+resource "huaweicloud_vpc" "vpc_v1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [ secondary_cidr ]
+  }
+}
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* `secondary_cidr` - (Optional, String) Specifies the secondary CIDR block of the VPC.

  -> The argument cannot be imported into your Terraform state. And the following secondary CIDR blocks cannot be added
  to a VPC: 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16.
  [View the complete list of unsupported CIDR blocks](https://support.huaweicloud.com/intl/en-us/usermanual-vpc/vpc_vpc_0007.html).

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_secondaryCIDR'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_secondaryCIDR -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== CONT  TestAccVpcV1_secondaryCIDR
--- PASS: TestAccVpcV1_secondaryCIDR (75.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       75.269s
```
