### PR TITLE
fix: test(secgroup/rule): fix the problem of the empty value

### DIFF
--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -4,8 +4,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 # huaweicloud_networking_secgroup_rule
 
-Manages a Security Group Rule resource within HuaweiCloud. This is an alternative
-to `huaweicloud_networking_secgroup_rule_v2`
+Manages a Security Group Rule resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -20,7 +19,8 @@ resource "huaweicloud_networking_secgroup_rule" "secgroup_rule" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  ports             = "334,466-468,8000"
+  port_range_min    = 8080
+  port_range_max    = 8080
   remote_ip_prefix  = "0.0.0.0/0"
 }
 ```
@@ -48,6 +48,14 @@ The following arguments are supported:
 * `protocol` - (Optional, String, ForceNew) Specifies the layer 4 protocol type, valid values are **tcp**, **udp**,
   **icmp** and **icmpv6**. If omitted, the protocol means that all protocols are supported.
   This is required if you want to specify a port range. Changing this creates a new security group rule.
+
+* `port_range_min` - (Optional, Int, ForceNew) Specifies the lower part of the allowed port range, valid integer value
+  needs to be between `1` and `65,535`. Changing this creates a new security group rule.
+  This parameter and `ports` are alternative.
+
+* `port_range_max` - (Optional, Int, ForceNew) Specifies the higher part of the allowed port range, valid integer value
+  needs to be between `1` and `65,535`. Changing this creates a new security group rule.
+  This parameter and `ports` are alternative.
 
 * `ports` - (Optional, String, ForceNew) Specifies the allowed port value range, which supports single port (80),
   continuous port (1-30) and discontinous port (22, 3389, 80) The valid port values is range form `1` to `65,535`.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The test case does not cover the rule creation of the icmp protocol type, so the case where the port parameter is empty is not checked.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. revert port_range_min and port_range_max.
2. add a new acc test of the icmp protocol type.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNetworkingSecGroupRule_noPorts'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNetworkingSecGroupRule_noPorts -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupRule_noPorts
=== PAUSE TestAccNetworkingSecGroupRule_noPorts
=== CONT  TestAccNetworkingSecGroupRule_noPorts
--- PASS: TestAccNetworkingSecGroupRule_noPorts (69.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       69.274s
```
