### PR TITLE
feat: add CTS data tracker resource

### DIFF
--- a/docs/resources/cts_data_tracker.md
+++ b/docs/resources/cts_data_tracker.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# huaweicloud_cts_data_tracker
+
+Manages CTS **data** tracker resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "data_bucket" {}
+variable "transfer_bucket" {}
+
+resource "huaweicloud_cts_data_tracker" "tracker" {
+  name        = "data-tracker"
+  data_bucket = var.data_bucket
+  bucket_name = var.transfer_bucket
+  file_prefix = "cloudTrace"
+  lts_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the CTS data tracker resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the data tracker name. The name cannot be system or ststem-trace.
+  Changing this creates a new resource.
+
+* `data_bucket` - (Required, String, ForceNew) Specifies the OBS bucket tracked by the data tracker.
+  Changing this creates a new resource.
+
+* `data_operation` - (Optional, List) Specifies an array of operation types tracked by the data tracker,
+  the value of operation can be **WRITE** or **READ**.
+
+* `bucket_name` - (Optional, String) Specifies the OBS bucket to which traces will be transferred.
+
+* `file_prefix` - (Optional, String) Specifies the file name prefix to mark trace files that need to be stored
+  in an OBS bucket. The value contains 0 to 64 characters. Only letters, numbers, hyphens (-), underscores (_),
+  and periods (.) are allowed.
+
+* `obs_retention_period` - (Optional, Int) Specifies the retention period that traces are stored in `bucket_name`,
+  the value can be **0**(permanent), **30**, **60**, **90**, **180** or **1095**.
+
+* `lts_enabled` - (Optional, Bool) Specifies whether trace analysis is enabled.
+
+* `validate_file` - (Optional, Bool) Specifies whether trace file verification is enabled during trace transfer.
+
+* `enabled` - (Optional, Bool) Specifies whether tracker is enabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the tracker name.
+* `type` - The tracker type, only **data** is available.
+* `transfer_enabled` - Whether traces will be transferred.
+* `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+CTS data tracker can be imported using `name`, e.g.:
+
+```
+$ terraform import huaweicloud_cts_data_tracker_v1.tracker your_tracker_name
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -537,10 +537,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_namespace":   cce.ResourceCCENamespaceV1(),
 			"huaweicloud_cce_pvc":         cce.ResourceCcePersistentVolumeClaimsV1(),
 
-			"huaweicloud_cts_tracker":   cts.ResourceCTSTracker(),
-			"huaweicloud_cci_namespace": cci.ResourceCciNamespace(),
-			"huaweicloud_cci_network":   cci.ResourceCciNetworkV1(),
-			"huaweicloud_cci_pvc":       ResourceCCIPersistentVolumeClaimV1(),
+			"huaweicloud_cts_tracker":      cts.ResourceCTSTracker(),
+			"huaweicloud_cts_data_tracker": cts.ResourceCTSDataTracker(),
+			"huaweicloud_cci_namespace":    cci.ResourceCciNamespace(),
+			"huaweicloud_cci_network":      cci.ResourceCciNetworkV1(),
+			"huaweicloud_cci_pvc":          ResourceCCIPersistentVolumeClaimV1(),
 
 			"huaweicloud_cdm_cluster": cdm.ResourceCdmCluster(),
 			"huaweicloud_cdm_job":     cdm.ResourceCdmJob(),

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
@@ -1,0 +1,137 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getCTSDataTrackerResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcCtsV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CTS client: %s", err)
+	}
+
+	name := state.Primary.ID
+	trackerType := cts.GetListTrackersRequestTrackerTypeEnum().DATA
+	listOpts := &cts.ListTrackersRequest{
+		TrackerName: &name,
+		TrackerType: &trackerType,
+	}
+
+	response, err := client.ListTrackers(listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CTS tracker: %s", err)
+	}
+
+	if response.Trackers == nil || len(*response.Trackers) == 0 {
+		return nil, fmt.Errorf("can not find the CTS tracker %s", name)
+	}
+
+	allTrackers := *response.Trackers
+	ctsTracker := allTrackers[0]
+
+	return ctsTracker, nil
+}
+
+func TestAccCTSDataTracker_basic(t *testing.T) {
+	var dataTracker cts.TrackerResponseBody
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_cts_data_tracker.tracker"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&dataTracker,
+		getCTSDataTrackerResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSDataTracker_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transfer_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "type", "data"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "data_operation.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_bucket",
+						"huaweicloud_obs_bucket.data_bucket", "bucket"),
+				),
+			},
+			{
+				Config: testAccCTSDataTracker_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "transfer_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name",
+						"huaweicloud_obs_bucket.trans_bucket", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts"),
+					resource.TestCheckResourceAttr(resourceName, "obs_retention_period", "30"),
+					resource.TestCheckResourceAttr(resourceName, "validate_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCTSDataTracker_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "data_bucket" {
+  bucket = "%[1]s-data"
+  acl    = "public-read"
+}
+
+resource "huaweicloud_cts_data_tracker" "tracker" {
+  name        = "%[1]s"
+  data_bucket = huaweicloud_obs_bucket.data_bucket.bucket
+  lts_enabled = true
+}
+`, rName)
+}
+
+func testAccCTSDataTracker_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "data_bucket" {
+  bucket = "%[1]s-data"
+  acl    = "public-read"
+}
+
+resource "huaweicloud_obs_bucket" "trans_bucket" {
+  bucket        = "%[1]s-log"
+  acl           = "private"
+  force_destroy = true
+
+  lifecycle {
+    ignore_changes = [lifecycle_rule]
+  }
+}
+
+resource "huaweicloud_cts_data_tracker" "tracker" {
+  name                 = "%[1]s"
+  data_bucket          = huaweicloud_obs_bucket.data_bucket.bucket
+  bucket_name          = huaweicloud_obs_bucket.trans_bucket.bucket
+  obs_retention_period = 30
+  file_prefix          = "cts"
+  validate_file        = false
+  lts_enabled          = false
+}
+`, rName)
+}

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
@@ -1,0 +1,368 @@
+package cts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	client "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3"
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// ResourceCTSDataTracker is the impl of huaweicloud_cts_data_tracker
+func ResourceCTSDataTracker() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCTSDataTrackerCreate,
+		ReadContext:   resourceCTSDataTrackerRead,
+		UpdateContext: resourceCTSDataTrackerUpdate,
+		DeleteContext: resourceCTSDataTrackerDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringNotInSlice([]string{"system", "system-trace"}, false),
+			},
+			"data_bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"data_operation": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 2,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"READ", "WRITE"}, false),
+				},
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"file_prefix": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 64),
+					validation.StringMatch(regexp.MustCompile(`^[\.\-_A-Za-z0-9]+$`),
+						"only letters, numbers, hyphens (-), underscores (_), and periods (.) are allowed"),
+				),
+			},
+			"obs_retention_period": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+				ValidateFunc: validation.IntInSlice([]int{0, 30, 60, 90, 180, 1095}),
+			},
+			"validate_file": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+			},
+			"lts_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"transfer_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+
+}
+
+func buildCreateRequestBody(d *schema.ResourceData) *cts.CreateTrackerRequestBody {
+	trackerType := cts.GetCreateTrackerRequestBodyTrackerTypeEnum().DATA
+	reqBody := cts.CreateTrackerRequestBody{
+		TrackerType:       trackerType,
+		TrackerName:       d.Get("name").(string),
+		IsLtsEnabled:      utils.Bool(d.Get("lts_enabled").(bool)),
+		IsSupportValidate: utils.Bool(d.Get("validate_file").(bool)),
+		DataBucket:        buildDataBucketOpts(d),
+		ObsInfo:           buildTransferBucketOpts(d),
+	}
+
+	log.Printf("[DEBUG] creating data CTS tracker options: %#v", reqBody)
+	return &reqBody
+}
+
+func buildDataBucketOpts(d *schema.ResourceData) *cts.DataBucket {
+	dataBucketCfg := cts.DataBucket{
+		DataBucketName: utils.String(d.Get("data_bucket").(string)),
+	}
+
+	var rawOperations []interface{}
+	if v, ok := d.GetOk("data_operation"); ok {
+		rawOperations = v.([]interface{})
+	} else {
+		rawOperations = []interface{}{"READ", "WRITE"}
+	}
+
+	operations := make([]cts.DataBucketDataEvent, len(rawOperations))
+	dataEvents := cts.GetDataBucketDataEventEnum()
+	for i, raw := range rawOperations {
+		if op, ok := raw.(string); ok {
+			if op == "READ" {
+				operations[i] = dataEvents.READ
+			} else if op == "WRITE" {
+				operations[i] = dataEvents.WRITE
+			}
+		}
+	}
+	dataBucketCfg.DataEvent = &operations
+
+	return &dataBucketCfg
+}
+
+func buildTransferBucketOpts(d *schema.ResourceData) *cts.TrackerObsInfo {
+	transferCfg := cts.TrackerObsInfo{
+		BucketName:     utils.String(d.Get("bucket_name").(string)),
+		FilePrefixName: utils.String(d.Get("file_prefix").(string)),
+	}
+	if v, ok := d.GetOk("obs_retention_period"); ok {
+		lifecycle := int32(v.(int))
+		transferCfg.BucketLifecycle = &lifecycle
+	}
+
+	return &transferCfg
+}
+
+func resourceCTSDataTrackerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.HcCtsV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	createOpts := cts.CreateTrackerRequest{
+		Body: buildCreateRequestBody(d),
+	}
+
+	if _, err := ctsClient.CreateTracker(&createOpts); err != nil {
+		return diag.Errorf("error creating data CTS tracker: %s", err)
+	}
+
+	trackerName := d.Get("name").(string)
+	d.SetId(trackerName)
+
+	// disable status if necessary
+	if enabled := d.Get("enabled").(bool); !enabled {
+		err = updateDataTrackerStatus(ctsClient, trackerName, "disabled")
+		if err != nil {
+			return diag.Errorf("failed to disable CTS data tracker: %s", err)
+		}
+	}
+
+	return resourceCTSDataTrackerRead(ctx, d, meta)
+}
+
+func resourceCTSDataTrackerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.HcCtsV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	trackerName := d.Id()
+	// update status firstly
+	if d.HasChange("enabled") {
+		status := "enabled"
+		if enabled := d.Get("enabled").(bool); !enabled {
+			status = "disabled"
+		}
+
+		err = updateDataTrackerStatus(ctsClient, trackerName, status)
+		if err != nil {
+			return diag.Errorf("error updating CTS tracker status: %s", err)
+		}
+	}
+
+	// update other configurations
+	if d.HasChangeExcept("enabled") {
+		trackerType := cts.GetUpdateTrackerRequestBodyTrackerTypeEnum().DATA
+		updateReq := cts.UpdateTrackerRequestBody{
+			TrackerName:       trackerName,
+			TrackerType:       trackerType,
+			IsLtsEnabled:      utils.Bool(d.Get("lts_enabled").(bool)),
+			IsSupportValidate: utils.Bool(d.Get("validate_file").(bool)),
+			DataBucket:        buildDataBucketOpts(d),
+		}
+
+		if d.HasChanges("bucket_name", "file_prefix", "obs_retention_period") {
+			updateReq.ObsInfo = buildTransferBucketOpts(d)
+		}
+
+		log.Printf("[DEBUG] updating CTS tracker options: %#v", updateReq)
+		updateOpts := cts.UpdateTrackerRequest{
+			Body: &updateReq,
+		}
+
+		_, err = ctsClient.UpdateTracker(&updateOpts)
+		if err != nil {
+			return diag.Errorf("error updating CTS tracker: %s", err)
+		}
+	}
+
+	return resourceCTSDataTrackerRead(ctx, d, meta)
+}
+
+func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	ctsClient, err := cfg.HcCtsV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	trackerName := d.Id()
+	trackerType := cts.GetListTrackersRequestTrackerTypeEnum().DATA
+	listOpts := &cts.ListTrackersRequest{
+		TrackerName: &trackerName,
+		TrackerType: &trackerType,
+	}
+
+	response, err := ctsClient.ListTrackers(listOpts)
+	if err != nil {
+		return common.CheckDeletedError(d, err, "error retrieving CTS data tracker")
+	}
+
+	if response.Trackers == nil || len(*response.Trackers) == 0 {
+		d.SetId("")
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Resource not found",
+				Detail:   fmt.Sprintf("cannot retrieve CTS data tracker %s", trackerName),
+			},
+		}
+	}
+
+	allTrackers := *response.Trackers
+	ctsTracker := allTrackers[0]
+
+	d.Set("region", region)
+	d.Set("name", ctsTracker.TrackerName)
+	d.Set("lts_enabled", ctsTracker.Lts.IsLtsEnabled)
+	d.Set("validate_file", ctsTracker.IsSupportValidate)
+
+	if ctsTracker.DataBucket != nil {
+		d.Set("data_bucket", ctsTracker.DataBucket.DataBucketName)
+
+		if ctsTracker.DataBucket.DataEvent != nil {
+			operations := make([]string, len(*ctsTracker.DataBucket.DataEvent))
+			for i, event := range *ctsTracker.DataBucket.DataEvent {
+				operations[i] = formatValue(event)
+			}
+			d.Set("data_operation", operations)
+		}
+	}
+
+	if ctsTracker.ObsInfo != nil {
+		bucketName := ctsTracker.ObsInfo.BucketName
+		d.Set("bucket_name", bucketName)
+		d.Set("file_prefix", ctsTracker.ObsInfo.FilePrefixName)
+
+		if *bucketName != "" {
+			d.Set("transfer_enabled", true)
+			d.Set("obs_retention_period", ctsTracker.ObsInfo.BucketLifecycle)
+		} else {
+			d.Set("transfer_enabled", false)
+		}
+	}
+
+	if ctsTracker.TrackerType != nil {
+		d.Set("type", formatValue(ctsTracker.TrackerType))
+	}
+	if ctsTracker.Status != nil {
+		status := formatValue(ctsTracker.Status)
+		d.Set("status", status)
+		d.Set("enabled", status == "enabled")
+	}
+
+	return nil
+}
+
+func resourceCTSDataTrackerDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	ctsClient, err := cfg.HcCtsV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	trackerName := d.Id()
+	trackerType := cts.GetDeleteTrackerRequestTrackerTypeEnum().DATA
+	deleteOpts := cts.DeleteTrackerRequest{
+		TrackerName: &trackerName,
+		TrackerType: &trackerType,
+	}
+
+	_, err = ctsClient.DeleteTracker(&deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting CTS data tracker %s: %s", trackerName, err)
+	}
+
+	return nil
+}
+
+func updateDataTrackerStatus(c *client.CtsClient, name, status string) error {
+	enabledStatus := new(cts.UpdateTrackerRequestBodyStatus)
+	if err := enabledStatus.UnmarshalJSON([]byte(status)); err != nil {
+		return fmt.Errorf("failed to parse status %s: %s", status, err)
+	}
+
+	trackerType := cts.GetUpdateTrackerRequestBodyTrackerTypeEnum().DATA
+	statusOpts := cts.UpdateTrackerRequestBody{
+		TrackerName: name,
+		TrackerType: trackerType,
+		Status:      enabledStatus,
+	}
+	statusReq := cts.UpdateTrackerRequest{
+		Body: &statusOpts,
+	}
+
+	_, err := c.UpdateTracker(&statusReq)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

add new resource **huaweicloud_cts_data_tracker** to manage CTS **data** tracker resource within HuaweiCloud.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/cts' TESTARGS='-run TestAccCTSDataTracker_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSDataTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (30.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       30.563s
```
