### PR TITLE
common: Add diag when resource was not found

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -92,7 +92,12 @@ func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 func CheckDeletedDiag(d *schema.ResourceData, err error, msg string) diag.Diagnostics {
 	if _, ok := err.(golangsdk.ErrDefault404); ok {
 		d.SetId("")
-		return nil
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Resource not found",
+			},
+		}
 	}
 
 	return fmtp.DiagErrorf("%s: %s", msg, err)
@@ -104,7 +109,12 @@ func CheckDeletedError(d *schema.ResourceData, err error, msg string) diag.Diagn
 	if responseErr, ok := err.(*sdkerr.ServiceResponseError); ok {
 		if responseErr.StatusCode == http.StatusNotFound {
 			d.SetId("")
-			return nil
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Resource not found",
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

Add diag when resource was not found, the result as follows:

![image](https://user-images.githubusercontent.com/55725251/163116198-67b8ce10-5ed1-4fda-a52f-045c4e0e4599.png)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

1. create a vpc resource with terraform
2. delete the vpc by console
3. exec terraform refresh
```
$ terraform refresh
huaweicloud_vpc.vpc_1: Refreshing state... [id=46134a10-6383-4ab9-a2b1-4d25b03390e0]
╷
│ Warning: Resource not found
│
│   with huaweicloud_vpc.vpc_1,
│   on main.tf line 9, in resource "huaweicloud_vpc" "vpc_1":
│    9: resource "huaweicloud_vpc" "vpc_1" {
│
```
