### PR TITLE
fix(apig/egress): fix the panic caused by the wrong type assertion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220411062043-8d5b40e86b1f
+	github.com/chnsz/golangsdk v0.0.0-20220415085410-47b3b9a9fb1e
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220411062043-8d5b40e86b1f h1:7CV1bF6lo9RqjjI1UoZkiN+vF8z8OLqbXy+jvwuw5Rc=
-github.com/chnsz/golangsdk v0.0.0-20220411062043-8d5b40e86b1f/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220415085410-47b3b9a9fb1e h1:K3MKzb7iq/RZ+Va7fp2oanOoxMpBz1GleQqbzkL55GA=
+github.com/chnsz/golangsdk v0.0.0-20220415085410-47b3b9a9fb1e/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances/results.go
@@ -180,12 +180,12 @@ type DeleteResult struct {
 
 // EnableEgressResult represents the result of a EnableEgressAccess operation.
 type EnableEgressResult struct {
-	EgressResult
+	golangsdk.Result
 }
 
 // UdpateEgressResult represents the result of a UpdateEgressBandwidth operation.
 type UdpateEgressResult struct {
-	EgressResult
+	golangsdk.Result
 }
 
 type EgressResult struct {
@@ -202,13 +202,25 @@ type Egress struct {
 	BandwidthSize    int    `json:"bandwidthSize"`
 }
 
-// Call its Extract method to interpret it as a Egress.
-func (r EgressResult) Extract() (*Egress, error) {
+// Extract is a method to interpret the response body or json string as an Egress.
+func (r UdpateEgressResult) Extract() (*Egress, error) {
 	var s Egress
 	if r.Err != nil {
 		return &s, r.Err
 	}
-	err := json.Unmarshal([]byte(r.Body.(string)), &s)
+	body, ok := r.Body.(string)
+	if ok {
+		err := json.Unmarshal([]byte(body), &s)
+		return &s, err
+	}
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// Extract is a method to interpret the response body as an Egress.
+func (r EnableEgressResult) Extract() (*Egress, error) {
+	var s Egress
+	err := r.ExtractInto(&s)
 	return &s, err
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220411062043-8d5b40e86b1f
+# github.com/chnsz/golangsdk v0.0.0-20220415085410-47b3b9a9fb1e
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a difference between the response body of `POST` request and `PUT` request. The `panic` is generated when the `Extract()` method is used to interpret a structure (not string).

```
panic: interface conversion: interface {} is map[string]interface {}, not string
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. separate and refactor `Extract()` to fix the panic when updating egress network.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigInstanceV2_egress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigInstanceV2_egress -timeout 360m -parallel 4
=== RUN   TestAccApigInstanceV2_egress
=== PAUSE TestAccApigInstanceV2_egress
=== CONT  TestAccApigInstanceV2_egress
--- PASS: TestAccApigInstanceV2_egress (595.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      595.318s
```
