### PR TITLE
Update css_cluster.md

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `engine_type` - (Optional, String, ForceNew) Engine type. The default value is "elasticsearch". Currently, the value
   can only be "elasticsearch". Changing this parameter will create a new resource.
 
-* `engine_version` - (Required, String, ForceNew) Engine version. Versions 5.5.1, 6.2.3, 6.5.4, 7.1.1, 7.6.2 and 7.9.3
+* `engine_version` - (Required, String, ForceNew) Engine version. Versions 7.6.2 and 7.9.3
   are supported. Changing this parameter will create a new resource.
 
 * `expect_node_num` - (Optional, Int) Number of cluster instances. The value range is 1 to 32. Defaults to 1.


### PR DESCRIPTION
Doc update

about css console ,engine_version only support 7.6.2 and 7.9.3

![屏幕截图 2022-04-16 102203](https://user-images.githubusercontent.com/40236947/163657889-442439f2-7b56-483e-ac3e-96d02ba03bc9.png)



