### PR TITLE
fix: test(evs/attach): fixed the disk bug that multiple ecs bind

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -15,12 +15,18 @@ import (
 	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 )
 
 const (
 	obsLogFile         string = "./.obs-sdk.log"
 	obsLogFileSize10MB int64  = 1024 * 1024 * 10
 )
+
+// MutexKV is a global lock on all resources, it can lock the specified shared string (such as resource ID, resource
+// Name, port, etc.) to prevent other resources from using it, for concurrency control.
+// Usage: MutexKV.Lock({resource ID}) and MutexKV.Unlock({resource ID})
+var MutexKV = mutexkv.NewMutexKV()
 
 type Config struct {
 	AccessKey           string

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/bms"
@@ -55,9 +54,6 @@ import (
 )
 
 const defaultCloud string = "myhuaweicloud.com"
-
-// This is a global MutexKV for use within this plugin.
-var osMutexKV = mutexkv.NewMutexKV()
 
 // Provider returns a schema.Provider for HuaweiCloud.
 func Provider() *schema.Provider {

--- a/huaweicloud/resource_huaweicloud_networking_router_route_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_router_route_v2.go
@@ -52,14 +52,14 @@ func resourceNetworkingRouterRouteV2() *schema.Resource {
 func resourceNetworkingRouterRouteV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	routerId := d.Get("router_id").(string)
-	osMutexKV.Lock(routerId)
-	defer osMutexKV.Unlock(routerId)
+	config.MutexKV.Lock(routerId)
+	defer config.MutexKV.Unlock(routerId)
 
 	var destCidr string = d.Get("destination_cidr").(string)
 	var nextHop string = d.Get("next_hop").(string)
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	networkingClient, err := conf.NetworkingV2Client(GetRegion(d, conf))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -116,8 +116,8 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 
 	routerId := d.Get("router_id").(string)
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	networkingClient, err := conf.NetworkingV2Client(GetRegion(d, conf))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -166,7 +166,7 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", GetRegion(d, conf))
 
 	return nil
 }
@@ -174,12 +174,12 @@ func resourceNetworkingRouterRouteV2Read(d *schema.ResourceData, meta interface{
 func resourceNetworkingRouterRouteV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 	routerId := d.Get("router_id").(string)
-	osMutexKV.Lock(routerId)
-	defer osMutexKV.Unlock(routerId)
+	config.MutexKV.Lock(routerId)
+	defer config.MutexKV.Unlock(routerId)
 
-	config := meta.(*config.Config)
+	conf := meta.(*config.Config)
 
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := conf.NetworkingV2Client(GetRegion(d, conf))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/resource_huaweicloud_networking_router_v2.go
+++ b/huaweicloud/resource_huaweicloud_networking_router_v2.go
@@ -96,8 +96,8 @@ func resourceNetworkingRouterV2() *schema.Resource {
 }
 
 func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	networkingClient, err := conf.NetworkingV2Client(GetRegion(d, conf))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -174,8 +174,8 @@ func resourceNetworkingRouterV2Create(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	networkingClient, err := conf.NetworkingV2Client(GetRegion(d, conf))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -196,7 +196,7 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("admin_state_up", n.AdminStateUp)
 	d.Set("distributed", n.Distributed)
 	d.Set("tenant_id", n.TenantID)
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", GetRegion(d, conf))
 
 	// Gateway settings
 	d.Set("external_network_id", n.GatewayInfo.NetworkID)
@@ -219,11 +219,11 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 
 func resourceNetworkingRouterV2Update(d *schema.ResourceData, meta interface{}) error {
 	routerId := d.Id()
-	osMutexKV.Lock(routerId)
-	defer osMutexKV.Unlock(routerId)
+	config.MutexKV.Lock(routerId)
+	defer config.MutexKV.Unlock(routerId)
 
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	networkingClient, err := conf.NetworkingV2Client(GetRegion(d, conf))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
@@ -70,15 +70,17 @@ func ResourceComputeVolumeAttach() *schema.Resource {
 }
 
 func resourceComputeVolumeAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	computeClient, err := config.ComputeV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	computeClient, err := conf.ComputeV1Client(region)
 	if err != nil {
 		return diag.Errorf("Error creating compute v1 client: %s", err)
 	}
 
 	instanceId := d.Get("instance_id").(string)
 	volumeId := d.Get("volume_id").(string)
+	config.MutexKV.Lock(volumeId)
+	defer config.MutexKV.Unlock(volumeId)
 
 	var device string
 	if v, ok := d.GetOk("device"); ok {
@@ -118,9 +120,9 @@ func resourceComputeVolumeAttachCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceComputeVolumeAttachRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	computeClient, err := config.ComputeV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	computeClient, err := conf.ComputeV1Client(region)
 	if err != nil {
 		return diag.Errorf("Error creating compute V1 client: %s", err)
 	}
@@ -149,15 +151,18 @@ func resourceComputeVolumeAttachRead(_ context.Context, d *schema.ResourceData, 
 }
 
 func resourceComputeVolumeAttachDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	computeClient, err := config.ComputeV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	computeClient, err := conf.ComputeV1Client(region)
 	if err != nil {
 		return diag.Errorf("Error creating compute V1 client: %s", err)
 	}
 
 	instanceId := d.Get("instance_id").(string)
 	volumeId := d.Get("volume_id").(string)
+	config.MutexKV.Lock(volumeId)
+	defer config.MutexKV.Unlock(volumeId)
+
 	opts := block_devices.DetachOpts{
 		ServerId: instanceId,
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
An error occurs when the `huaweicloud_compute_volume_attach` resource mounts a shared disk to multiple ECS instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new test of multiple volumes attach.
2. rename the config object.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ecs' TESTARGS='-run=TestAccComputeVolumeAttach_multiple'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run=TestAccComputeVolumeAttach_multiple -timeout 360m -parallel 4
=== RUN   TestAccComputeVolumeAttach_multiple
=== PAUSE TestAccComputeVolumeAttach_multiple
=== CONT  TestAccComputeVolumeAttach_multiple
--- PASS: TestAccComputeVolumeAttach_multiple (247.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs 247.162s
```
