### PR TITLE
feat(servicestage): add new runtime query resource support

### DIFF
--- a/docs/data-sources/servicestage_component_runtimes.md
+++ b/docs/data-sources/servicestage_component_runtimes.md
@@ -1,0 +1,39 @@
+---
+subcategory: "ServiceStage"
+---
+
+# huaweicloud_servicestage_component_runtimes
+
+Use this data source to query available runtimes within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestage_component_runtimes" "test" {}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the component runtimes.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the runtime name to use for filtering.
+  For the runtime names corresponding to each type of component, please refer to the [document](https://support.huaweicloud.com/intl/en-us/usermanual-servicestage/servicestage_user_0411.html).
+
+* `default_port` - (Optional, Int) Specifies the default container port to use for filtering.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `runtimes` - The list of runtime details.
+
+The `runtimes` block contains:
+
+* `name` - The runtime name.
+
+* `default_port` - The default container port.
+
+* `description` - The runtime description.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -425,6 +425,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_engine_versions": rds.DataSourceRdsEngineVersionsV3(),
 			"huaweicloud_rds_instances":       rds.DataSourceRdsInstances(),
 
+			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
+
 			"huaweicloud_sfs_file_system":   DataSourceSFSFileSystemV2(),
 			"huaweicloud_vbs_backup_policy": dataSourceVBSBackupPolicyV2(),
 			"huaweicloud_vbs_backup":        dataSourceVBSBackupV2(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestage_component_runtimes_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestage_component_runtimes_test.go
@@ -1,0 +1,82 @@
+package servicestage
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataComponentRuntimes_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_servicestage_component_runtimes.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataComponentRuntimes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "runtimes.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataComponentRuntimes_byName(t *testing.T) {
+	dataSourceName := "data.huaweicloud_servicestage_component_runtimes.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataComponentRuntimes_byName,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "runtimes.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataComponentRuntimes_byPort(t *testing.T) {
+	dataSourceName := "data.huaweicloud_servicestage_component_runtimes.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataComponentRuntimes_byPort,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "runtimes.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataComponentRuntimes_basic = `
+data "huaweicloud_servicestage_component_runtimes" "test" {}
+`
+
+const testAccDataComponentRuntimes_byName = `
+data "huaweicloud_servicestage_component_runtimes" "test" {
+  name = "Nodejs14"
+}
+`
+
+const testAccDataComponentRuntimes_byPort = `
+data "huaweicloud_servicestage_component_runtimes" "test" {
+  default_port = 80
+}
+`

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestage_component_runtimes.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestage_component_runtimes.go
@@ -1,0 +1,99 @@
+package servicestage
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceComponentRuntimes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceComponentRuntimesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"default_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"runtimes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceComponentRuntimesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ServiceStageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage v2 client: %s", err)
+	}
+
+	resp, err := metadata.ListRuntimes(client)
+	if err != nil {
+		return diag.Errorf("error retrieving the runtimes list: %s", err)
+	}
+
+	filter := map[string]interface{}{
+		"Type":                 d.Get("name"),
+		"ContainerDefaultPort": d.Get("default_port"),
+	}
+	filtResult, err := utils.FilterSliceWithField(resp, filter)
+	if err != nil {
+		return diag.Errorf("filter component runtimes failed: %s", err)
+	}
+	log.Printf("filter %d component runtimes from %d through option %v", len(filtResult), len(resp), filter)
+
+	types := make([]string, len(filtResult))
+	runtimes := make([]map[string]interface{}, len(filtResult))
+	for i, val := range filtResult {
+		runtime := val.(metadata.Runtime)
+		types[i] = runtime.Type
+		runtimes[i] = map[string]interface{}{
+			"name":         runtime.Type,
+			"default_port": runtime.ContainerDefaultPort,
+			"description":  runtime.TypeDesc,
+		}
+	}
+	d.SetId(hashcode.Strings(types))
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("runtimes", runtimes),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata/requests.go
@@ -1,0 +1,33 @@
+package metadata
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// ListRuntimes is a method to obtain all component runtimes.
+func ListRuntimes(c *golangsdk.ServiceClient) ([]Runtime, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(runtimeURL(c), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	var r []Runtime
+	err = rst.ExtractIntoSlicePtr(&r, "runtimes")
+	return r, err
+}
+
+// ListFlavors is a method to obtain all application flavors.
+func ListFlavors(c *golangsdk.ServiceClient) ([]Flavor, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(flavorURL(c), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	var r []Flavor
+	err = rst.ExtractIntoSlicePtr(&r, "flavors")
+	return r, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata/results.go
@@ -1,0 +1,33 @@
+package metadata
+
+// Runtime is the structure that represents the detail of the ServiceStage runtime.
+type Runtime struct {
+	// Type.
+	Type string `json:"type_name"`
+	// Display name.
+	DisplayName string `json:"display_name"`
+	// Default container port.
+	ContainerDefaultPort int `json:"container_default_port"`
+	// Type description.
+	TypeDesc string `json:"type_desc"`
+}
+
+// Flavor is the structure that represents the detail of the ServiceStage flavor.
+type Flavor struct {
+	// Flavor ID.
+	ID string `json:"flavor_id"`
+	// Storage size.
+	StorageSize string `json:"storage_size"`
+	// CPU limit.
+	NumCpu string `json:"num_cpu"`
+	// Initial CPU value.
+	NumCpuInit string `json:"num_cpu_init"`
+	// Memory limit.
+	MemorySize string `json:"memory_size"`
+	// Initial memory value.
+	MemorySizeInit string `json:"memory_size_init"`
+	// Label.
+	Label string `json:"label"`
+	// Whether resource specifications are customized.
+	Custom bool `json:"custom"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata/urls.go
@@ -1,0 +1,13 @@
+package metadata
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "cas/metadata"
+
+func runtimeURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "runtimes")
+}
+
+func flavorURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "flavors")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,6 +241,7 @@ github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories
 github.com/chnsz/golangsdk/openstack/servicestage/v2/applications
 github.com/chnsz/golangsdk/openstack/servicestage/v2/components
 github.com/chnsz/golangsdk/openstack/servicestage/v2/environments
+github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata
 github.com/chnsz/golangsdk/openstack/sfs/v2/shares
 github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares
 github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data-source to query runtime list of ServiceStage component,

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference #2030 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new runtime query resource support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccDataComponentRuntimes_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccDataComponentRuntimes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataComponentRuntimes_basic
=== PAUSE TestAccDataComponentRuntimes_basic
=== CONT  TestAccDataComponentRuntimes_basic
--- PASS: TestAccDataComponentRuntimes_basic (23.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage 24.437s
```
