### PR TITLE
fix(ecs/instance): fix a bug of source_dest_check in ecs instance

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -37,7 +37,7 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "network.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "network.0.port"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
-					resource.TestCheckResourceAttr(resourceName, "network.0.source_dest_check", "true"),
+					resource.TestCheckResourceAttr(resourceName, "network.0.source_dest_check", "false"),
 					resource.TestCheckResourceAttr(resourceName, "stop_before_destroy", "true"),
 				),
 			},
@@ -360,7 +360,8 @@ resource "huaweicloud_compute_instance" "test" {
   stop_before_destroy = true
 
   network {
-    uuid = data.huaweicloud_vpc_subnet.test.id
+    uuid              = data.huaweicloud_vpc_subnet.test.id
+    source_dest_check = false
   }
 }
 `, testAccCompute_data, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

If the source_dest_check is set to false in creating, it's actually not working. Because if we put d.Get("network") after resourceComputeInstanceV2Read, we will get the value of source_dest_check from the state file, which has been set to true (the default value) in the Read func.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix a bug of source_dest_check in ecs instance
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (192.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       192.150s
```
