### PR TITLE
fix(cce/node): fix a bug in prepaid cce node Unsubscribe

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -10,7 +10,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/cce/v3/clusters"
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
-	"github.com/chnsz/golangsdk/openstack/compute/v2/servers"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -1004,12 +1004,9 @@ func resourceCCENodeV3Delete(ctx context.Context, d *schema.ResourceData, meta i
 			// check whether the ecs server of the perPaid exists before unsubscribe it
 			// because resource could not be found cannot be unsubscribed
 			if serverID != "" {
-				server, err := servers.Get(computeClient, serverID).Extract()
-
+				server, err := cloudservers.Get(computeClient, serverID).Extract()
 				if err != nil {
-					if _, ok := err.(golangsdk.ErrDefault404); !ok {
-						return fmtp.DiagErrorf("Error retrieving HuaweiCloud ecs intance: %s", err)
-					}
+					return common.CheckDeletedDiag(d, err, "error retrieving compute instance")
 				} else {
 					if server.Status != "DELETED" && server.Status != "SOFT_DELETED" {
 						resourceIDs = append(resourceIDs, serverID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

the sdk version of getting ecs instance before unsubscribing the node is not correct 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix a bug in prepaid cce node Unsubscribe
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3 -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== RUN   TestAccCCENodeV3_auto_assign_eip
=== PAUSE TestAccCCENodeV3_auto_assign_eip
=== RUN   TestAccCCENodeV3_existing_eip
=== PAUSE TestAccCCENodeV3_existing_eip
=== RUN   TestAccCCENodeV3_volume_extendParams
=== PAUSE TestAccCCENodeV3_volume_extendParams
=== RUN   TestAccCCENodeV3_data_volume_encryption
=== PAUSE TestAccCCENodeV3_data_volume_encryption
=== RUN   TestAccCCENodeV3_prePaid
=== PAUSE TestAccCCENodeV3_prePaid
=== RUN   TestAccCCENodeV3_password
=== PAUSE TestAccCCENodeV3_password
=== RUN   TestAccCCENodeV3_storage
=== PAUSE TestAccCCENodeV3_storage
=== CONT  TestAccCCENodeV3DataSource_basic
=== CONT  TestAccCCENodeV3_data_volume_encryption
=== CONT  TestAccCCENodeV3_existing_eip
=== CONT  TestAccCCENodeV3_auto_assign_eip
--- PASS: TestAccCCENodeV3_data_volume_encryption (878.90s)
=== CONT  TestAccCCENodeV3_storage
--- PASS: TestAccCCENodeV3_auto_assign_eip (879.80s)
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3DataSource_basic (880.38s)
=== CONT  TestAccCCENodeV3_password
--- PASS: TestAccCCENodeV3_existing_eip (896.70s)
=== CONT  TestAccCCENodeV3_prePaid
=== CONT  TestAccCCENodeV3_volume_extendParams
--- PASS: TestAccCCENodeV3_basic (938.14s)
--- PASS: TestAccCCENodeV3_storage (1055.00s)
--- PASS: TestAccCCENodeV3_password (1060.29s)
--- PASS: TestAccCCENodeV3_prePaid (1130.14s)
--- PASS: TestAccCCENodeV3_volume_extendParams (973.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       2791.372s
```
