### PR TITLE
feat(Modelarts):add a datasource to get dataset versions

### DIFF
--- a/docs/data-sources/modelarts_dataset_versions.md
+++ b/docs/data-sources/modelarts_dataset_versions.md
@@ -1,0 +1,68 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+---
+
+# huaweicloud_modelarts_dataset_versions
+
+Use this data source to get a list of ModelArts dataset versions.
+
+## Example Usage
+
+```hcl
+variable "dataset_id" {}
+data "huaweicloud_modelarts_dataset_versions" "test" {
+  dataset_id = var.dataset_id
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available dataset versions in the current region.
+All dataset versions that meet the filter criteria will be exported as attributes.
+
+* `region` - (Optional, String) Specifies the region in which to obtain dataset versions. If omitted, the
+provider-level region will be used.
+
+* `dataset_id` - (Required, String) Specifies the ID of dataset.
+
+* `split_ratio` - (Optional, String) Specifies the range of splitting ratio which randomly divides a labeled sample
+into a training set and a validation set. Separate the minimum and maximum split ratios with commas,
+for example: "0.0,1.0".
+
+* `name` - (Optional, String) Specifies the name of the dataset version.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `versions` - Indicates a list of all dataset versions found. Structure is documented below.
+
+The `versions` block contains:
+
+* `id` - The ID of the dataset version.
+
+* `name` - The name of the dataset version.
+
+* `description` - The description of the dataset version.
+
+* `split_ratio` - The ratio of splitting which randomly divides a labeled sample into a training set and
+a validation set.
+
+* `status` - Dataset version status. Valid values are as follows:
+  + **0**: Creating.
+  + **1**: Normal.
+  + **2**: Deleting.
+  + **3**: Deleted.
+  + **4**: Exception.
+  
+* `files` - The total number of samples.
+
+* `storage_path` - The path to save the manifest file of the version.
+
+* `is_current` - Whether this version is current version.
+
+* `created_at` - The creation time, in UTC format.
+
+* `updated_at` - The last update time, in UTC format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -417,8 +417,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_secgroup":  DataSourceNetworkingSecGroup(),
 			"huaweicloud_networking_secgroups": vpc.DataSourceNetworkingSecGroups(),
 
-			"huaweicloud_modelarts_datasets":        modelarts.DataSourceDatasets(),
-			"huaweicloud_modelarts_notebook_images": modelarts.DataSourceNotebookImages(),
+			"huaweicloud_modelarts_datasets":         modelarts.DataSourceDatasets(),
+			"huaweicloud_modelarts_dataset_versions": modelarts.DataSourceDatasetVerions(),
+			"huaweicloud_modelarts_notebook_images":  modelarts.DataSourceNotebookImages(),
 
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": DataSourceObsBucketObject(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
@@ -1,0 +1,97 @@
+package modelarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceDatasetVersions_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_modelarts_dataset_versions.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	name := acceptance.RandomAccResourceName()
+	obsName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDatasetVersions_basic(name, obsName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.id",
+						"huaweicloud_modelarts_dataset_version.test", "version_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.description",
+						"huaweicloud_modelarts_dataset_version.test", "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.name",
+						"huaweicloud_modelarts_dataset_version.test", "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.split_ratio",
+						"huaweicloud_modelarts_dataset_version.test", "split_ratio"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.status",
+						"huaweicloud_modelarts_dataset_version.test", "status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.name",
+						"huaweicloud_modelarts_dataset_version.test", "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.files",
+						"huaweicloud_modelarts_dataset_version.test", "files"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.storage_path",
+						"huaweicloud_modelarts_dataset_version.test", "storage_path"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.is_current",
+						"huaweicloud_modelarts_dataset_version.test", "is_current"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.created_at",
+						"huaweicloud_modelarts_dataset_version.test", "created_at"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.updated_at",
+						"huaweicloud_modelarts_dataset_version.test", "updated_at"),
+				),
+			},
+			{
+				Config: testAccDataSourceDatasetVersions_name(name, obsName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "versions.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDatasetVersions_basic(rName, obsName string) string {
+	datasetVersion := testAccDatasetVersion_basic(rName, obsName)
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_modelarts_dataset_versions" "test" {
+  dataset_id  = huaweicloud_modelarts_dataset.test.id
+  split_ratio = "0,2.9"
+
+  depends_on = [
+    huaweicloud_modelarts_dataset_version.test
+  ]
+}
+`, datasetVersion)
+}
+
+func testAccDataSourceDatasetVersions_name(rName, obsName string) string {
+	datasetVersion := testAccDatasetVersion_basic(rName, obsName)
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_modelarts_dataset_versions" "test" {
+  dataset_id  = huaweicloud_modelarts_dataset.test.id
+  split_ratio = "0,2.9"
+  name        = "wrong_name"
+
+  depends_on = [
+    huaweicloud_modelarts_dataset_version.test
+  ]
+}
+`, datasetVersion)
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_dataset_versions.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_dataset_versions.go
@@ -1,0 +1,171 @@
+package modelarts
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDatasetVerions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDatasetVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"dataset_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"split_ratio": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`([+-]?\d+(\.\d*)?|[+-]?\.\d+),([+-]?\d+(\.\d*)?|[+-]?\.\d+)`),
+					"separate the minimum and maximum split ratios with commas"),
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"split_ratio": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"files": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"storage_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"is_current": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDatasetVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ModelArtsV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
+	}
+
+	datasetId := d.Get("dataset_id").(string)
+	opts := version.ListOpts{
+		TrainEvaluateRatio: d.Get("split_ratio").(string),
+	}
+
+	page, err := version.List(client, datasetId, opts)
+	if err != nil {
+		return diag.Errorf("error querying ModelArts dataset versions: %s ", err)
+	}
+
+	p, err := page.AllPages()
+	if err != nil {
+		return diag.Errorf("error querying ModelArts dataset versions: %s", err)
+	}
+
+	ds, err := version.ExtractDatasetVersions(p)
+	if err != nil {
+		return diag.Errorf("error parsing ModelArts dataset versions: %s", err)
+	}
+
+	filter := map[string]interface{}{
+		"VersionName": d.Get("name"),
+	}
+	filtResult, err := utils.FilterSliceWithField(ds, filter)
+	if err != nil {
+		return diag.Errorf("filtering dataset versions failed: %s", err)
+	}
+	log.Printf("filter %d dataset versions from %d through option %v", len(filtResult), len(ds), filter)
+
+	var rst []map[string]interface{}
+	var ids []string
+	for _, f := range filtResult {
+		v := f.(version.DatasetVersion)
+		item := map[string]interface{}{
+			"id":           v.VersionId,
+			"name":         v.VersionName,
+			"description":  v.Description,
+			"split_ratio":  v.TrainEvaluateSampleRatio,
+			"status":       v.Status,
+			"files":        v.TotalSampleCount,
+			"storage_path": v.ManifestPath,
+			"is_current":   v.IsCurrent,
+			"created_at":   utils.FormatTimeStampUTC(int64(v.CreateTime)),
+			"updated_at":   utils.FormatTimeStampUTC(int64(v.UpdateTime)),
+		}
+		rst = append(rst, item)
+		ids = append(ids, v.VersionId)
+	}
+
+	err = d.Set("versions", rst)
+	if err != nil {
+		return diag.Errorf("error setting versions: %s", err)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a datasource to get dataset versions

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccDataSourceDatasetVersions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccDataSourceDatasetVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDatasetVersions_basic
=== PAUSE TestAccDataSourceDatasetVersions_basic
=== CONT  TestAccDataSourceDatasetVersions_basic
--- PASS: TestAccDataSourceDatasetVersions_basic (112.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 112.137s
```
