### PR TITLE
fix: add validation for secgroup rule remote_ip_prefix

### DIFF
--- a/huaweicloud/resource_huaweicloud_networking_secgroup_rule.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_rule.go
@@ -17,6 +17,7 @@ import (
 	v3Rules "github.com/chnsz/golangsdk/openstack/networking/v3/security/rules"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -103,10 +104,11 @@ func ResourceNetworkingSecGroupRule() *schema.Resource {
 				Computed: true,
 			},
 			"remote_ip_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: utils.ValidateCIDR,
 				StateFunc: func(v interface{}) string {
 					return strings.ToLower(v.(string))
 				},

--- a/huaweicloud/utils/validators.go
+++ b/huaweicloud/utils/validators.go
@@ -76,7 +76,7 @@ func ValidateCIDR(v interface{}, k string) (ws []string, errors []error) {
 		return
 	}
 
-	if ipnet == nil || value != ipnet.String() {
+	if ipnet == nil || strings.ToLower(value) != ipnet.String() {
 		errors = append(errors, fmt.Errorf(
 			"%q must contain a valid network CIDR, got %q", k, value))
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**remote_ip_prefix** should be a valid CIDR.
If we set it to an IP address  (i.e. 192.168.0.183),  the secgroup rule also can be created, but it would be forces replacement when we execute terraform command again.

```
      ~ id                = "7953a898-9329-4cbe-a96a-76d9ce6b4378" -> (known after apply)
      + remote_group_id   = (known after apply)
      ~ remote_ip_prefix  = "192.168.0.183/32" -> "192.168.0.183" # forces replacement
      ~ tenant_id         = "d41e3756c24248946b896fd43" -> (known after apply)
        # (6 unchanged attributes hidden)
    }
```

It's better to add a validation for this parameter.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccNetworkingSecGroupRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccNetworkingSecGroupRule -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupRule_basic
=== PAUSE TestAccNetworkingSecGroupRule_basic
=== RUN   TestAccNetworkingSecGroupRule_oldPorts
=== PAUSE TestAccNetworkingSecGroupRule_oldPorts
=== RUN   TestAccNetworkingSecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingSecGroupRule_remoteGroup
=== RUN   TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== PAUSE TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== RUN   TestAccNetworkingSecGroupRule_noPorts
=== PAUSE TestAccNetworkingSecGroupRule_noPorts
=== CONT  TestAccNetworkingSecGroupRule_basic
=== CONT  TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== CONT  TestAccNetworkingSecGroupRule_remoteGroup
=== CONT  TestAccNetworkingSecGroupRule_oldPorts
--- PASS: TestAccNetworkingSecGroupRule_remoteGroup (72.98s)
=== CONT  TestAccNetworkingSecGroupRule_noPorts
--- PASS: TestAccNetworkingSecGroupRule_basic (73.77s)
--- PASS: TestAccNetworkingSecGroupRule_oldPorts (79.99s)
--- PASS: TestAccNetworkingSecGroupRule_lowerCaseCIDR (80.31s)
--- PASS: TestAccNetworkingSecGroupRule_noPorts (55.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       130.797s
```
