### PR TITLE
feat(servicestage): add new component resource support

### DIFF
--- a/docs/resources/servicestage_component.md
+++ b/docs/resources/servicestage_component.md
@@ -1,0 +1,144 @@
+---
+subcategory: "ServiceStage"
+---
+
+# huaweicloud_servicestage_component
+
+This resource is used to manage a component under specified application within HuaweiCloud ServiceStage service.
+
+## Example Usage
+
+### Create a Web component using GitHub repository
+
+```hcl
+variable "application_id"
+variable "component_name"
+variable "token_auth_name"
+variable "repo_url"
+variable "domain_name"
+variable "cluster_id"
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = var.application_id
+  name           = var.component_name
+  type           = "Webapp"
+  runtime        = "Nodejs14"
+  framework      = "Web"
+
+  source {
+    type          = "GitHub"
+    authorization = var.token_auth_name
+    url           = var.repo_url
+  }
+
+  builder {
+    organization = var.domain_name
+    cluster_id   = var.cluster_id
+
+    node_label = {
+      owner = "terraform"
+    }
+  }
+}
+```
+
+### Create a MicroService Docker component
+
+```hcl
+variable "application_id"
+variable "component_name"
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = var.application_id
+  name           = var.component_name
+  type           = "MicroService"
+  runtime        = "Docker"
+  framework      = "Mesher"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the application and component are located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new component.
+
+* `application_id` - (Required, String, ForceNew) Specifies the application ID to which the component belongs.
+  Changing this parameter will create a new component.
+
+* `name` - (Required, String) Specifies the authorization name.
+  The name can contain of 2 to 64 characters, only letters, digits, underscores (_) and hyphens (-) are allowed, and the
+  name must start with a letter and end with a letter or digit.
+
+* `type` - (Required, String, ForceNew) Specifies the component type. The valid values are as follows:
+  + **Webapp**
+  + **MicroService**
+  + **Common**
+
+  Changing this parameter will create a new component.
+
+* `runtime` - (Required, String, ForceNew) Specifies the component runtime, such as **Docker**, **Java8**, etc.
+  Changing this parameter will create a new component.
+
+* `framework` - (Optional, String, ForceNew) Specifies the component framework.
+  + The framework of type **Webapp** is **Web**.
+  + The framework of type **MicroService** supports: **Java Classis**, **Go Classis**, **Mesher**, **Spring Cloud**,
+  **Dubbo**.
+  + The framework of type **Common** can be empty.
+
+  Changing this parameter will create a new component.
+
+-> For the runtime and framework corresponding to each type of component, please refer to the [document](https://support.huaweicloud.com/intl/en-us/usermanual-servicestage/servicestage_user_0411.html).
+
+* `source` - (Optional, List) Specifies the repository source.
+  The [object](#servicestage_component_source) structure is documented below.
+
+* `builder` - (Optional, List) Specifies the component builder.
+  The [object](#servicestage_component_builder) structure is documented below.
+
+<a name="servicestage_component_source"></a>
+The `source` block supports:
+
+* `type` - (Required, String) Specifies the type of repository source or storage.
+  The valid values are **GitHub**, **GitLab**, **Gitee**, **Bitbucket** and **package**.
+
+* `url` - (Required, String) Specifies the URL of the repository or package storage.
+
+* `authorization` - (Optional, String) Specifies the authorization name.
+  This parameter and `storage_type` are alternative.
+
+* `storage_type` - (Optional, String) Specifies the storage type, such as **obs**, **swr**.
+
+<a name="servicestage_component_builder"></a>
+The `builder` block supports:
+
+* `organization` - (Required, String) Specifies the organization name.
+  The organization is usually **domain name**.
+
+* `cluster_id` - (Required, String) Specifies the cluster ID.
+
+* `cmd` - (Optional, String) Specifies the build command. If omitted, the default command will be used.
+  + About the  default command or script: build.sh in the root directory will be preferentially executed.
+    If build.sh does not exist, the code will be compiled using the common method of the selected language,
+    for example, mvn clean package for Java.
+  + About the custom command: Commands will be customized using the selected language.
+    Alternatively, the default command or script will be used after build.sh is modified.
+
+* `node_label` - (Optional, Map) Specifies the filter labels for CCE nodes.
+
+-> Before using the label, please make sure that the node is bound to the EIP and can access the public network.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+Components can be imported using their `application_id` and `id`, separated by a slash (/), e.g.
+
+```
+$ terraform import huaweicloud_servicestage_component.test dd7a1ce2-c48c-4f41-85bb-d0d09969eec9/9ab8ef79-d318-4de5-acf9-e1e1e25a0395
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -706,6 +706,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_read_replica_instance": rds.ResourceRdsReadReplicaInstance(),
 
 			"huaweicloud_servicestage_application":                 servicestage.ResourceApplication(),
+			"huaweicloud_servicestage_component":                   servicestage.ResourceComponent(),
 			"huaweicloud_servicestage_environment":                 servicestage.ResourceEnvironment(),
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
 			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -66,6 +66,8 @@ var (
 	HW_GITHUB_REPO_HOST      = os.Getenv("HW_GITHUB_REPO_HOST")      // Repository host (Github, Gitlab, Gitee)
 	HW_GITHUB_PERSONAL_TOKEN = os.Getenv("HW_GITHUB_PERSONAL_TOKEN") // Personal access token (Github, Gitlab, Gitee)
 	HW_GITHUB_REPO_PWD       = os.Getenv("HW_GITHUB_REPO_PWD")       // Repository password (DevCloud, BitBucket)
+	HW_GITHUB_REPO_URL       = os.Getenv("HW_GITHUB_REPO_URL")       // Repository URL (Github, Gitlab, Gitee)
+	HW_OBS_STORAGE_URL       = os.Getenv("HW_OBS_STORAGE_URL")       // OBS storage URL where ZIP file is located
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -480,5 +482,12 @@ func TestAccPreCheckRepoTokenAuth(t *testing.T) {
 func TestAccPreCheckRepoPwdAuth(t *testing.T) {
 	if HW_DOMAIN_NAME == "" || HW_USER_NAME == "" || HW_GITHUB_REPO_PWD == "" {
 		t.Skip("Repository configuration are not completed for acceptance test of password authorization.")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckComponent(t *testing.T) {
+	if HW_DOMAIN_NAME == "" || HW_GITHUB_REPO_URL == "" || HW_OBS_STORAGE_URL == "" {
+		t.Skip("Repository (package) configuration are not completed for acceptance test of component.")
 	}
 }

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
@@ -1,0 +1,341 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v2/components"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getComponentFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.ServiceStageV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage V2 client: %s", err)
+	}
+	return components.Get(c, state.Primary.Attributes["application_id"], state.Primary.ID)
+}
+
+func TestAccComponent_basic(t *testing.T) {
+	var (
+		component    components.Component
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_servicestage_component.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&component,
+		getComponentFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponent_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "type", "MicroService"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Docker"),
+					resource.TestCheckResourceAttr(resourceName, "framework", "Mesher"),
+				),
+			},
+			{
+				Config: testAccComponent_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MicroService"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Docker"),
+					resource.TestCheckResourceAttr(resourceName, "framework", "Mesher"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccComponentImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func TestAccComponent_web(t *testing.T) {
+	var (
+		component    components.Component
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_servicestage_component.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&component,
+		getComponentFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRepoTokenAuth(t)
+			acceptance.TestAccPreCheckComponent(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponent_web(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "type", "Webapp"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Nodejs14"),
+					resource.TestCheckResourceAttr(resourceName, "framework", "Web"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.type", "GitHub"),
+					resource.TestCheckResourceAttrPair(resourceName, "source.0.authorization",
+						"huaweicloud_servicestage_repo_token_authorization.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.url", acceptance.HW_GITHUB_REPO_URL),
+					resource.TestCheckResourceAttr(resourceName, "builder.0.organization", acceptance.HW_DOMAIN_NAME),
+					resource.TestCheckResourceAttrPair(resourceName, "builder.0.cluster_id",
+						"huaweicloud_cce_cluster.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "builder.0.node_label.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccComponent_webUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Webapp"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Nodejs14"),
+					resource.TestCheckResourceAttr(resourceName, "framework", "Web"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.type", "package"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.storage_type", "obs"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.url", acceptance.HW_OBS_STORAGE_URL),
+					resource.TestCheckResourceAttr(resourceName, "builder.0.organization", acceptance.HW_DOMAIN_NAME),
+					resource.TestCheckResourceAttrPair(resourceName, "builder.0.cluster_id",
+						"huaweicloud_cce_cluster.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "builder.0.node_label.foo", "bar"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccComponentImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccComponentImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var appId, componentId string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_servicestage_component" {
+				appId = rs.Primary.Attributes["application_id"]
+				componentId = rs.Primary.ID
+			}
+		}
+		if appId == "" || componentId == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", appId, componentId)
+		}
+		return fmt.Sprintf("%s/%s", appId, componentId), nil
+	}
+}
+
+func testAccComponent_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestage_application" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+
+  name = "%[1]s"
+
+  type      = "MicroService"
+  runtime   = "Docker"
+  framework = "Mesher"
+}`, rName)
+}
+
+func testAccComponent_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestage_application" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+
+  name = "%[1]s-update"
+
+  type      = "MicroService"
+  runtime   = "Docker"
+  framework = "Mesher"
+}`, rName)
+}
+
+func testAccComponent_buildConfig(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 8
+  memory_size       = 16
+}
+
+data "huaweicloud_images_image" "test" {
+  name        = "Ubuntu 18.04 server 64bit"
+  most_recent = true
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  vpc_id      = huaweicloud_vpc.test.id
+  ipv6_enable = true
+}
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%[1]s"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  flavor_id              = "cce.s2.medium"
+  container_network_type = "vpc-router"
+  cluster_version        = "v1.19"
+  cluster_type           = "VirtualMachine"
+
+  kube_proxy_mode = "iptables"
+
+  dynamic "masters" {
+    for_each = slice(data.huaweicloud_availability_zones.test.names, 0, 3)
+
+    content {
+      availability_zone = masters.value
+    }
+  }
+}
+
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
+  name              = "%[1]s"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  key_pair          = huaweicloud_kps_keypair.test.name
+
+  root_volume {
+    volumetype = "SSD"
+    size       = 100
+  }
+
+  data_volumes {
+    volumetype = "SSD"
+    size       = 100
+  }
+
+  tags = {
+    owner = "terraform"
+    foo   = "bar"
+  }
+}
+
+resource "huaweicloud_servicestage_repo_token_authorization" "test" {
+  type  = "github"
+  name  = "%[1]s"
+  host  = "%[2]s"
+  token = "%[3]s"
+}
+`, rName, acceptance.HW_GITHUB_REPO_HOST, acceptance.HW_GITHUB_PERSONAL_TOKEN)
+}
+
+func testAccComponent_web(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestage_application" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+  type           = "Webapp"
+  runtime        = "Nodejs14"
+  framework      = "Web"
+
+  name = "%[2]s"
+
+  source {
+    type          = "GitHub"
+    authorization = huaweicloud_servicestage_repo_token_authorization.test.name
+    url           = "%[3]s"
+  }
+
+  builder {
+    organization = "%[4]s"
+    cluster_id   = huaweicloud_cce_cluster.test.id
+
+    node_label = {
+      owner = "terraform"
+    }
+  }
+}
+`, testAccComponent_buildConfig(rName), rName, acceptance.HW_GITHUB_REPO_URL, acceptance.HW_DOMAIN_NAME)
+}
+
+func testAccComponent_webUpdate(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestage_application" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+  type           = "Webapp"
+  runtime        = "Nodejs14"
+  framework      = "Web"
+
+  name = "%[2]s-update"
+
+  source {
+    type         = "package"
+    storage_type = "obs"
+    url          = "%[3]s"
+  }
+
+  builder {
+    organization = "%[4]s"
+    cluster_id   = huaweicloud_cce_cluster.test.id
+
+    node_label = {
+      foo = "bar"
+    }
+  }
+}
+`, testAccComponent_buildConfig(rName), rName, acceptance.HW_OBS_STORAGE_URL, acceptance.HW_DOMAIN_NAME)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component.go
@@ -1,0 +1,328 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v2/components"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceComponent() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComponentCreate,
+		ReadContext:   resourceComponentRead,
+		UpdateContext: resourceComponentUpdate,
+		DeleteContext: resourceComponentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceComponentImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z]([\w-]*[A-Za-z0-9])?$`),
+						"The name can only contain letters, digits, underscores (_) and hyphens (-), and the name must"+
+							" start with a letter and end with a letter or digit."),
+					validation.StringLenBetween(2, 64),
+				),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Webapp", "MicroService", "Common",
+				}, false),
+			},
+			"runtime": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"framework": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"GitHub", "GitLab", "Gitee", "Bitbucket", "package",
+							}, false),
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"authorization": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ExactlyOneOf: []string{"source.0.storage_type"},
+						},
+						"storage_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"builder": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"organization": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"cmd": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"node_label": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildRepoBuilderStructure(params []interface{}) *components.Builder {
+	if len(params) < 1 {
+		return nil
+	}
+
+	param := params[0].(map[string]interface{})
+	return &components.Builder{
+		Parameter: components.Parameter{
+			BuildCmd:          param["cmd"].(string),
+			ArtifactNamespace: param["organization"].(string),
+			ClusterId:         param["cluster_id"].(string),
+			NodeLabelSelector: param["node_label"].(map[string]interface{}),
+		},
+	}
+}
+
+func buildRepoSourceStructure(sources []interface{}) *components.Source {
+	if len(sources) < 1 {
+		return nil
+	}
+	var result components.Source
+
+	source := sources[0].(map[string]interface{})
+	rType := source["type"].(string)
+	switch rType {
+	case "package":
+		result = components.Source{
+			Kind: "artifact",
+			Spec: components.Spec{
+				Type:    rType,
+				Storage: source["storage_type"].(string),
+				Url:     source["url"].(string),
+			},
+		}
+	case "GitHub", "GitLab", "Gitee", "Bitbucket":
+		result = components.Source{
+			Kind: "code",
+			Spec: components.Spec{
+				RepoType: rType,
+				RepoAuth: source["authorization"].(string),
+				RepoUrl:  source["url"].(string),
+			},
+		}
+	default:
+	}
+	return &result
+}
+
+func resourceComponentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	v2Client, err := conf.ServiceStageV2Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage V2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	opt := components.CreateOpts{
+		Name:     d.Get("name").(string),
+		Runtime:  d.Get("runtime").(string),
+		Type:     d.Get("type").(string),
+		Framwork: d.Get("framework").(string),
+		Builder:  buildRepoBuilderStructure(d.Get("builder").([]interface{})),
+		Source:   buildRepoSourceStructure(d.Get("source").([]interface{})),
+	}
+	resp, err := components.Create(v2Client, appId, opt)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage component: %s", err)
+	}
+
+	d.SetId(resp.ID)
+
+	return resourceComponentRead(ctx, d, meta)
+}
+
+func flattenRepoBuilder(builder components.Builder) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening builder structure: %#v", r)
+		}
+	}()
+
+	if !reflect.DeepEqual(builder, components.Builder{}) {
+		result = append(result, map[string]interface{}{
+			"cmd":          builder.Parameter.BuildCmd,
+			"organization": builder.Parameter.ArtifactNamespace,
+			"cluster_id":   builder.Parameter.ClusterId,
+			"node_label":   builder.Parameter.NodeLabelSelector,
+		})
+	}
+
+	return
+}
+
+func flattenRepoSource(source components.Source) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening source structure: %#v", r)
+		}
+	}()
+
+	if (source != components.Source{}) {
+		if source.Spec.Type == "package" {
+			result = append(result, map[string]interface{}{
+				"type":         source.Spec.Type,
+				"storage_type": source.Spec.Storage,
+				"url":          source.Spec.Url,
+			})
+		} else if source.Spec.RepoType == "GitHub" || source.Spec.Type == "GitLab" ||
+			source.Spec.Type == "Gitee" || source.Spec.Type == "Bitbucket" {
+			result = append(result, map[string]interface{}{
+				"type":          source.Spec.RepoType,
+				"authorization": source.Spec.RepoAuth,
+				"url":           source.Spec.RepoUrl,
+			})
+		}
+	}
+
+	return
+}
+
+func resourceComponentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.ServiceStageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage V2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	resp, err := components.Get(client, appId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ServiceStage component")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", resp.Name),
+		d.Set("type", resp.Type),
+		d.Set("runtime", resp.Runtime),
+		d.Set("framework", resp.Framwork),
+		d.Set("builder", flattenRepoBuilder(resp.Builder)),
+		d.Set("source", flattenRepoSource(resp.Source)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceComponentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.ServiceStageV2Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage V2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	// In normal changes, there is no situation in which source and builder are empty, so these two empty values are
+	// ignored.
+	opt := components.UpdateOpts{
+		Name:    d.Get("name").(string),
+		Builder: buildRepoBuilderStructure(d.Get("builder").([]interface{})),
+		Source:  buildRepoSourceStructure(d.Get("source").([]interface{})),
+	}
+	_, err = components.Update(client, appId, d.Id(), opt)
+	if err != nil {
+		return diag.Errorf("error updating ServiceStage component (%s): %s", d.Id(), err)
+	}
+
+	return resourceComponentRead(ctx, d, meta)
+}
+
+func resourceComponentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.ServiceStageV2Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage V2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	err = components.Delete(client, appId, d.Id())
+	if err != nil {
+		return diag.Errorf("error deleting ServiceStage component: %s", err)
+	}
+	return nil
+}
+
+func resourceComponentImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid format specified for import id, must be <application_id>/<component_id>")
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("application_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In order to better manage microservice related resources, ServiceStage service needs to support more resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
reference: #2030 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new resource to manage ServiceStage component.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccComponent'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccComponent -timeout 360m -parallel 4
=== RUN   TestAccComponent_basic
=== PAUSE TestAccComponent_basic
=== RUN   TestAccComponent_web
=== PAUSE TestAccComponent_web
=== CONT  TestAccComponent_web
=== CONT  TestAccComponent_basic
--- PASS: TestAccComponent_basic (39.28s)
--- PASS: TestAccComponent_web (908.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage        908.274s
```
