### PR TITLE
chore(workflow): ignore the error-check of d.set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,3 @@ jobs:
           version: latest
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
-          args: --timeout 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# Options for analysis running.
+run:
+  # See the dedicated "run" documentation section.
+  timeout: 5m
+  # Which dirs to skip: issues from them won't be reported.
+  # Can use regexp here: `generated.*`, regexp is applied on full path.
+  # Default value is empty list,
+  # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work on Windows.
+  skip-dirs:
+    - huaweicloud/services/deprecated
+    - huaweicloud/services/acceptance/deprecated
+issues:
+  # List of regexps of issue texts to exclude.
+  #
+  # But independently of this option we use default exclude patterns,
+  # it can be disabled by `exclude-use-default: false`.
+  # To list all excluded by default patterns execute `golangci-lint run --help`
+  #
+  # Default: []
+  exclude:
+    - "Error return value of `d.Set` is not checked"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 1. add a config file of golangci
 2. ignore the error check:  **Error return value of `d.Set` is not checked**


