### PR TITLE
feat(kafka): support the cross vpc parameters

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -177,6 +177,14 @@ In addition to all arguments above, the following attributes are exported:
 * `user_name` - Indicates the name of the user who created the DMS kafka instance
 * `connect_address` - Indicates the IP address of the DMS kafka instance.
 * `manegement_connect_address` - Indicates the connection address of the Kafka Manager of a Kafka instance.
+* `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
+
+The `cross_vpc_accesses` block supports:
+
+* `lisenter_ip` - The listener IP address.
+* `advertised_ip` - The advertised IP Address.
+* `port` - The port number.
+* `port_id` - The port ID associated with the address.
 
 ## Timeouts
 

--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -17,7 +17,7 @@ import (
 )
 
 // MAXFieldLength is the maximum string length of single field when logging
-const MAXFieldLength int = 256
+const MAXFieldLength int = 1024
 
 var maxTimeout = 10 * time.Minute
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -2,6 +2,7 @@ package dms
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances"
@@ -45,6 +46,7 @@ func TestAccDmsKafkaInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine", "kafka"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestMatchResourceAttr(resourceName, "cross_vpc_accesses.#", regexp.MustCompile(`[1-9]\d*`)),
 				),
 			},
 			{
@@ -65,6 +67,7 @@ func TestAccDmsKafkaInstances_basic(t *testing.T) {
 					"password",
 					"manager_password",
 					"used_storage_space",
+					"cross_vpc_accesses",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the user requests, we added a attribute to support the cross-VPC parameters reference:
- address
- port
- port_id

In this way, users no longer need to use `huaweicloud_networking_port` to query the port ID.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new cross-VPC stucture to support the port IDs querying.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run=TestAccDmsKafkaInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run=TestAccDmsKafkaInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaInstances_basic
=== PAUSE TestAccDmsKafkaInstances_basic
=== CONT  TestAccDmsKafkaInstances_basic
--- PASS: TestAccDmsKafkaInstances_basic (1156.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms        1156.272s
```
