### PR TITLE
feat(dms/kafka): add new data-source to query instance list

### DIFF
--- a/docs/data-sources/dms_kafka_instances.md
+++ b/docs/data-sources/dms_kafka_instances.md
@@ -1,0 +1,126 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_instances
+
+Use this data source to query the available instances within HuaweiCloud DMS service.
+
+## Example Usage
+
+### Query all instances with the keyword in the name
+
+```hcl
+variable "keyword" {}
+
+data "huaweicloud_dms_kafka_instances" "test" {
+  name = var.keyword
+}
+```
+
+### Query the instance with the specified name
+
+```hcl
+variable "instance_name" {}
+
+data "huaweicloud_dms_kafka_instances" "test" {
+  name           = var.instance_name
+  is_exact_match = true
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to query the kafka instance list.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the kafka instance ID to match exactly.
+
+* `name` - (Optional, String) Specifies the kafka instance name for data-source queries.
+
+* `is_exact_match` - (Optional, Bool) Specifies whether to match the instance name exactly, the default is a fuzzy
+  match (`flase`).
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which all instances of the list
+  belong.
+
+* `status` - (Optional, String) Specifies the kafka instance status for data-source queries.
+
+* `include_failure` - (Optional, Bool) Specifies whether the query results contain instances that failed to create.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The result of the query's list of kafka instances. The structure is documented below.
+
+The `instances` block supports:
+
+* `id` - The instance ID.
+
+* `type` - The instance type.
+
+* `name` - The instance name.
+
+* `description` - The instance description.
+
+* `availability_zones` - The list of AZ names.
+
+* `enterprise_project_id` - The enterprise project ID to which the instance belongs.
+
+* `product_id` - The product ID used by the instance.
+
+* `engine_version` - The kafka engine version.
+
+* `storage_spec_code` - The storage I/O specification.
+
+* `storage_space` - The message storage capacity, in GB unit.
+
+* `vpc_id` - The VPC ID to which the instance belongs.
+
+* `network_id` - The subnet ID to which the instance belongs.
+
+* `security_group_id` - The security group ID associated with the instance.
+
+* `manager_user` - The username for logging in to the Kafka Manager.
+
+* `access_user` - The access username.
+
+* `maintain_begin` - The time at which a maintenance time window starts, the format is `HH:mm`.
+
+* `maintain_end` - The time at which a maintenance time window ends, the format is `HH:mm`.
+
+* `enable_public_ip` - Whether public access to the instance is enabled.
+
+* `public_ip_ids` - The IDs of the elastic IP address (EIP).
+
+* `public_conn_addresses` - The instance public access address.
+  The format of each connection address is `{IP address}:{port}`.
+
+* `dumping` - Whether to dumping is enabled.
+
+* `enable_auto_topic` - Whether to enable automatic topic creation.
+
+* `partition_num` - The maximum number of topics in the DMS kafka instance.
+
+* `ssl_enable` - Whether the Kafka SASL_SSL is enabled.
+
+* `used_storage_space` - The used message storage space, in GB unit.
+
+* `connect_address` - The IP address for instance connection.
+
+* `port` - The port number of the instance.
+
+* `status` - The instance status.
+
+* `resource_spec_code` - The resource specifications identifier.
+
+* `user_id` - The user ID who created the instance.
+
+* `user_name` - The username who created the instance.
+
+* `manegement_connect_address` - The connection address of the Kafka manager of an instance.
+
+* `tags` - The key/value pairs to associate with the instance.

--- a/docs/data-sources/dms_kafka_instances.md
+++ b/docs/data-sources/dms_kafka_instances.md
@@ -14,7 +14,8 @@ Use this data source to query the available instances within HuaweiCloud DMS ser
 variable "keyword" {}
 
 data "huaweicloud_dms_kafka_instances" "test" {
-  name = var.keyword
+  name        = var.keyword
+  fuzzy_match = true
 }
 ```
 
@@ -24,8 +25,7 @@ data "huaweicloud_dms_kafka_instances" "test" {
 variable "instance_name" {}
 
 data "huaweicloud_dms_kafka_instances" "test" {
-  name           = var.instance_name
-  is_exact_match = true
+  name = var.instance_name
 }
 ```
 
@@ -38,7 +38,7 @@ data "huaweicloud_dms_kafka_instances" "test" {
 
 * `name` - (Optional, String) Specifies the kafka instance name for data-source queries.
 
-* `is_exact_match` - (Optional, Bool) Specifies whether to match the instance name exactly, the default is a fuzzy
+* `fuzzy_match` - (Optional, Bool) Specifies whether to match the instance name fuzzily, the default is a exact
   match (`flase`).
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which all instances of the list
@@ -124,3 +124,15 @@ The `instances` block supports:
 * `manegement_connect_address` - The connection address of the Kafka manager of an instance.
 
 * `tags` - The key/value pairs to associate with the instance.
+
+* `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
+
+The `cross_vpc_accesses` block supports:
+
+* `lisenter_ip` - The listener IP address.
+
+* `advertised_ip` - The advertised IP Address.
+
+* `port` - The port number.
+
+* `port_id` - The port ID associated with the address.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -364,10 +364,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_maintainwindow": dcs.DataSourceDcsMaintainWindow(),
 			"huaweicloud_dcs_product":        deprecated.DataSourceDcsProductV1(),
 
-			"huaweicloud_dds_flavors":        dds.DataSourceDDSFlavorV3(),
-			"huaweicloud_dms_az":             deprecated.DataSourceDmsAZ(),
-			"huaweicloud_dms_product":        dms.DataSourceDmsProduct(),
-			"huaweicloud_dms_maintainwindow": dms.DataSourceDmsMaintainWindow(),
+			"huaweicloud_dds_flavors": dds.DataSourceDDSFlavorV3(),
+
+			"huaweicloud_dms_az":              deprecated.DataSourceDmsAZ(),
+			"huaweicloud_dms_kafka_instances": dms.DataSourceDmsKafkaInstances(),
+			"huaweicloud_dms_product":         dms.DataSourceDmsProduct(),
+			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
 
 			"huaweicloud_elb_flavors":        dataSourceElbFlavorsV3(),
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_instances_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_instances_test.go
@@ -1,0 +1,83 @@
+package dms
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKafkaInstancesDataSource_basic(t *testing.T) {
+	dc0 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_0")
+	dc1 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_1")
+	dc2 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_2")
+	dc3 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_3")
+	dc4 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_4")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaInstancesDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc0.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.huaweicloud_dms_kafka_instances.query_0",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc1.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.huaweicloud_dms_kafka_instances.query_1",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc2.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.huaweicloud_dms_kafka_instances.query_2",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc3.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.huaweicloud_dms_kafka_instances.query_3",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc4.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.huaweicloud_dms_kafka_instances.query_4",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccKafkaInstancesDataSource_basic() string {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dms_kafka_instances" "query_0" {
+  depends_on = [
+    huaweicloud_dms_kafka_instance.test,
+  ]
+
+  name        = "tf-acc-test"
+  fuzzy_match = true
+}
+
+data "huaweicloud_dms_kafka_instances" "query_1" {
+  name = huaweicloud_dms_kafka_instance.test.name
+}
+
+data "huaweicloud_dms_kafka_instances" "query_2" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+}
+
+data "huaweicloud_dms_kafka_instances" "query_3" {
+  enterprise_project_id = huaweicloud_dms_kafka_instance.test.enterprise_project_id
+}
+
+data "huaweicloud_dms_kafka_instances" "query_4" {
+  depends_on = [
+    huaweicloud_dms_kafka_instance.test,
+  ]
+
+  status = "RUNNING"
+}
+`, testAccDmsKafkaInstance_basic(rName))
+}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
@@ -199,6 +199,30 @@ func DataSourceDmsKafkaInstances() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"cross_vpc_accesses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lisenter_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"advertised_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"port": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"port_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -278,6 +302,12 @@ func flattenKafkaInstanceList(client *golangsdk.ServiceClient, conf *config.Conf
 			instance["enable_public_ip"] = val.EnablePublicIP
 			instance["public_conn_addresses"] = strings.TrimSpace(val.PublicConnectionAddress)
 		}
+
+		crossVpcAccess, err := flattenConnectPorts(val.CrossVpcInfo)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error retriving details of the cross-VPC information: %v", err)
+		}
+		instance["cross_vpc_accesses"] = crossVpcAccess
 
 		result[i] = instance
 		ids[i] = val.InstanceID

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
@@ -1,0 +1,325 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDmsKafkaInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDmsKafkaInstances,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"fuzzy_match": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				RequiredWith: []string{
+					"name",
+				},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"include_failure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			// Attributes
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zones": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_spec_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_space": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"manager_user": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_user": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"maintain_begin": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"maintain_end": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enable_public_ip": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"public_ip_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"public_conn_addresses": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"retention_policy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dumping": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"enable_auto_topic": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"partition_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ssl_enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"used_storage_space": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"connect_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_spec_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"manegement_connect_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func isPubilcIPEnabled(val instances.Instance) bool {
+	return val.EnablePublicIP
+}
+
+func flattenKafkaInstanceList(client *golangsdk.ServiceClient, conf *config.Config, region string,
+	list []instances.Instance) ([]map[string]interface{}, []string, error) {
+	ids := make([]string, len(list))
+	result := make([]map[string]interface{}, len(list))
+
+	for i, val := range list {
+		partitionNum, err := strconv.ParseInt(val.PartitionNum, 10, 64)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// convert the ids of the availability zone into codes
+		availableZoneIDs := val.AvailableZones
+		availableZoneCodes, err := getAvailableZoneCodeByID(conf, region, availableZoneIDs)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		instance := map[string]interface{}{
+			"id":                         val.InstanceID,
+			"type":                       val.Type,
+			"name":                       val.Name,
+			"description":                val.Description,
+			"availability_zones":         availableZoneCodes,
+			"enterprise_project_id":      val.EnterpriseProjectID,
+			"product_id":                 val.ProductID,
+			"engine_version":             val.EngineVersion,
+			"storage_spec_code":          val.StorageSpecCode,
+			"storage_space":              val.TotalStorageSpace,
+			"vpc_id":                     val.VPCID,
+			"network_id":                 val.SubnetID,
+			"security_group_id":          val.SecurityGroupID,
+			"manager_user":               val.KafkaManagerUser,
+			"access_user":                val.AccessUser,
+			"maintain_begin":             val.MaintainBegin,
+			"maintain_end":               val.MaintainEnd,
+			"retention_policy":           val.RetentionPolicy,
+			"dumping":                    val.ConnectorEnalbe,
+			"enable_auto_topic":          val.EnableAutoTopic,
+			"partition_num":              partitionNum,
+			"ssl_enable":                 val.SslEnable,
+			"used_storage_space":         val.UsedStorageSpace,
+			"connect_address":            val.ConnectAddress,
+			"port":                       val.Port,
+			"status":                     val.Status,
+			"resource_spec_code":         val.ResourceSpecCode,
+			"user_id":                    val.UserID,
+			"user_name":                  val.UserName,
+			"manegement_connect_address": val.ManagementConnectAddress,
+			"tags":                       utils.TagsToMap(val.Tags),
+		}
+		if isPubilcIPEnabled(val) {
+			addrList := strings.Split(strings.TrimSpace(val.PublicConnectionAddress), ",")
+			log.Printf("[DEBUG] The address list is: %v", addrList)
+
+			publicIPs := make([]string, len(addrList))
+			re := regexp.MustCompile(`(.*):\d+`)
+			for i, val := range addrList {
+				resp := re.FindStringSubmatch(val)
+				if len(resp) < 2 {
+					return nil, nil, fmt.Errorf("wrong public IP format, want '{public IP}:{port}', but '%v'", val)
+				}
+				publicIPs[i] = resp[1]
+			}
+			instance["public_ip_ids"] = publicIPs
+			instance["enable_public_ip"] = val.EnablePublicIP
+			instance["public_conn_addresses"] = strings.TrimSpace(val.PublicConnectionAddress)
+		}
+
+		result[i] = instance
+		ids[i] = val.InstanceID
+	}
+
+	return result, ids, nil
+}
+
+func dataSourceDmsKafkaInstances(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+
+	client, err := conf.DmsV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DMS instance client: %s", err)
+	}
+
+	isFuzzyMatch := d.Get("fuzzy_match").(bool)
+	opt := instances.ListOpts{
+		InstanceId:          d.Get("instance_id").(string),
+		Name:                d.Get("name").(string),
+		ExactMatchName:      strconv.FormatBool(!isFuzzyMatch),
+		Engine:              "kafka",
+		Status:              d.Get("status").(string),
+		IncludeFailure:      strconv.FormatBool(d.Get("include_failure").(bool)),
+		EnterpriseProjectID: conf.GetEnterpriseProjectID(d),
+	}
+	pages, err := instances.List(client, opt).AllPages()
+	if err != nil {
+		return diag.Errorf("error querying DMS kafka instance list：%v", err)
+	}
+	list, err := instances.ExtractInstances(pages)
+	if err != nil {
+		return diag.Errorf("error parsing DMS kafka instance list：%v", err)
+	}
+
+	log.Printf("[DEBUG] The result of the DMS kafka instance list query is: %v", list)
+	result, ids, err := flattenKafkaInstanceList(client, conf, region, list.Instances)
+	if err != nil {
+		return diag.Errorf("error flattening DMS kafka instance list：%v", err)
+	}
+	d.SetId(hashcode.Strings(ids))
+
+	return diag.FromErr(d.Set("instances", result))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support for multiple query data source, which allow user to filter the list by given parameters:
- instance_id
- name (support fuzzy mode and exact mode)
- enterprise_project_id
- status
- include_failure (whether failure instance are included)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data-source to query instance list
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run=TestAccKafkaInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run=TestAccKafkaInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstancesDataSource_basic
=== PAUSE TestAccKafkaInstancesDataSource_basic
=== CONT  TestAccKafkaInstancesDataSource_basic
--- PASS: TestAccKafkaInstancesDataSource_basic (563.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       563.755s
```
