### PR TITLE
feat(obs/object): support import in obs object resource

### DIFF
--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -86,3 +86,29 @@ In addition to all arguments above, the following attributes are exported:
   server-side encryption.
 * `size` - the size of the object in bytes.
 * `version_id` - A unique version ID value for the object, if bucket versioning is enabled.
+
+## Import
+
+OBS bucket object can be imported using the bucket and key separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_obs_bucket_object.object bucket/key
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include: `content_type`, `encryption`, `source`,
+`acl`, `sse_kms_key_id` and `version_id`. It is generally recommended running `terraform plan` after importing an object.
+You can then decide if changes should be applied to the object, or the resource
+definition should be updated to align with the object. Also you can ignore changes as below.
+
+```
+resource "huaweicloud_obs_bucket_object" "object" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      content_type, encryption, source, acl, sse_kms_key_id, version_id,
+    ]
+  }
+}
+```

--- a/huaweicloud/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_object.go
@@ -19,6 +19,9 @@ func ResourceObsBucketObject() *schema.Resource {
 		Read:   resourceObsBucketObjectRead,
 		Update: resourceObsBucketObjectPut,
 		Delete: resourceObsBucketObjectDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceObsBucketObjectImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -293,4 +296,21 @@ func resourceObsBucketObjectDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return nil
+}
+
+func resourceObsBucketObjectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmtp.Errorf("Invalid format specified for OBS bucket object. Format must be <bucket>/<key>")
+		return nil, err
+	}
+
+	bucket := parts[0]
+	key := parts[1]
+
+	d.Set("bucket", bucket)
+	d.Set("key", key)
+	d.SetId(key)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/huaweicloud/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/resource_huaweicloud_obs_bucket_object_test.go
@@ -51,6 +51,15 @@ func TestAccObsBucketObject_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccObsBucketObjecImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"content_type", "encryption", "source", "version_id",
+				},
+			},
 		},
 	})
 }
@@ -158,6 +167,23 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+func testAccObsBucketObjecImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		bucket, ok := s.RootModule().Resources["huaweicloud_obs_bucket.object_bucket"]
+		if !ok {
+			return "", fmtp.Errorf("Bucket not found: %s", bucket)
+		}
+		object, ok := s.RootModule().Resources["huaweicloud_obs_bucket_object.object"]
+		if !ok {
+			return "", fmtp.Errorf("Object not found: %s", object)
+		}
+		if bucket.Primary.ID == "" || object.Primary.ID == "" {
+			return "", fmtp.Errorf("resource not found: %s/%s", bucket.Primary.ID, object.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", bucket.Primary.ID, object.Primary.ID), nil
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support import in obs object resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support import in obs object resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucketObject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucketObject -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (20.83s)
=== CONT  TestAccObsBucketObjectDataSource_source
--- PASS: TestAccObsBucketObjectDataSource_allParams (30.05s)
--- PASS: TestAccObsBucketObjectDataSource_content (32.70s)
--- PASS: TestAccObsBucketObject_source (34.45s)
--- PASS: TestAccObsBucketObjectDataSource_source (26.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       47.860s
```
