### PR TITLE
feat(cbr): make consistent_level be optional

### DIFF
--- a/docs/json/resources/cbr_vault.json
+++ b/docs/json/resources/cbr_vault.json
@@ -16,7 +16,7 @@
               },
               "consistent_level": {
                 "type": "string",
-                "required": true,
+                "optional": true,
                 "forcenew": true
               },
               "enterprise_project_id": {

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -50,7 +50,6 @@ resource "huaweicloud_cbr_vault" "test" {
   name             = var.vault_name
   type             = "disk"
   protection_type  = "backup"
-  consistent_level = "crash_consistent"
   size             = 50
   auto_expand      = true
 
@@ -74,7 +73,6 @@ variable "sfs_turbo_id" {}
 
 resource "huaweicloud_cbr_vault" "test" {
   name             = var.vault_name
-  consistent_level = "crash_consistent"
   type             = "turbo"
   protection_type  = "backup"
   size             = 1000
@@ -98,7 +96,6 @@ variable "vault_name" {}
 
 resource "huaweicloud_cbr_vault" "test" {
   name             = var.vault_name
-  consistent_level = "crash_consistent"
   type             = "turbo"
   protection_type  = "replication"
   size             = 1000
@@ -121,21 +118,22 @@ The following arguments are supported:
   + **disk** (EVS Disks)
   + **turbo** (SFS Turbo file systems)
 
-* `consistent_level` - (Required, String, ForceNew) Specifies the backup specifications.
-  The valid values are as follows:
-  + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
-  + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
-
-  Only server type vaults support application consistent. Changing this will create a new vault.
-
 * `protection_type` - (Required, String, ForceNew) Specifies the protection type of the CBR vault.
   The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
   Changing this will create a new vault.
 
 * `size` - (Required, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
 
+* `consistent_level` - (Optional, String, ForceNew) Specifies the backup specifications.
+  The valid values are as follows:
+  + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
+  + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
+
+  Only **server** type vaults support application consistent and defaults to **crash_consistent**.
+  Changing this will create a new vault.
+
 * `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
-  Default to **false**.
+  Defaults to **false**.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies a unique ID in UUID format of enterprise project.
   Changing this will create a new vault.

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -476,7 +476,6 @@ func testAccCBRV3Vault_volumeBasic(rName string) string {
 
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s"
-  consistent_level      = "crash_consistent"
   type                  = "disk"
   protection_type       = "backup"
   size                  = 50
@@ -498,7 +497,6 @@ func testAccCBRV3Vault_volumeUpdate(rName string) string {
 
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s-update"
-  consistent_level      = "crash_consistent"
   type                  = "disk"
   protection_type       = "backup"
   size                  = 100
@@ -552,7 +550,6 @@ func testAccCBRV3Vault_turboBasic(rName string) string {
 
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s"
-  consistent_level      = "crash_consistent"
   type                  = "turbo"
   protection_type       = "backup"
   size                  = 800
@@ -585,7 +582,6 @@ resource "huaweicloud_sfs_turbo" "test2" {
 
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s-update"
-  consistent_level      = "crash_consistent"
   type                  = "turbo"
   protection_type       = "backup"
   size                  = 1000
@@ -607,7 +603,6 @@ func testAccCBRV3Vault_turboReplication(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s"
-  consistent_level      = "crash_consistent"
   type                  = "turbo"
   protection_type       = "replication"
   size                  = 1000

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -70,14 +70,6 @@ func ResourceCBRVaultV3() *schema.Resource {
 					VaultTypeServer, VaultTypeDisk, VaultTypeTurbo,
 				}, false),
 			},
-			"consistent_level": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"crash_consistent", "app_consistent",
-				}, false),
-			},
 			"protection_type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -90,6 +82,15 @@ func ResourceCBRVaultV3() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validation.IntBetween(1, 10485760),
+			},
+			"consistent_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "crash_consistent",
+				ValidateFunc: validation.StringInSlice([]string{
+					"crash_consistent", "app_consistent",
+				}, false),
 			},
 			"auto_expand": {
 				Type:     schema.TypeBool,
@@ -407,10 +408,10 @@ func resourceCBRVaultV3Read(d *schema.ResourceData, meta interface{}) error {
 	mErr := multierror.Append(
 		// Required && Optional
 		d.Set("name", resp.Name),
-		d.Set("consistent_level", resp.Billing.ConsistentLevel),
 		d.Set("type", resp.Billing.ObjectType),
 		d.Set("protection_type", resp.Billing.ProtectType),
 		d.Set("size", resp.Billing.Size),
+		d.Set("consistent_level", resp.Billing.ConsistentLevel),
 		d.Set("auto_expand", resp.AutoExpand),
 		d.Set("enterprise_project_id", resp.EnterpriseProjectID),
 		d.Set("tags", utils.TagsToMap(resp.Tags)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* **consistent_level** is not shown in console UI, so we can update it to be optional with a default value. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run TestAccCBRV3Vault_BasicServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run TestAccCBRV3Vault_BasicServer -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Vault_BasicServer
=== PAUSE TestAccCBRV3Vault_BasicServer
=== CONT  TestAccCBRV3Vault_BasicServer
--- PASS: TestAccCBRV3Vault_BasicServer (354.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       354.644s
$
$ make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run TestAccCBRV3Vault_BasicVolume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run TestAccCBRV3Vault_BasicVolume -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Vault_BasicVolume
=== PAUSE TestAccCBRV3Vault_BasicVolume
=== CONT  TestAccCBRV3Vault_BasicVolume
--- PASS: TestAccCBRV3Vault_BasicVolume (296.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       296.850s
$
$ make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run TestAccCBRV3Vault_ReplicaTurbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run TestAccCBRV3Vault_ReplicaTurbo -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Vault_ReplicaTurbo
=== PAUSE TestAccCBRV3Vault_ReplicaTurbo
=== CONT  TestAccCBRV3Vault_ReplicaTurbo
--- PASS: TestAccCBRV3Vault_ReplicaTurbo (33.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       33.533s
```
