### PR TITLE
chore(ecs): unset V2 in functions using cloudservers package

### DIFF
--- a/huaweicloud/data_source_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instance_test.go
@@ -20,12 +20,12 @@ func TestAccComputeInstanceDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstanceDataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
+					testAccCheckComputeInstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckComputeInstanceDataSourceID(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),

--- a/huaweicloud/data_source_huaweicloud_compute_instances_test.go
+++ b/huaweicloud/data_source_huaweicloud_compute_instances_test.go
@@ -20,12 +20,12 @@ func TestAccComputeInstancesDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstancesDataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
+					testAccCheckComputeInstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckComputeInstancesDataSourceID(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "instances.#", "1"),

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
@@ -31,7 +31,7 @@ func TestAccComputeEIPAssociate_basic(t *testing.T) {
 			{
 				Config: testAccComputeEIPAssociate_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
+					testAccCheckComputeInstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
 					testAccCheckComputeEIPAssociateAssociated(&eip, &instance, 1),
 					resource.TestCheckResourceAttrSet(resourceName, "port_id"),
@@ -61,7 +61,7 @@ func TestAccComputeEIPAssociate_fixedIP(t *testing.T) {
 			{
 				Config: testAccComputeEIPAssociate_fixedIP(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.test", &instance),
+					testAccCheckComputeInstanceExists("huaweicloud_compute_instance.test", &instance),
 					testAccCheckVpcV1EIPExists("huaweicloud_vpc_eip.test", &eip),
 					testAccCheckComputeEIPAssociateAssociated(&eip, &instance, 1),
 					resource.TestCheckResourceAttrSet(resourceName, "port_id"),

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -500,9 +500,9 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 			VpcId:            vpcId,
 			SecurityGroups:   secGroups,
 			AvailabilityZone: d.Get("availability_zone").(string),
-			Nics:             resourceInstanceNicsV2(d),
 			RootVolume:       resourceInstanceRootVolumeV1(d),
 			DataVolumes:      resourceInstanceDataVolumesV1(d),
+			Nics:             buildInstanceNicsRequest(d),
 			UserData:         []byte(d.Get("user_data").(string)),
 		}
 
@@ -1311,6 +1311,23 @@ func validateComputeInstanceConfig(d *schema.ResourceData, config *config.Config
 	return nil
 }
 
+func buildInstanceNicsRequest(d *schema.ResourceData) []cloudservers.Nic {
+	var nicRequests []cloudservers.Nic
+
+	networks := d.Get("network").([]interface{})
+	for _, v := range networks {
+		network := v.(map[string]interface{})
+		nicRequest := cloudservers.Nic{
+			SubnetId:   network["uuid"].(string),
+			IpAddress:  network["fixed_ip_v4"].(string),
+			Ipv6Enable: network["ipv6_enable"].(bool),
+		}
+
+		nicRequests = append(nicRequests, nicRequest)
+	}
+	return nicRequests
+}
+
 func resourceInstanceSecGroupsV2(d *schema.ResourceData) []string {
 	rawSecGroups := d.Get("security_groups").(*schema.Set).List()
 	secgroups := make([]string, len(rawSecGroups))
@@ -1326,23 +1343,6 @@ func resourceInstanceMetadataV2(d *schema.ResourceData) map[string]string {
 		m[key] = val.(string)
 	}
 	return m
-}
-
-func resourceInstanceNicsV2(d *schema.ResourceData) []cloudservers.Nic {
-	var nicRequests []cloudservers.Nic
-
-	networks := d.Get("network").([]interface{})
-	for _, v := range networks {
-		network := v.(map[string]interface{})
-		nicRequest := cloudservers.Nic{
-			SubnetId:   network["uuid"].(string),
-			IpAddress:  network["fixed_ip_v4"].(string),
-			Ipv6Enable: network["ipv6_enable"].(bool),
-		}
-
-		nicRequests = append(nicRequests, nicRequest)
-	}
-	return nicRequests
 }
 
 func resourceInstanceBlockDevicesV2(d *schema.ResourceData, bds []interface{}) ([]bootfromvolume.BlockDevice, error) {

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
-func TestAccComputeV2Instance_basic(t *testing.T) {
+func TestAccComputeInstance_basic(t *testing.T) {
 	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -23,12 +23,12 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_basic(rName),
+				Config: testAccComputeInstance_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
@@ -54,7 +54,7 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_disks(t *testing.T) {
+func TestAccComputeInstance_disks(t *testing.T) {
 	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -63,20 +63,20 @@ func TestAccComputeV2Instance_disks(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_disks(rName, 50),
+				Config: testAccComputeInstance_disks(rName, 50),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "50"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_disks(rName, 60),
+				Config: testAccComputeInstance_disks(rName, 60),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "60"),
 				),
@@ -85,7 +85,7 @@ func TestAccComputeV2Instance_disks(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_prePaid(t *testing.T) {
+func TestAccComputeInstance_prePaid(t *testing.T) {
 	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -94,12 +94,12 @@ func TestAccComputeV2Instance_prePaid(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_prePaid(rName),
+				Config: testAccComputeInstance_prePaid(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
@@ -107,7 +107,7 @@ func TestAccComputeV2Instance_prePaid(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_tags(t *testing.T) {
+func TestAccComputeInstance_tags(t *testing.T) {
 	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -116,44 +116,44 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_tags(rName),
+				Config: testAccComputeInstance_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					testAccCheckComputeV2InstanceTags(&instance, "foo", "bar"),
-					testAccCheckComputeV2InstanceTags(&instance, "key", "value"),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceTags(&instance, "foo", "bar"),
+					testAccCheckComputeInstanceTags(&instance, "key", "value"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_tags2(rName),
+				Config: testAccComputeInstance_tags2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					testAccCheckComputeV2InstanceTags(&instance, "foo2", "bar2"),
-					testAccCheckComputeV2InstanceTags(&instance, "key", "value2"),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceTags(&instance, "foo2", "bar2"),
+					testAccCheckComputeInstanceTags(&instance, "key", "value2"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_notags(rName),
+				Config: testAccComputeInstance_notags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					testAccCheckComputeV2InstanceNoTags(&instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceNoTags(&instance),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_tags(rName),
+				Config: testAccComputeInstance_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					testAccCheckComputeV2InstanceTags(&instance, "foo", "bar"),
-					testAccCheckComputeV2InstanceTags(&instance, "key", "value"),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceTags(&instance, "foo", "bar"),
+					testAccCheckComputeInstanceTags(&instance, "key", "value"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccComputeV2Instance_powerAction(t *testing.T) {
+func TestAccComputeInstance_powerAction(t *testing.T) {
 	var instance cloudservers.CloudServer
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -162,48 +162,48 @@ func TestAccComputeV2Instance_powerAction(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_powerAction(rName, "OFF"),
+				Config: testAccComputeInstance_powerAction(rName, "OFF"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "power_action", "OFF"),
 					resource.TestCheckResourceAttr(resourceName, "status", "SHUTOFF"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_powerAction(rName, "ON"),
+				Config: testAccComputeInstance_powerAction(rName, "ON"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "power_action", "ON"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_powerAction(rName, "REBOOT"),
+				Config: testAccComputeInstance_powerAction(rName, "REBOOT"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "power_action", "REBOOT"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_powerAction(rName, "FORCE-REBOOT"),
+				Config: testAccComputeInstance_powerAction(rName, "FORCE-REBOOT"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "power_action", "FORCE-REBOOT"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_powerAction(rName, "FORCE-OFF"),
+				Config: testAccComputeInstance_powerAction(rName, "FORCE-OFF"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "power_action", "FORCE-OFF"),
 					resource.TestCheckResourceAttr(resourceName, "status", "SHUTOFF"),
@@ -222,7 +222,7 @@ func TestAccComputeV2Instance_powerAction(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
+func testAccCheckComputeInstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
 	computeClient, err := config.ComputeV1Client(HW_REGION_NAME)
 	if err != nil {
@@ -245,7 +245,7 @@ func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeV2InstanceExists(n string, instance *cloudservers.CloudServer) resource.TestCheckFunc {
+func testAccCheckComputeInstanceExists(n string, instance *cloudservers.CloudServer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -277,7 +277,7 @@ func testAccCheckComputeV2InstanceExists(n string, instance *cloudservers.CloudS
 	}
 }
 
-func testAccCheckComputeV2InstanceTags(
+func testAccCheckComputeInstanceTags(
 	instance *cloudservers.CloudServer, k, v string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*config.Config)
@@ -303,7 +303,7 @@ func testAccCheckComputeV2InstanceTags(
 	}
 }
 
-func testAccCheckComputeV2InstanceNoTags(
+func testAccCheckComputeInstanceNoTags(
 	instance *cloudservers.CloudServer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*config.Config)
@@ -349,7 +349,7 @@ data "huaweicloud_networking_secgroup" "test" {
 }
 `
 
-func testAccComputeV2Instance_basic(rName string) string {
+func testAccComputeInstance_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -369,7 +369,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName)
 }
 
-func testAccComputeV2Instance_disks(rName string, systemDiskSize int) string {
+func testAccComputeInstance_disks(rName string, systemDiskSize int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -396,7 +396,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName, systemDiskSize)
 }
 
-func testAccComputeV2Instance_prePaid(rName string) string {
+func testAccComputeInstance_prePaid(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -418,7 +418,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName)
 }
 
-func testAccComputeV2Instance_tags(rName string) string {
+func testAccComputeInstance_tags(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -441,7 +441,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName)
 }
 
-func testAccComputeV2Instance_tags2(rName string) string {
+func testAccComputeInstance_tags2(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -464,7 +464,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName)
 }
 
-func testAccComputeV2Instance_notags(rName string) string {
+func testAccComputeInstance_notags(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -482,7 +482,7 @@ resource "huaweicloud_compute_instance" "test" {
 `, testAccCompute_data, rName)
 }
 
-func testAccComputeV2Instance_powerAction(rName, powerAction string) string {
+func testAccComputeInstance_powerAction(rName, powerAction string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
@@ -54,7 +54,7 @@ func TestAccComputeServerGroup_scheduler(t *testing.T) {
 				Config: testAccComputeServerGroup_scheduler(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeServerGroupExists(resourceName, &sg),
-					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.instance_1", &instance),
+					testAccCheckComputeInstanceExists("huaweicloud_compute_instance.instance_1", &instance),
 					testAccCheckComputeInstanceInServerGroup(&instance, &sg),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -78,7 +78,7 @@ func TestAccComputeServerGroup_members(t *testing.T) {
 				Config: testAccComputeServerGroup_members(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeServerGroupExists(resourceName, &sg),
-					testAccCheckComputeV2InstanceExists("huaweicloud_compute_instance.instance_1", &instance),
+					testAccCheckComputeInstanceExists("huaweicloud_compute_instance.instance_1", &instance),
 					testAccCheckComputeInstanceInServerGroup(&instance, &sg),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),

--- a/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_networking_vip_associate_v2_test.go
@@ -80,5 +80,5 @@ resource "huaweicloud_networking_vip_associate" "vip_associate_1" {
   vip_id   = huaweicloud_networking_vip.vip_1.id
   port_ids = [huaweicloud_compute_instance.test.network[0].port]
 }
-`, testAccComputeV2Instance_basic(rName))
+`, testAccComputeInstance_basic(rName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

we can find the following functions using **cloudservers** package, but their names has **V2**
```
$ grep -rn cloudservers huaweicloud/ | grep V2
huaweicloud/resource_huaweicloud_compute_instance.go:1420:func resourceInstanceNicsV2(d *schema.ResourceData) []cloudservers.Nic {
huaweicloud/resource_huaweicloud_compute_instance_test.go:248:func testAccCheckComputeV2InstanceExists(n string, instance *cloudservers.CloudServer) resource.TestCheckFunc {
```
it's safe to remove the **V2** tag.

```
$ grep -rn cloudservers huaweicloud/ | grep V2
$
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
