### PR TITLE
feat(servicestage): support a new component instance resource

### DIFF
--- a/docs/resources/servicestage_component_instance.md
+++ b/docs/resources/servicestage_component_instance.md
@@ -1,0 +1,407 @@
+---
+subcategory: "ServiceStage"
+---
+
+# huaweicloud_servicestage_component_instance
+
+This resource is used to deploy a component under specified application within HuaweiCloud ServiceStage service.
+
+## Example Usage
+
+### Deploy a component with specified SWR image
+
+```hcl
+variable "app_id" {}
+variable "component_id" {}
+variable "env_id" {}
+variable "instance_name" {}
+variable "flavor_id" {}
+variable "component_name" {}
+variable "swr_image_url" {}
+variable "cce_cluster_id" {}
+variable "cse_engine_id" {}
+
+resource "huaweicloud_servicestage_component_instance" "default" {
+  application_id = var.app_id
+  component_id   = var.component_id
+  environment_id = var.env_id
+
+  name      = var.instance_name
+  version   = "1.0.0"
+  replica   = 1
+  flavor_id = var.flavor_id
+
+  artifact {
+    name      = var.component_name
+    type      = "image"
+    storage   = "swr"
+    url       = var.swr_image_url
+    auth_type = "iam"
+  }
+
+  refer_resource {
+    type = "cce"
+    id   = var.cce_cluster_id
+
+    parameters = {
+      type      = "VirtualMachine"
+      namespace = "default"
+    }
+  }
+
+  refer_resource {
+    type = "cse"
+    id   = var.cse_engine_id
+  }
+
+  configuration {
+    env_variable {
+      name  = "TZ"
+      value = "Asia/Shanghai"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create (deploy) the ServiceStage (component) instance.
+  If omitted, the provider-level region will be used. Changing this will create a new instance.
+
+* `application_id` - (Required, String, ForceNew) Specifies the application ID to which the instance belongs.
+  Changing this will create a new instance.
+
+* `component_id` - (Required, String, ForceNew) Specifies the component ID to build (deploy).
+  Changing this will create a new instance.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the environment ID in which the component to build (deployed).
+  Changing this will create a new instance.
+
+* `name` - (Required, String, ForceNew) Specifies the instance name.
+  The name can contain `2` to `63` characters, only lowercase letters, digits and hyphens (-) are allowed.
+  The name must start with a lowercase letter and end with a lowercase letter or digit.
+  Changing this will create a new instance.
+
+* `version` - (Required, String) Specifies the application component version that meets version semantics.
+  For example: `1.0.0`.
+
+* `replica` - (Required, Int, ForceNew) Specifies the number of instance replicas.
+  Changing this will create a new instance.
+
+* `flavor_id` - (Required, String) Specifies the resource specifications, which can be obtained by using data source or
+  the customize resource specifications.
+  The format of customize resource specifications is **CUSTOM-xxG:xxC-xxC:xxGi-xxGi**.
+  The meaning of each part is:
+    + **xxG**: storage capacity allocated to a component instance (reserved field). You can set it to a fixed number.
+    + **xxC-xxC**: the maximum and minimum number of CPU cores allocated to a component instance.
+    + **xxGi-xxGi**: the maximum and minimum memory allocated to a component instance.
+
+  For example, **CUSTOM-10G:0.5C-0.25C:1.6Gi-0.8Gi** indicates the maximum number of CPU cores allocated to a
+  component instance is 0.5, the minimum number of CPU cores is 0.25, the maximum memory is 1.6 Gi, and the minimum
+  memory is 0.8 Gi.
+
+* `refer_resource` - (Required, List) Specifies the deployed resources.
+  The [object](#servicestage_refer_resource) structure is documented below.
+
+* `artifact` - (Optional, List) Specifies the component artifact settings.
+  The key indicates the component name. In the Docker container scenario, the key indicates the container name.
+  The [object](#servicestage_artifact) structure is documented below.
+
+-> If the source parameters of the component resource specify the software package source, this parameter is optional,
+  and the software package source of the component is inherited by default. Otherwise, this parameter is required.
+
+* `description` - (Optional, String) Specifies the description of the instance.
+  The description can contian a maximum of `128` characters.
+
+* `configuration` - (Optional, List) Specifies the configuration parameters, such as environment variables,
+  deployment configurations, and O&M monitoring.
+  The [object](#servicestage_configuration) structure is documented below.
+
+* `external_access` - (Optional, List) Specifies the configuration of the external network access.
+  The [object](#servicestage_external_access) structure is documented below.
+
+<a name="servicestage_refer_resource"></a>
+The `refer_resource` block supports:
+
+* `type` - (Required, String) Specifies the resource type.
+  The basic resources include:
+  + **cce**: Cloud Container Engine (CCE)
+  + **cci**: Cloud Container Instance (CCI)
+  + **ecs**: Elastic Cloud Server (ECS).
+  + **as**: Auto Scaling (AS)
+
+  The Optional resources include:
+  + **rds**: Relational Database Service (RDS)
+  + **dcs**: Distributed Cache Service (DCS),
+  + **elb**: Elastic Load Balance (ELB)
+
+  For other resource types, please refer to the environment documentation.
+
+* `id` - (Required, String) Specifies the resource ID.
+  If the `type` is set to **ecs**, the value of this parameter must be **Default**.
+
+* `alias` - (Optional, String) Specifies the application alias, which is provided only in DCS scenario.
+  The valid values are: **distributed_session**, **distributed_cache** and **distributed_session, distributed_cache**.
+  Defaults to **distributed_session, distributed_cache**.
+
+* `parameters` - (Optional, String) Specifies the reference resource parameter.
+  + When `type` is set to **cce**, this parameter is mandatory, and need to specify the namespace of the cluster where
+  the component is to be deployed, such as **{"namespace": "default"}**.
+  + When `type` is set to **ecs**, this parameter is mandatory, and need to specify the hosts where the component is to
+  be deployed, such as **{"hosts":["04d9f887-9860-4029-91d1-7d3102903a69", "04d9f887-9860-4029-91d1-7d3102903a70"]}}**.
+
+<a name="servicestage_artifact"></a>
+The `artifact` block supports:
+
+* `name` - (Required, String) Specifies the component name.
+  But for **Docker container scenario**, this name is the container name.
+
+* `type` - (Required, String) Specifies the source type.
+  The valid values are **package** (VM-based deployment) and **image** (container-based deployment).
+
+* `storage` - (Required, String) Specifies the storage mode. The valid values are **swr** and **obs**.
+
+* `url` - (Required, String) Specifies the software package or image address.
+  For a component deployed on a VM, this parameter is the software package address.
+  For a component deployed based on a container, this parameter is the image address or component name:v${index}.
+  The latter indicates that the component source code or the image automatically built using the software package
+  will be used.
+
+* `auth_type` - (Optional, String) Specifies the authentication mode.
+  The valid values are **iam** and **none**. Defaults to **iam**.
+
+* `version` - (Optional, String) Specifies the version number.
+
+<a name="servicestage_configuration"></a>
+The `configuration` block supports:
+
+* `env_variable` - (Optional, List) Specifies the environment variables.
+  The [object](#servicestage_env_variables) structure is documented below.
+
+* `storage` - (Optional, List) Specifies the data storage configuration.
+  The [object](#servicestage_storages) structure is documented below.
+
+* `strategy` - (Optional, List) Specifies the upgrade policy.
+  The [object](#servicestage_strategy) structure is documented below.
+
+* `lifecycle` - (Optional, List) Specifies the lifecycle.
+  The [object](#servicestage_lifecycle) structure is documented below.
+
+* `scheduler` - (Optional, List) Specifies the scheduling policy.
+  The key indicates the component name. In the Docker container scenario, key indicates the container name.
+  If the source parameters of a component specify the software package source, this parameter is optional, and the
+  software package source of the component is inherited by default. Otherwise, this parameter is required.
+  The [object](#servicestage_scheduler) structure is documented below.
+
+* `probe` - (Optional, List) Specifies the variable value.
+  The [object](#servicestage_probe) structure is documented below.
+
+<a name="servicestage_env_variables"></a>
+The `env_variable` block supports:
+
+* `name` - (Required, String) Specifies the variable name.
+  The name can contain `1` to `64` characters, only letters, digits, hyphens (-), underscores (_) and dots (.) are
+  allowed. The name cannot start with a digit.
+
+* `value` - (Required, String) Specifies the variable value. After the instance is created, the system will
+  automatically add a series of environment variables to it. We have filtered the system parameters, please be careful
+  not to set the parameters of the following styles:
+  + Starting with the feature keyword: **PAAS_**, **CAS_**, and **AOM_**.
+  + Specific variable name: **servicecomb_engine_name**.
+
+<a name="servicestage_storages"></a>
+The `storage` block supports:
+
+* `type` - (Required, String) Specifies the variable name.
+  The valid values are as follows:
+  + **HostPath**: host path mounting.
+  + **EmptyDir**: temporary directory mounting.
+  + **ConfigMap**: configuration item mounting.
+  + **Secret**: secret volume mounting.
+  + **PersistentVolumeClaim**: cloud storage mounting.
+
+* `parameter` - (Required, List) Specifies the storage parameters.
+  The [object](#servicestage_storage_parameters) structure is documented below.
+
+* `mount` - (Required, List) Specifies the directory mounted to the container.
+  The [object](#servicestage_storage_mounts) structure is documented below.
+
+<a name="servicestage_storage_parameters"></a>
+The `parameter` block supports:
+
+* `path` - (Optional, String) Specifies the host path. Required if the storage `type` is **HostPath**.
+
+* `name` - (Optional, String) Specifies the name of a configuration item or secret.
+
+* `claim_name` - (Optional, String) Specifies the PVC name.
+
+<a name="servicestage_storage_mounts"></a>
+The `mount` block supports:
+
+* `path` - (Required, String) Specifies the mounted disk path.
+
+* `readonly` - (Required, Bool) Specifies the mounted disk permission is read-only or read-write.
+  + **true**: read-only.
+  + **false**: read-write.
+
+* `subpath` - (Optional, String) Specifies the subpath of the mounted disk.
+  This parameter is applicable to `http` type.
+
+<a name="servicestage_strategy"></a>
+The `strategy` block supports:
+
+* `upgrade` - (Optional, String) Specifies the upgrade policy.
+  The valid values are **Recreate** or **RollingUpdate**. The default value is **RollingUpdate**.
+  The **Recreate** indicates in-place upgrade while the **RollingUpdate** indicates rolling upgrade.
+
+<a name="servicestage_lifecycle"></a>
+The `lifecycle` block supports:
+
+* `entrypoint` - (Required, List) Specifies the startup commands.
+  The [object](#servicestage_entrypoint) structure is documented below.
+
+* `post_start` - (Required, List) Specifies the post-start processing.
+  The [object](#servicestage_lifecycle_process) structure is documented below.
+
+* `pre_stop` - (Required, List) Specifies the pre-stop processing.
+  The [object](#servicestage_lifecycle_process) structure is documented below.
+
+<a name="servicestage_entrypoint"></a>
+The `entrypoint` block supports:
+
+* `commands` - (Required, List) Specifies the commands.
+
+* `args` - (Required, List) Specifies the running parameters.
+
+<a name="servicestage_lifecycle_process"></a>
+The `post_start` and `pre_stop` block supports:
+
+* `type` - (Required, List) Specifies the process type. The valid values are `command` and `http`.
+
+* `parameters` - (Required, List) Specifies the start post-processing or stop pre-processing parameters.
+  The [object](#servicestage_process_param) structure is documented below.
+
+<a name="servicestage_process_param"></a>
+The `parameters` block supports:
+
+* `commands` - (Required, List) Specifies the commands, such as **["sleep", "1"]**.
+  This parameter is applicable to **command** type.
+
+* `port` - (Required, Int) Specifies the port number.
+  This parameter is applicable to **http** type.
+
+* `path` - (Required, String) Specifies the request URL.
+  This parameter is applicable to **http** type.
+
+* `host` - (Optional, String) Specifies the custom IP address. The defualt address is pod IP address.
+  This parameter is applicable to **http** type.
+
+<a name="servicestage_scheduler"></a>
+The `scheduler` block supports:
+
+* `affinity` - (Optional, List) Specifies the commands.
+  The [object](#servicestage_affinity) structure is documented below.
+
+* `anti_affinity` - (Optional, List) Specifies the commands.
+  The [object](#servicestage_affinity) structure is documented below.
+
+<a name="servicestage_affinity"></a>
+The `affinity` and `anti_affinity` block supports:
+
+* `availability_zones` - (Optional, List) Specifies the AZ list.
+
+* `private_ips` - (Optional, List) Specifies the node private IP address list.
+
+* `instance_names` - (Optional, List) Specifies the list of component instance names.
+
+<a name="servicestage_probe"></a>
+The `probe` block supports:
+
+* `liveness` - (Optional, List) Specifies the component liveness probe.
+  The [object](#servicestage_probe_detail) structure is documented below.
+
+* `readiness` - (Optional, List) Specifies the component service probe.
+  The [object](#servicestage_probe_detail) structure is documented below.
+
+<a name="servicestage_probe_detail"></a>
+The `liveness` and `readiness` block supports:
+
+* `type` - (Required, String) Specifies the probe type. The valid values are as follows:
+  + **command**: command execution check.
+  + **http**: HTTP request check.
+  + **tcp**: TCP port check.
+
+* `command_param` - (Optional, List) Specifies the commands. Required if `type` is **command**.
+  The [object](#servicestage_command_param) structure is documented below.
+
+* `http_param` - (Optional, List) Specifies the commands. Required if `type` is **http**.
+  The [object](#servicestage_http_param) structure is documented below.
+
+* `tcp_param` - (Optional, List) Specifies the commands. Required if `type` is **tcp**.
+  The [object](#servicestage_tcp_param) structure is documented below.
+
+* `delay` - (Optional, Int) Specifies the interval between the startup and detection.
+
+* `timeout` - (Optional, Int) Specifies the detection timeout interval.
+
+<a name="servicestage_command_param"></a>
+The `command_param` block supports:
+
+* `commands` - (Required, List) Specifies the command list.
+
+<a name="servicestage_http_param"></a>
+The `http_param` block supports:
+
+* `protocol` - (Required, String) Specifies the protocol. The valid values are `HTTP` and `HTTPS`.
+
+* `port` - (Required, Int) Specifies the port number.
+
+* `path` - (Required, String) Specifies the request path.
+
+* `host` - (Optional, String) Specifies the custom IP address. The defualt address is pod IP address.
+
+<a name="servicestage_tcp_param"></a>
+The `tcp_param` block supports:
+
+* `port` - (Optional, Int) Specifies the port number.
+
+<a name="servicestage_external_access"></a>
+The `external_access` block supports:
+
+* `protocol` - (Optional, String) Specifies the protocol. The valid values are **HTTP** and **HTTPS**.
+
+* `address` - (Optional, String) Specifies the access address. For example: **www.example.com**.
+
+* `port` - (Optional, Int) Specifies the listening port of the application component process.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The instance ID in UUID format.
+
+* `status` - The instance status, which supports:
+  + **FAILED**
+  + **RUNNING**
+  + **DOWN**
+  + **STOPPED**
+  + **UNKNOWN**
+  + **PARTIALLY_FAILED**
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+Instances can be imported using their related `application_id`, `component_id` and `id`, separated by a slash (/), e.g.
+
+```
+terraform import huaweicloud_servicestage_component_instance.test 4e65a759-e7b1-4e9e-8277-857f8e261f3c/4e65a759-e7b1-4e9e-8277-857f8e261f3c/c0a13d88-d4e3-11ec-93a9-0255ac101d30
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -723,6 +723,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_read_replica_instance": rds.ResourceRdsReadReplicaInstance(),
 
 			"huaweicloud_servicestage_application":                 servicestage.ResourceApplication(),
+			"huaweicloud_servicestage_component_instance":          servicestage.ResourceComponentInstance(),
 			"huaweicloud_servicestage_component":                   servicestage.ResourceComponent(),
 			"huaweicloud_servicestage_environment":                 servicestage.ResourceEnvironment(),
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -68,6 +68,7 @@ var (
 	HW_GITHUB_REPO_PWD       = os.Getenv("HW_GITHUB_REPO_PWD")       // Repository password (DevCloud, BitBucket)
 	HW_GITHUB_REPO_URL       = os.Getenv("HW_GITHUB_REPO_URL")       // Repository URL (Github, Gitlab, Gitee)
 	HW_OBS_STORAGE_URL       = os.Getenv("HW_OBS_STORAGE_URL")       // OBS storage URL where ZIP file is located
+	HW_BUILD_IMAGE_URL       = os.Getenv("HW_BUILD_IMAGE_URL")       // SWR Image URL for component deployment
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -474,20 +475,27 @@ func TestAccPreCheckDliJarPath(t *testing.T) {
 //lintignore:AT003
 func TestAccPreCheckRepoTokenAuth(t *testing.T) {
 	if HW_GITHUB_REPO_HOST == "" || HW_GITHUB_PERSONAL_TOKEN == "" {
-		t.Skip("Repository configuration are not completed for acceptance test of personal access token authorization.")
+		t.Skip("Repository configurations are not completed for acceptance test of personal access token authorization.")
 	}
 }
 
 //lintignore:AT003
 func TestAccPreCheckRepoPwdAuth(t *testing.T) {
 	if HW_DOMAIN_NAME == "" || HW_USER_NAME == "" || HW_GITHUB_REPO_PWD == "" {
-		t.Skip("Repository configuration are not completed for acceptance test of password authorization.")
+		t.Skip("Repository configurations are not completed for acceptance test of password authorization.")
 	}
 }
 
 //lintignore:AT003
 func TestAccPreCheckComponent(t *testing.T) {
 	if HW_DOMAIN_NAME == "" || HW_GITHUB_REPO_URL == "" || HW_OBS_STORAGE_URL == "" {
-		t.Skip("Repository (package) configuration are not completed for acceptance test of component.")
+		t.Skip("Repository (package) configurations are not completed for acceptance test of component.")
+	}
+}
+
+//lintignore:AT003
+func TestAccPreCheckComponentDeployment(t *testing.T) {
+	if HW_BUILD_IMAGE_URL == "" {
+		t.Skip("SWR image URL configuration is not completed for acceptance test of component deployment.")
 	}
 }

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
@@ -1,0 +1,330 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/servicestage/v2/instances"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getComponentInstanceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.ServiceStageV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage v2 client: %s", err)
+	}
+	return instances.Get(c, state.Primary.Attributes["application_id"], state.Primary.Attributes["component_id"],
+		state.Primary.ID)
+}
+
+func TestAccComponentInstance_basic(t *testing.T) {
+	var (
+		instance     instances.Instance
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_servicestage_component_instance.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getComponentInstanceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRepoTokenAuth(t)
+			acceptance.TestAccPreCheckComponent(t)
+			acceptance.TestAccPreCheckComponentDeployment(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentInstance_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "application_id", "huaweicloud_servicestage_application.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "component_id", "huaweicloud_servicestage_component.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "environment_id", "huaweicloud_servicestage_environment.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "replica", "1"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "CUSTOM-10G:250m-250m:0.5Gi-0.5Gi"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "artifact.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "artifact.0.name", "huaweicloud_servicestage_component.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "artifact.0.type", "image"),
+					resource.TestCheckResourceAttr(resourceName, "artifact.0.storage", "swr"),
+					resource.TestCheckResourceAttr(resourceName, "artifact.0.url", acceptance.HW_BUILD_IMAGE_URL),
+					resource.TestCheckResourceAttr(resourceName, "artifact.0.auth_type", "iam"),
+					resource.TestCheckResourceAttr(resourceName, "refer_resource.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.name", "TZ"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.value", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+				),
+			},
+			{
+				Config: testAccComponentInstance_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.0.2"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "CUSTOM-15G:500m-500m:1Gi-1Gi"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccInstanceImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccInstanceImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var appId, componentId, instance_id string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_servicestage_component_instance" {
+				appId = rs.Primary.Attributes["application_id"]
+				componentId = rs.Primary.Attributes["component_id"]
+				instance_id = rs.Primary.ID
+			}
+		}
+		if appId == "" || componentId == "" || instance_id == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", appId, componentId, instance_id)
+		}
+		return fmt.Sprintf("%s/%s/%s", appId, componentId, instance_id), nil
+	}
+}
+
+func testAccComponentInstance_base(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 8
+  memory_size       = 16
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  vpc_id      = huaweicloud_vpc.test.id
+  ipv6_enable = true
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    size        = 5
+    name        = "%[1]s"
+    charge_mode = "traffic"
+  }
+}
+  
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%[1]s"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  flavor_id              = "cce.s2.medium"
+  cluster_version        = "v1.19"
+  cluster_type           = "VirtualMachine"
+  container_network_type = "vpc-router"
+  kube_proxy_mode        = "iptables"
+
+  dynamic "masters" {
+    for_each = slice(data.huaweicloud_availability_zones.test.names, 0, 3)
+
+    content {
+      availability_zone = masters.value
+    }
+  }
+}
+
+resource "huaweicloud_cce_node" "test" {
+  cluster_id        = huaweicloud_cce_cluster.test.id
+  name              = "%[1]s"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  key_pair          = huaweicloud_kps_keypair.test.name
+  eip_id            = huaweicloud_vpc_eip.test.id
+
+  root_volume {
+    volumetype = "SSD"
+    size       = 100
+  }
+
+  data_volumes {
+    volumetype = "SSD"
+    size       = 100
+  }
+}
+
+resource "huaweicloud_servicestage_environment" "test" {
+  name   = "%[1]s"
+  vpc_id = huaweicloud_vpc.test.id
+
+  basic_resources {
+    type = "cce"
+    id   = huaweicloud_cce_cluster.test.id
+  }
+
+  optional_resources {
+    type = "cse"
+    id   = "default"
+  }
+}
+
+resource "huaweicloud_servicestage_application" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_servicestage_repo_token_authorization" "test" {
+  type  = "github"
+  name  = "%[1]s"
+  host  = "%[2]s"
+  token = "%[3]s"
+}
+
+resource "huaweicloud_servicestage_component" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+
+  name      = "%[1]s"
+  type      = "MicroService"
+  runtime   = "Docker"
+  framework = "Java Classis"
+}
+`, rName, acceptance.HW_GITHUB_REPO_HOST, acceptance.HW_GITHUB_PERSONAL_TOKEN, acceptance.HW_GITHUB_REPO_URL,
+		acceptance.HW_DOMAIN_NAME)
+}
+
+func testAccComponentInstance_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestage_component_instance" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+  component_id   = huaweicloud_servicestage_component.test.id
+  environment_id = huaweicloud_servicestage_environment.test.id
+
+  name        = "%[2]s"
+  version     = "1.0.0"
+  replica     = 1
+  flavor_id   = "CUSTOM-10G:250m-250m:0.5Gi-0.5Gi"
+  description = "Created by terraform test"
+
+  artifact {
+    name      = huaweicloud_servicestage_component.test.name
+    type      = "image"
+    storage   = "swr"
+    url       = "%[3]s"
+    auth_type = "iam"
+  }
+
+  refer_resource {
+    type = "cce"
+    id   = huaweicloud_cce_cluster.test.id
+
+    parameters = {
+      type      = "VirtualMachine"
+      namespace = "default"
+    }
+  }
+
+  refer_resource {
+    type = "cse"
+    id   = "default"
+  }
+
+  configuration {
+    env_variable {
+      name  = "TZ"
+      value = "Asia/Shanghai"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      configuration[0].env_variable,
+    ]
+  }
+}
+`, testAccComponentInstance_base(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
+}
+
+func testAccComponentInstance_update(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestage_component_instance" "test" {
+  application_id = huaweicloud_servicestage_application.test.id
+  component_id   = huaweicloud_servicestage_component.test.id
+  environment_id = huaweicloud_servicestage_environment.test.id
+
+  name        = "%[2]s"
+  version     = "1.0.2"
+  replica     = 1
+  flavor_id   = "CUSTOM-15G:500m-500m:1Gi-1Gi"
+
+  artifact {
+    name      = huaweicloud_servicestage_component.test.name
+    type      = "image"
+    storage   = "swr"
+    url       = "%[3]s"
+    auth_type = "iam"
+  }
+
+  refer_resource {
+    type = "cce"
+    id   = huaweicloud_cce_cluster.test.id
+
+    parameters = {
+      type      = "VirtualMachine"
+      namespace = "default"
+    }
+  }
+
+  refer_resource {
+    type = "cse"
+    id   = "default"
+  }
+
+  configuration {
+    env_variable {
+      name  = "TZ"
+      value = "Asia/Shanghai"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      configuration[0].env_variable,
+    ]
+  }
+}
+`, testAccComponentInstance_base(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
@@ -1,0 +1,1400 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/servicestage/v2/instances"
+	"github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func lifecycleProcessSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"command", "http",
+				}, false),
+			},
+			"parameters": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"commands": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"host": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func affinitySchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"private_ips": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instance_names": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func probeDetailSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"command", "http", "tcp",
+				}, false),
+			},
+			"command_param": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"commands": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"http_param": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"HTTP", "HTTPS",
+							}, false),
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"host": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tcp_param": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"delay": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// ResourceComponentInstance is the imple of huaweicloud_servicestage_component_instance
+func ResourceComponentInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComponentInstanceCreate,
+		ReadContext:   resourceComponentInstanceRead,
+		UpdateContext: resourceComponentInstanceUpdate,
+		DeleteContext: resourceComponentInstanceDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceComponentInstanceImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"component_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"environment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[a-z]([a-z0-9-]*[a-z0-9])?$`),
+						"The name must start with a lowercase letter and end with a lowercase letter or digit, and "+
+							"can only contain lowercase letters, digits and hyphens (-)."),
+					validation.StringLenBetween(2, 63),
+				),
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"replica": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"refer_resource": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"alias": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"parameters": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"artifact": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"package", "image",
+							}, false),
+						},
+						"storage": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"swr", "obs",
+							}, false), // The devcloud does not support yet.
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"auth_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "iam",
+							ValidateFunc: validation.StringInSlice([]string{
+								"iam", "none",
+							}, false),
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						// Currently, we don't know how to configure the properties.
+					},
+				},
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 128),
+			},
+			"configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"env_variable": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_.]([\w-.]*)?$`),
+												"The name can only contain letters, digits, underscores (_), "+
+													"hyphens (-) and dots (.), and cannot start with a digit."),
+											validation.StringLenBetween(1, 64),
+										),
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"storage": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"HostPath", "EmptyDir", "ConfigMap", "Secret", "PersistentVolumeClaim",
+										}, false),
+									},
+									"parameter": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"path": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+												"claim_name": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"mount": {
+										Type:     schema.TypeSet,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"path": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"readonly": {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+												"subpath": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"strategy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"upgrade": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "RollingUpdate",
+										ValidateFunc: validation.StringInSlice([]string{
+											"RollingUpdate", "Recreate",
+										}, false),
+									},
+								},
+							},
+						},
+						"lifecycle": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"entrypoint": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"commands": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"args": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"post_start": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem:     lifecycleProcessSchemaResource(),
+									},
+									"pre_stop": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem:     lifecycleProcessSchemaResource(),
+									},
+								},
+							},
+						},
+						"scheduler": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"affinity": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem:     affinitySchemaResource(),
+									},
+									"anti_affinity": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem:     affinitySchemaResource(),
+									},
+								},
+							},
+						},
+						"probe": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"liveness": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem:     probeDetailSchemaResource(),
+									},
+									"readiness": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem:     probeDetailSchemaResource(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"external_access": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"HTTP", "HTTPS",
+							}, false),
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildArtifactStructure(artifacts *schema.Set) map[string]instances.Artifact {
+	if artifacts.Len() < 1 {
+		return nil
+	}
+
+	result := make(map[string]instances.Artifact)
+	for _, val := range artifacts.List() {
+		artifact := val.(map[string]interface{})
+		result[artifact["name"].(string)] = instances.Artifact{
+			Type:    artifact["type"].(string),
+			Storage: artifact["storage"].(string),
+			URL:     artifact["url"].(string),
+			Auth:    artifact["auth_type"].(string),
+			Version: artifact["version"].(string),
+		}
+	}
+
+	return result
+}
+
+func buildReferResourcesList(resources *schema.Set) []instances.ReferResource {
+	if resources.Len() < 1 {
+		return nil
+	}
+
+	result := make([]instances.ReferResource, resources.Len())
+	for i, val := range resources.List() {
+		res := val.(map[string]interface{})
+		refer := instances.ReferResource{
+			Type:       res["type"].(string),
+			ID:         res["id"].(string),
+			ReferAlias: res["alias"].(string),
+		}
+		if param, ok := res["parameters"]; ok {
+			refer.Parameters = param.(map[string]interface{})
+		}
+		result[i] = refer
+	}
+
+	return result
+}
+
+func buildEnvVariables(variables *schema.Set) []instances.Variable {
+	if variables.Len() < 1 {
+		return nil
+	}
+
+	result := make([]instances.Variable, 0, variables.Len())
+	for _, val := range variables.List() {
+		variable := val.(map[string]interface{})
+		result = append(result, instances.Variable{
+			Name:  variable["name"].(string),
+			Value: variable["value"].(string),
+		})
+	}
+
+	return result
+}
+
+func buildMountsList(mounts *schema.Set) []instances.Mount {
+	if mounts.Len() < 1 {
+		return nil
+	}
+
+	result := make([]instances.Mount, 0, mounts.Len())
+	for i, val := range mounts.List() {
+		mount := val.(map[string]interface{})
+		result[i] = instances.Mount{
+			Path:     mount["path"].(string),
+			SubPath:  mount["subpath"].(string),
+			ReadOnly: mount["readonly"].(bool),
+		}
+	}
+
+	return result
+}
+
+func buildStoragesList(storages *schema.Set) []instances.Storage {
+	if storages.Len() < 1 {
+		return nil
+	}
+
+	result := make([]instances.Storage, storages.Len())
+	for i, val := range storages.List() {
+		storage := val.(map[string]interface{})
+		var parameters instances.StorageParams
+		if paramVal, ok := storage["parameter"]; ok {
+			parameter := paramVal.([]interface{})[0].(map[string]interface{})
+			parameters.Path = parameter["path"].(string)
+			parameters.Name = parameter["name"].(string)
+			parameters.ClaimName = parameter["claim_name"].(string)
+		}
+
+		result[i] = instances.Storage{
+			Type:       storage["type"].(string),
+			Parameters: &parameters,
+			Mounts:     buildMountsList(storage["mounts"].(*schema.Set)),
+		}
+	}
+
+	return result
+}
+
+func buildStrategyStructure(strategies []interface{}) *instances.Strategy {
+	if len(strategies) < 1 {
+		return nil
+	}
+
+	strategy := strategies[0].(map[string]interface{})
+
+	return &instances.Strategy{
+		Upgrade: strategy["upgrade"].(string),
+	}
+}
+
+func buildLifecycleProcess(processes []interface{}) *instances.Process {
+	if len(processes) < 1 {
+		return nil
+	}
+
+	process := processes[0].(map[string]interface{})
+
+	return &instances.Process{
+		Type: process["type"].(string),
+		Parameters: &instances.ProcessParams{
+			Commands: utils.ExpandToStringList(process["commands"].([]interface{})),
+			Port:     process["port"].(int),
+			Path:     process["path"].(string),
+			Host:     process["host"].(string),
+		},
+	}
+}
+
+func buildLifecycleStructure(lifecycles []interface{}) *instances.Lifecycle {
+	if len(lifecycles) < 1 {
+		return nil
+	}
+
+	lifecycle := lifecycles[0].(map[string]interface{})
+	result := instances.Lifecycle{
+		PostStart: buildLifecycleProcess(lifecycle["post_start"].([]interface{})),
+		PreStop:   buildLifecycleProcess(lifecycle["pre_stop"].([]interface{})),
+	}
+
+	if val, ok := lifecycle["entrypoint"]; ok && len(val.([]interface{})) > 0 {
+		entrypoint := val.([]interface{})[0].(map[string]interface{})
+		result.Entrypoint = &instances.Entrypoint{
+			Commands: utils.ExpandToStringList(entrypoint["commands"].([]interface{})),
+			Args:     utils.ExpandToStringList(entrypoint["args"].([]interface{})),
+		}
+	}
+
+	return &result
+}
+
+func buildAffinityStructure(affinities []interface{}) *instances.Affinity {
+	if len(affinities) < 1 {
+		return nil
+	}
+
+	result := instances.Affinity{}
+
+	affinity := affinities[0].(map[string]interface{})
+	if val, ok := affinity["availability_zones"]; ok && len(val.([]interface{})) > 0 {
+		result.AvailabilityZones = utils.ExpandToStringList(val.([]interface{}))
+	}
+	if val, ok := affinity["private_ips"]; ok && len(val.([]interface{})) > 0 {
+		result.Nodes = utils.ExpandToStringList(val.([]interface{}))
+	}
+	if val, ok := affinity["instance_names"]; ok && len(val.([]interface{})) > 0 {
+		result.Applications = utils.ExpandToStringList(val.([]interface{}))
+	}
+
+	return &result
+}
+
+func buildSchedulerStructure(schedulers []interface{}) *instances.Scheduler {
+	if len(schedulers) < 1 {
+		return nil
+	}
+
+	scheduler := schedulers[0].(map[string]interface{})
+	return &instances.Scheduler{
+		Affinity:     buildAffinityStructure(scheduler["affinity"].([]interface{})),
+		AntiAffinity: buildAffinityStructure(scheduler["anti_affinity"].([]interface{})),
+	}
+}
+
+func buildProbeDetailStructure(details []interface{}) (*instances.ProbeDetail, error) {
+	if len(details) < 1 {
+		return nil, nil
+	}
+
+	detail := details[0].(map[string]interface{})
+	pType := detail["type"].(string)
+	result := instances.ProbeDetail{
+		Type:    pType,
+		Delay:   detail["delay"].(int),
+		Timeout: detail["timeout"].(int),
+	}
+
+	params := make(map[string]interface{})
+	switch pType {
+	case "command":
+		cmdParams := detail["command_param"].([]interface{})
+		if len(cmdParams) < 1 {
+			return nil, fmt.Errorf("The command parameters must be set if the probe type is 'command'.")
+		}
+		cmdParam := cmdParams[0].(map[string]interface{})
+		params["command"] = utils.ExpandToStringList(cmdParam["commands"].([]interface{}))
+	case "http":
+		httpParams := detail["http_param"].([]interface{})
+		if len(httpParams) < 1 {
+			return nil, fmt.Errorf("The http parameters must be set if the probe type is 'http'.")
+		}
+		httpParam := httpParams[0].(map[string]interface{})
+		params["scheme"] = httpParam["scheme"]
+		params["port"] = httpParam["port"]
+		params["path"] = httpParam["path"]
+		params["host"] = httpParam["host"]
+	case "tcp":
+		tcpParams := detail["tcp_param"].([]interface{})
+		if len(tcpParams) < 1 {
+			return nil, fmt.Errorf("The tcp parameters must be set if the probe type is 'tcp'.")
+		}
+		tcpParam := tcpParams[0].(map[string]interface{})
+		params["port"] = tcpParam["port"]
+	default:
+		return nil, fmt.Errorf("One of the following parameters must be set: command, http or tcp.")
+	}
+
+	result.Parameters = params
+	return &result, nil
+}
+
+func buildProbeStructure(probes []interface{}) (*instances.Probe, error) {
+	if len(probes) < 1 {
+		return nil, nil
+	}
+
+	probe := probes[0].(map[string]interface{})
+	liveness, err := buildProbeDetailStructure(probe["liveness"].([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	readiness, err := buildProbeDetailStructure(probe["readiness"].([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+
+	return &instances.Probe{
+		LivenessProbe:  liveness,
+		ReadinessProbe: readiness,
+	}, nil
+}
+
+func buildConfigurationStructure(configs []interface{}) (*instances.Configuration, error) {
+	if len(configs) < 1 {
+		return nil, nil
+	}
+
+	config := configs[0].(map[string]interface{})
+	probe, err := buildProbeStructure(config["probe"].([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+
+	return &instances.Configuration{
+		EnvVariables: buildEnvVariables(config["env_variable"].(*schema.Set)),
+		Storages:     buildStoragesList(config["storage"].(*schema.Set)),
+		Strategy:     buildStrategyStructure(config["strategy"].([]interface{})),
+		Lifecycle:    buildLifecycleStructure(config["lifecycle"].([]interface{})),
+		Scheduler:    buildSchedulerStructure(config["lifecycle"].([]interface{})),
+		Probe:        probe,
+	}, nil
+}
+
+func buildExternalAccessList(accesses *schema.Set) []instances.ExternalAccess {
+	if accesses.Len() < 1 {
+		return nil
+	}
+
+	result := make([]instances.ExternalAccess, accesses.Len())
+	for i, val := range accesses.List() {
+		access := val.(map[string]interface{})
+		result[i] = instances.ExternalAccess{
+			Protocol:    access["protocol"].(string),
+			Address:     access["address"].(string),
+			ForwardPort: access["port"].(int),
+		}
+	}
+
+	return result
+}
+
+func buildInstanceCreateOpts(d *schema.ResourceData) (instances.CreateOpts, error) {
+	result := instances.CreateOpts{
+		EnvId:            d.Get("environment_id").(string),
+		Name:             d.Get("name").(string),
+		Version:          d.Get("version").(string),
+		Replica:          d.Get("replica").(int),
+		FlavorId:         d.Get("flavor_id").(string),
+		Description:      d.Get("description").(string),
+		Artifacts:        buildArtifactStructure(d.Get("artifact").(*schema.Set)),
+		ReferResources:   buildReferResourcesList(d.Get("refer_resource").(*schema.Set)),
+		ExternalAccesses: buildExternalAccessList(d.Get("external_access").(*schema.Set)),
+	}
+
+	conf, err := buildConfigurationStructure(d.Get("configuration").([]interface{}))
+	if err != nil {
+		return result, err
+	}
+
+	result.Configuration = conf
+	return result, nil
+}
+
+func resourceComponentInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.ServiceStageV2Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage v2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	componentId := d.Get("component_id").(string)
+	opt, err := buildInstanceCreateOpts(d)
+	if err != nil {
+		return diag.Errorf("error building the CreateOpts of the component instance: %s", err)
+	}
+	log.Printf("[DEBUG] The instance create option of ServiceStage component is: %v", opt)
+
+	resp, err := instances.Create(client, appId, componentId, opt)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage component instance: %s", err)
+	}
+
+	d.SetId(resp.InstanceId)
+
+	log.Printf("[DEBUG] Waiting for the component instance to become running, the instance ID is %s.", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING"},
+		Target:       []string{"SUCCEEDED"},
+		Refresh:      componentInstanceRefreshFunc(client, resp.JobId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the creation of component instance (%s) to complete: %s",
+			d.Id(), err)
+	}
+
+	return resourceComponentInstanceRead(ctx, d, meta)
+}
+
+func flattenArtifact(artifacts map[string]instances.Artifact) (result []map[string]interface{}) {
+	if len(artifacts) < 1 {
+		return nil
+	}
+
+	for key, val := range artifacts {
+		result = append(result, map[string]interface{}{
+			"name":      key,
+			"type":      val.Type,
+			"storage":   val.Storage,
+			"url":       val.URL,
+			"auth_type": val.Auth,
+			"version":   val.Version,
+		})
+	}
+
+	log.Printf("[DEBUG] The artifacts result is %#v", result)
+	return result
+}
+
+func flattenReferResources(resources []instances.ReferResource) (result []map[string]interface{}) {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	for _, val := range resources {
+		result = append(result, map[string]interface{}{
+			"type":       val.Type,
+			"id":         val.ID,
+			"parameters": val.Parameters,
+			"alias":      val.ReferAlias,
+		})
+	}
+
+	log.Printf("[DEBUG] The resources result is %#v", result)
+	return
+}
+
+// After the instance is created, the system will automatically add a series of environment variables to it.
+// In order to ensure that users do not produce unexpected changes when executing the "terraform apply" command, system
+// variables need to be filtered.
+func isSystemVariable(varName string) bool {
+	prefixes := []string{"PAAS_", "AOM_", "CAS_"}
+	words := []string{"servicecomb_engine_name"}
+
+	// Check whether specified prefix is included.
+	for _, prefix := range prefixes {
+		if strings.Index(varName, prefix) == 0 {
+			return true
+		}
+	}
+
+	// Check whether the name is a specific word.
+	for _, word := range words {
+		if varName == word {
+			return true
+		}
+	}
+	return false
+}
+
+func flattenEnvVariables(variables []instances.Variable) (result []map[string]interface{}) {
+	if len(variables) < 1 {
+		return nil
+	}
+
+	for _, val := range variables {
+		if isSystemVariable(val.Name) {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"name":  val.Name,
+			"value": val.Value,
+		})
+	}
+
+	log.Printf("[DEBUG] The environment variables result is %#v", result)
+	return
+}
+
+func flattenMounts(mounts []instances.Mount) (result []map[string]interface{}) {
+	if len(mounts) < 1 {
+		return nil
+	}
+
+	for _, val := range mounts {
+		result = append(result, map[string]interface{}{
+			"path":     val.Path,
+			"readonly": val.ReadOnly,
+			"subpath":  val.SubPath,
+		})
+	}
+
+	log.Printf("[DEBUG] The mounts result is %#v", result)
+	return
+}
+
+func flattenStorages(storages []instances.StorageResp) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening storage structure: %#v", r)
+		}
+	}()
+
+	if len(storages) < 1 {
+		return nil
+	}
+
+	for _, val := range storages {
+		result = append(result, map[string]interface{}{
+			"type": val.Type,
+			"parameter": []map[string]interface{}{
+				{
+					"path":       val.Parameters.Path,
+					"name":       val.Parameters.Name,
+					"claim_name": val.Parameters.ClaimName,
+				},
+			},
+			"mounts": flattenMounts(val.Mounts),
+		})
+	}
+
+	log.Printf("[DEBUG] The storages result is %#v", result)
+	return result
+}
+
+func flattenStrategy(strategy instances.StrategyResp) (result []map[string]interface{}) {
+	if reflect.DeepEqual(strategy, instances.StrategyResp{}) {
+		return nil
+	}
+
+	result = append(result, map[string]interface{}{
+		"upgrade": strategy.Upgrade,
+	})
+
+	log.Printf("[DEBUG] The strategy result is %#v", result)
+	return
+}
+
+func flattenProcess(process instances.ProcessResp) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening process structure: %#v", r)
+		}
+	}()
+
+	if reflect.DeepEqual(process, instances.ProcessResp{}) {
+		return nil
+	}
+
+	result = append(result, map[string]interface{}{
+		"type": process.Type,
+		"parameters": []map[string]interface{}{
+			{
+				"commands": process.Parameters.Commands,
+				"port":     process.Parameters.Port,
+				"path":     process.Parameters.Path,
+				"host":     process.Parameters.Host,
+			},
+		},
+	})
+
+	log.Printf("[DEBUG] The process result is %#v", result)
+	return
+}
+
+func flattenLifecycle(lifecycle instances.LifecycleResp) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening lifecycle structure: %#v", r)
+		}
+	}()
+
+	if reflect.DeepEqual(lifecycle, instances.LifecycleResp{}) {
+		return nil
+	}
+
+	result = append(result, map[string]interface{}{
+		"entrypoint": []map[string]interface{}{
+			{
+				"commands": lifecycle.Entrypoint.Commands,
+				"args":     lifecycle.Entrypoint.Args,
+			},
+		},
+		"post_start": flattenProcess(lifecycle.PostStart),
+		"pre_stop":   flattenProcess(lifecycle.PreStop),
+	})
+
+	log.Printf("[DEBUG] The lifecycle result is %#v", result)
+	return
+}
+
+func flattenScheduler(scheduler instances.SchedulerResp) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening scheduler structure: %#v", r)
+		}
+	}()
+
+	if reflect.DeepEqual(scheduler, instances.SchedulerResp{}) {
+		return nil
+	}
+
+	result = append(result, map[string]interface{}{
+		"affinity": []map[string]interface{}{
+			{
+				"availability_zones": scheduler.Affinity.AvailabilityZones,
+				"private_ips":        scheduler.Affinity.Nodes,
+				"instance_names":     scheduler.Affinity.Applications,
+			},
+		},
+		"anti_affinity": []map[string]interface{}{
+			{
+				"availability_zones": scheduler.AntiAffinity.AvailabilityZones,
+				"private_ips":        scheduler.AntiAffinity.Nodes,
+				"instance_names":     scheduler.AntiAffinity.Applications,
+			},
+		},
+	})
+
+	log.Printf("[DEBUG] The scheduler result is %#v", result)
+	return
+}
+
+func flattenProbeDetail(detail instances.ProbeDetail) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening probe detail structure: %#v", r)
+		}
+	}()
+
+	if reflect.DeepEqual(detail, instances.ProbeDetail{}) {
+		return nil
+	}
+
+	pType := detail.Type
+	structure := map[string]interface{}{
+		"type":    pType,
+		"delay":   detail.Delay,
+		"timeout": detail.Timeout,
+	}
+	switch pType {
+	case "command":
+		structure["command_param"] = []map[string]interface{}{
+			{
+				"commands": detail.Parameters["command"],
+			},
+		}
+	case "http":
+		structure["http_param"] = []map[string]interface{}{
+			{
+				"scheme": detail.Parameters["scheme"],
+				"port":   detail.Parameters["port"],
+				"path":   detail.Parameters["path"],
+				"host":   detail.Parameters["host"],
+			},
+		}
+	case "tcp":
+		structure["tcp_param"] = []map[string]interface{}{
+			{
+				"port": detail.Parameters["port"],
+			},
+		}
+	default:
+	}
+
+	result = append(result, structure)
+	log.Printf("[DEBUG] The probe detail result is %#v", result)
+	return
+}
+
+func flattenProbe(probe instances.ProbeResp) []map[string]interface{} {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening probe structure: %#v", r)
+		}
+	}()
+
+	if reflect.DeepEqual(probe, instances.ProbeResp{}) {
+		return nil
+	}
+
+	result := []map[string]interface{}{
+		{
+			"liveness":  flattenProbeDetail(probe.LivenessProbe),
+			"readiness": flattenProbeDetail(probe.ReadinessProbe),
+		},
+	}
+	log.Printf("[DEBUG] The probe result is %#v", result)
+	return result
+}
+
+func flattenConfiguration(configuration instances.ConfigurationResp) (result []map[string]interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[ERROR] Recover panic when flattening configuration structure: %#v", r)
+		}
+	}()
+
+	if reflect.DeepEqual(configuration, instances.ConfigurationResp{}) {
+		return nil
+	}
+
+	result = []map[string]interface{}{
+		{
+			"env_variable": flattenEnvVariables(configuration.EnvVariables),
+			"storage":      flattenStorages(configuration.Storages),
+			"strategy":     flattenStrategy(configuration.Strategy),
+			"lifecycle":    flattenLifecycle(configuration.Lifecycle),
+			"scheduler":    flattenScheduler(configuration.Scheduler),
+			"probe":        flattenProbe(configuration.Probe),
+		},
+	}
+	log.Printf("[DEBUG] The configuration result is %#v", result)
+	return result
+}
+
+func flattenExternalAccesses(accesses []instances.ExternalAccessResp) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(accesses))
+
+	if len(accesses) < 1 {
+		return nil
+	}
+
+	for i, val := range accesses {
+		result[i] = map[string]interface{}{
+			"protocol": val.Protocol,
+			"address":  val.Address,
+			"port":     val.ForwardPort,
+		}
+	}
+	log.Printf("[DEBUG] The accesses result is %#v", result)
+	return result
+}
+
+func resourceComponentInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ServiceStageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage v2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	componentId := d.Get("component_id").(string)
+	resp, err := instances.Get(client, appId, componentId, d.Id())
+	if err != nil {
+		common.CheckDeletedDiag(d, err, "error retrieving ServiceStage component instance")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("environment_id", resp.EnvironmentId),
+		d.Set("name", resp.Name),
+		d.Set("version", resp.Version),
+		d.Set("replica", resp.StatusDetail.Replica),
+		d.Set("flavor_id", resp.FlavorId),
+		d.Set("description", resp.Description),
+		d.Set("artifact", flattenArtifact(resp.Artifacts)),
+		d.Set("refer_resource", flattenReferResources(resp.ReferResources)),
+		d.Set("configuration", flattenConfiguration(resp.Configuration)),
+		d.Set("external_access", flattenExternalAccesses(resp.ExternalAccesses)),
+		// Attributes
+		d.Set("status", resp.StatusDetail.Status),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildInstanceUpdateOpts(d *schema.ResourceData) (instances.UpdateOpts, error) {
+	desc := d.Get("description").(string)
+	result := instances.UpdateOpts{
+		Version:          d.Get("version").(string),
+		FlavorId:         d.Get("flavor_id").(string),
+		Description:      &desc,
+		Artifacts:        buildArtifactStructure(d.Get("artifact").(*schema.Set)),
+		ReferResources:   buildReferResourcesList(d.Get("refer_resource").(*schema.Set)),
+		ExternalAccesses: buildExternalAccessList(d.Get("external_access").(*schema.Set)),
+	}
+
+	conf, err := buildConfigurationStructure(d.Get("configuration").([]interface{}))
+	if err != nil {
+		return result, err
+	}
+
+	result.Configuration = conf
+	return result, nil
+}
+
+func resourceComponentInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ServiceStageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage v2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	componentId := d.Get("component_id").(string)
+	opt, err := buildInstanceUpdateOpts(d)
+	if err != nil {
+		return diag.Errorf("error building the UpdateOpts of the component instance: %s", err)
+	}
+	log.Printf("[DEBUG] The instance update option of ServiceStage component is: %v", opt)
+
+	resp, err := instances.Update(client, appId, componentId, d.Id(), opt)
+	if err != nil {
+		return diag.Errorf("error updating component instance: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for the component instance to become running, the instance ID is %s.", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING"},
+		Target:       []string{"SUCCEEDED"},
+		Refresh:      componentInstanceRefreshFunc(client, resp.JobId),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the updation of component instance (%s) to complete: %s",
+			d.Id(), err)
+	}
+
+	return resourceComponentInstanceRead(ctx, d, meta)
+}
+
+func resourceComponentInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ServiceStageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage v2 client: %s", err)
+	}
+
+	appId := d.Get("application_id").(string)
+	componentId := d.Get("component_id").(string)
+	resp, err := instances.Delete(client, appId, componentId, d.Id())
+	if err != nil {
+		return diag.Errorf("error deleting ServiceStage component instance (%s): %s", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Waiting for the component instance to become deleted, the instance ID is %s.", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING"},
+		Target:       []string{"SUCCEEDED"},
+		Refresh:      componentInstanceRefreshFunc(client, resp.JobId),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the delete of component instance (%s) to complete: %s",
+			d.Id(), err)
+	}
+
+	return nil
+}
+
+func componentInstanceRefreshFunc(c *golangsdk.ServiceClient, instance string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := jobs.Get(c, instance)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+		if resp.TaskCount < 1 {
+			return resp, "NO TASK", nil
+		}
+		return resp, resp.Tasks[resp.TaskCount-1].Status, nil
+	}
+}
+
+func resourceComponentInstanceImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid format specified for import id, must be " +
+			"<application_id>/<component_id>/<instance_id>")
+	}
+
+	d.SetId(parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("application_id", parts[0]),
+		d.Set("component_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/requests.go
@@ -1,0 +1,420 @@
+package instances
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure required by the Create method to deploy a specified component.
+type CreateOpts struct {
+	// Specified the component instance name.
+	// The value can contain 2 to 63 characters, including lowercase letters, digits, and hyphens (-).
+	// It must start with a lowercase letter and end with a lowercase letter or digit.
+	Name string `json:"name" required:"true"`
+	// Specified the environment ID.
+	EnvId string `json:"environment_id" required:"true"`
+	// Specified the number of instance replicas.
+	Replica int `json:"replica" required:"true"`
+	// Resource specifications, which can be obtained by using the API in Obtaining All Supported Flavors of Application
+	// Resources. If you need to customize resource specifications, the format is as follows:
+	//   CUSTOM-xxG:xxC-xxC:xxGi-xxGi
+	// The meaning of each part is:
+	//   xxG: storage capacity allocated to a component instance (reserved field). You can set it to a fixed number.
+	//   xxC-xxC: the maximum and minimum number of CPU cores allocated to a component instance.
+	//   xxGi-xxGi: the maximum and minimum memory allocated to a component instance.
+	// For example, CUSTOM-10G:0.5C-0.25C:1.6Gi-0.8Gi indicates that the maximum number of CPU cores allocated to a
+	// component instance is 0.5, the minimum number of CPU cores is 0.25, the maximum memory is 1.6 Gi, and the minimum
+	// memory is 0.8 Gi.
+	FlavorId string `json:"flavor_id" required:"true"`
+	// Deployed resources.
+	ReferResources []ReferResource `json:"refer_resources" required:"true"`
+	// Application component version that meets version semantics. Example: 1.0.0.
+	Version string `json:"version" required:"true"`
+	// Artifact. key indicates the component name. In the Docker container scenario, key indicates the container name.
+	// If the source parameters of a component specify the software package source, this parameter is optional, and the
+	// software package source of the component is inherited by default. Otherwise, this parameter is mandatory.
+	Artifacts map[string]Artifact `json:"artifacts,omitempty"`
+	// Configuration parameters, such as environment variables, deployment configurations, and O&M monitoring.
+	// By default, this parameter is left blank.
+	Configuration *Configuration `json:"configuration,omitempty"`
+	// Description. The value can contain up to 128 characters.
+	Description string `json:"description,omitempty"`
+	// External network access.
+	ExternalAccesses []ExternalAccess `json:"external_accesses,omitempty"`
+}
+
+// ReferResource is an object that specifies the deployed basic and optional resources.
+type ReferResource struct {
+	// Resource ID.
+	// Note: If type is set to ecs, the value of this parameter must be Default.
+	ID string `json:"id" required:"true"`
+	// Resource type.
+	// Basic resources: Cloud Container Engine (CCE), Auto Scaling (AS), and Elastic Cloud Server (ECS).
+	// Optional resources: Relational Database Service (RDS), Distributed Cache Service (DCS),
+	// Elastic Load Balance (ELB), and other services.
+	Type string `json:"type" required:"true"`
+	// Application alias, which is provided only in DCS scenario. Value: distributed_session, distributed_cache, or
+	// distributed_session, distributed_cache. Default value: distributed_session, distributed_cache.
+	ReferAlias string `json:"refer_alias,omitempty"`
+	// Reference resource parameter.
+	// NOTICE:
+	// When type is set to cce, this parameter is mandatory. You need to specify the namespace of the cluster where the
+	// component is to be deployed. Example: {"namespace": "default"}.
+	// When type is set to ecs, this parameter is mandatory. You need to specify the hosts where the component is to be
+	// deployed. Example: {"hosts":["04d9f887-9860-4029-91d1-7d3102903a69", "04d9f887-9860-4029-91d1-7d3102903a70"]}}.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// Artifact is an object that specifies the image storage of the software package.
+type Artifact struct {
+	// Storage mode. Value: swr, devcloud, or obs.
+	Storage string `json:"storage" required:"true"`
+	// Type. Value: package (VM-based deployment) or image (container-based deployment).
+	Type string `json:"type" required:"true"`
+	// Software package or image address.
+	// For a component deployed on a VM, this parameter is the software package address.
+	// For a component deployed based on a container, this parameter is the image address or component name:v${index}.
+	// The latter indicates that the component source code or the image automatically built using the software package
+	// will be used.
+	URL string `json:"url" required:"true"`
+	// Authentication mode. Value: iam or none. Default value: iam.
+	Auth string `json:"auth,omitempty"`
+	// Version number.
+	Version string `json:"version,omitempty"`
+	// Property information.
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+// Configuration is an object that specifies the build configuration for a component instance.
+type Configuration struct {
+	// Environment variable.
+	EnvVariables []Variable `json:"env,omitempty"`
+	// Data storage configuration.
+	Storages []Storage `json:"storage,omitempty"`
+	// Upgrade policy.
+	Strategy *Strategy `json:"strategy,omitempty"`
+	// Lifecycle.
+	Lifecycle *Lifecycle `json:"lifecycle,omitempty"`
+	// Scheduling policy.
+	Scheduler *Scheduler `json:"scheduler,omitempty"`
+	// Health check.
+	Probe *Probe `json:"probes,omitempty"`
+}
+
+// Configuration is an object that specifies the environment variable for the component instance.
+type Variable struct {
+	// Environment variable name.
+	// The value contains 1 to 64 characters, including letters, digits, underscores (_), hyphens (-), and dots (.),
+	// and cannot start with a digit.
+	Name string `json:"name" required:"true"`
+	// Environment variable value.
+	Value string `json:"value" required:"true"`
+}
+
+// Storage is an object that specifies the data storage.
+type Storage struct {
+	// Storage type. Value:
+	// HostPath: host path mounting.
+	// EmptyDir: temporary directory mounting.
+	// ConfigMap: configuration item mounting.
+	// Secret: secret volume mounting.
+	// PersistentVolumeClaim: cloud storage mounting.
+	Type string `json:"type" required:"true"`
+	// Storage parameter.
+	Parameters *StorageParams `json:"parameters" required:"true"`
+	// Directory mounted to the container.
+	Mounts []Mount `json:"mounts" required:"true"`
+}
+
+// StorageParams is an extend object that specifies the storage path and name.
+type StorageParams struct {
+	// Host path. This parameter is applicable to the HostPath storage type.
+	Path string `json:"path,omitempty"`
+	// Name of a configuration item or secret. This parameter is applicable to the ConfigMap and Secret storage type.
+	Name string `json:"name,omitempty"`
+	// PVC name. This parameter is applicable to the PersistentVolumeClaim storage type.
+	ClaimName string `json:"claimName,omitempty"`
+}
+
+// Mount is an object that specifies the directory mounted to the container.
+type Mount struct {
+	// Specifies the mounted disk path.
+	Path string `json:"path" required:"true"`
+	// Specifies the mounted disk permission is read-only or read-write.
+	ReadOnly bool `json:"readOnly" required:"true"`
+	// Specifies the subpath of the mounted disk.
+	SubPath string `json:"subpath,omitempty"`
+}
+
+// Strategy is an object that specifies the upgrade type, including in-place upgrade and rolling upgrade.
+type Strategy struct {
+	// Upgrade policy. Value: Recreate or RollingUpdate (default).
+	// The former indicates in-place upgrade while the latter indicates rolling upgrade.
+	Upgrade string `json:"upgrade,omitempty"`
+}
+
+// Lifecycle is an object that specifies the lifecycle of the component deployment.
+type Lifecycle struct {
+	// Startup command.
+	Entrypoint *Entrypoint `json:"entrypoint,omitempty"`
+	// Post-start processing.
+	PostStart *Process `json:"post-start,omitempty"`
+	// Pre-stop processing.
+	PreStop *Process `json:"pre-stop,omitempty"`
+}
+
+// Entrypoint is an object that specifies the commands when launching up the deployment.
+type Entrypoint struct {
+	// Command that can be executed.
+	Commands []string `json:"command" required:"true"`
+	// Running parameters.
+	Args []string `json:"args" required:"true"`
+}
+
+// Process is an object that specifies the post-processing or stop pre-processing.
+type Process struct {
+	// Process type. The value is command or http.
+	// The command is to execute the command line, and http is to send an http request.
+	Type string `json:"type" required:"true"`
+	// Start post-processing or stop pre-processing parameters.
+	Parameters *ProcessParams `json:"parameters" required:"true"`
+}
+
+// ProcessParams is an object that specifies the arguments of the post-processing or stop pre-processing.
+type ProcessParams struct {
+	// Command parameters, such as ["sleep", "1"]. Applies to command type.
+	Commands []string `json:"command,omitempty"`
+	// The port number. Applies to http type.
+	Port int `json:"port,omitempty"`
+	// Request URL. Applies to http type.
+	Path string `json:"path,omitempty"`
+	// Defaults to the IP address of the POD instance. You can also specify it yourself. Applies to http type.
+	Host string `json:"host,omitempty"`
+}
+
+// Scheduler is an object that specifies the scheduling policy.
+type Scheduler struct {
+	// Affinity.
+	Affinity *Affinity `json:"affinity,omitempty"`
+	// Anti-affinity.
+	AntiAffinity *Affinity `json:"anti-affinity,omitempty"`
+}
+
+// Affinity is an object that specifies the configuration details of the affinity or anti-affinity.
+type Affinity struct {
+	// AZ list.
+	AvailabilityZones []string `json:"az,omitempty"`
+	// Node private IP address list.
+	Nodes []string `json:"node,omitempty"`
+	// List of component instance names.
+	Applications []string `json:"application,omitempty"`
+}
+
+// Probe is an object that specifies which probe members we have.
+type Probe struct {
+	// Component liveness probe.
+	LivenessProbe *ProbeDetail `json:"livenessProbe,omitempty"`
+	// Component service probe.
+	ReadinessProbe *ProbeDetail `json:"readinessProbe,omitempty"`
+}
+
+// ProbeDetail is an object that specifies the configuration details of the liveness probe and service probe.
+type ProbeDetail struct {
+	// Value: http, tcp, or command.
+	// The check methods are HTTP request check, TCP port check, and command execution check, respectively.
+	Type string `json:"type" required:"true"`
+	// Parameters.
+	// If type is set to http, the object is HttpObject.
+	// If type is set to tcp, the object is CommandObject.
+	// If type is set to command, the object is TcpObject.
+	Parameters map[string]interface{} `json:"parameters" required:"true"`
+	// Interval between the startup and detection.
+	Delay int `json:"delay,omitempty"`
+	// Detection timeout interval.
+	Timeout int `json:"timeout,omitempty"`
+}
+
+// HttpObject is an object that specifies the check parameters of the HTTP probe.
+type HttpObject struct {
+	// Value: HTTP or HTTPS.
+	Scheme string `json:"scheme" required:"true"`
+	// Port number.
+	Port int `json:"port" required:"true"`
+	// Request path.
+	Path string `json:"path" required:"true"`
+	// Pod IP address (default). You can specify an IP address.
+	Host string `json:"host,omitempty"`
+}
+
+// CommandObject is an object that specifies the check parameters of the command probe.
+type CommandObject struct {
+	// Command list.
+	Command []string `json:"command" required:"true"`
+}
+
+// TcpObject is an object that specifies the check parameters of the TCP probe.
+type TcpObject struct {
+	// Port number.
+	Port int `json:"port" required:"true"`
+}
+
+// ExternalAccess is an object that specifies the configuration of the external IP access.
+type ExternalAccess struct {
+	// Protocol. Value: http or https.
+	Protocol string `json:"protocol,omitempty"`
+	// Access address.
+	Address string `json:"address,omitempty"`
+	// Port number.
+	ForwardPort int `json:"forward_port,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new instance under ServiceStage application using create option.
+// Environment is a collection of infrestructures, covering computing, storage and networks, used for application
+// deployment and running.
+func Create(c *golangsdk.ServiceClient, appId string, componentId string, opts CreateOpts) (*JobResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r JobResp
+	_, err = c.Post(rootURL(c, appId, componentId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Get is a method to obtain the details of a specified component instance (deployment) using its ID.
+func Get(c *golangsdk.ServiceClient, appId, componentId, instanceId string) (*Instance, error) {
+	var r Instance
+	_, err := c.Get(resourceURL(c, appId, componentId, instanceId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// Value range: 0–100.
+	// Default value: 1000, indicating that a maximum of 1000 records can be queried and all records are displayed on
+	// the same page.
+	Limit int `q:"limit"`
+	// The offset number.
+	Offset int `q:"offset"`
+	// Sorting field. By default, query results are sorted by creation time.
+	// The following enumerated values are supported: create_time, name, and update_time.
+	OrderBy string `q:"order_by"`
+	// Descending or ascending order. Default value: desc.
+	Order string `q:"order"`
+}
+
+// List is a method to query the list of the component instances (deployment) using given opts.
+func List(c *golangsdk.ServiceClient, appId, componentId string, opts ListOpts) ([]Instance, error) {
+	url := rootURL(c, appId, componentId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := InstancePage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractInstances(pages)
+}
+
+// UpdateOpts is the structure required by the Update method to update the configuration of the component instance.
+type UpdateOpts struct {
+	// Application component version that meets version semantics. Example: 1.0.0.
+	Version string `json:"version" required:"true"`
+	// Resource specifications, which can be obtained by using the API in Obtaining All Supported Flavors of Application
+	// Resources. If you need to customize resource specifications, the format is as follows:
+	//   CUSTOM-xxG:xxC-xxC:xxGi-xxGi
+	// The meaning of each part is:
+	//   xxG: storage capacity allocated to a component instance (reserved field). You can set it to a fixed number.
+	//   xxC-xxC: the maximum and minimum number of CPU cores allocated to a component instance.
+	//   xxGi-xxGi: the maximum and minimum memory allocated to a component instance.
+	// For example, CUSTOM-10G:0.5C-0.25C:1.6Gi-0.8Gi indicates that the maximum number of CPU cores allocated to a
+	// component instance is 0.5, the minimum number of CPU cores is 0.25, the maximum memory is 1.6 Gi, and the minimum
+	// memory is 0.8 Gi.
+	FlavorId string `json:"flavor_id,omitempty"`
+	// Artifact. key indicates the component name. In the Docker container scenario, key indicates the container name.
+	// If the source parameters of a component specify the software package source, this parameter is optional, and the
+	// software package source of the component is inherited by default. Otherwise, this parameter is mandatory.
+	Artifacts map[string]Artifact `json:"artifacts,omitempty"`
+	// Configuration parameters, such as environment variables, deployment configurations, and O&M monitoring.
+	// By default, this parameter is left blank.
+	Configuration *Configuration `json:"configuration,omitempty"`
+	// Description. The value can contain up to 128 characters.
+	Description *string `json:"description,omitempty"`
+	// External network access.
+	ExternalAccesses []ExternalAccess `json:"external_accesses,omitempty"`
+	// Deployed resources.
+	ReferResources []ReferResource `json:"refer_resources" required:"true"`
+}
+
+// Update is a method to update the current dependency configuration.
+func Update(c *golangsdk.ServiceClient, appId, componentId, instanceId string, opts UpdateOpts) (*JobResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r JobResp
+	_, err = c.Put(resourceURL(c, appId, componentId, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Delete is a method to remove an existing instance.
+func Delete(c *golangsdk.ServiceClient, appId, componentId, instanceId string) (*JobResp, error) {
+	var r JobResp
+	_, err := c.Delete(resourceURL(c, appId, componentId, instanceId), &golangsdk.RequestOpts{
+		JSONResponse: &r,
+		MoreHeaders:  requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// UpdateOpts is the structure required by the DoAction method to change component status or upgrade it.
+type ActionOpts struct {
+	// Specified the actions, the valid actions are: start, stop, restart, scale and rollback.
+	Action string `json:"action" required:"true"`
+	// Specified the action parameters, required if action is scale or rollback.
+	Parameters ActionParams `json:"parameters,omitempty"`
+}
+
+// ActionParams is an object that specifies the operate parameters.
+type ActionParams struct {
+	// Specified the number of replica, required if action is scale.
+	Replica string `json:"replica,omitempty"`
+	// Specified the list of ECS instance to be deployed during VM scaling, required if action is scale.
+	Host []string `json:"hosts,omitempty"`
+	// Specified the verison number, required if action is rollback.
+	Version string `json:"version,omitempty"`
+}
+
+// DoAction is a method to change component status or upgrade the instance.
+func DoAction(c *golangsdk.ServiceClient, appId string, componentId, instanceId string, opts CreateOpts) (*Job, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst Job
+	_, err = c.Post(rootURL(c, appId, componentId), b, &rst, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &rst, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/results.go
@@ -1,0 +1,181 @@
+package instances
+
+import "github.com/chnsz/golangsdk/pagination"
+
+type JobResp struct {
+	// Component instance ID.
+	InstanceId string `json:"instance_id"`
+	// Job ID.
+	JobId string `json:"job_id"`
+}
+
+// Instance is the structure that represents the details of the ServiceStage component instance.
+type Instance struct {
+	// Component instance ID.
+	ID string `json:"id"`
+	// Component instance name.
+	Name string `json:"name"`
+	// Component environment ID.
+	EnvironmentId string `json:"environment_id"`
+	// Platform type.
+	// Value: cce or vmapp.
+	PlatformType string `json:"platform_type"`
+	// Instance description.
+	Description string `json:"description"`
+	// Resource flavor.
+	FlavorId string `json:"flavor_id"`
+	// Artifact. key indicates the component name. In the Docker container scenario, key indicates the container name.
+	Artifacts map[string]Artifact `json:"artifacts"`
+	// Component version.
+	Version string `json:"version"`
+	// Component configurations, such as environment variables.
+	Configuration ConfigurationResp `json:"configuration"`
+	// Creator.
+	Creator string `json:"creator"`
+	// Creation time.
+	CreatedAt int `json:"create_time"`
+	// Update time.
+	UpdatedAt int `json:"update_time"`
+	// Access mode.
+	ExternalAccesses []ExternalAccessResp `json:"external_accesses"`
+	// Deployed resources.
+	ReferResources []ReferResource `json:"refer_resources"`
+	// Status details.
+	StatusDetail StatusDetail `json:"status_detail"`
+}
+
+// ConfigurationResp is an object represents the configuration details of the deployment.
+type ConfigurationResp struct {
+	// Environment variable.
+	EnvVariables []Variable `json:"env,omitempty"`
+	// Data storage configuration.
+	Storages []StorageResp `json:"storage,omitempty"`
+	// Upgrade policy.
+	Strategy StrategyResp `json:"strategy,omitempty"`
+	// Lifecycle.
+	Lifecycle LifecycleResp `json:"lifecycle,omitempty"`
+	// Scheduling policy.
+	Scheduler SchedulerResp `json:"scheduler,omitempty"`
+	// Health check.
+	Probe ProbeResp `json:"probes,omitempty"`
+}
+
+// StorageResp is an object represents the storage configuration of the deployment.
+type StorageResp struct {
+	// Storage type. Value:
+	// HostPath: host path mounting.
+	// EmptyDir: temporary directory mounting.
+	// ConfigMap: configuration item mounting.
+	// Secret: secret volume mounting.
+	// PersistentVolumeClaim: cloud storage mounting.
+	Type string `json:"type" required:"true"`
+	// Storage parameter.
+	Parameters StorageParams `json:"parameters" required:"true"`
+	// Directory mounted to the container.
+	Mounts []Mount `json:"mounts" required:"true"`
+}
+
+// StrategyResp is an object represents the upgrade information of the deployment.
+type StrategyResp struct {
+	Spec Spec `json:"spec"`
+	// Upgrade policy. Value: Recreate or RollingUpdate (default).
+	// The former indicates in-place upgrade while the latter indicates rolling upgrade.
+	Upgrade string `json:"upgrade,omitempty"`
+}
+
+// Spec is an object represents the other upgrade details.
+type Spec struct {
+	// The maximum surge number.
+	MaxSurge int `json:"maxSurge"`
+	// The maximum unavailable upgrade count.
+	MaxUnavailable int `json:"maxUnavailable"`
+}
+
+// LifecycleResp is an object represents the lifecycle of the deployment.
+type LifecycleResp struct {
+	// Startup command.
+	Entrypoint Entrypoint `json:"entrypoint"`
+	// Post-start processing.
+	PostStart ProcessResp `json:"post-start"`
+	// Pre-stop processing.
+	PreStop ProcessResp `json:"pre-stop"`
+}
+
+// ProcessResp is an object represents the details of the post-processing or stop pre-processing.
+type ProcessResp struct {
+	// Process type. The value is command or http.
+	// The command is to execute the command line, and http is to send an http request.
+	Type string `json:"type" required:"true"`
+	// Start post-processing or stop pre-processing parameters.
+	Parameters ProcessParams `json:"parameters" required:"true"`
+}
+
+// SchedulerResp is an object represents the scheduling policy.
+type SchedulerResp struct {
+	// Affinity.
+	Affinity Affinity `json:"affinity,omitempty"`
+	// Anti-affinity.
+	AntiAffinity Affinity `json:"anti-affinity,omitempty"`
+}
+
+// ProbeResp is an object represents the probe members configuration of the deployment.
+type ProbeResp struct {
+	// Component liveness probe.
+	LivenessProbe ProbeDetail `json:"livenessProbe,omitempty"`
+	// Component service probe.
+	ReadinessProbe ProbeDetail `json:"readinessProbe,omitempty"`
+}
+
+// ExternalAccessResp is an object represents the configuration of the external IP access.
+type ExternalAccessResp struct {
+	// Protocol. Value: http or https.
+	Protocol string `json:"protocol"`
+	// Access address.
+	Address string `json:"address"`
+	// Port number.
+	ForwardPort int `json:"forward_port"`
+	// Type.
+	Type string `json:"type"`
+	// Status.
+	Status string `json:"status"`
+	// Creation time.
+	CreatedAt int `json:"create_time"`
+	// Update time.
+	UpdatedAt int `json:"update_time"`
+}
+
+// StorageResp is an object represents the status details of the deployment.
+type StatusDetail struct {
+	// Enterprise project ID.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Instance status.
+	Status string `json:"status"`
+	// Number of normal instance replicas.
+	AvailableReplica int `json:"available_replica"`
+	// Number of instance replicas.
+	Replica int `json:"replica"`
+	// Failure description.
+	FailDetail string `json:"fail_detail"`
+	// Latest job ID.
+	LastJobId string `json:"last_job_id"`
+	// Latest job status.
+	LastJobStatus string `json:"last_job_status"`
+}
+
+// InstancePage is a single page maximum result representing a query by offset page.
+type InstancePage struct {
+	pagination.OffsetPageBase
+}
+
+// ExtractInstances is a method to extract the list of environment details for ServiceStage service.
+func ExtractInstances(r pagination.Page) ([]Instance, error) {
+	var s []Instance
+	r.(InstancePage).Result.ExtractIntoSlicePtr(&s, "isntances")
+	return s, nil
+}
+
+// Job is the structure that represents the result of the Action.
+type Job struct {
+	// Job ID.
+	ID string `json:"job_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/urls.go
@@ -1,0 +1,17 @@
+package instances
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "cas/applications"
+
+func rootURL(client *golangsdk.ServiceClient, appId, componentId string) string {
+	return client.ServiceURL(rootPath, appId, "components", componentId, "instances")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, appId, componentId, instanceId string) string {
+	return client.ServiceURL(rootPath, appId, "components", componentId, "instances", instanceId)
+}
+
+func actionURL(client *golangsdk.ServiceClient, appId, componentId, instanceId string) string {
+	return client.ServiceURL(rootPath, appId, "components", componentId, "instances", instanceId, "action")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs/requests.go
@@ -1,0 +1,18 @@
+package jobs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Get is a method to obtain the details of a specified deployment job using its ID.
+func Get(c *golangsdk.ServiceClient, jobId string) (*JobResp, error) {
+	var r JobResp
+	_, err := c.Get(rootURL(c, jobId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs/results.go
@@ -1,0 +1,55 @@
+package jobs
+
+// JobResp is the structure that represents the detail of the deployment job and task list.
+type JobResp struct {
+	// Number of tasks.
+	TaskCount int `json:"task_count"`
+	// Job parameters.
+	Job Job `json:"job"`
+	// Task parameters.
+	Tasks []Task `json:"tasks"`
+}
+
+// Job is the structure that represents the detail of the deployment action.
+type Job struct {
+	// Creator.
+	Creator string `json:"created_by"`
+	// Execution status.
+	ExecutionStatus string `json:"execution_status"`
+	// Job description.
+	Description string `json:"job_desc"`
+	// Job ID.
+	ID string `json:"job_id"`
+	// Job name.
+	Name string `json:"job_name"`
+	// Type.
+	Type string `json:"job_type"`
+	// Order ID.
+	OrderId string `json:"order_id"`
+	// Tenant's project ID.
+	ProjectId string `json:"project_id"`
+	// Instance ID.
+	InstanceId string `json:"service_instance_id"`
+}
+
+// Task is the structure that represents the detail of the deployment task.
+type Task struct {
+	// Creation time.
+	CreatedAt string `json:"created_at"`
+	// Health check time.
+	LastHealthCheck string `json:"last_health_check"`
+	// Message.
+	Messages string `json:"messages"`
+	// Creator ID.
+	OwnerId string `json:"owner_id"`
+	// Task ID.
+	ID string `json:"task_id"`
+	// Task index.
+	Index int `json:"task_index"`
+	// Task name.
+	Name string `json:"task_name"`
+	// Task status.
+	Status string `json:"task_status"`
+	// Task type.
+	Type string `json:"task_type"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs/urls.go
@@ -1,0 +1,7 @@
+package jobs
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, jobId string) string {
+	return client.ServiceURL("cas/jobs", jobId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,6 +242,8 @@ github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories
 github.com/chnsz/golangsdk/openstack/servicestage/v2/applications
 github.com/chnsz/golangsdk/openstack/servicestage/v2/components
 github.com/chnsz/golangsdk/openstack/servicestage/v2/environments
+github.com/chnsz/golangsdk/openstack/servicestage/v2/instances
+github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs
 github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata
 github.com/chnsz/golangsdk/openstack/sfs/v2/shares
 github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, we have these reources:
- huaweicloud_servicestage_application
- huaweicloud_servicestage_component
- huaweicloud_servicestage_environment
- huaweicloud_servicestage_repo_password_authorization
- huaweicloud_servicestage_repo_token_authorization
- data.huaweicloud_servicestage_component_runtimes

Now, these resources can be integrated by implementing `huaweicloud_servicestage_component_instance` resource.
Using this resource, we can quickly build a CSE instance by deploying a component using a given image.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2030

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new resource for component deployment.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccComponentInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccComponentInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComponentInstance_basic
=== PAUSE TestAccComponentInstance_basic
=== CONT  TestAccComponentInstance_basic
--- PASS: TestAccComponentInstance_basic (946.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      946.812s
```
