### PR TITLE
feat(Live): add a new resource for callback configuration

### DIFF
--- a/docs/resources/live_record_callback.md
+++ b/docs/resources/live_record_callback.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Live"
+---
+
+# huaweicloud_live_record_callback
+
+Manages a callback configuration within HuaweiCloud Live.
+
+-> Only one callback configuration can be created for an ingestion domain name.
+
+## Example Usage
+
+### Create a callback configuration for an ingest domain name
+
+```hcl
+variable "ingest_domain_name" {}
+
+resource "huaweicloud_live_domain" "ingestDomain" {
+  name = var.ingest_domain_name
+  type = "push"
+}
+
+resource "huaweicloud_live_record_callback" "callback" {
+  domain_name = var.ingest_domain_name
+  url         = "http://mycallback.com.cn/record_notify"
+  types       = ["RECORD_NEW_FILE_START"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String, ForceNew) Specifies the ingest domain name.
+Changing this parameter will create a new resource.
+
+* `url` - (Required, String) Specifies the callback URL for sending recording notifications, which must start with
+`http://` or `https://`, and cannot contain message headers or parameters.
+
+* `types` - (Required, List) Specifies the types of recording notifications. The options are as follows:
+  + **RECORD_NEW_FILE_START**: Recording started.
+  + **RECORD_FILE_COMPLETE**: Recording file generated.
+  + **RECORD_OVER**: Recording completed.
+  + **RECORD_FAILED**: Recording failed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+Callback configurations can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_live_record_callback.test 55534eaa-533a-419d-9b40-ec427ea7195a
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -673,7 +673,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_pool":         lb.ResourcePoolV2(),
 			"huaweicloud_lb_whitelist":    lb.ResourceWhitelistV2(),
 
-			"huaweicloud_live_domain": live.ResourceDomain(),
+			"huaweicloud_live_domain":          live.ResourceDomain(),
+			"huaweicloud_live_record_callback": live.ResourceRecordCallback(),
 
 			"huaweicloud_lts_group":  ResourceLTSGroupV2(),
 			"huaweicloud_lts_stream": ResourceLTSStreamV2(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_record_callback_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_record_callback_test.go
@@ -1,0 +1,79 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getRecordCallbackResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcLiveV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live v1 client: %s", err)
+	}
+	return client.ShowRecordCallbackConfig(&model.ShowRecordCallbackConfigRequest{Id: state.Primary.ID})
+}
+
+func TestAccRecordCallback_basic(t *testing.T) {
+	var obj model.ShowRecordCallbackConfigResponse
+
+	pushDomainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceNameWithDash())
+	rName := "huaweicloud_live_record_callback.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRecordCallbackResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCallBack_basic(pushDomainName, "http://mycallback.com.cn/record_notify"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", pushDomainName),
+					resource.TestCheckResourceAttr(rName, "types.0", "RECORD_NEW_FILE_START"),
+					resource.TestCheckResourceAttr(rName, "url", "http://mycallback.com.cn/record_notify"),
+				),
+			},
+			{
+				Config: testCallBack_basic(pushDomainName, "http://mycallback.com.cn/record_notify2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "domain_name", pushDomainName),
+					resource.TestCheckResourceAttr(rName, "types.0", "RECORD_NEW_FILE_START"),
+					resource.TestCheckResourceAttr(rName, "url", "http://mycallback.com.cn/record_notify2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCallBack_basic(pushDomainName, callbackUrl string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_live_domain" "ingestDomain" {
+  name = "%s"
+  type = "push"
+}
+
+resource "huaweicloud_live_record_callback" "test" {
+  domain_name = huaweicloud_live_domain.ingestDomain.name
+  types       = ["RECORD_NEW_FILE_START"]
+  url         = "%s"
+}
+`, pushDomainName, callbackUrl)
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_record_callback.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_record_callback.go
@@ -1,0 +1,228 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	v1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	eventRecordNewFileStart = "RECORD_NEW_FILE_START"
+	eventRecordFileComplete = "RECORD_FILE_COMPLETE"
+	eventRecordOver         = "RECORD_OVER"
+	eventRecordFailed       = "RECORD_FAILED"
+
+	allAppName = "*"
+)
+
+func ResourceRecordCallback() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecordCallbackCreate,
+		ReadContext:   resourceRecordCallbackRead,
+		UpdateContext: resourceRecordCallbackUpdate,
+		DeleteContext: resourceRecordCallbackDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^http://|^https://`),
+						"The URL must start with http:// or https://."),
+					validation.StringDoesNotMatch(regexp.MustCompile(`\?{1}`), "The URL cannot contain parameters."),
+				),
+			},
+
+			"types": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 4,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{eventRecordNewFileStart, eventRecordFileComplete,
+						eventRecordOver, eventRecordFailed}, false),
+				},
+			},
+		},
+	}
+}
+
+func resourceRecordCallbackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	createBody, err := buildCallbackConfigParams(d, region)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	createOpts := &model.CreateRecordCallbackConfigRequest{
+		Body: createBody,
+	}
+
+	log.Printf("[DEBUG] Create Live callback configuration params : %#v", createOpts)
+
+	_, err = client.CreateRecordCallbackConfig(createOpts)
+	if err != nil {
+		return diag.Errorf("error creating Live callback configuration: %s", err)
+	}
+
+	// ID is lost in CreateRecordCallbackConfig, so get from List API
+	id, err := getRecordCallBackId(client, createOpts.Body.PublishDomain, createOpts.Body.App)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	return resourceRecordCallbackRead(ctx, d, meta)
+}
+
+func resourceRecordCallbackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	response, err := client.ShowRecordCallbackConfig(&model.ShowRecordCallbackConfigRequest{Id: d.Id()})
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Live callback configuration")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", response.PublishDomain),
+		setTypeToState(d, response.NotifyEventSubscription),
+		d.Set("url", response.NotifyCallbackUrl),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRecordCallbackUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	updateBody, err := buildCallbackConfigParams(d, region)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	updateOpts := &model.UpdateRecordCallbackConfigRequest{
+		Id:   d.Id(),
+		Body: updateBody,
+	}
+
+	_, err = client.UpdateRecordCallbackConfig(updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating Live callback configuration: %s", err)
+	}
+
+	return resourceRecordCallbackRead(ctx, d, meta)
+}
+
+func resourceRecordCallbackDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	deleteOpts := &model.DeleteRecordCallbackConfigRequest{
+		Id: d.Id(),
+	}
+	_, err = client.DeleteRecordCallbackConfig(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting Live callback configuration: %s", err)
+	}
+
+	return nil
+}
+
+func buildCallbackConfigParams(d *schema.ResourceData, region string) (*model.RecordCallbackConfigRequest, error) {
+	v := d.Get("types").([]interface{})
+	events := make([]model.RecordCallbackConfigRequestNotifyEventSubscription, len(v))
+	for i, v := range v {
+		var event model.RecordCallbackConfigRequestNotifyEventSubscription
+		err := event.UnmarshalJSON([]byte(v.(string)))
+		if err != nil {
+			return nil, fmt.Errorf("error getting the argument %q: %s", "types", err)
+		}
+		events[i] = event
+	}
+
+	req := model.RecordCallbackConfigRequest{
+		PublishDomain:           d.Get("domain_name").(string),
+		App:                     allAppName,
+		NotifyEventSubscription: &events,
+		NotifyCallbackUrl:       utils.String(d.Get("url").(string)),
+	}
+
+	return &req, nil
+
+}
+
+func getRecordCallBackId(client *v1.LiveClient, publishDomain, appName string) (string, error) {
+	resp, err := client.ListRecordCallbackConfigs(&model.ListRecordCallbackConfigsRequest{
+		PublishDomain: &publishDomain,
+		App:           &appName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error retrieving Live callback configuration: %s", err)
+	}
+
+	if resp == nil || resp.CallbackConfig == nil || len(*resp.CallbackConfig) < 1 {
+		return "", fmt.Errorf("error retrieving Live callback configuration: no data")
+	}
+
+	callbacks := *resp.CallbackConfig
+
+	return *callbacks[0].Id, nil
+}
+
+func setTypeToState(d *schema.ResourceData, event *[]model.ShowRecordCallbackConfigResponseNotifyEventSubscription) error {
+	if event != nil {
+		types := make([]string, len(*event))
+		for i, v := range *event {
+			event := utils.MarshalValue(v)
+			types[i] = event
+		}
+		return d.Set("types", types)
+	}
+	return nil
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/live_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/live_client.go
@@ -19,7 +19,12 @@ func LiveClientBuilder() *http_client.HcHttpClientBuilder {
 	return builder
 }
 
-//可单独创建直播播放域名或推流域名，每个租户最多可配置64条域名记录。
+// 创建直播域名
+//
+// 可单独创建直播播放域名或推流域名，每个租户最多可配置64条域名记录。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) CreateDomain(request *model.CreateDomainRequest) (*model.CreateDomainResponse, error) {
 	requestDef := GenReqDefForCreateDomain()
 
@@ -30,7 +35,12 @@ func (c *LiveClient) CreateDomain(request *model.CreateDomainRequest) (*model.Cr
 	}
 }
 
-//将用户已创建的播放域名和推流域名建立域名映射关系
+// 域名映射
+//
+// 将用户已创建的播放域名和推流域名建立域名映射关系
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) CreateDomainMapping(request *model.CreateDomainMappingRequest) (*model.CreateDomainMappingResponse, error) {
 	requestDef := GenReqDefForCreateDomainMapping()
 
@@ -41,7 +51,12 @@ func (c *LiveClient) CreateDomainMapping(request *model.CreateDomainMappingReque
 	}
 }
 
-//创建录制回调配置接口
+// 创建录制回调配置
+//
+// 创建录制回调配置接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) CreateRecordCallbackConfig(request *model.CreateRecordCallbackConfigRequest) (*model.CreateRecordCallbackConfigResponse, error) {
 	requestDef := GenReqDefForCreateRecordCallbackConfig()
 
@@ -52,7 +67,12 @@ func (c *LiveClient) CreateRecordCallbackConfig(request *model.CreateRecordCallb
 	}
 }
 
-//创建录制规则接口，录制规则对新推送的流生效，对已经推送中的流不生效
+// 创建录制规则
+//
+// 创建录制规则接口，录制规则对新推送的流生效，对已经推送中的流不生效
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) CreateRecordRule(request *model.CreateRecordRuleRequest) (*model.CreateRecordRuleResponse, error) {
 	requestDef := GenReqDefForCreateRecordRule()
 
@@ -63,7 +83,12 @@ func (c *LiveClient) CreateRecordRule(request *model.CreateRecordRuleRequest) (*
 	}
 }
 
-//禁止直播推流
+// 禁止直播推流
+//
+// 禁止直播推流
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) CreateStreamForbidden(request *model.CreateStreamForbiddenRequest) (*model.CreateStreamForbiddenResponse, error) {
 	requestDef := GenReqDefForCreateStreamForbidden()
 
@@ -74,7 +99,12 @@ func (c *LiveClient) CreateStreamForbidden(request *model.CreateStreamForbiddenR
 	}
 }
 
-//创建直播转码模板
+// 创建直播转码模板
+//
+// 创建直播转码模板
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) CreateTranscodingsTemplate(request *model.CreateTranscodingsTemplateRequest) (*model.CreateTranscodingsTemplateResponse, error) {
 	requestDef := GenReqDefForCreateTranscodingsTemplate()
 
@@ -85,7 +115,12 @@ func (c *LiveClient) CreateTranscodingsTemplate(request *model.CreateTranscoding
 	}
 }
 
-//删除域名。只有在域名停用（off）状态时才能删除。
+// 删除直播域名
+//
+// 删除域名。只有在域名停用（off）状态时才能删除。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) DeleteDomain(request *model.DeleteDomainRequest) (*model.DeleteDomainResponse, error) {
 	requestDef := GenReqDefForDeleteDomain()
 
@@ -96,7 +131,12 @@ func (c *LiveClient) DeleteDomain(request *model.DeleteDomainRequest) (*model.De
 	}
 }
 
-//将播放域名和推流域名的域名映射关系删除
+// 删除直播域名映射关系
+//
+// 将播放域名和推流域名的域名映射关系删除
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) DeleteDomainMapping(request *model.DeleteDomainMappingRequest) (*model.DeleteDomainMappingResponse, error) {
 	requestDef := GenReqDefForDeleteDomainMapping()
 
@@ -107,7 +147,12 @@ func (c *LiveClient) DeleteDomainMapping(request *model.DeleteDomainMappingReque
 	}
 }
 
-//删除录制回调配置接口
+// 删除录制回调配置
+//
+// 删除录制回调配置接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) DeleteRecordCallbackConfig(request *model.DeleteRecordCallbackConfigRequest) (*model.DeleteRecordCallbackConfigResponse, error) {
 	requestDef := GenReqDefForDeleteRecordCallbackConfig()
 
@@ -118,7 +163,12 @@ func (c *LiveClient) DeleteRecordCallbackConfig(request *model.DeleteRecordCallb
 	}
 }
 
-//删除录制规则接口
+// 删除录制规则
+//
+// 删除录制规则接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) DeleteRecordRule(request *model.DeleteRecordRuleRequest) (*model.DeleteRecordRuleResponse, error) {
 	requestDef := GenReqDefForDeleteRecordRule()
 
@@ -129,7 +179,12 @@ func (c *LiveClient) DeleteRecordRule(request *model.DeleteRecordRuleRequest) (*
 	}
 }
 
-//恢复直播推流接口
+// 禁推恢复
+//
+// 恢复直播推流接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) DeleteStreamForbidden(request *model.DeleteStreamForbiddenRequest) (*model.DeleteStreamForbiddenResponse, error) {
 	requestDef := GenReqDefForDeleteStreamForbidden()
 
@@ -140,7 +195,12 @@ func (c *LiveClient) DeleteStreamForbidden(request *model.DeleteStreamForbiddenR
 	}
 }
 
-//删除直播转码模板
+// 删除直播转码模板
+//
+// 删除直播转码模板
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) DeleteTranscodingsTemplate(request *model.DeleteTranscodingsTemplateRequest) (*model.DeleteTranscodingsTemplateResponse, error) {
 	requestDef := GenReqDefForDeleteTranscodingsTemplate()
 
@@ -151,7 +211,12 @@ func (c *LiveClient) DeleteTranscodingsTemplate(request *model.DeleteTranscoding
 	}
 }
 
-//获取直播播放日志，基于域名以5分钟粒度进行打包，日志内容以 \"|\" 进行分隔。
+// 获取直播播放日志
+//
+// 获取直播播放日志，基于域名以5分钟粒度进行打包，日志内容以 \&quot;|\&quot; 进行分隔。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ListLiveSampleLogs(request *model.ListLiveSampleLogsRequest) (*model.ListLiveSampleLogsResponse, error) {
 	requestDef := GenReqDefForListLiveSampleLogs()
 
@@ -162,7 +227,12 @@ func (c *LiveClient) ListLiveSampleLogs(request *model.ListLiveSampleLogsRequest
 	}
 }
 
-//查询直播中的流信息
+// 查询直播中的流信息
+//
+// 查询直播中的流信息
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ListLiveStreamsOnline(request *model.ListLiveStreamsOnlineRequest) (*model.ListLiveStreamsOnlineResponse, error) {
 	requestDef := GenReqDefForListLiveStreamsOnline()
 
@@ -173,7 +243,12 @@ func (c *LiveClient) ListLiveStreamsOnline(request *model.ListLiveStreamsOnlineR
 	}
 }
 
-//查询录制回调配置列表接口。通过指定条件，查询满足条件的配置列表。
+// 查询录制回调配置列表
+//
+// 查询录制回调配置列表接口。通过指定条件，查询满足条件的配置列表。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ListRecordCallbackConfigs(request *model.ListRecordCallbackConfigsRequest) (*model.ListRecordCallbackConfigsResponse, error) {
 	requestDef := GenReqDefForListRecordCallbackConfigs()
 
@@ -184,7 +259,12 @@ func (c *LiveClient) ListRecordCallbackConfigs(request *model.ListRecordCallback
 	}
 }
 
-//录制完成的内容查询
+// 录制完成内容的查询
+//
+// 录制完成的内容查询
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ListRecordContents(request *model.ListRecordContentsRequest) (*model.ListRecordContentsResponse, error) {
 	requestDef := GenReqDefForListRecordContents()
 
@@ -195,7 +275,12 @@ func (c *LiveClient) ListRecordContents(request *model.ListRecordContentsRequest
 	}
 }
 
-//查询录制规则列表接口，通过指定条件，查询满足条件的录制规则列表。
+// 查询录制规则列表
+//
+// 查询录制规则列表接口，通过指定条件，查询满足条件的录制规则列表。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ListRecordRules(request *model.ListRecordRulesRequest) (*model.ListRecordRulesResponse, error) {
 	requestDef := GenReqDefForListRecordRules()
 
@@ -206,7 +291,12 @@ func (c *LiveClient) ListRecordRules(request *model.ListRecordRulesRequest) (*mo
 	}
 }
 
-//查询禁播黑名单列表
+// 查询禁止直播推流列表
+//
+// 查询禁播黑名单列表
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ListStreamForbidden(request *model.ListStreamForbiddenRequest) (*model.ListStreamForbiddenResponse, error) {
 	requestDef := GenReqDefForListStreamForbidden()
 
@@ -217,7 +307,12 @@ func (c *LiveClient) ListStreamForbidden(request *model.ListStreamForbiddenReque
 	}
 }
 
-//对单条流的实时录制控制接口。
+// 提交录制控制命令
+//
+// 对单条流的实时录制控制接口。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) RunRecord(request *model.RunRecordRequest) (*model.RunRecordResponse, error) {
 	requestDef := GenReqDefForRunRecord()
 
@@ -228,7 +323,12 @@ func (c *LiveClient) RunRecord(request *model.RunRecordRequest) (*model.RunRecor
 	}
 }
 
-//查询直播域名
+// 查询直播域名
+//
+// 查询直播域名
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ShowDomain(request *model.ShowDomainRequest) (*model.ShowDomainResponse, error) {
 	requestDef := GenReqDefForShowDomain()
 
@@ -239,7 +339,12 @@ func (c *LiveClient) ShowDomain(request *model.ShowDomainRequest) (*model.ShowDo
 	}
 }
 
-//查询录制回调配置接口
+// 查询录制回调配置
+//
+// 查询录制回调配置接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ShowRecordCallbackConfig(request *model.ShowRecordCallbackConfigRequest) (*model.ShowRecordCallbackConfigResponse, error) {
 	requestDef := GenReqDefForShowRecordCallbackConfig()
 
@@ -250,7 +355,12 @@ func (c *LiveClient) ShowRecordCallbackConfig(request *model.ShowRecordCallbackC
 	}
 }
 
-//查询录制规则接口
+// 查询录制规则配置
+//
+// 查询录制规则接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ShowRecordRule(request *model.ShowRecordRuleRequest) (*model.ShowRecordRuleResponse, error) {
 	requestDef := GenReqDefForShowRecordRule()
 
@@ -261,7 +371,12 @@ func (c *LiveClient) ShowRecordRule(request *model.ShowRecordRuleRequest) (*mode
 	}
 }
 
-//查询直播转码模板
+// 查询直播转码模板
+//
+// 查询直播转码模板
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) ShowTranscodingsTemplate(request *model.ShowTranscodingsTemplateRequest) (*model.ShowTranscodingsTemplateResponse, error) {
 	requestDef := GenReqDefForShowTranscodingsTemplate()
 
@@ -272,7 +387,12 @@ func (c *LiveClient) ShowTranscodingsTemplate(request *model.ShowTranscodingsTem
 	}
 }
 
-//修改直播播放、RTMP推流加速域名相关信息
+// 修改直播域名
+//
+// 修改直播播放、RTMP推流加速域名相关信息
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) UpdateDomain(request *model.UpdateDomainRequest) (*model.UpdateDomainResponse, error) {
 	requestDef := GenReqDefForUpdateDomain()
 
@@ -283,7 +403,12 @@ func (c *LiveClient) UpdateDomain(request *model.UpdateDomainRequest) (*model.Up
 	}
 }
 
-//修改录制回调配置接口
+// 修改录制回调配置
+//
+// 修改录制回调配置接口
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) UpdateRecordCallbackConfig(request *model.UpdateRecordCallbackConfigRequest) (*model.UpdateRecordCallbackConfigResponse, error) {
 	requestDef := GenReqDefForUpdateRecordCallbackConfig()
 
@@ -294,7 +419,12 @@ func (c *LiveClient) UpdateRecordCallbackConfig(request *model.UpdateRecordCallb
 	}
 }
 
-//修改录制规则接口，如果规则修改后，修改后的规则对正在录制的流无效，对新的流有效。
+// 修改录制规则
+//
+// 修改录制规则接口，如果规则修改后，修改后的规则对正在录制的流无效，对新的流有效。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) UpdateRecordRule(request *model.UpdateRecordRuleRequest) (*model.UpdateRecordRuleResponse, error) {
 	requestDef := GenReqDefForUpdateRecordRule()
 
@@ -305,7 +435,12 @@ func (c *LiveClient) UpdateRecordRule(request *model.UpdateRecordRuleRequest) (*
 	}
 }
 
-//修改禁推属性
+// 修改禁推属性
+//
+// 修改禁推属性
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) UpdateStreamForbidden(request *model.UpdateStreamForbiddenRequest) (*model.UpdateStreamForbiddenResponse, error) {
 	requestDef := GenReqDefForUpdateStreamForbidden()
 
@@ -316,7 +451,12 @@ func (c *LiveClient) UpdateStreamForbidden(request *model.UpdateStreamForbiddenR
 	}
 }
 
-//修改直播转码模板
+// 配置直播转码模板
+//
+// 修改直播转码模板
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
 func (c *LiveClient) UpdateTranscodingsTemplate(request *model.UpdateTranscodingsTemplateRequest) (*model.UpdateTranscodingsTemplateResponse, error) {
 	requestDef := GenReqDefForUpdateTranscodingsTemplate()
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_app_quality_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_app_quality_info.go
@@ -7,11 +7,11 @@ import (
 )
 
 type AppQualityInfo struct {
+
 	// 应用名称
-
 	AppName *string `json:"app_name,omitempty"`
-	// 视频质量信息
 
+	// 视频质量信息
 	QualityInfo *[]QualityInfo `json:"quality_info,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_domain_mapping_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_domain_mapping_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type CreateDomainMappingRequest struct {
-	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
 
+	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
 	SpecifyProject *string `json:"specify_project,omitempty"`
 
 	Body *DomainMapping `json:"body,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_domain_mapping_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_domain_mapping_response.go
@@ -8,11 +8,11 @@ import (
 
 // Response Object
 type CreateDomainMappingResponse struct {
+
 	// 直播播放域名
-
 	PullDomain *string `json:"pull_domain,omitempty"`
-	// 直播播放域名关联的推流域名
 
+	// 直播播放域名关联的推流域名
 	PushDomain     *string `json:"push_domain,omitempty"`
 	HttpStatusCode int     `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_domain_response.go
@@ -10,29 +10,29 @@ import (
 
 // Response Object
 type CreateDomainResponse struct {
+
 	// 直播域名
-
 	Domain *string `json:"domain,omitempty"`
+
 	// 域名类型 - pull表示播放域名 - push表示推流域名
-
 	DomainType *CreateDomainResponseDomainType `json:"domain_type,omitempty"`
+
 	// 直播域名的CNAME
-
 	DomainCname *string `json:"domain_cname,omitempty"`
+
 	// 直播所属直播中心
-
 	Region *string `json:"region,omitempty"`
+
 	// 直播域名的状态
-
 	Status *CreateDomainResponseStatus `json:"status,omitempty"`
+
 	// 域名创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间
-
 	CreateTime *sdktime.SdkTime `json:"create_time,omitempty"`
+
 	// 状态描述
-
 	StatusDescribe *string `json:"status_describe,omitempty"`
-	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 
+	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 	ServiceArea    *CreateDomainResponseServiceArea `json:"service_area,omitempty"`
 	HttpStatusCode int                              `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_record_rule_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_record_rule_response.go
@@ -11,28 +11,28 @@ import (
 
 // Response Object
 type CreateRecordRuleResponse struct {
+
 	// 规则id，由服务端返回。创建或修改的时候不携带
-
 	Id *string `json:"id,omitempty"`
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 应用名，如果任意应用填写*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App *string `json:"app,omitempty"`
+
 	// 录制的流名，如果任意流名则填写*。录制规则匹配的时候，优先精确stream匹配，如果匹配不到，则匹配*
-
 	Stream *string `json:"stream,omitempty"`
-	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 
+	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 	RecordType *CreateRecordRuleResponseRecordType `json:"record_type,omitempty"`
 
 	DefaultRecordConfig *DefaultRecordConfig `json:"default_record_config,omitempty"`
+
 	// 创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
-
 	CreateTime *string `json:"create_time,omitempty"`
-	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 
+	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 	UpdateTime     *string `json:"update_time,omitempty"`
 	HttpStatusCode int     `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_stream_forbidden_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_create_stream_forbidden_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type CreateStreamForbiddenRequest struct {
-	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
 
+	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
 	SpecifyProject *string `json:"specify_project,omitempty"`
 
 	Body *StreamForbiddenSetting `json:"body,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_decoupled_live_domain_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_decoupled_live_domain_info.go
@@ -9,35 +9,35 @@ import (
 )
 
 type DecoupledLiveDomainInfo struct {
+
 	// 直播域名
-
 	Domain string `json:"domain"`
+
 	// 域名类型
-
 	DomainType DecoupledLiveDomainInfoDomainType `json:"domain_type"`
+
 	// CDN厂商
-
 	Vendor DecoupledLiveDomainInfoVendor `json:"vendor"`
+
 	// 直播所属直播中心
-
 	Region string `json:"region"`
+
 	// 直播域名的CName
-
 	DomainCname string `json:"domain_cname"`
+
 	// 直播域名的状态
-
 	Status DecoupledLiveDomainInfoStatus `json:"status"`
+
 	// 播放域名关联的推流域名（只有domain_type为pull的时候有效）
-
 	RelatedDomain string `json:"related_domain"`
+
 	// 域名创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间
-
 	CreateTime *sdktime.SdkTime `json:"create_time"`
+
 	// 状态描述
-
 	StatusDescribe *string `json:"status_describe,omitempty"`
-	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 
+	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 	ServiceArea *DecoupledLiveDomainInfoServiceArea `json:"service_area,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_default_record_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_default_record_config.go
@@ -7,8 +7,8 @@ import (
 )
 
 type DefaultRecordConfig struct {
-	// 录制格式，当前支持：FLV，HLS，MP4三种格式，设置格式时必须使用大写字母
 
+	// 录制格式，当前支持：FLV，HLS，MP4三种格式，设置格式时必须使用大写字母
 	RecordFormat []VideoFormatVar `json:"record_format"`
 
 	ObsAddr *RecordObsFileAddr `json:"obs_addr"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_domain_mapping_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_domain_mapping_request.go
@@ -8,14 +8,14 @@ import (
 
 // Request Object
 type DeleteDomainMappingRequest struct {
+
 	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
-
 	SpecifyProject *string `json:"specify_project,omitempty"`
+
 	// 直播播放域名
-
 	PullDomain string `json:"pull_domain"`
-	// 直播推流域名
 
+	// 直播推流域名
 	PushDomain string `json:"push_domain"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_domain_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type DeleteDomainRequest struct {
-	// 直播域名
 
+	// 直播域名
 	Domain string `json:"domain"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_record_callback_config_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_record_callback_config_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type DeleteRecordCallbackConfigRequest struct {
-	// 配置ID
 
+	// 配置ID
 	Id string `json:"id"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_record_rule_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_record_rule_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type DeleteRecordRuleRequest struct {
-	// 规则ID
 
+	// 规则ID
 	Id string `json:"id"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_stream_forbidden_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_stream_forbidden_request.go
@@ -8,17 +8,17 @@ import (
 
 // Request Object
 type DeleteStreamForbiddenRequest struct {
+
 	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
-
 	SpecifyProject *string `json:"specify_project,omitempty"`
+
 	// 推流域名
-
 	Domain string `json:"domain"`
+
 	// RTMP应用名称
-
 	AppName string `json:"app_name"`
-	// 流名称
 
+	// 流名称
 	StreamName string `json:"stream_name"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_transcodings_template_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_delete_transcodings_template_request.go
@@ -8,11 +8,11 @@ import (
 
 // Request Object
 type DeleteTranscodingsTemplateRequest struct {
+
 	// 推流域名
-
 	Domain string `json:"domain"`
-	// 应用名称
 
+	// 应用名称
 	AppName string `json:"app_name"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_domain_mapping.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_domain_mapping.go
@@ -7,11 +7,11 @@ import (
 )
 
 type DomainMapping struct {
+
 	// 直播播放域名
-
 	PullDomain string `json:"pull_domain"`
-	// 直播播放域名关联的推流域名
 
+	// 直播播放域名关联的推流域名
 	PushDomain string `json:"push_domain"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_flv_record_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_flv_record_config.go
@@ -7,14 +7,14 @@ import (
 )
 
 type FlvRecordConfig struct {
+
 	// 单位为秒，周期录制时长，最小1分钟，最大12小时。如果为0则整个流录制一个文件。
-
 	RecordCycle int32 `json:"record_cycle"`
+
 	// 录制FLV文件含路径和文件名的前缀， 默认Record/{publish_domain}/{app}/{record_type}/{record_format}/{stream}_{file_start_time}/{file_start_time}
-
 	RecordPrefix *string `json:"record_prefix,omitempty"`
-	// 录制flv拼接时长，如果流中断超过该时间，则生成新文件。单位秒。如果为0表示流中断就生成新文件。默认为0。
 
+	// 录制flv拼接时长，如果流中断超过该时间，则生成新文件。单位秒。如果为0表示流中断就生成新文件。默认为0。
 	RecordMaxDurationToMergeFile *int32 `json:"record_max_duration_to_merge_file,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_hls_record_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_hls_record_config.go
@@ -7,20 +7,20 @@ import (
 )
 
 type HlsRecordConfig struct {
+
 	// 单位为秒，周期录制时长，最小1分钟（60秒），最大12小时。如果为0则整个流录制一个文件。
-
 	RecordCycle int32 `json:"record_cycle"`
+
 	// 录制m3u8文件含路径和文件名的前缀， 默认Record/{publish_domain}/{app}/{record_type}/{record_format}/{stream}_{file_start_time}/{stream}_{file_start_time}
-
 	RecordPrefix *string `json:"record_prefix,omitempty"`
+
 	// 录制ts文件名的前缀， 默认{file_start_time_unix}_{file_end_time_unix}_{ts_sequence_number}
-
 	RecordTsPrefix *string `json:"record_ts_prefix,omitempty"`
+
 	// 录制HLS时ts的切片时长，非必须，缺省为10，单位秒，最小2，最大60
-
 	RecordSliceDuration *int32 `json:"record_slice_duration,omitempty"`
-	// 录制HLS文件拼接时长，如果流中断超过该时间，则生成新文件。单位秒。如果为0表示流中断就生成新文件，如果为-1则表示相同的流中断恢复后继续在30天内的前一个文件保存。默认为0。
 
+	// 录制HLS文件拼接时长，如果流中断超过该时间，则生成新文件。单位秒。如果为0表示流中断就生成新文件，如果为-1则表示相同的流中断恢复后继续在30天内的前一个文件保存。默认为0。
 	RecordMaxDurationToMergeFile *int32 `json:"record_max_duration_to_merge_file,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_sample_logs_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_sample_logs_request.go
@@ -9,14 +9,14 @@ import (
 
 // Request Object
 type ListLiveSampleLogsRequest struct {
+
 	// 播放域名。
-
 	PlayDomain string `json:"play_domain"`
+
 	// 查询开始时间，UTC时间：YYYY-MM-DDTHH:mm:ssZ，如北京时间2020年3月4日16点00分00秒可表示为2020-03-04T08:00:00Z。仅支持查询最近3个月内的数据。
-
 	StartTime *sdktime.SdkTime `json:"start_time"`
-	// 查询结束时间，UTC时间：YYYY-MM-DDTHH:mm:ssZ，如北京时间2020年3月4日16点00分00秒可表示为2020-03-04T08:00:00Z。查询时间跨度不能大于7天。
 
+	// 查询结束时间，UTC时间：YYYY-MM-DDTHH:mm:ssZ，如北京时间2020年3月4日16点00分00秒可表示为2020-03-04T08:00:00Z。查询时间跨度不能大于7天。
 	EndTime *sdktime.SdkTime `json:"end_time"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_sample_logs_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_sample_logs_response.go
@@ -8,14 +8,14 @@ import (
 
 // Response Object
 type ListLiveSampleLogsResponse struct {
+
 	// 符合查询条件的总条目数
-
 	Total *int32 `json:"total,omitempty"`
+
 	// 播放域名
-
 	Domain *string `json:"domain,omitempty"`
-	// 日志信息列表
 
+	// 日志信息列表
 	Logs           *[]LogInfo `json:"logs,omitempty"`
 	HttpStatusCode int        `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_streams_online_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_streams_online_request.go
@@ -8,20 +8,20 @@ import (
 
 // Request Object
 type ListLiveStreamsOnlineRequest struct {
+
 	// 推流域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// 应用名
-
 	App *string `json:"app,omitempty"`
+
 	// 偏移量，表示从此偏移量开始查询， offset大于等于0
-
 	Offset *int32 `json:"offset,omitempty"`
+
 	// 每页记录数，取值范围[1,100]，默认值10
-
 	Limit *int32 `json:"limit,omitempty"`
-	// 流名，用于单流查询，携带stream参数时app不能缺省
 
+	// 流名，用于单流查询，携带stream参数时app不能缺省
 	Stream *string `json:"stream,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_streams_online_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_live_streams_online_response.go
@@ -8,23 +8,23 @@ import (
 
 // Response Object
 type ListLiveStreamsOnlineResponse struct {
+
 	// 总条页数
-
 	TotalPage *int64 `json:"total_page,omitempty"`
+
 	// 总条目数
-
 	TotalNum *int64 `json:"total_num,omitempty"`
+
 	// 偏移量
-
 	Offset *int64 `json:"offset,omitempty"`
+
 	// 每页条目数
-
 	Limit *int64 `json:"limit,omitempty"`
+
 	// 请求唯一标识
-
 	RequestId *string `json:"request_id,omitempty"`
-	// 推流统计
 
+	// 推流统计
 	Streams        *[]OnlineInfo `json:"streams,omitempty"`
 	HttpStatusCode int           `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_callback_configs_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_callback_configs_request.go
@@ -8,17 +8,17 @@ import (
 
 // Request Object
 type ListRecordCallbackConfigsRequest struct {
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 流应用名称
-
 	App *string `json:"app,omitempty"`
+
 	// 偏移量，表示从此偏移量开始查询，offset大于等于0
-
 	Offset *int32 `json:"offset,omitempty"`
-	// 每页记录数，取值范围[1,100]，默认值10
 
+	// 每页记录数，取值范围[1,100]，默认值10
 	Limit *int32 `json:"limit,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_callback_configs_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_callback_configs_response.go
@@ -8,11 +8,11 @@ import (
 
 // Response Object
 type ListRecordCallbackConfigsResponse struct {
+
 	// 查询结果的总元素数量
-
 	Total *int32 `json:"total,omitempty"`
-	// 回调配置
 
+	// 回调配置
 	CallbackConfig *[]RecordCallbackConfig `json:"callback_config,omitempty"`
 	HttpStatusCode int                     `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_contents_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_contents_request.go
@@ -11,29 +11,29 @@ import (
 
 // Request Object
 type ListRecordContentsRequest struct {
+
 	// 直播推流放域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 流应用名称
-
 	App *string `json:"app,omitempty"`
+
 	// 流名称
-
 	Stream *string `json:"stream,omitempty"`
+
 	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD，ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD：持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD：命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。 - PLAN_RECORD：计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD：按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。
-
 	RecordType *ListRecordContentsRequestRecordType `json:"record_type,omitempty"`
+
 	// 开始时间,格式为：yyyy-mm-ddThh:mm:ssZ，UTC时间
-
 	StartTime string `json:"start_time"`
+
 	// 结束时间，格式为：yyyy-mm-ddThh:mm:ssZ，UTC时间
-
 	EndTime *string `json:"end_time,omitempty"`
+
 	// 分页编号，从0开始算
-
 	Offset *int32 `json:"offset,omitempty"`
-	// 每页记录数，取值范围[1,100]
 
+	// 每页记录数，取值范围[1,100]
 	Limit *int32 `json:"limit,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_contents_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_contents_response.go
@@ -8,11 +8,11 @@ import (
 
 // Response Object
 type ListRecordContentsResponse struct {
+
 	// 查询结果的总元素数量
-
 	Total *int32 `json:"total,omitempty"`
-	// 录制内容数组
 
+	// 录制内容数组
 	RecordContents *[]RecordContentInfoV2 `json:"record_contents,omitempty"`
 
 	XRequestId     *string `json:"X-request-id,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_rules_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_rules_request.go
@@ -11,23 +11,23 @@ import (
 
 // Request Object
 type ListRecordRulesRequest struct {
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 流应用名称
-
 	App *string `json:"app,omitempty"`
+
 	// 流名称
-
 	Stream *string `json:"stream,omitempty"`
+
 	// 录制类型，如果不填写则查询所有录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD，ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD：持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD：命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。 - PLAN_RECORD：计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD：按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。
-
 	RecordType *ListRecordRulesRequestRecordType `json:"record_type,omitempty"`
+
 	// 偏移量，表示从此偏移量开始查询，offset大于等于0
-
 	Offset *int32 `json:"offset,omitempty"`
-	// 每页记录数，取值范围[1,100]，默认值10
 
+	// 每页记录数，取值范围[1,100]，默认值10
 	Limit *int32 `json:"limit,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_rules_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_record_rules_response.go
@@ -8,11 +8,11 @@ import (
 
 // Response Object
 type ListRecordRulesResponse struct {
+
 	// 查询结果的总元素数量
-
 	Total *int32 `json:"total,omitempty"`
-	// 录制配置数组
 
+	// 录制配置数组
 	RecordConfig   *[]RecordRule `json:"record_config,omitempty"`
 	HttpStatusCode int           `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_stream_forbidden_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_stream_forbidden_request.go
@@ -8,23 +8,23 @@ import (
 
 // Request Object
 type ListStreamForbiddenRequest struct {
+
 	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
-
 	SpecifyProject *string `json:"specify_project,omitempty"`
+
 	// 推流域名
-
 	Domain string `json:"domain"`
+
 	// 应用名称，不指定则查询domain下所有应用的禁止直播推流信息
-
 	AppName *string `json:"app_name,omitempty"`
+
 	// 流名称
-
 	StreamName *string `json:"stream_name,omitempty"`
+
 	// 分页编号。 默认为0。
-
 	Page *int32 `json:"page,omitempty"`
-	// 每页记录数。  取值范围：1-100。  默认为10。
 
+	// 每页记录数。  取值范围：1-100。  默认为10。
 	Size *int32 `json:"size,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_stream_forbidden_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_list_stream_forbidden_response.go
@@ -8,11 +8,11 @@ import (
 
 // Response Object
 type ListStreamForbiddenResponse struct {
+
 	// 查询结果的总元素数量
-
 	Total *int32 `json:"total,omitempty"`
-	// 禁播黑名单列表
 
+	// 禁播黑名单列表
 	Blocks         *[]StreamForbiddenList `json:"blocks,omitempty"`
 	HttpStatusCode int                    `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_live_domain_create_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_live_domain_create_req.go
@@ -10,17 +10,17 @@ import (
 )
 
 type LiveDomainCreateReq struct {
+
 	// 直播域名
-
 	Domain string `json:"domain"`
+
 	// 域名类型 - pull表示播放域名 - push表示推流域名
-
 	DomainType LiveDomainCreateReqDomainType `json:"domain_type"`
+
 	// 直播所属的直播中心
-
 	Region string `json:"region"`
-	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 
+	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 	ServiceArea *LiveDomainCreateReqServiceArea `json:"service_area,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_live_domain_modify_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_live_domain_modify_req.go
@@ -10,11 +10,11 @@ import (
 )
 
 type LiveDomainModifyReq struct {
+
 	// 直播域名，不允许修改
-
 	Domain string `json:"domain"`
-	// 直播域名状态，通过修改此字段，实现域名的启用和停用。注意：域名处于“配置中”状态时，不允对该域名执行启停操作。
 
+	// 直播域名状态，通过修改此字段，实现域名的启用和停用。注意：域名处于“配置中”状态时，不允对该域名执行启停操作。
 	Status *LiveDomainModifyReqStatus `json:"status,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_log_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_log_info.go
@@ -7,20 +7,20 @@ import (
 )
 
 type LogInfo struct {
+
 	// 日志文件名，打包文件名格式：{Domain}_{logStartTimeStamp}.log.gz
-
 	Name string `json:"name"`
+
 	// 日志下载链接
-
 	Url string `json:"url"`
+
 	// 日志文件大小
-
 	Size int64 `json:"size"`
+
 	// 日志文件中日志开始时间，北京时间
-
 	StartTime string `json:"start_time"`
-	// 日志文件中日志结束时间，北京时间
 
+	// 日志文件中日志结束时间，北京时间
 	EndTime string `json:"end_time"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_mp4_record_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_mp4_record_config.go
@@ -7,14 +7,14 @@ import (
 )
 
 type Mp4RecordConfig struct {
+
 	// 单位为秒，周期录制时长，最小1分钟，最大12小时。如果为0则整个流录制一个文件。
-
 	RecordCycle int32 `json:"record_cycle"`
+
 	// 录制文件含路径和文件名的前缀， 默认Record/{publish_domain}/{app}/{record_type}/{record_format}/{stream}_{file_start_time}/{file_start_time}
-
 	RecordPrefix *string `json:"record_prefix,omitempty"`
-	// 录制mp4拼接时长，如果流中断超过该时间，则生成新文件。单位秒。如果为0表示流中断就生成新文件。默认为0。
 
+	// 录制mp4拼接时长，如果流中断超过该时间，则生成新文件。单位秒。如果为0表示流中断就生成新文件。默认为0。
 	RecordMaxDurationToMergeFile *int32 `json:"record_max_duration_to_merge_file,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_online_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_online_info.go
@@ -10,41 +10,41 @@ import (
 )
 
 type OnlineInfo struct {
+
 	// 域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// 应用名
-
 	App string `json:"app"`
+
 	// 流名
-
 	Stream string `json:"stream"`
+
 	// 视频编码方式 - H264 - H265
-
 	VideoCodec OnlineInfoVideoCodec `json:"video_codec"`
+
 	// 音频编码方式 - AAC
-
 	AudioCodec OnlineInfoAudioCodec `json:"audio_codec"`
+
 	// 视频帧率
-
 	VideoFrameRate *int64 `json:"video_frame_rate,omitempty"`
+
 	// 音频帧率
-
 	AudioFrameRate *int64 `json:"audio_frame_rate,omitempty"`
+
 	// 视频码率
-
 	VideoBitrate *int64 `json:"video_bitrate,omitempty"`
+
 	// 音频码率
-
 	AudioBitrate *int64 `json:"audio_bitrate,omitempty"`
+
 	// 视频分辨率
-
 	Resolution *string `json:"resolution,omitempty"`
+
 	// 推流设备的ip
-
 	ClientIp string `json:"client_ip"`
-	// 开始推流时刻 UTC格式 2006-01-02T15:04:05Z
 
+	// 开始推流时刻 UTC格式 2006-01-02T15:04:05Z
 	StartTime string `json:"start_time"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_quality_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_quality_info.go
@@ -10,41 +10,41 @@ import (
 )
 
 type QualityInfo struct {
+
 	// 模板名称。
-
 	TemplateName *string `json:"templateName,omitempty"`
+
 	// 包含如下取值： - FHD： 超高清，系统缺省名称 - HD： 高清，系统缺省名称 - SD： 标清，系统缺省名称 - LD： 流畅，系统缺省名称 - XXX： 租户自定义名称。用户自定义名称不能与系统缺省名称冲突；多个自定义名称不能重复
-
 	Quality string `json:"quality"`
+
 	// 是否使用窄带高清转码，模板组里不同模板的PVC选项必须相同。 - on：启用。 - off：不启用。 默认为off
-
 	Pvc *QualityInfoPvc `json:"PVC,omitempty"`
+
 	// 是否启用高清低码，较PVC相比画质增强。 - on：启用。 - off：不启用。 默认为off。
-
 	Hdlb *QualityInfoHdlb `json:"hdlb,omitempty"`
+
 	// 视频编码格式，模板组里不同模板的编码格式必须相同。 - H264：使用H.264。 - H265：使用H.265。 默认为H264。
-
 	Codec *QualityInfoCodec `json:"codec,omitempty"`
+
 	// 视频宽度（单位：像素） - H264   取值范围：32-3840，必须为2的倍数 。 - H265   取值范围：320-3840 ，必须为4的倍数。
-
 	Width int32 `json:"width"`
+
 	// 视频高度（单位：像素） - H264   取值范围：32-2160，必须为2的倍数。 - H265   取值范围：240-2160，必须为4的倍数。
-
 	Height int32 `json:"height"`
+
 	// 转码视频的码率（单位：Kbps）。 取值范围：40-30000。
-
 	Bitrate int32 `json:"bitrate"`
+
 	// 转码视频帧率（单位：fps）。 取值范围：0-30，0表示保持帧率不变。
-
 	VideoFrameRate *int32 `json:"video_frame_rate,omitempty"`
+
 	// 转码输出支持的协议类型。当前只支持RTMP和HLS，且模板组里不同模板的输出协议类型必须相同。 - RTMP - HLS - DASH  默认为RTMP。
-
 	Protocol *QualityInfoProtocol `json:"protocol,omitempty"`
+
 	// I帧间隔（单位：帧）。  取值范围：0-500。  默认为25。
-
 	IFrameInterval *int32 `json:"iFrameInterval,omitempty"`
-	// 按时间设置I帧间隔，与“iFrameInterval”选择一个设置即可。  取值范围：[0,10]  默认值：4
 
+	// 按时间设置I帧间隔，与“iFrameInterval”选择一个设置即可。  取值范围：[0,10]  默认值：4
 	Gop *int32 `json:"gop,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_callback_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_callback_config.go
@@ -10,29 +10,29 @@ import (
 )
 
 type RecordCallbackConfig struct {
+
 	// 配置id，由服务端返回。创建或修改的时候不携带
-
 	Id *string `json:"id,omitempty"`
+
 	// 直播推流域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// app名称。如果匹配任意需填写为*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App string `json:"app"`
+
 	// 录制回调通知url地址
-
 	NotifyCallbackUrl *string `json:"notify_callback_url,omitempty"`
+
 	// 订阅录制通知消息。消息类型。RECORD_NEW_FILE_START开始创建新的录制文件。RECORD_FILE_COMPLETE录制文件生成完成。RECORD_OVER录制结束。RECORD_FAILED表示录制失败。如果不填写,默认订阅RECORD_FILE_COMPLETE
-
 	NotifyEventSubscription *[]RecordCallbackConfigNotifyEventSubscription `json:"notify_event_subscription,omitempty"`
+
 	// 加密类型
-
 	SignType *RecordCallbackConfigSignType `json:"sign_type,omitempty"`
+
 	// 创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
-
 	CreateTime *string `json:"create_time,omitempty"`
-	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 
+	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 	UpdateTime *string `json:"update_time,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_callback_config_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_callback_config_request.go
@@ -10,20 +10,20 @@ import (
 )
 
 type RecordCallbackConfigRequest struct {
+
 	// 直播推流域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// app名称。如果需要匹配任意应用则需填写*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App string `json:"app"`
+
 	// 录制回调通知url地址
-
 	NotifyCallbackUrl *string `json:"notify_callback_url,omitempty"`
+
 	// 订阅录制通知消息。消息类型。RECORD_NEW_FILE_START开始创建新的录制文件。RECORD_FILE_COMPLETE录制文件生成完成。RECORD_OVER录制结束。RECORD_FAILED表示录制失败。如果不填写,默认订阅RECORD_FILE_COMPLETE
-
 	NotifyEventSubscription *[]RecordCallbackConfigRequestNotifyEventSubscription `json:"notify_event_subscription,omitempty"`
-	// 加密类型
 
+	// 加密类型
 	SignType *RecordCallbackConfigRequestSignType `json:"sign_type,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_content_info_v2.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_content_info_v2.go
@@ -10,39 +10,39 @@ import (
 )
 
 type RecordContentInfoV2 struct {
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 录制文件名
-
 	FileName *string `json:"file_name,omitempty"`
+
 	// 应用名
-
 	App *string `json:"app,omitempty"`
+
 	// 录制的流名
-
 	Stream *string `json:"stream,omitempty"`
+
 	// 录制格式flv，hls，mp4
-
 	RecordFormat *RecordContentInfoV2RecordFormat `json:"record_format,omitempty"`
-	// 录制类型，CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD：持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD：命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。 - PLAN_RECORD：计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD：按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。
 
+	// 录制类型，CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD：持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD：命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。 - PLAN_RECORD：计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD：按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。
 	RecordType *RecordContentInfoV2RecordType `json:"record_type,omitempty"`
 
 	ObsAddr *RecordObsFileAddr `json:"obs_addr,omitempty"`
 
 	VodInfo *VodInfoV2 `json:"vod_info,omitempty"`
+
 	// OBS下载地址
-
 	DownloadUrl *string `json:"download_url,omitempty"`
+
 	// 录制开始时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。对record_type为PLAN_RECORD有效
-
 	StartTime *string `json:"start_time,omitempty"`
+
 	// 录制结束时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。对record_type为PLAN_RECORD有效
-
 	EndTime *string `json:"end_time,omitempty"`
-	// 该录制文件时长，单位为秒
 
+	// 该录制文件时长，单位为秒
 	Duration *int32 `json:"duration,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_control_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_control_info.go
@@ -7,14 +7,14 @@ import (
 )
 
 type RecordControlInfo struct {
+
 	// 直播推流域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// 应用名
-
 	App string `json:"app"`
-	// 待启动或停止录制的流名
 
+	// 待启动或停止录制的流名
 	Stream string `json:"stream"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_obs_file_addr.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_obs_file_addr.go
@@ -10,14 +10,14 @@ import (
 )
 
 type RecordObsFileAddr struct {
+
 	// OBS的bucket名称
-
 	Bucket string `json:"bucket"`
+
 	// OBS Bucket所在RegionID
-
 	Location RecordObsFileAddrLocation `json:"location"`
-	// OBS对象路径，遵守OBS Object定义。如果为空则保存到根目录
 
+	// OBS对象路径，遵守OBS Object定义。如果为空则保存到根目录
 	Object string `json:"object"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_rule.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_rule.go
@@ -10,28 +10,28 @@ import (
 )
 
 type RecordRule struct {
+
 	// 规则id，由服务端返回。创建或修改的时候不携带
-
 	Id *string `json:"id,omitempty"`
+
 	// 直播推流域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// 应用名，如果任意应用填写*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App string `json:"app"`
+
 	// 录制的流名，如果任意流名则填写*。录制规则匹配的时候，优先精确stream匹配，如果匹配不到，则匹配*
-
 	Stream string `json:"stream"`
-	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 
+	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 	RecordType *RecordRuleRecordType `json:"record_type,omitempty"`
 
 	DefaultRecordConfig *DefaultRecordConfig `json:"default_record_config,omitempty"`
+
 	// 创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
-
 	CreateTime *string `json:"create_time,omitempty"`
-	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 
+	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 	UpdateTime *string `json:"update_time,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_rule_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_record_rule_request.go
@@ -10,17 +10,17 @@ import (
 )
 
 type RecordRuleRequest struct {
+
 	// 直播推流域名
-
 	PublishDomain string `json:"publish_domain"`
+
 	// 应用名，如需匹配任意应用则填写*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App string `json:"app"`
+
 	// 录制的流名，如需匹配任流名则填写*。录制规则匹配的时候，优先精确stream匹配，如果匹配不到，则匹配*
-
 	Stream string `json:"stream"`
-	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD，ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD：持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD：命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。 - PLAN_RECORD：计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD：按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。
 
+	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD，ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD：持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD：命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。 - PLAN_RECORD：计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD：按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。
 	RecordType *RecordRuleRequestRecordType `json:"record_type,omitempty"`
 
 	DefaultRecordConfig *DefaultRecordConfig `json:"default_record_config"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_run_record_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_run_record_request.go
@@ -11,8 +11,8 @@ import (
 
 // Request Object
 type RunRecordRequest struct {
-	// 操作行为。 取值如下： - START：对指定流开始录制，必须在直播流已经推送情况下才能正常启动，使用此命令启动录制的直播流如果发生了断流且超出断流时长，就会停止录制，并且重新推流后不会自动启动录制。 - STOP：对指定流停止录制。
 
+	// 操作行为。 取值如下： - START：对指定流开始录制，必须在直播流已经推送情况下才能正常启动，使用此命令启动录制的直播流如果发生了断流且超出断流时长，就会停止录制，并且重新推流后不会自动启动录制。 - STOP：对指定流停止录制。
 	Action RunRecordRequestAction `json:"action"`
 
 	Body *RecordControlInfo `json:"body,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_domain_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type ShowDomainRequest struct {
-	// 直播域名，如果不设置此字段，则返回租户所有的域名信息
 
+	// 直播域名，如果不设置此字段，则返回租户所有的域名信息
 	Domain *string `json:"domain,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_domain_response.go
@@ -8,11 +8,11 @@ import (
 
 // Response Object
 type ShowDomainResponse struct {
+
 	// 查询结果的总数量
-
 	Total float32 `json:"total,omitempty"`
-	// 直播域名列表
 
+	// 直播域名列表
 	DomainInfo     *[]DecoupledLiveDomainInfo `json:"domain_info,omitempty"`
 	HttpStatusCode int                        `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_callback_config_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_callback_config_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type ShowRecordCallbackConfigRequest struct {
-	// 配置ID
 
+	// 配置ID
 	Id string `json:"id"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_callback_config_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_callback_config_response.go
@@ -11,29 +11,29 @@ import (
 
 // Response Object
 type ShowRecordCallbackConfigResponse struct {
+
 	// 配置id，由服务端返回。创建或修改的时候不携带
-
 	Id *string `json:"id,omitempty"`
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// app名称。如果匹配任意需填写为*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App *string `json:"app,omitempty"`
+
 	// 录制回调通知url地址
-
 	NotifyCallbackUrl *string `json:"notify_callback_url,omitempty"`
+
 	// 订阅录制通知消息。消息类型。RECORD_NEW_FILE_START开始创建新的录制文件。RECORD_FILE_COMPLETE录制文件生成完成。RECORD_OVER录制结束。RECORD_FAILED表示录制失败。如果不填写,默认订阅RECORD_FILE_COMPLETE
-
 	NotifyEventSubscription *[]ShowRecordCallbackConfigResponseNotifyEventSubscription `json:"notify_event_subscription,omitempty"`
+
 	// 加密类型
-
 	SignType *ShowRecordCallbackConfigResponseSignType `json:"sign_type,omitempty"`
+
 	// 创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
-
 	CreateTime *string `json:"create_time,omitempty"`
-	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 
+	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 	UpdateTime     *string `json:"update_time,omitempty"`
 	HttpStatusCode int     `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_rule_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_rule_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type ShowRecordRuleRequest struct {
-	// 规则ID
 
+	// 规则ID
 	Id string `json:"id"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_rule_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_record_rule_response.go
@@ -11,28 +11,28 @@ import (
 
 // Response Object
 type ShowRecordRuleResponse struct {
+
 	// 规则id，由服务端返回。创建或修改的时候不携带
-
 	Id *string `json:"id,omitempty"`
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 应用名，如果任意应用填写*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App *string `json:"app,omitempty"`
+
 	// 录制的流名，如果任意流名则填写*。录制规则匹配的时候，优先精确stream匹配，如果匹配不到，则匹配*
-
 	Stream *string `json:"stream,omitempty"`
-	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 
+	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 	RecordType *ShowRecordRuleResponseRecordType `json:"record_type,omitempty"`
 
 	DefaultRecordConfig *DefaultRecordConfig `json:"default_record_config,omitempty"`
+
 	// 创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
-
 	CreateTime *string `json:"create_time,omitempty"`
-	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 
+	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 	UpdateTime     *string `json:"update_time,omitempty"`
 	HttpStatusCode int     `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_transcodings_template_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_transcodings_template_request.go
@@ -8,17 +8,17 @@ import (
 
 // Request Object
 type ShowTranscodingsTemplateRequest struct {
+
 	// 推流域名
-
 	Domain string `json:"domain"`
+
 	// 应用名称
-
 	AppName *string `json:"app_name,omitempty"`
+
 	// 分页编号，默认为0。
-
 	Page *int32 `json:"page,omitempty"`
-	// 每页记录数。  取值范围：1-100。  默认为10。
 
+	// 每页记录数。  取值范围：1-100。  默认为10。
 	Size *int32 `json:"size,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_transcodings_template_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_show_transcodings_template_response.go
@@ -8,14 +8,14 @@ import (
 
 // Response Object
 type ShowTranscodingsTemplateResponse struct {
+
 	// 查询结果的总元素数量
-
 	Total *int32 `json:"total,omitempty"`
+
 	// 播放域名
-
 	Domain *string `json:"domain,omitempty"`
-	// 转码模板
 
+	// 转码模板
 	Templates      *[]AppQualityInfo `json:"templates,omitempty"`
 	HttpStatusCode int               `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_stream_forbidden_list.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_stream_forbidden_list.go
@@ -7,14 +7,14 @@ import (
 )
 
 type StreamForbiddenList struct {
+
 	// 流应用名称
-
 	AppName string `json:"app_name"`
+
 	// 流名称
-
 	StreamName string `json:"stream_name"`
-	// 恢复流时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间，不指定则默认7天，最大禁推为90天
 
+	// 恢复流时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间，不指定则默认7天，最大禁推为90天
 	ResumeTime *string `json:"resume_time,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_stream_forbidden_setting.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_stream_forbidden_setting.go
@@ -8,17 +8,17 @@ import (
 )
 
 type StreamForbiddenSetting struct {
+
 	// 推流域名
-
 	Domain string `json:"domain"`
+
 	// 流应用名称
-
 	AppName string `json:"app_name"`
+
 	// 流名称
-
 	StreamName string `json:"stream_name"`
-	// 恢复流时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间，不指定则默认7天，最大禁推为90天
 
+	// 恢复流时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间，不指定则默认7天，最大禁推为90天
 	ResumeTime *sdktime.SdkTime `json:"resume_time,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_stream_transcoding_template.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_stream_transcoding_template.go
@@ -7,14 +7,14 @@ import (
 )
 
 type StreamTranscodingTemplate struct {
+
 	// 推流域名
-
 	Domain string `json:"domain"`
+
 	// 应用名称。 默认为“live”，若您需要自定义应用名称，请先提交工单申请。
-
 	AppName string `json:"app_name"`
-	// 视频质量信息
 
+	// 视频质量信息
 	QualityInfo []QualityInfo `json:"quality_info"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_domain_response.go
@@ -10,29 +10,29 @@ import (
 
 // Response Object
 type UpdateDomainResponse struct {
+
 	// 直播域名
-
 	Domain *string `json:"domain,omitempty"`
+
 	// 域名类型 - pull表示播放域名 - push表示推流域名
-
 	DomainType *UpdateDomainResponseDomainType `json:"domain_type,omitempty"`
+
 	// 直播域名的CNAME
-
 	DomainCname *string `json:"domain_cname,omitempty"`
+
 	// 直播所属直播中心
-
 	Region *string `json:"region,omitempty"`
+
 	// 直播域名的状态
-
 	Status *UpdateDomainResponseStatus `json:"status,omitempty"`
+
 	// 域名创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间
-
 	CreateTime *sdktime.SdkTime `json:"create_time,omitempty"`
+
 	// 状态描述
-
 	StatusDescribe *string `json:"status_describe,omitempty"`
-	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 
+	// 域名应用区域 - mainland_china表示中国大陆区域 - outside_mainland_china表示中国大陆以外区域 - global表示全球区域
 	ServiceArea    *UpdateDomainResponseServiceArea `json:"service_area,omitempty"`
 	HttpStatusCode int                              `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_record_callback_config_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_record_callback_config_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type UpdateRecordCallbackConfigRequest struct {
-	// 配置ID，在创建配置成功后返回
 
+	// 配置ID，在创建配置成功后返回
 	Id string `json:"id"`
 
 	Body *RecordCallbackConfigRequest `json:"body,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_record_rule_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_record_rule_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type UpdateRecordRuleRequest struct {
-	// 规则ID，在创建成功规则后返回
 
+	// 规则ID，在创建成功规则后返回
 	Id string `json:"id"`
 
 	Body *RecordRuleRequest `json:"body,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_record_rule_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_record_rule_response.go
@@ -11,28 +11,28 @@ import (
 
 // Response Object
 type UpdateRecordRuleResponse struct {
+
 	// 规则id，由服务端返回。创建或修改的时候不携带
-
 	Id *string `json:"id,omitempty"`
+
 	// 直播推流域名
-
 	PublishDomain *string `json:"publish_domain,omitempty"`
+
 	// 应用名，如果任意应用填写*。录制规则匹配的时候，优先精确app匹配，如果匹配不到，则匹配*
-
 	App *string `json:"app,omitempty"`
+
 	// 录制的流名，如果任意流名则填写*。录制规则匹配的时候，优先精确stream匹配，如果匹配不到，则匹配*
-
 	Stream *string `json:"stream,omitempty"`
-	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 
+	// 录制类型，包括：CONTINUOUS_RECORD，COMMAND_RECORD，PLAN_RECORD, ON_DEMAND_RECORD。默认CONTINUOUS_RECORD。 - CONTINUOUS_RECORD: 持续录制，在该规则类型配置后，只要有流到推送到录制系统，就触发录制。 - COMMAND_RECORD: 命令录制，在该规则类型配置后，在流推送到录制系统后，租户需要通过命令控制该流的录制开始和结束。命令控制的接口参考/v1/{project_id}/record/control - PLAN_RECORD: 计划录制，在该规则类型配置后，推的流如果在计划录制的时间区间则触发录制。 - ON_DEMAND_RECORD: 按需录制，在该规则类型配置后，录制系统收到推流后，需要调用租户提供的接口查询录制规则，并根据规则录制。租户提供的接口定义参考：/customer-record-ondemand-url
 	RecordType *UpdateRecordRuleResponseRecordType `json:"record_type,omitempty"`
 
 	DefaultRecordConfig *DefaultRecordConfig `json:"default_record_config,omitempty"`
+
 	// 创建时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
-
 	CreateTime *string `json:"create_time,omitempty"`
-	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 
+	// 修改时间，格式：yyyy-mm-ddThh:mm:ssZ，UTC时间。 在查询的时候返回
 	UpdateTime     *string `json:"update_time,omitempty"`
 	HttpStatusCode int     `json:"-"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_stream_forbidden_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_update_stream_forbidden_request.go
@@ -8,8 +8,8 @@ import (
 
 // Request Object
 type UpdateStreamForbiddenRequest struct {
-	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
 
+	// op账号需要携带的特定project_id，当使用op账号时该值为所操作租户的project_id
 	SpecifyProject *string `json:"specify_project,omitempty"`
 
 	Body *StreamForbiddenSetting `json:"body,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_vod_info_v2.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model/model_vod_info_v2.go
@@ -7,11 +7,11 @@ import (
 )
 
 type VodInfoV2 struct {
+
 	// VOD媒资id
-
 	AssetId string `json:"asset_id"`
-	// 点播播放地址
 
+	// 点播播放地址
 	PlayUrl *string `json:"play_url,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. add a new resource for callback configuration.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run=TestAccRecordCallback_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run=TestAccRecordCallback_basic -timeout 360m -parallel 4
=== RUN   TestAccRecordCallback_basic
--- PASS: TestAccRecordCallback_basic (330.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      330.416s
```
