### PR TITLE
feat(prepaid): add autopay support for DCS ELB EVS GaussDB CCE

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -189,6 +189,10 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are **true** and
   **false**. Changing this parameter will create a new cluster resource.
 
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this creates a new cluster resource.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of the CCE cluster.
   Changing this parameter will create a new cluster resource.
 

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -294,6 +294,10 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are "true" and "
   false". Changing this creates a new resource.
 
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this creates a new resource.
+
 * `runtime` - (Optional, String, ForceNew) Specifies the runtime of the CCE node. Valid values are *docker* and
   *containerd*. Changing this creates a new resource.
 

--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -201,6 +201,10 @@ The following arguments are supported:
   Valid values are `true` and `false`, defaults to `false`.
   Changing this creates a new instance.
 
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this creates a new instance.
+
 * `tags` - (Optional, Map) The key/value pairs to associate with the dcs instance.
 
 * `access_user` - (Optional, String, ForceNew) Specifies the username used for accessing a DCS Memcached instance.

--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -156,6 +156,10 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are **true** and
   **false**. Changing this parameter will create a new resource.
 
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this will create a new resource.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -129,6 +129,10 @@ The following arguments are supported:
   Valid values are **true** and **false**.
   Changing this creates a new disk.
 
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this creates a new disk.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -111,6 +111,10 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
   Valid values are "true" and "false". Changing this will do nothing.
 
+* `auto_pay` - (Optional, String) Specifies whether auto pay is enabled.
+  Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
+  yourself in time, be careful about the timeout of resource creation. Changing this will do nothing.
+
 * `datastore` - (Optional, List, ForceNew) Specifies the database information. Structure is documented below. Changing
   this parameter will create a new resource.
 

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -185,3 +185,10 @@ func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
 		return false
 	}
 }
+
+func GetAutoPay(d *schema.ResourceData) string {
+	if d.Get("auto_pay").(string) == "false" {
+		return "false"
+	}
+	return "true"
+}

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3.go
@@ -220,11 +220,12 @@ func ResourceCCEClusterV3() *schema.Resource {
 			},
 			"tags": tagsForceNewSchema(),
 
-			// charge info: charging_mode, period_unit, period, auto_renew
+			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
 			"charging_mode": schemaChargingMode(nil),
 			"period_unit":   schemaPeriodUnit(nil),
 			"period":        schemaPeriod(nil),
 			"auto_renew":    schemaAutoRenew(nil),
+			"auto_pay":      schemaAutoPay(nil),
 
 			"delete_efs": associateDeleteSchema,
 			"delete_eni": associateDeleteSchema,
@@ -343,8 +344,8 @@ func resourceClusterExtendParamV3(d *schema.ResourceData, config *config.Config)
 		billingMode = v.(int)
 	}
 	if isPrePaid || billingMode == 1 {
-		extendParam["isAutoPay"] = "true"
 		extendParam["isAutoRenew"] = "false"
+		extendParam["isAutoPay"] = common.GetAutoPay(d)
 	}
 
 	if v, ok := d.GetOk("period_unit"); ok {

--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
@@ -53,6 +53,31 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 	})
 }
 
+func TestAccCCEClusterV3_prePaid(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3_prePaid(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCCEClusterV3_withEip(t *testing.T) {
 	var cluster clusters.Clusters
 
@@ -237,6 +262,30 @@ resource "huaweicloud_vpc_subnet" "test" {
   vpc_id        = huaweicloud_vpc.test.id
 }
 `, rName, rName)
+}
+
+func testAccCCEClusterV3_prePaid(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  service_network_cidr   = "10.248.0.0/16"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = "1"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCCEClusterV3_Base(rName), rName)
 }
 
 func testAccCCEClusterV3_basic(rName string) string {

--- a/huaweicloud/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_v3.go
@@ -397,11 +397,12 @@ func ResourceCCENodeV3() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			// charge info: charging_mode, period_unit, period, auto_renew
+			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
 			"charging_mode": schemaChargingMode(nil),
 			"period_unit":   schemaPeriodUnit(nil),
 			"period":        schemaPeriod(nil),
 			"auto_renew":    schemaAutoRenew(nil),
+			"auto_pay":      schemaAutoPay(nil),
 
 			"extend_param": {
 				Type:     schema.TypeMap,
@@ -585,8 +586,8 @@ func resourceCCEExtendParam(d *schema.ResourceData) map[string]interface{} {
 	}
 	if isPrePaid || billingMode == 2 {
 		extendParam["chargingMode"] = 2
-		extendParam["isAutoPay"] = "true"
 		extendParam["isAutoRenew"] = "false"
+		extendParam["isAutoPay"] = common.GetAutoPay(d)
 	}
 
 	if v, ok := d.GetOk("period_unit"); ok {

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -516,11 +516,7 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 			extendParam.PeriodType = d.Get("period_unit").(string)
 			extendParam.PeriodNum = d.Get("period").(int)
 			extendParam.IsAutoRenew = d.Get("auto_renew").(string)
-			if d.Get("auto_pay").(string) == "false" {
-				extendParam.IsAutoPay = "false"
-			} else {
-				extendParam.IsAutoPay = "true"
-			}
+			extendParam.IsAutoPay = common.GetAutoPay(d)
 		}
 
 		epsID := GetEnterpriseProjectID(d, config)
@@ -1022,10 +1018,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 		}
 
 		extendParam := &cloudservers.ResizeExtendParam{
-			AutoPay: "true",
-		}
-		if d.Get("auto_pay").(string) == "false" {
-			extendParam.AutoPay = "false"
+			AutoPay: common.GetAutoPay(d),
 		}
 		resizeOpts := &cloudservers.ResizeOpts{
 			FlavorRef:   newFlavorId,
@@ -1074,9 +1067,9 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 			},
 		}
 
-		if strings.EqualFold(d.Get("charging_mode").(string), "prePaid") && d.Get("auto_pay").(string) == "true" {
+		if strings.EqualFold(d.Get("charging_mode").(string), "prePaid") {
 			extendOpts.ChargeInfo = &cloudvolumes.ExtendChargeOpts{
-				IsAutoPay: "true",
+				IsAutoPay: common.GetAutoPay(d),
 			}
 		}
 

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -236,6 +236,7 @@ func ResourceDcsInstance() *schema.Resource {
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenew(nil),
+			"auto_pay":      common.SchemaAutoPay(nil),
 			"tags":          common.TagsSchema(),
 			"order_id": {
 				Type:     schema.TypeString,
@@ -420,9 +421,9 @@ func buildBssParamParams(d *schema.ResourceData) instances.DcsBssParam {
 	}
 	if strings.EqualFold(bp.ChargingMode, chargeModePrePaid) {
 		bp.IsAutoRenew = d.Get("auto_renew").(string)
-		bp.IsAutoPay = "true"
 		bp.PeriodType = d.Get("period_unit").(string)
 		bp.PeriodNum = d.Get("period").(int)
+		bp.IsAutoPay = common.GetAutoPay(d)
 	}
 	return bp
 }
@@ -888,7 +889,7 @@ func resizeDcsInstance(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 		if d.Get("charging_mode").(string) == chargeModePrePaid {
 			opts.BssParam = instances.DcsBssParamOpts{
-				IsAutoPay: "true",
+				IsAutoPay: common.GetAutoPay(d),
 			}
 		}
 		logp.Printf("[DEBUG] Resize DCS dcs instance options : %#v", opts)

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -232,11 +232,7 @@ func resourceVpcEIPV1Create(d *schema.ResourceData, meta interface{}) error {
 			PeriodType:  d.Get("period_unit").(string),
 			PeriodNum:   d.Get("period").(int),
 			IsAutoRenew: d.Get("auto_renew").(string),
-		}
-		if d.Get("auto_pay").(string) == "false" {
-			chargeInfo.IsAutoPay = "false"
-		} else {
-			chargeInfo.IsAutoPay = "true"
+			IsAutoPay:   common.GetAutoPay(d),
 		}
 		createOpts.ExtendParam = chargeInfo
 	}
@@ -398,10 +394,7 @@ func resourceVpcEIPV1Update(d *schema.ResourceData, meta interface{}) error {
 				Size: newMap["size"].(int),
 			}
 			extendParam := &bandwidthsv2.ExtendParam{
-				IsAutoPay: "true",
-			}
-			if d.Get("auto_pay").(string) == "false" {
-				extendParam.IsAutoPay = "false"
+				IsAutoPay: common.GetAutoPay(d),
 			}
 			updateOpts := bandwidthsv2.UpdateOpts{
 				Bandwidth:   bandwidth,

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -165,11 +165,12 @@ func ResourceLoadBalancerV3() *schema.Resource {
 
 			"tags": common.TagsSchema(),
 
-			// charge info: charging_mode, period_unit, period, auto_renew
+			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
 			"charging_mode": common.SchemaChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenew(nil),
+			"auto_pay":      common.SchemaAutoPay(nil),
 
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
@@ -259,7 +260,9 @@ func resourceLoadBalancerV3Create(ctx context.Context, d *schema.ResourceData, m
 			PeriodType: d.Get("period_unit").(string),
 			PeriodNum:  d.Get("period").(int),
 			AutoRenew:  autoRenew,
-			AutoPay:    true,
+		}
+		if d.Get("auto_pay").(string) != "false" {
+			prepaidOpts.AutoPay = true
 		}
 		createOpts.PrepaidOpts = &prepaidOpts
 
@@ -434,7 +437,9 @@ func resourceLoadBalancerV3Update(ctx context.Context, d *schema.ResourceData, m
 				PeriodType: d.Get("period_unit").(string),
 				PeriodNum:  d.Get("period").(int),
 				AutoRenew:  autoRenew,
-				AutoPay:    true,
+			}
+			if d.Get("auto_pay").(string) != "false" {
+				prepaidOpts.AutoPay = true
 			}
 			updateOpts.PrepaidOpts = &prepaidOpts
 

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -113,6 +113,7 @@ func ResourceEvsVolume() *schema.Resource {
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenew(nil),
+			"auto_pay":      common.SchemaAutoPay(nil),
 			"tags":          common.TagsSchema(),
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
@@ -155,13 +156,14 @@ func ResourceEvsVolume() *schema.Resource {
 }
 
 func buildBssParamParams(d *schema.ResourceData) *cloudvolumes.BssParam {
-	return &cloudvolumes.BssParam{
+	bssParams := &cloudvolumes.BssParam{
 		ChargingMode: d.Get("charging_mode").(string),
 		PeriodType:   d.Get("period_unit").(string),
 		PeriodNum:    d.Get("period").(int),
 		IsAutoRenew:  d.Get("auto_renew").(string),
-		IsAutoPay:    "true",
+		IsAutoPay:    common.GetAutoPay(d),
 	}
+	return bssParams
 }
 
 func resourceVolumeAttachmentHash(v interface{}) int {
@@ -367,7 +369,7 @@ func resourceEvsVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		// If charging mode is PrePaid, the order is automatically paid to adjust the volume size.
 		if strings.EqualFold(d.Get("charging_mode").(string), "prePaid") {
 			extendOpts.ChargeInfo = &cloudvolumes.ExtendChargeOpts{
-				IsAutoPay: "true",
+				IsAutoPay: common.GetAutoPay(d),
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccCCENodeV3'   ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccCCENodeV3 -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== RUN   TestAccCCENodeV3_auto_assign_eip
=== PAUSE TestAccCCENodeV3_auto_assign_eip
=== RUN   TestAccCCENodeV3_existing_eip
=== PAUSE TestAccCCENodeV3_existing_eip
=== RUN   TestAccCCENodeV3_volume_extendParams
=== PAUSE TestAccCCENodeV3_volume_extendParams
=== RUN   TestAccCCENodeV3_data_volume_encryption
=== PAUSE TestAccCCENodeV3_data_volume_encryption
=== RUN   TestAccCCENodeV3_prePaid
=== PAUSE TestAccCCENodeV3_prePaid
=== RUN   TestAccCCENodeV3_password
=== PAUSE TestAccCCENodeV3_password
=== RUN   TestAccCCENodeV3_storage
=== PAUSE TestAccCCENodeV3_storage
=== CONT  TestAccCCENodeV3DataSource_basic
=== CONT  TestAccCCENodeV3_auto_assign_eip
=== CONT  TestAccCCENodeV3_existing_eip
=== CONT  TestAccCCENodeV3_volume_extendParams
--- PASS: TestAccCCENodeV3_auto_assign_eip (823.64s)
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_volume_extendParams (838.88s)
=== CONT  TestAccCCENodeV3_password
--- PASS: TestAccCCENodeV3_existing_eip (867.92s)
=== CONT  TestAccCCENodeV3_storage
--- PASS: TestAccCCENodeV3DataSource_basic (873.01s)
=== CONT  TestAccCCENodeV3_prePaid
--- PASS: TestAccCCENodeV3_storage (844.78s)
--- PASS: TestAccCCENodeV3_basic (974.12s)
--- PASS: TestAccCCENodeV3_prePaid (1150.72s)
--- PASS: TestAccCCEClusterV3_prePaid (579.96s)
--- PASS: TestAccCCEClusterV3_withEip (521.64s)
--- PASS: TestAccCCEClusterV3_basic (618.79s)
```
```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccGaussDBInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccGaussDBInstance -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_basic
--- PASS: TestAccGaussDBInstance_basic (1507.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1507.127s
```
```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run=TestAccDcsInstances'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run=TestAccDcsInstances -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_single
--- PASS: TestAccDcsInstances_single (102.00s)
=== CONT  TestAccDcsInstances_withEpsId
    acceptance.go:357: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccDcsInstances_withEpsId (0.00s)
--- PASS: TestAccDcsInstances_tiny (113.23s)
--- PASS: TestAccDcsInstances_whitelists (131.38s)
--- PASS: TestAccDcsInstances_basic (192.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       192.313s
```
```
make testacc TEST=./huaweicloud/services/acceptance/evs TESTARGS='-run=TestAccEvsVolume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolume -timeout 360m -parallel 4
=== RUN   TestAccEvsVolumesDataSource_basic
=== PAUSE TestAccEvsVolumesDataSource_basic
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== RUN   TestAccEvsVolume_withEpsId
=== PAUSE TestAccEvsVolume_withEpsId
=== RUN   TestAccEvsVolume_prePaid
=== PAUSE TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolumesDataSource_basic
=== CONT  TestAccEvsVolume_withEpsId
=== CONT  TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_withEpsId
    acceptance.go:357: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccEvsVolume_withEpsId (0.00s)
--- PASS: TestAccEvsVolume_prePaid (115.65s)
--- PASS: TestAccEvsVolume_basic (139.05s)
--- PASS: TestAccEvsVolumesDataSource_basic (295.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       295.986s
```
```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run=TestAccElbV3LoadBalancer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run=TestAccElbV3LoadBalancer -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_withEIP
=== CONT  TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_withEpsId
    acceptance.go:357: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3LoadBalancer_withEpsId (0.00s)
--- PASS: TestAccElbV3LoadBalancer_withEIP (70.52s)
--- PASS: TestAccElbV3LoadBalancer_basic (130.84s)
--- PASS: TestAccElbV3LoadBalancer_prePaid (212.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       212.060s
```