### PR TITLE
feat(live):  add a new resource to manage Live recording template

### DIFF
--- a/docs/resources/live_recording.md
+++ b/docs/resources/live_recording.md
@@ -1,0 +1,128 @@
+---
+subcategory: "Live"
+---
+
+# huaweicloud_live_recording
+
+Manages a recording template within HuaweiCloud Live.
+
+## Example Usage
+
+### Create a recording template for an ingest domain name
+
+```hcl
+variable "ingest_domain_name" {}
+variable "bucket_region" {}
+variable "bucket_name" {}
+
+resource "huaweicloud_live_domain" "ingestDomain" {
+  name = var.ingest_domain_name
+  type = "push"
+}
+
+resource "huaweicloud_live_recording" "recording" {
+  domain_name = huaweicloud_live_domain.ingestDomain.name
+  app_name    = "live"
+  stream_name = "stream_name"
+  type        = "CONTINUOUS_RECORD"
+
+  obs {
+    region = var.bucket_region
+    bucket = var.bucket_name
+  }
+
+  hls {
+    recording_length = 15
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String) Specifies the ingest domain name.
+
+* `app_name` - (Required, String) Specifies the application name. To match all names, use an asterisk (*).
+
+* `stream_name` - (Required, String) Specifies the stream name. To match all names, use an asterisk (*).
+
+* `type` - (Optional, String, ForceNew) Specifies the types of recording notifications. The options are as follows:
+  + **CONTINUOUS_RECORD**: continuous recording. Recording is triggered once streams are pushed to the recording system.
+  + **COMMAND_RECORD**: command-based recording. Tenants need to run commands to start and stop recording after streams
+   are pushed to the recording system.
+
+  Defaults to `CONTINUOUS_RECORD`. Changing this parameter will create a new resource.
+
+* `obs` - (Required, List) Specifies the obs for storing recordings.
+The [obs](#recording_obs) structure is documented below.
+
+* `hls` - (Required, List) Specifies the HLS configuration rule for storing recording as HLS.
+The [hls](#recording_HLS) structure is documented below.
+
+* `flv` - (Required, List) Specifies the FLV configuration rule for storing recording as FLV.
+The [flv](#recording_FLV_MP4) structure is documented below.
+
+* `mp4` - (Required, List) Specifies the MP4 configuration rule for storing recording as MP4.
+The [mp4](#recording_FLV_MP4) structure is documented below.
+
+-> At least one of `hls`, `flv`, `mp4` must be specified.
+
+<a name="recording_obs"></a>
+The `obs` block supports:
+
+* `region` - (Required, String) Specifies the region of OBS.
+
+* `bucket` - (Required, String) Specifies OBS bucket.
+
+* `object` - (Optional, String) Specifies OBS object path. If omitted, recordings will be saved to the root directory.
+
+<a name="recording_HLS"></a>
+The `hls` block supports:
+
+* `recording_length` - (Required, Int) Specifies the recording length. Value range: 15 ~ 720, unit: `minute`.
+A stream exceeding the recording length will generate a new recording.
+
+* `file_naming` - (Optional, String) Specifies the path and file name prefix of an M3U8 file. The default value is
+`Record/{publish_domain}/{app}/{record_type}/{record_format}/{stream}_{file_start_time}/{stream}_{file_start_time}`.
+
+* `ts_file_naming` - (Optional, String) Specifies TS file name prefix.
+The default value is `{file_start_time_unix}_{file_end_time_unix}_{ts_sequence_number}`.
+
+* `max_stream_pause_length` - (Optional, Int) Specifies the interval threshold for combining HLS chunks. If the stream
+pause length exceeds the value of this parameter, a new recording is generated. Value range: -1 ~ 300, unit: `second`.
+If the value is set to `0`, a new file will be generated once the stream is interrupted.
+If the value is set to `-1`, the HLS chunks will be combined to the previous file generated within 30 days after
+the same stream is recovered.
+Defaults to `0`.
+
+<a name="recording_FLV_MP4"></a>
+The `flv` and `mp4` block support:
+
+* `recording_length` - (Required, Int) Specifies the recording length. Value range: 15 ~ 180, unit: `minute`.
+A stream exceeding the recording length will generate a new recording.
+
+* `file_naming` - (Optional, String) Specifies the path and file name prefix of a recording file. The default value is
+`Record/{publish_domain}/{app}/{record_type}/{record_format}/{stream}_{file_start_time}/{file_start_time}`.
+
+* `max_stream_pause_length` - (Optional, Int) Specifies the interval threshold for combining recording chunks. If the
+stream pause length exceeds the value of this parameter, a new recording is generated.
+Value range: 0 ~ 300, unit: `second`.
+If the value is set to `0`, a new file will be generated once the stream is interrupted. Defaults to `0`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+Recording templates can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_live_recording.test 55534eaa-533a-419d-9b40-ec427ea7195a
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -680,6 +680,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_whitelist":    lb.ResourceWhitelistV2(),
 
 			"huaweicloud_live_domain":          live.ResourceDomain(),
+			"huaweicloud_live_recording":       live.ResourceRecording(),
 			"huaweicloud_live_record_callback": live.ResourceRecordCallback(),
 			"huaweicloud_live_transcoding":     live.ResourceTranscoding(),
 

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_recording_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_recording_test.go
@@ -1,0 +1,145 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getRecordingResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcLiveV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Live v1 client: %s", err)
+	}
+	return client.ShowRecordRule(&model.ShowRecordRuleRequest{Id: state.Primary.ID})
+}
+
+func TestAccRecording_basic(t *testing.T) {
+	var obj model.ShowRecordRuleRequest
+
+	name := acceptance.RandomAccResourceNameWithDash()
+	pushDomainName := fmt.Sprintf("%s.huaweicloud.com", name)
+	rName := "huaweicloud_live_recording.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRecordingResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRecording_basic(pushDomainName, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", pushDomainName),
+					resource.TestCheckResourceAttr(rName, "app_name", "live"),
+					resource.TestCheckResourceAttr(rName, "stream_name", "streamname"),
+					resource.TestCheckResourceAttr(rName, "type", "CONTINUOUS_RECORD"),
+					resource.TestCheckResourceAttr(rName, "obs.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(rName, "mp4.0.recording_length", "120"),
+					resource.TestCheckResourceAttrSet(rName, "mp4.0.file_naming"),
+				),
+			},
+			{
+				Config: testRecording_basic_update(pushDomainName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "domain_name", pushDomainName),
+					resource.TestCheckResourceAttr(rName, "app_name", "live"),
+					resource.TestCheckResourceAttr(rName, "stream_name", "streamname"),
+					resource.TestCheckResourceAttr(rName, "type", "CONTINUOUS_RECORD"),
+					resource.TestCheckResourceAttr(rName, "obs.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(rName, "hls.0.recording_length", "120"),
+					resource.TestCheckResourceAttrSet(rName, "hls.0.file_naming"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccLiveObs(obsName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "private"
+  force_destroy = true
+
+  lifecycle {
+    ignore_changes = [
+      cors_rule,
+    ]
+  }
+}
+`, obsName)
+}
+
+func testRecording_basic(pushDomainName, obsName string) string {
+	obsConfig := testAccLiveObs(obsName)
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_live_domain" "ingestDomain" {
+  name = "%s"
+  type = "push"
+}
+
+resource "huaweicloud_live_recording" "test" {
+  domain_name = huaweicloud_live_domain.ingestDomain.name
+  app_name    = "live"
+  stream_name = "streamname"
+  type        = "CONTINUOUS_RECORD"
+
+  obs {
+    region = huaweicloud_obs_bucket.bucket.region
+    bucket = huaweicloud_obs_bucket.bucket.bucket
+  }
+
+  mp4 {
+    recording_length = 120
+  }
+}
+`, obsConfig, pushDomainName)
+}
+
+func testRecording_basic_update(pushDomainName, obsName string) string {
+	obsConfig := testAccLiveObs(obsName)
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_live_domain" "ingestDomain" {
+  name = "%s"
+  type = "push"
+}
+
+resource "huaweicloud_live_recording" "test" {
+  domain_name = huaweicloud_live_domain.ingestDomain.name
+  app_name    = "live"
+  stream_name = "streamname"
+  type        = "CONTINUOUS_RECORD"
+
+  obs {
+    region = huaweicloud_obs_bucket.bucket.region
+    bucket = huaweicloud_obs_bucket.bucket.bucket
+  }
+
+  hls {
+    recording_length = 120
+  }
+}
+`, obsConfig, pushDomainName)
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_recording.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_recording.go
@@ -1,0 +1,387 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	recordingTypeAuto   = "CONTINUOUS_RECORD"
+	recordingTypeManual = "COMMAND_RECORD"
+)
+
+func ResourceRecording() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecordingCreate,
+		ReadContext:   resourceRecordingRead,
+		UpdateContext: resourceRecordingUpdate,
+		DeleteContext: resourceRecordingDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"app_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"stream_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"obs": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"bucket": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"object": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"hls": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				AtLeastOneOf: []string{"hls", "flv", "mp4"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"recording_length": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(15, 720), // same with console
+						},
+
+						"file_naming": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"ts_file_naming": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"max_stream_pause_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(-1, 300),
+							Computed:     true,
+						},
+					},
+				},
+			},
+
+			"flv": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     formatSchema(),
+			},
+
+			"mp4": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     formatSchema(),
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{recordingTypeAuto, recordingTypeManual}, false),
+			},
+		},
+	}
+}
+
+func formatSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"recording_length": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(15, 180), // same with console
+			},
+
+			"file_naming": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"max_stream_pause_length": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 300),
+				Computed:     true,
+			},
+		},
+	}
+}
+
+func resourceRecordingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	createBody, err := buildRecordingParams(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	createOpts := &model.CreateRecordRuleRequest{
+		Body: createBody,
+	}
+
+	log.Printf("[DEBUG] Create Live recording params: %#v", createOpts)
+
+	resp, err := client.CreateRecordRule(createOpts)
+	if err != nil {
+		return diag.Errorf("error creating Live recording: %s", err)
+	}
+
+	if resp.Id == nil {
+		return diag.Errorf("error creating Live recording: ID not found in the API response")
+	}
+
+	d.SetId(*resp.Id)
+
+	return resourceRecordingRead(ctx, d, meta)
+}
+
+func resourceRecordingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	response, err := client.ShowRecordRule(&model.ShowRecordRuleRequest{Id: d.Id()})
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Live recording")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("domain_name", response.PublishDomain),
+		d.Set("app_name", response.App),
+		d.Set("stream_name", response.Stream),
+		d.Set("type", utils.MarshalValue(response.RecordType)),
+		d.Set("obs", flattenObs(response.DefaultRecordConfig)),
+		d.Set("hls", flattenHls(response.DefaultRecordConfig)),
+		d.Set("flv", flattenFlv(response.DefaultRecordConfig)),
+		d.Set("mp4", flattenMp4(response.DefaultRecordConfig)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRecordingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	updateBody, err := buildRecordingParams(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	updateOpts := &model.UpdateRecordRuleRequest{
+		Id:   d.Id(),
+		Body: updateBody,
+	}
+
+	_, err = client.UpdateRecordRule(updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating Live recording: %s", err)
+	}
+
+	return resourceRecordingRead(ctx, d, meta)
+}
+
+func resourceRecordingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcLiveV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Live v1 client: %s", err)
+	}
+
+	deleteOpts := &model.DeleteRecordRuleRequest{
+		Id: d.Id(),
+	}
+	_, err = client.DeleteRecordRule(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting Live recording: %s", err)
+	}
+
+	return nil
+}
+
+func buildRecordingParams(d *schema.ResourceData) (*model.RecordRuleRequest, error) {
+	var recordType model.RecordRuleRequestRecordType
+	if v, ok := d.GetOk("type"); ok {
+		if err := recordType.UnmarshalJSON([]byte(v.(string))); err != nil {
+			return nil, fmt.Errorf("error parsing the argument %q: %s", "type", err)
+		}
+	}
+
+	r := d.Get("obs.0.region").(string)
+	var region model.RecordObsFileAddrLocation
+	if err := region.UnmarshalJSON([]byte(r)); err != nil {
+		return nil, fmt.Errorf("error parsing the argument %q: %s", "obs region", err)
+	}
+	obs := model.RecordObsFileAddr{
+		Location: region,
+		Bucket:   d.Get("obs.0.bucket").(string),
+		Object:   d.Get("obs.0.object").(string),
+	}
+
+	recordFormat := []model.VideoFormatVar{}
+	var hlsConfig *model.HlsRecordConfig
+	if _, ok := d.GetOk("hls"); ok {
+		recordFormat = append(recordFormat, model.GetVideoFormatVarEnum().HLS)
+		hlsConfig = &model.HlsRecordConfig{
+			RecordCycle:                  int32(d.Get("hls.0.recording_length").(int) * 60),
+			RecordPrefix:                 utils.String(d.Get("hls.0.file_naming").(string)),
+			RecordTsPrefix:               utils.String(d.Get("hls.0.ts_file_naming").(string)),
+			RecordMaxDurationToMergeFile: utils.Int32(int32(d.Get("hls.0.max_stream_pause_length").(int))),
+		}
+	}
+	var flvConfig *model.FlvRecordConfig
+	if _, ok := d.GetOk("flv"); ok {
+		recordFormat = append(recordFormat, model.GetVideoFormatVarEnum().FLV)
+		flvConfig = &model.FlvRecordConfig{
+			RecordCycle:                  int32(d.Get("flv.0.recording_length").(int) * 60),
+			RecordPrefix:                 utils.String(d.Get("flv.0.file_naming").(string)),
+			RecordMaxDurationToMergeFile: utils.Int32(int32(d.Get("flv.0.max_stream_pause_length").(int))),
+		}
+	}
+	var mp4Config *model.Mp4RecordConfig
+	if _, ok := d.GetOk("mp4"); ok {
+		recordFormat = append(recordFormat, model.GetVideoFormatVarEnum().MP4)
+		mp4Config = &model.Mp4RecordConfig{
+			RecordCycle:                  int32(d.Get("mp4.0.recording_length").(int) * 60),
+			RecordPrefix:                 utils.String(d.Get("mp4.0.file_naming").(string)),
+			RecordMaxDurationToMergeFile: utils.Int32(int32(d.Get("mp4.0.max_stream_pause_length").(int))),
+		}
+	}
+
+	req := model.RecordRuleRequest{
+		PublishDomain: d.Get("domain_name").(string),
+		App:           d.Get("app_name").(string),
+		Stream:        d.Get("stream_name").(string),
+		RecordType:    &recordType,
+		DefaultRecordConfig: &model.DefaultRecordConfig{
+			ObsAddr:      &obs,
+			RecordFormat: recordFormat,
+			HlsConfig:    hlsConfig,
+			FlvConfig:    flvConfig,
+			Mp4Config:    mp4Config,
+		},
+	}
+
+	return &req, nil
+}
+
+func flattenObs(r *model.DefaultRecordConfig) []interface{} {
+	if r != nil && r.ObsAddr != nil {
+		m := map[string]interface{}{
+			"region": utils.MarshalValue(r.ObsAddr.Location),
+			"bucket": r.ObsAddr.Bucket,
+			"object": r.ObsAddr.Object,
+		}
+		return []interface{}{m}
+	}
+
+	return make([]interface{}, 0)
+}
+
+func flattenHls(r *model.DefaultRecordConfig) []interface{} {
+	if r != nil && r.HlsConfig != nil && r.HlsConfig.RecordPrefix != nil && len(*r.HlsConfig.RecordPrefix) > 0 {
+		m := map[string]interface{}{
+			"recording_length":        r.HlsConfig.RecordCycle / 60,
+			"file_naming":             r.HlsConfig.RecordPrefix,
+			"ts_file_naming":          r.HlsConfig.RecordTsPrefix,
+			"max_stream_pause_length": r.HlsConfig.RecordMaxDurationToMergeFile,
+		}
+		return []interface{}{m}
+	}
+
+	return make([]interface{}, 0)
+}
+
+func flattenFlv(r *model.DefaultRecordConfig) []interface{} {
+	if r != nil && r.FlvConfig != nil && r.FlvConfig.RecordPrefix != nil && len(*r.FlvConfig.RecordPrefix) > 0 {
+		m := map[string]interface{}{
+			"recording_length":        r.FlvConfig.RecordCycle / 60,
+			"file_naming":             r.FlvConfig.RecordPrefix,
+			"max_stream_pause_length": r.FlvConfig.RecordMaxDurationToMergeFile,
+		}
+		return []interface{}{m}
+	}
+
+	return make([]interface{}, 0)
+}
+
+func flattenMp4(r *model.DefaultRecordConfig) []interface{} {
+	if r != nil && r.Mp4Config != nil && r.Mp4Config.RecordPrefix != nil && len(*r.Mp4Config.RecordPrefix) > 0 {
+		m := map[string]interface{}{
+			"recording_length":        r.Mp4Config.RecordCycle / 60,
+			"file_naming":             r.Mp4Config.RecordPrefix,
+			"max_stream_pause_length": r.Mp4Config.RecordMaxDurationToMergeFile,
+		}
+		return []interface{}{m}
+	}
+
+	return make([]interface{}, 0)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. add a new resource to manage Live recording template

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run=TestAccRecording_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run=TestAccRecording_basic -timeout 360m -parallel 4
=== RUN   TestAccRecording_basic
--- PASS: TestAccRecording_basic (312.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      312.663s
```
