### PR TITLE
feat(servicestage): add two entrypoint parameters

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -90,6 +90,19 @@ In addition to all arguments above, the following attributes are exported:
 
 * `instance_limit` - The maximum number of the microservice instance resources.
 
+* `service_registry_addresses` - The connection address of service center.
+  The [object](#engine_center_addresses) structure is documented below.
+
+* `config_center_addresses` - The address of config center.
+  The [object](#engine_center_addresses) structure is documented below.
+
+<a name="engine_center_addresses"></a>
+The `service_registry_addresses` and `config_center_addresses` block supports:
+
+* `private` - The internal access address.
+
+* `public` - The public access address. This address is only set when EIP is bound.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220520084815-ea06a7b5ab32
+	github.com/chnsz/golangsdk v0.0.0-20220525074017-4bf2680686cb
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/chnsz/golangsdk v0.0.0-20220518060535-eb80e58ab616 h1:PAK8XU0r8O898fS
 github.com/chnsz/golangsdk v0.0.0-20220518060535-eb80e58ab616/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220520084815-ea06a7b5ab32 h1:HuJIvzVnVPBKhzkFYlPy0f+KNUsQ7mSNk0mNGWenaYI=
 github.com/chnsz/golangsdk v0.0.0-20220520084815-ea06a7b5ab32/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220525074017-4bf2680686cb h1:DuFMtNfBDwuh/7w0xNMwwClguvckNBdBqTn1VovhrQ4=
+github.com/chnsz/golangsdk v0.0.0-20220525074017-4bf2680686cb/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -61,6 +61,8 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(resourceName, "service_limit", "200"),
 					resource.TestCheckResourceAttr(resourceName, "instance_limit", "100"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_registry_addresses.0.private"),
+					resource.TestCheckResourceAttrSet(resourceName, "config_center_addresses.0.private"),
 				),
 			},
 			{

--- a/vendor/github.com/chnsz/golangsdk/openstack/cse/dedicated/v2/engines/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cse/dedicated/v2/engines/results.go
@@ -130,8 +130,16 @@ type ExternalEntrypoint struct {
 	PublicServiceEndpoint ServiceEndpoint `json:"publicServiceEndpoint"`
 }
 
-// ExternalEntrypoint is an object that represent the details of the access addresses.
+// ServiceEndpoint is an object that represent the entrypoints of the service center and config center.
 type ServiceEndpoint struct {
+	// The entrypoint details of the service center.
+	ServiceCenter Detail `json:"serviceCenter"`
+	// The entrypoint details of the config center.
+	ConfigCenter Detail `json:"kie"`
+}
+
+// Detail is an object that represent the endpoint informations of the service center or config center.
+type Detail struct {
 	// The main ipv4 access address in the VPC of the Microservice Engine Exclusive Edition component.
 	MasterEntrypoint string `json:"masterEntrypoint"`
 	// The main ipv6 access address in the VPC of the Microservice Engine Exclusive Edition component.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220520084815-ea06a7b5ab32
+# github.com/chnsz/golangsdk v0.0.0-20220525074017-4bf2680686cb
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Both microservices and microservice instances and related token queries need to use this address in the URL.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add two entrypoint parameters.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cse' TESTARGS='-run=TestAccMicroserviceEngine_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse -v -run=TestAccMicroserviceEngine_basic -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_basic
--- PASS: TestAccMicroserviceEngine_basic (882.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       882.659s
```
