### PR TITLE
[WIP]feat(iam/assign): add new project name parameter

### DIFF
--- a/docs/resources/identity_role_assignment.md
+++ b/docs/resources/identity_role_assignment.md
@@ -28,6 +28,25 @@ resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
 }
 ```
 
+## Example Usage: Assign Role On Project Level and assign with the project name
+
+```hcl
+data "huaweicloud_identity_role" "role_1" {
+  # Security Administrator
+  name = "secu_admin"
+}
+
+resource "huaweicloud_identity_group" "group_1" {
+  name = "group_1"
+}
+
+resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
+  role_id      = data.huaweicloud_identity_role.role_1.id
+  group_id     = huaweicloud_identity_group.group_1.id
+  project_name = "MOS"
+}
+```
+
 ## Example Usage: Assign Role On Domain Level
 
 ```hcl
@@ -51,15 +70,16 @@ resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
 
 The following arguments are supported:
 
-* `role_id` - (Required, String, ForceNew) Specifies the role to assign.
+* `role_id` - (Required, String, ForceNew) Specifies the role ID to assign.
 
-* `group_id` - (Required, String, ForceNew) Specifies the group to assign the role to.
+* `group_id` - (Required, String, ForceNew) Specifies the group ID to assign the role to.
 
-* `domain_id` - (Optional, String, ForceNew; Required if `project_id` is empty) Specifies the domain to assign the role
-  in.
+* `domain_id` - (Optional, String, ForceNew) Specifies the domain ID to assign the role in.
+  One of `domain_id`, `project_id` and `project_name` must be set.
 
-* `project_id` - (Optional, String, ForceNew; Required if `domain_id` is empty) Specifies the project to assign the role
-  in.
+* `project_id` - (Optional, String, ForceNew) Specifies the project ID to assign the role in.
+
+* `project_name` - (Optional, String, ForceNew) Specifies the project name to assign the role in.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_role_assignment.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_role_assignment.go
@@ -3,9 +3,11 @@ package iam
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/v3/projects"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/roles"
 	"github.com/chnsz/golangsdk/pagination"
 	"github.com/hashicorp/go-multierror"
@@ -34,19 +36,51 @@ func ResourceIdentityRoleAssignmentV3() *schema.Resource {
 				ForceNew: true,
 			},
 			"domain_id": {
-				Type:          schema.TypeString,
-				ConflictsWith: []string{"project_id"},
-				Optional:      true,
-				ForceNew:      true,
+				Type:         schema.TypeString,
+				ExactlyOneOf: []string{"project_id", "project_name"},
+				Optional:     true,
+				ForceNew:     true,
 			},
 			"project_id": {
-				Type:          schema.TypeString,
-				ConflictsWith: []string{"domain_id"},
-				Optional:      true,
-				ForceNew:      true,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 		},
 	}
+}
+
+func GetProjectId(client *golangsdk.ServiceClient, projectInfo string) (string, error) {
+	projectName, projectID := flattenProjcetInfo(projectInfo)
+	if projectID != "" {
+		return projectID, nil
+	}
+
+	listOpts := projects.ListOpts{
+		Name: projectName,
+	}
+	pages, err := projects.List(client, listOpts).AllPages()
+	if err != nil {
+		return "", fmt.Errorf("error retrieving project list: %v", err)
+	}
+	projectList, err := projects.ExtractProjects(pages)
+	if err != nil {
+		return "", fmt.Errorf("error fetching project object: %v", err)
+	}
+	if len(projectList) < 1 {
+		return "", fmt.Errorf("unable to find any project by name (%s), please check your input", projectName)
+	}
+	if len(projectList) > 1 {
+		return "", fmt.Errorf("more than one projects are found within project name (%s), please use project ID "+
+			"instead", projectName)
+	}
+	return projectList[0].ID, nil
 }
 
 func resourceIdentityRoleAssignmentV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -59,7 +93,16 @@ func resourceIdentityRoleAssignmentV3Create(ctx context.Context, d *schema.Resou
 	roleID := d.Get("role_id").(string)
 	groupID := d.Get("group_id").(string)
 	domainID := d.Get("domain_id").(string)
-	projectID := d.Get("project_id").(string)
+
+	var projectID string
+	if val, ok := d.GetOk("project_id"); ok {
+		projectID = val.(string)
+	} else {
+		projectID, err = GetProjectId(identityClient, d.Get("project_name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	opts := roles.AssignOpts{
 		GroupID:   groupID,
@@ -72,9 +115,23 @@ func resourceIdentityRoleAssignmentV3Create(ctx context.Context, d *schema.Resou
 		return fmtp.DiagErrorf("Error assigning role: %s", err)
 	}
 
-	d.SetId(buildRoleAssignmentID(domainID, projectID, groupID, roleID))
+	if val, ok := d.GetOk("project_name"); ok {
+		d.SetId(buildRoleAssignmentID(domainID, val.(string), groupID, roleID))
+	} else {
+		d.SetId(buildRoleAssignmentID(domainID, projectID, groupID, roleID))
+	}
 
 	return resourceIdentityRoleAssignmentV3Read(ctx, d, meta)
+}
+
+func flattenProjcetInfo(projectInfo string) (projectName, projectID string) {
+	re, _ := regexp.Compile(`[a-f0-9]{32}$`) // project ID format
+	if re.FindString(projectInfo) != "" {
+		projectID = projectInfo
+		return
+	}
+	projectName = projectInfo
+	return
 }
 
 func resourceIdentityRoleAssignmentV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -88,15 +145,17 @@ func resourceIdentityRoleAssignmentV3Read(_ context.Context, d *schema.ResourceD
 	if err != nil {
 		return fmtp.DiagErrorf("Error getting role assignment: %s", err)
 	}
-	domainID, projectID, groupID, _ := ExtractRoleAssignmentID(d.Id())
 
+	domainID, projectInfo, groupID, _ := ExtractRoleAssignmentID(d.Id())
 	logp.Printf("[DEBUG] Retrieved HuaweiCloud role assignment: %#v", roleAssignment)
 
+	projectName, projcetId := flattenProjcetInfo(projectInfo)
 	mErr := multierror.Append(nil,
 		d.Set("role_id", roleAssignment.ID),
 		d.Set("group_id", groupID),
 		d.Set("domain_id", domainID),
-		d.Set("project_id", projectID),
+		d.Set("project_name", projectName),
+		d.Set("project_id", projcetId),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
 		return fmtp.DiagErrorf("error setting identity role assignment fields: %s", err)
@@ -112,7 +171,12 @@ func resourceIdentityRoleAssignmentV3Delete(_ context.Context, d *schema.Resourc
 		return fmtp.DiagErrorf("Error creating HuaweiCloud identity client: %s", err)
 	}
 
-	domainID, projectID, groupID, roleID := ExtractRoleAssignmentID(d.Id())
+	domainID, projectInfo, groupID, roleID := ExtractRoleAssignmentID(d.Id())
+	projectID, err := GetProjectId(identityClient, projectInfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	opts := roles.UnassignOpts{
 		GroupID:   groupID,
 		DomainID:  domainID,
@@ -126,19 +190,22 @@ func resourceIdentityRoleAssignmentV3Delete(_ context.Context, d *schema.Resourc
 	return nil
 }
 
-func getRoleAssignment(identityClient *golangsdk.ServiceClient, d *schema.ResourceData) (roles.RoleAssignment, error) {
-	domainID, projectID, groupID, roleID := ExtractRoleAssignmentID(d.Id())
+func getRoleAssignment(identityClient *golangsdk.ServiceClient, d *schema.ResourceData) (*roles.RoleAssignment, error) {
+	domainID, projectInfo, groupID, roleID := ExtractRoleAssignmentID(d.Id())
+	projectID, err := GetProjectId(identityClient, projectInfo)
+	if err != nil {
+		return nil, err
+	}
 
 	opts := roles.ListAssignmentsOpts{
 		GroupID:        groupID,
 		ScopeDomainID:  domainID,
 		ScopeProjectID: projectID,
 	}
-
 	pager := roles.ListAssignments(identityClient, opts)
 	var assignment roles.RoleAssignment
 
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+	err = pager.EachPage(func(page pagination.Page) (bool, error) {
 		assignmentList, err := roles.ExtractRoleAssignments(page)
 		if err != nil {
 			return false, err
@@ -154,14 +221,18 @@ func getRoleAssignment(identityClient *golangsdk.ServiceClient, d *schema.Resour
 		return true, nil
 	})
 
-	return assignment, err
+	return &assignment, err
 }
 
-// Role assignments have no ID in HuaweiCloud. Build an ID out of the IDs that make up the role assignment
-func buildRoleAssignmentID(domainID, projectID, groupID, roleID string) string {
-	return fmt.Sprintf("%s/%s/%s/%s", domainID, projectID, groupID, roleID)
+// Role assignments have no ID in HuaweiCloud. Build an ID out of the IDs (maybe contain project name, not ID) that make
+// up the role assignment.
+// Input: domain ID, project ID (or project name), group ID, role ID
+func buildRoleAssignmentID(domainID, projectInfo, groupID, roleID string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", domainID, projectInfo, groupID, roleID)
 }
 
+// ExtractRoleAssignmentID is a method to flatten a composite ID format into multiple IDs.
+// Return: domain ID, project ID (or project name), group ID, role ID
 func ExtractRoleAssignmentID(roleAssignmentID string) (string, string, string, string) {
 	split := strings.Split(roleAssignmentID, "/")
 	return split[0], split[1], split[2], split[3]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the creation of OBS authorization agency, the MOS project must be assigned, but we cannot find the ID in the console.
So, we need to support a new parameter to assign MOS project.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new parameter: project_name
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run=TestAccIdentityV3RoleAssignment_mos'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run=TestAccIdentityV3RoleAssignment_mos -timeout 360m -parallel 4
=== RUN   TestAccIdentityV3RoleAssignment_mos
=== PAUSE TestAccIdentityV3RoleAssignment_mos
=== CONT  TestAccIdentityV3RoleAssignment_mos
--- PASS: TestAccIdentityV3RoleAssignment_mos (18.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       18.837
```
