### PR TITLE
bugfix(sms): add bandwidth_size param to support public IP

### DIFF
--- a/docs/resources/sms_server_template.md
+++ b/docs/resources/sms_server_template.md
@@ -65,7 +65,10 @@ The following arguments are supported:
 
 * `flavor` - (Optional, String) Specifies the flavor ID for the target server.
 
-* `target_server_name` - (Optional, String) Specifies the name of the target server.
+* `target_server_name` - (Optional, String) Specifies the name of the target server. Defaults to the template name.
+
+* `bandwidth_size` - (Optional, Int) Specifies the bandwidth size in Mbit/s about the public IP address
+  that will be used for migration.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/acceptance/sms/resource_huaweicloud_sms_server_template_test.go
+++ b/huaweicloud/services/acceptance/sms/resource_huaweicloud_sms_server_template_test.go
@@ -43,6 +43,7 @@ func TestAccServerTemplate_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "target_server_name", name),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_name", "autoCreate"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.0", "autoCreate"),
@@ -54,6 +55,7 @@ func TestAccServerTemplate_basic(t *testing.T) {
 				Config: testAccServerTemplate_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", name)),
+					resource.TestCheckResourceAttr(resourceName, "target_server_name", name),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", azDataName, "names.1"),
 				),
@@ -88,6 +90,7 @@ func TestAccServerTemplate_existing(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "target_server_name", name),
 					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_name", name),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.0", "autoCreate"),
@@ -129,11 +132,12 @@ func testAccServerTemplate_update(name string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_sms_server_template" "test" {
-  name              = "%s-update"
-  availability_zone = data.huaweicloud_availability_zones.test.names[1]
-  volume_type       = "GPSSD"
+  name               = "%s-update"
+  target_server_name = "%s"
+  availability_zone  = data.huaweicloud_availability_zones.test.names[1]
+  volume_type        = "GPSSD"
 }
-`, name)
+`, name, name)
 }
 
 func testAccServerTemplate_network(name string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
- add `bandwidth_size` param to support public IP
- set the default value of `target_server_name` to the template name
- ignore 404 error when deleting

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/sms' TESTARGS='-run TestAccServerTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sms -v -run TestAccServerTemplate -timeout 360m -parallel 4
=== RUN   TestAccServerTemplate_basic
=== PAUSE TestAccServerTemplate_basic
=== RUN   TestAccServerTemplate_existing
=== PAUSE TestAccServerTemplate_existing
=== CONT  TestAccServerTemplate_basic
=== CONT  TestAccServerTemplate_existing
--- PASS: TestAccServerTemplate_basic (55.45s)
--- PASS: TestAccServerTemplate_existing (98.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sms     98.801s
```
