### PR TITLE
feat(iam/projects): add new projcets query resource

### DIFF
--- a/docs/data-sources/identity_projects.md
+++ b/docs/data-sources/identity_projects.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_projects
+
+Use this data source to query the project list within HuaweiCloud.
+
+Note: You *must* have admin privileges in your HuaweiCloud cloud to use this data source.
+
+## Example Usage
+
+### Obtain project information by name
+
+```hcl
+resource "huaweicloud_identity_projects" "test" {
+  name = "cn-north-4"
+}
+```
+
+### Obtain special project information by name
+
+```hcl
+resource "huaweicloud_identity_projects" "test" {
+  name = "MOS" // The project for OBS Billing
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, String) Specifies the project name to query.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `projects` - The details of the query projects. The structure is documented below.
+
+The `projects` block supports:
+
+* `id` - The project ID.
+
+* `name` - The project name.
+
+* `enabled` - Whether project is enabled.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -398,6 +398,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRoleV3(),
 			"huaweicloud_identity_custom_role": iam.DataSourceIdentityCustomRole(),
 			"huaweicloud_identity_group":       iam.DataSourceIdentityGroup(),
+			"huaweicloud_identity_projects":    iam.DataSourceIdentityProjects(),
 
 			"huaweicloud_iec_bandwidths":     dataSourceIECBandWidths(),
 			"huaweicloud_iec_eips":           dataSourceIECNetworkEips(),

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_projects_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_projects_test.go
@@ -1,0 +1,62 @@
+package iam
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIdentityProjectsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_identity_projects.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProjectsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "projects.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "projects.0.name", "MOS"),
+					resource.TestCheckResourceAttr(dataSourceName, "projects.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityProjectsDataSource_subProject(t *testing.T) {
+	dataSourceName := "data.huaweicloud_identity_projects.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProjectsDataSource_subProject,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "projects.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "projects.0.name", "cn-north-4_test"),
+					resource.TestCheckResourceAttr(dataSourceName, "projects.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccIdentityProjectsDataSource_basic string = `
+data "huaweicloud_identity_projects" "test" {
+  name = "MOS"
+}
+`
+
+const testAccIdentityProjectsDataSource_subProject string = `
+data "huaweicloud_identity_projects" "test" {
+  name = "cn-north-4_test"
+}
+`

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_projects.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_projects.go
@@ -1,0 +1,86 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3/projects"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+)
+
+func DataSourceIdentityProjects() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIdentityProjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"projects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenProjectList(projectList []projects.Project) ([]map[string]interface{}, []string) {
+	if len(projectList) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(projectList))
+	ids := make([]string, len(projectList))
+	for i, val := range projectList {
+		result[i] = map[string]interface{}{
+			"id":      val.ID,
+			"name":    val.Name,
+			"enabled": val.Enabled,
+		}
+	}
+	return result, ids
+}
+
+func dataSourceIdentityProjectsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.IdentityV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM v3 client: %s", err)
+	}
+
+	listOpts := projects.ListOpts{
+		Name: d.Get("name").(string),
+	}
+	pages, err := projects.List(client, listOpts).AllPages()
+	if err != nil {
+		return diag.Errorf("error retrieving project list: %v", err)
+	}
+	projectList, err := projects.ExtractProjects(pages)
+	if err != nil {
+		return diag.Errorf("error fetching project objects: %v", err)
+	}
+
+	result, ids := flattenProjectList(projectList)
+
+	d.SetId(hashcode.Strings(ids))
+	return diag.FromErr(d.Set("projects", result))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the creation of OBS authorization agency, the MOS project must be assigned, but we cannot find the ID in the console.
So, we need to support a new data source to query it before MOS project assignment.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new projcets query resource support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run=TestAccIdentityProjectsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run=TestAccIdentityProjectsDataSource -timeout 360m -parallel 4
=== RUN   TestAccIdentityProjectsDataSource_basic
=== PAUSE TestAccIdentityProjectsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_subProject
=== PAUSE TestAccIdentityProjectsDataSource_subProject
=== CONT  TestAccIdentityProjectsDataSource_basic
=== CONT  TestAccIdentityProjectsDataSource_subProject
--- PASS: TestAccIdentityProjectsDataSource_basic (12.49s)
--- PASS: TestAccIdentityProjectsDataSource_subProject (12.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       12.761s
```
