### PR TITLE
feat(IoTDA) add a new resource to manage device

### DIFF
--- a/docs/resources/iotda_device.md
+++ b/docs/resources/iotda_device.md
@@ -1,0 +1,105 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_device
+
+Manages an IoTDA device within HuaweiCloud.
+
+## Example Usage
+
+### Create a directly connected device and an indirectly connected device
+
+```hcl
+variable "spaceId" {}
+variable "productId" {}
+variable "secret" {}
+
+resource "huaweicloud_iotda_device" "device" {
+  node_id    = "device_SN_1"
+  name       = "device_name"
+  space      = var.spaceId
+  product_id = var.productId
+  secret     = var.secret
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_iotda_device" "sub_device" {
+  node_id    = "device_SN_2"
+  name       = "device_name_2"
+  space      = var.spaceId
+  product_id = var.productId
+  gateway_id = huaweicloud_iotda_device.device.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA device resource.
+If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the device name, which contains 4 to 256 characters. Only letters,
+Chinese characters, digits, hyphens (-), underscore (_) and the following specail characters are allowed: `?'#().,&%@!`.
+
+* `node_id` - (Required, String, ForceNew) Specifies the node ID, which contains 4 to 256 characters.
+The node ID can be IMEI, MAC address, or serial number. Changing this parameter will create a new resource.
+
+* `space` - (Required, String, ForceNew) Specifies the resource space ID which the device belongs to.
+Changing this parameter will create a new resource.
+
+* `product_id` - (Required, String, ForceNew) Specifies the product ID which the device belongs to.
+Changing this parameter will create a new resource.
+
+* `device_id` - (Optional, String, ForceNew) Specifies the device ID, which contains 4 to 256 characters.
+Only letters, digits, hyphens (-) and underscore (_) are allowed. If omitted, the platform will automatically allocate
+a device ID. Changing this parameter will create a new resource.
+
+* `secret` - (Optional, String) Specifies a secret for identity authentication, which contains 8 to 32 characters.
+Only letters, digits, hyphens (-) and underscore (_) are allowed.
+
+* `fingerprint` - (Optional, String) Specifies a fingerprint of X.509 certificate for identity authentication,
+which is a 40-digit or 64-digit hexadecimal string. For more detail, please see
+[Registering a Device Authenticated by an X.509 Certificate](https://support.huaweicloud.com/en-us/usermanual-iothub/iot_01_0055.html).
+
+* `gateway_id` - (Optional, String) Specifies the gateway ID which is the device ID of the parent device.
+The child device is not directly connected to the platform. If omitted, it means to create a device directly connected
+to the platform, the `device_id` of the device is the same as the `gateway_id`.
+
+* `description` - (Optional, String) Specifies the description of device. The description contains a maximum of 2048
+characters. Only letters, Chinese characters, digits, hyphens (-), underscore (_) and the following specail characters
+are allowed: `?'#().,&%@!`.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the device.
+
+* `frozen` - (Optional, Bool) Specifies whether to freeze the device. Defaults to `false`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The device ID in UUID format.
+
+* `status` - The status of device. The valid values are **INACTIVE**, **ONLINE**, **OFFLINE**, **FROZEN**, **ABNORMAL**.
+
+* `auth_type` - The authentication type of device. The options are as follows:
+  + **SECRET**: Use a secret for identity authentication.
+  + **CERTIFICATES**: Use an x.509 certificate for identity authentication.
+
+* `node_type` - The node type of device. The options are as follows:
+  + **GATEWAY**: Directly connected device.
+  + **ENDPOINT**: Indirectly connected device.
+  + **UNKNOWN**: Unknown type.
+
+## Import
+
+Devices can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iotda_device.test 10022532f4f94f26b01daa1e424853e1
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -676,6 +676,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_iotda_space":   iotda.ResourceSpace(),
 			"huaweicloud_iotda_product": iotda.ResourceProduct(),
+			"huaweicloud_iotda_device":  iotda.ResourceDevice(),
 
 			"huaweicloud_kms_key":     ResourceKmsKeyV1(),
 			"huaweicloud_kps_keypair": dew.ResourceKeypair(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -1,0 +1,148 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDeviceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	return client.ShowDevice(&model.ShowDeviceRequest{DeviceId: state.Primary.ID})
+}
+
+func TestAccDevice_basic(t *testing.T) {
+	var obj model.ShowDeviceResponse
+
+	nodeId := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_device.test"
+	childDeviceName := "huaweicloud_iotda_device.test2"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDevice_basic(nodeId, nodeId),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", nodeId),
+					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
+					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
+					resource.TestCheckResourceAttr(rName, "description", "demo"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(rName, "auth_type", "SECRET"),
+					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
+					resource.TestCheckResourceAttr(rName, "frozen", "false"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", nodeId+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
+					resource.TestCheckResourceAttrPair(rName, "id", childDeviceName, "gateway_id"),
+				),
+			},
+			{
+				Config: testDevice_basic_update(updateName, nodeId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
+					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
+					resource.TestCheckResourceAttr(rName, "description", "demo_update"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(rName, "status", "FROZEN"),
+					resource.TestCheckResourceAttr(rName, "frozen", "true"),
+					resource.TestCheckResourceAttr(rName, "auth_type", "CERTIFICATES"),
+					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", updateName+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
+					resource.TestCheckResourceAttrPair(rName, "id", childDeviceName, "gateway_id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDevice_basic(name, nodeId string) string {
+	productbasic := testProduct_basic(name)
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_iotda_device" "test" {
+  node_id     = "%[3]s"
+  name        = "%[2]s"
+  space       = huaweicloud_iotda_space.test.id
+  product_id  = huaweicloud_iotda_product.test.id
+  secret      = "1234567890"
+  description = "demo"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_iotda_device" "test2" {
+  node_id    = "%[3]s_2"
+  name       = "%[2]s_2"
+  space      = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+  gateway_id = huaweicloud_iotda_device.test.id
+}
+`, productbasic, name, nodeId)
+}
+
+func testDevice_basic_update(name, nodeId string) string {
+	productbasic := testProduct_basic(name)
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_iotda_device" "test" {
+  node_id     = "%[3]s"
+  name        = "%[2]s"
+  space       = huaweicloud_iotda_space.test.id
+  product_id  = huaweicloud_iotda_product.test.id
+  fingerprint = "1234567890123456789012345678901234567890"
+  description = "demo_update"
+  frozen      = true
+
+  tags = {
+    foo = "bar_update"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_iotda_device" "test2" {
+  node_id    = "%[3]s_2"
+  name       = "%[2]s_2"
+  space      = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+  gateway_id = huaweicloud_iotda_device.test.id
+}
+`, productbasic, name, nodeId)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -1,0 +1,452 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	v5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	deviceStatusFrozen = "FROZEN"
+)
+
+func ResourceDevice() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceDeviceCreate,
+		UpdateContext: ResourceDeviceUpdate,
+		DeleteContext: ResourceDeviceDelete,
+		ReadContext:   ResourceDeviceRead,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(4, 256),
+					validation.StringMatch(regexp.MustCompile(stringRegxp), stringFormatMsg),
+				),
+			},
+
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(4, 256),
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_0-9]*$`),
+						"Only letters, digits, underscores (_) and hyphens (-) are allowed."),
+				),
+			},
+
+			"space": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"device_id": { //keep same with console
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(4, 256),
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_0-9]*$`),
+						"Only letters, digits, underscores (_) and hyphens (-) are allowed."),
+				),
+			},
+
+			"secret": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"fingerprint"},
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(8, 32),
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_0-9]*$`),
+						"Only letters, digits, underscores (_) and hyphens (-) are allowed."),
+				),
+			},
+
+			"fingerprint": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"secret"},
+				ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+					v, ok := i.(string)
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+						return warnings, errors
+					}
+
+					if len(v) != 40 && len(v) != 64 {
+						errors = append(errors,
+							fmt.Errorf("expected the fingerprint is a 40-digit or 64-digit hexadecimal string"))
+					}
+
+					return warnings, errors
+				},
+			},
+
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"tags": common.TagsSchema(),
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 2048),
+					validation.StringMatch(regexp.MustCompile(stringRegxp), stringFormatMsg),
+				),
+			},
+
+			"frozen": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"auth_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"node_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	createOpts := buildDeviceCreateParams(d)
+	resp, err := client.AddDevice(createOpts)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA device: %s", err)
+	}
+
+	if resp.DeviceId == nil {
+		return diag.Errorf("error creating IoTDA device: id is not found in API response")
+	}
+
+	d.SetId(*resp.DeviceId)
+
+	// bind tags
+	err = bindDeviceTags(client, d.Id(), nil, d.Get("tags").(map[string]interface{}))
+	if err != nil {
+		return diag.Errorf("error binding tags when creating IoTDA device: %s", err)
+	}
+
+	// freeze device
+	isFrozen := d.Get("frozen").(bool)
+	err = updateDeviceStatus(client, d.Id(), utils.StringValue(resp.Status), isFrozen)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return ResourceDeviceRead(ctx, d, meta)
+}
+
+func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	response, err := client.ShowDevice(&model.ShowDeviceRequest{DeviceId: d.Id()})
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA device")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", response.DeviceName),
+		d.Set("device_id", response.DeviceId),
+		d.Set("node_id", response.NodeId),
+		d.Set("name", response.DeviceName),
+		d.Set("product_id", response.ProductId),
+		d.Set("gateway_id", response.GatewayId),
+		d.Set("description", response.Description),
+		d.Set("space", response.AppId),
+		d.Set("status", response.Status),
+		d.Set("node_type", response.NodeType),
+		d.Set("tags", flattenTags(response.Tags)),
+		d.Set("frozen", utils.StringValue(response.Status) == deviceStatusFrozen),
+	)
+
+	if response.AuthInfo != nil {
+		mErr = multierror.Append(mErr,
+			d.Set("secret", response.AuthInfo.Secret),
+			d.Set("fingerprint", response.AuthInfo.Fingerprint),
+			d.Set("auth_type", response.AuthInfo.AuthType),
+		)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	// name,desc
+	if d.HasChanges("name", "description") {
+		updateOpts := buildDeviceUpdateParams(d)
+		_, err = client.UpdateDevice(updateOpts)
+		if err != nil {
+			return diag.Errorf("error updating IoTDA device: %s", err)
+		}
+	}
+
+	// Reset Device Secret
+	if d.HasChange("secret") {
+		_, err = client.ResetDeviceSecret(&model.ResetDeviceSecretRequest{
+			DeviceId: d.Id(),
+			ActionId: "resetSecret",
+			Body: &model.ResetDeviceSecret{
+				Secret: utils.StringIgnoreEmpty(d.Get("secret").(string)),
+			},
+		})
+		if err != nil {
+			return diag.Errorf("error updating the secret of IoTDA device: %s", err)
+		}
+	}
+
+	// Reset Fingerprint
+	if d.HasChange("fingerprint") {
+		_, err = client.ResetFingerprint(&model.ResetFingerprintRequest{
+			DeviceId: d.Id(),
+			Body: &model.ResetFingerprint{
+				Fingerprint: utils.StringIgnoreEmpty(d.Get("fingerprint").(string)),
+			},
+		})
+		if err != nil {
+			return diag.Errorf("error updating the fingerprint of IoTDA device: %s", err)
+		}
+	}
+
+	// frozen
+	if d.HasChange("frozen") {
+		isFrozen := d.Get("frozen").(bool)
+		status := d.Get("status").(string)
+		err = updateDeviceStatus(client, d.Id(), status, isFrozen)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// tags
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		err = bindDeviceTags(client, d.Id(), o.(map[string]interface{}), n.(map[string]interface{}))
+		if err != nil {
+			return diag.Errorf("error updating the tags of IoTDA device: %s", err)
+		}
+	}
+
+	return ResourceDeviceRead(ctx, d, meta)
+}
+
+func ResourceDeviceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	deleteOpts := &model.DeleteDeviceRequest{DeviceId: d.Id()}
+	_, err = client.DeleteDevice(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting IoTDA device: %s", err)
+	}
+
+	return nil
+}
+
+func bindDeviceTags(client *v5.IoTDAClient, deviceId string, oMap, nMap map[string]interface{}) error {
+	// remove old tags
+	if len(oMap) > 0 {
+		keys := ExpandKeyOfTags(oMap)
+		_, err := client.UntagDevice(&model.UntagDeviceRequest{
+			Body: &model.UnbindTagsDto{
+				ResourceType: "device",
+				ResourceId:   deviceId,
+				TagKeys:      keys,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// set new tags
+	if len(nMap) > 0 {
+		taglist := ExpandResourceTags(nMap)
+		_, err := client.TagDevice(&model.TagDeviceRequest{
+			Body: &model.BindTagsDto{
+				ResourceType: "device",
+				ResourceId:   deviceId,
+				Tags:         taglist,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ExpandResourceTags(tagmap map[string]interface{}) []model.TagV5Dto {
+	var taglist []model.TagV5Dto
+
+	for k, v := range tagmap {
+		tag := model.TagV5Dto{
+			TagKey:   k,
+			TagValue: utils.StringIgnoreEmpty(v.(string)),
+		}
+		taglist = append(taglist, tag)
+	}
+	return taglist
+}
+
+func ExpandKeyOfTags(tagmap map[string]interface{}) []string {
+	var taglist []string
+	for k := range tagmap {
+		taglist = append(taglist, k)
+	}
+	return taglist
+}
+
+func buildDeviceCreateParams(d *schema.ResourceData) *model.AddDeviceRequest {
+	req := model.AddDeviceRequest{
+		Body: &model.AddDevice{
+			DeviceId:    utils.StringIgnoreEmpty(d.Get("device_id").(string)),
+			NodeId:      d.Get("node_id").(string),
+			DeviceName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
+			ProductId:   d.Get("product_id").(string),
+			GatewayId:   utils.StringIgnoreEmpty(d.Get("gateway_id").(string)),
+			Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
+			AppId:       utils.StringIgnoreEmpty(d.Get("space").(string)),
+			AuthInfo:    buildAuthInfo(d.Get("secret").(string), d.Get("fingerprint").(string)),
+		},
+	}
+	return &req
+}
+
+func buildDeviceUpdateParams(d *schema.ResourceData) *model.UpdateDeviceRequest {
+	req := model.UpdateDeviceRequest{
+		DeviceId: d.Id(),
+		Body: &model.UpdateDevice{
+			DeviceName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
+			Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
+		},
+	}
+	return &req
+}
+
+func buildAuthInfo(secret, fingerprint string) *model.AuthInfo {
+	if len(secret) > 0 {
+		return &model.AuthInfo{
+			AuthType: utils.String("SECRET"),
+			Secret:   &secret,
+		}
+	}
+
+	if len(fingerprint) > 0 {
+		return &model.AuthInfo{
+			AuthType:    utils.String("CERTIFICATES"),
+			Fingerprint: &fingerprint,
+		}
+	}
+
+	return nil
+}
+
+func flattenTags(s *[]model.TagV5Dto) map[string]interface{} {
+	if s == nil {
+		return nil
+	}
+
+	rst := make(map[string]interface{})
+	for _, v := range *s {
+		rst[v.TagKey] = v.TagValue
+	}
+
+	return rst
+}
+
+func updateDeviceStatus(client *v5.IoTDAClient, deviceId, status string, isFrozen bool) error {
+	if isFrozen && status != deviceStatusFrozen {
+		_, err := client.FreezeDevice(&model.FreezeDeviceRequest{
+			DeviceId: deviceId,
+		})
+		if err != nil {
+			return fmt.Errorf("error freezing IoTDA device: %s", err)
+		}
+	}
+
+	if !isFrozen && status == deviceStatusFrozen {
+		_, err := client.UnfreezeDevice(&model.UnfreezeDeviceRequest{
+			DeviceId: deviceId,
+		})
+		if err != nil {
+			return fmt.Errorf("error unfreezing IoTDA device: %s", err)
+		}
+	}
+	return nil
+}

--- a/huaweicloud/utils/type_convert.go
+++ b/huaweicloud/utils/type_convert.go
@@ -45,3 +45,11 @@ func StringToInt(i *string) *int {
 	}
 	return &r
 }
+
+// StringValue returns the string value
+func StringValue(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource to manage device

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. An API error occurred while setting the shadow, so don't support shadow in this PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run=TestAccDevice_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run=TestAccDevice_basic -timeout 360m -parallel 4
=== RUN   TestAccDevice_basic
--- PASS: TestAccDevice_basic (29.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     29.632s
```