### PR TITLE
feat: refactor(cbr/vault): support the prepaid mode creation

### DIFF
--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -124,6 +124,8 @@ The following arguments are supported:
 
 * `size` - (Required, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
 
+  -> You cannot update `size` if the vault is **prePaid** mode.
+
 * `consistent_level` - (Optional, String, ForceNew) Specifies the backup specifications.
   The valid values are as follows:
   + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
@@ -135,6 +137,8 @@ The following arguments are supported:
 * `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
   Defaults to **false**.
 
+  -> You cannot configure `auto_expand` if the vault is **prePaid** mode.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies a unique ID in UUID format of enterprise project.
   Changing this will create a new vault.
 
@@ -145,6 +149,30 @@ The following arguments are supported:
   The [object](#cbr_vault_resources) structure is documented below.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBR vault.
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the vault.
+  The valid values are as follows:
+  + **prePaid**: the yearly/monthly billing mode.
+  + **postPaid**: the pay-per-use billing mode.
+
+  Changing this will create a new vault.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the vault.
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this will create a new vault.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the vault.
+  If `period_unit` is set to **month**, the value ranges from 1 to 9.
+  If `period_unit` is set to **year**, the value ranges from 1 to 5.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this will create a new vault.
+
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+  Valid values are **true** and **false**. Defaults to **false**. Changing this will create a new vault.
+
+* `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
+  Valid values are **true** and **false**. Defaults to **true**. If you set this to **false**, you need to pay the order
+  yourself in time. Be careful about the timeout of resource creation. Changing this will create a new vault.
 
 <a name="cbr_vault_resources"></a>
 The `resources` block supports:
@@ -173,10 +201,35 @@ In addition to all arguments above, the following attributes are exported:
 
 * `storage` - The name of the bucket for the vault.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 5 minute.
+
 ## Import
 
 Vaults can be imported by their `id`. For example,
 
 ```
 $ terraform import huaweicloud_cbr_vault.test 01c33779-7c83-4182-8b6b-24a671fcedf8
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include: `period_unit`, `period`, `auto_renew`,
+`auto_pay`. It is generally recommended running `terraform plan` after importing a vault.
+You can then decide if changes should be applied to the vault, or the resource definition should be updated to align
+with the vault. Also you can ignore changes as below.
+
+```
+resource "huaweicloud_cbr_vault" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      period_unit, period, auto_renew, auto_pay,
+    ]
+  }
+}
 ```

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -183,6 +183,11 @@ func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
 	}
 }
 
+// GetAutoPay is a method to return whether order is auto pay according to the user input.
+// auto_pay parameter inputs and returns:
+//   false: false
+//   true, empty: true
+// Before using this function, make sure the parameter behavior is auto pay (the default value is "true").
 func GetAutoPay(d *schema.ResourceData) string {
 	if d.Get("auto_pay").(string) == "false" {
 		return "false"

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -548,7 +548,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_bcs_instance": resourceBCSInstanceV2(),
 
 			"huaweicloud_cbr_policy": cbr.ResourceCBRPolicyV3(),
-			"huaweicloud_cbr_vault":  cbr.ResourceCBRVaultV3(),
+			"huaweicloud_cbr_vault":  cbr.ResourceVault(),
 
 			"huaweicloud_cce_cluster":     ResourceCCEClusterV3(),
 			"huaweicloud_cce_node":        ResourceCCENodeV3(),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 )
 
-func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
+func TestAccVaults_BasicServer(t *testing.T) {
 	randName := acceptance.RandomAccResourceNameWithDash()
 	dataSourceName := "data.huaweicloud_cbr_vaults.test"
 
@@ -23,7 +23,7 @@ func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCbrVaultsV3_serverBasic(randName),
+				Config: testAccVaults_basic(testAccVault_serverBasic(randName)),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
@@ -43,7 +43,7 @@ func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
 	})
 }
 
-func TestAccCbrVaultsV3_ReplicaServer(t *testing.T) {
+func TestAccVaults_ReplicaServer(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	dataSourceName := "data.huaweicloud_cbr_vaults.test"
 
@@ -57,7 +57,7 @@ func TestAccCbrVaultsV3_ReplicaServer(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCbrVaultsV3_serverReplication(randName),
+				Config: testAccVaults_basic(testAccVault_serverReplication(randName)),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
@@ -72,7 +72,7 @@ func TestAccCbrVaultsV3_ReplicaServer(t *testing.T) {
 	})
 }
 
-func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
+func TestAccVaults_BasicVolume(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	dataSourceName := "data.huaweicloud_cbr_vaults.test"
 
@@ -86,7 +86,7 @@ func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCbrVaultsV3_volumeBasic(randName),
+				Config: testAccVaults_basic(testAccVault_volumeBasic(randName)),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
@@ -104,7 +104,7 @@ func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
 	})
 }
 
-func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
+func TestAccVaults_BasicTurbo(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	dataSourceName := "data.huaweicloud_cbr_vaults.test"
 
@@ -118,7 +118,7 @@ func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCbrVaultsV3_turboBasic(randName),
+				Config: testAccVaults_basic(testAccVault_turboBasic(randName)),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
@@ -136,7 +136,7 @@ func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
 	})
 }
 
-func TestAccCbrVaultsV3_ReplicaTurbo(t *testing.T) {
+func TestAccVaults_ReplicaTurbo(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	dataSourceName := "data.huaweicloud_cbr_vaults.test"
 
@@ -150,7 +150,7 @@ func TestAccCbrVaultsV3_ReplicaTurbo(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCbrVaultsV3_turboReplication(randName),
+				Config: testAccVaults_basic(testAccVault_turboReplication(randName)),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
@@ -167,52 +167,12 @@ func TestAccCbrVaultsV3_ReplicaTurbo(t *testing.T) {
 	})
 }
 
-func testAccCbrVaultsV3_serverBasic(rName string) string {
+func testAccVaults_basic(config string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_cbr_vaults" "test" {
   name = huaweicloud_cbr_vault.test.name
 }
-`, testAccCBRV3Vault_serverBasic(rName))
-}
-
-func testAccCbrVaultsV3_serverReplication(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_cbr_vaults" "test" {
-  name = huaweicloud_cbr_vault.test.name
-}
-`, testAccCBRV3Vault_serverReplication(rName))
-}
-
-func testAccCbrVaultsV3_volumeBasic(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_cbr_vaults" "test" {
-  name = huaweicloud_cbr_vault.test.name
-}
-`, testAccCBRV3Vault_volumeBasic(rName))
-}
-
-func testAccCbrVaultsV3_turboBasic(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_cbr_vaults" "test" {
-  name = huaweicloud_cbr_vault.test.name
-}
-`, testAccCBRV3Vault_turboBasic(rName))
-}
-
-func testAccCbrVaultsV3_turboReplication(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_cbr_vaults" "test" {
-  name = huaweicloud_cbr_vault.test.name
-}
-`, testAccCBRV3Vault_turboReplication(rName))
+`, config)
 }

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -15,12 +15,12 @@ import (
 func getVaultResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	c, err := conf.CbrV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud CBR client: %s", err)
+		return nil, fmt.Errorf("error creating CBR v3 client: %s", err)
 	}
 	return vaults.Get(c, state.Primary.ID).Extract()
 }
 
-func TestAccCBRV3Vault_BasicServer(t *testing.T) {
+func TestAccVault_BasicServer(t *testing.T) {
 	var vault vaults.Vault
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_vault.test"
@@ -40,7 +40,7 @@ func TestAccCBRV3Vault_BasicServer(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCBRV3Vault_serverBasic(randName),
+				Config: testAccVault_serverBasic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
@@ -56,7 +56,7 @@ func TestAccCBRV3Vault_BasicServer(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCBRV3Vault_serverUpdate(randName),
+				Config: testAccVault_serverUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
@@ -82,7 +82,7 @@ func TestAccCBRV3Vault_BasicServer(t *testing.T) {
 	})
 }
 
-func TestAccCBRV3Vault_ReplicaServer(t *testing.T) {
+func TestAccVault_ReplicaServer(t *testing.T) {
 	var vault vaults.Vault
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_vault.test"
@@ -102,7 +102,7 @@ func TestAccCBRV3Vault_ReplicaServer(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCBRV3Vault_serverReplication(randName),
+				Config: testAccVault_serverReplication(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
@@ -121,7 +121,7 @@ func TestAccCBRV3Vault_ReplicaServer(t *testing.T) {
 	})
 }
 
-func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
+func TestAccVault_BasicVolume(t *testing.T) {
 	var vault vaults.Vault
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_vault.test"
@@ -141,7 +141,7 @@ func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCBRV3Vault_volumeBasic(randName),
+				Config: testAccVault_volumeBasic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
@@ -156,7 +156,7 @@ func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCBRV3Vault_volumeUpdate(randName),
+				Config: testAccVault_volumeUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
@@ -180,7 +180,7 @@ func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
 	})
 }
 
-func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
+func TestAccVault_BasicTurbo(t *testing.T) {
 	var vault vaults.Vault
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_vault.test"
@@ -200,7 +200,7 @@ func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCBRV3Vault_turboBasic(randName),
+				Config: testAccVault_turboBasic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
@@ -213,7 +213,7 @@ func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCBRV3Vault_turboUpdate(randName),
+				Config: testAccVault_turboUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
@@ -235,7 +235,7 @@ func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
 	})
 }
 
-func TestAccCBRV3Vault_ReplicaTurbo(t *testing.T) {
+func TestAccVault_ReplicaTurbo(t *testing.T) {
 	var vault vaults.Vault
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_cbr_vault.test"
@@ -255,7 +255,7 @@ func TestAccCBRV3Vault_ReplicaTurbo(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCBRV3Vault_turboReplication(randName),
+				Config: testAccVault_turboReplication(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
@@ -275,7 +275,7 @@ func TestAccCBRV3Vault_ReplicaTurbo(t *testing.T) {
 	})
 }
 
-func testAccCBRV3Vault_policy(rName string) string {
+func testAccVault_policy(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cbr_policy" "test" {
   name        = "%s"
@@ -320,7 +320,7 @@ variable "volume_configuration" {
 }`
 }
 
-func testAccCBRV3VaultBasicConfiguration(config, rName string) string {
+func testAccVaultBasicConfiguration(config, rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -401,7 +401,7 @@ resource "huaweicloud_compute_volume_attach" "test" {
 }`, config, rName, rName, rName, rName, rName, rName)
 }
 
-func testAccCBRV3Vault_serverBasic(rName string) string {
+func testAccVault_serverBasic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -423,11 +423,11 @@ resource "huaweicloud_cbr_vault" "test" {
     key = "value"
   }
 }
-`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+`, testAccVaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
 		rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccCBRV3Vault_serverUpdate(rName string) string {
+func testAccVault_serverUpdate(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -453,11 +453,11 @@ resource "huaweicloud_cbr_vault" "test" {
     key  = "value_update"
   }
 }
-`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_update(), rName), testAccCBRV3Vault_policy(rName),
+`, testAccVaultBasicConfiguration(testAccEvsVolumeConfiguration_update(), rName), testAccVault_policy(rName),
 		rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccCBRV3Vault_serverReplication(rName string) string {
+func testAccVault_serverReplication(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s"
@@ -470,7 +470,7 @@ resource "huaweicloud_cbr_vault" "test" {
 `, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccCBRV3Vault_volumeBasic(rName string) string {
+func testAccVault_volumeBasic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -485,11 +485,11 @@ resource "huaweicloud_cbr_vault" "test" {
     includes = huaweicloud_compute_volume_attach.test[*].volume_id
   }
 }
-`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+`, testAccVaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
 		rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccCBRV3Vault_volumeUpdate(rName string) string {
+func testAccVault_volumeUpdate(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -508,12 +508,12 @@ resource "huaweicloud_cbr_vault" "test" {
     includes = huaweicloud_compute_volume_attach.test[*].volume_id
   }
 }
-`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
-		testAccCBRV3Vault_policy(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccVaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		testAccVault_policy(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 //Vaults of type 'turbo'
-func testAccCBRV3Vault_turboBase(rName string) string {
+func testAccVault_turboBase(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -544,7 +544,7 @@ resource "huaweicloud_sfs_turbo" "test1" {
 }`, rName, rName, rName, rName)
 }
 
-func testAccCBRV3Vault_turboBasic(rName string) string {
+func testAccVault_turboBasic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -561,10 +561,10 @@ resource "huaweicloud_cbr_vault" "test" {
     ]
   }
 }
-`, testAccCBRV3Vault_turboBase(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccVault_turboBase(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccCBRV3Vault_turboUpdate(rName string) string {
+func testAccVault_turboUpdate(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -595,11 +595,11 @@ resource "huaweicloud_cbr_vault" "test" {
     ]
   }
 }
-`, testAccCBRV3Vault_turboBase(rName), testAccCBRV3Vault_policy(rName), rName, rName,
+`, testAccVault_turboBase(rName), testAccVault_policy(rName), rName, rName,
 		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-func testAccCBRV3Vault_turboReplication(rName string) string {
+func testAccVault_turboReplication(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%s"

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
@@ -230,7 +230,7 @@ func setCbrAllVaultParameters(client *golangsdk.ServiceClient, d *schema.Resourc
 			"storage":               vault.Billing.StorageUnit,
 			"auto_expand_enabled":   vault.AutoExpand,
 			"tags":                  utils.TagsToMap(vault.Tags),
-			"resources":             makeCbrVaultResources(vault.Billing.ObjectType, vault.Resources),
+			"resources":             makeVaultResources(vault.Billing.ObjectType, vault.Resources),
 		}
 
 		// Query the CBR policy which bound to the vault by ID

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -1,19 +1,22 @@
 package cbr
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"math"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
 	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 const (
@@ -38,15 +41,15 @@ var ResourceType map[string]string = map[string]string{
 	VaultTypeTurbo:  ResourceTypeTurbo,
 }
 
-func ResourceCBRVaultV3() *schema.Resource {
+func ResourceVault() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCBRVaultV3Create,
-		Read:   resourceCBRVaultV3Read,
-		Update: resourceCBRVaultV3Update,
-		Delete: resourceCBRVaultV3Delete,
+		CreateContext: resourceVaultCreate,
+		ReadContext:   resourceVaultRead,
+		UpdateContext: resourceVaultUpdate,
+		DeleteContext: resourceVaultDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -178,7 +181,7 @@ func buildAssociateResourcesForServer(rType string, resources []interface{}) ([]
 			result.ExtraInfo.ExcludeVolumes = volumes
 		}
 		if res["includes"].(*schema.Set).Len() > 0 {
-			return results, fmtp.Errorf("Server vault does not support includes.")
+			return results, fmt.Errorf("server vault does not support includes")
 		}
 		results[i] = result
 	}
@@ -188,7 +191,7 @@ func buildAssociateResourcesForServer(rType string, resources []interface{}) ([]
 func buildAssociateResourcesForDisk(rType string, resources []interface{}) ([]vaults.ResourceCreate, error) {
 	if len(resources) > 1 {
 		return []vaults.ResourceCreate{},
-			fmtp.Errorf("The size of resources cannot grant than one for disk and turbo vault.")
+			fmt.Errorf("the size of resources cannot grant than one for disk and turbo vault")
 	} else if len(resources) == 0 {
 		return []vaults.ResourceCreate{}, nil
 	}
@@ -203,7 +206,7 @@ func buildAssociateResourcesForDisk(rType string, resources []interface{}) ([]va
 		}
 		return result, nil
 	}
-	return []vaults.ResourceCreate{}, fmtp.Errorf("Only includes can be set for disk and turbo vault.")
+	return []vaults.ResourceCreate{}, fmt.Errorf("only includes can be set for disk and turbo vault")
 }
 
 func buildAssociateResources(vType string, resources *schema.Set) ([]vaults.ResourceCreate, error) {
@@ -211,16 +214,16 @@ func buildAssociateResources(vType string, resources *schema.Set) ([]vaults.Reso
 	var err error
 	rType, ok := ResourceType[vType]
 	if !ok {
-		return nil, fmtp.Errorf("Invalid resource type: %s", vType)
+		return nil, fmt.Errorf("invalid resource type: %s", vType)
 	}
-	logp.Printf("[DEBUG] The resource type is %s", rType)
+	log.Printf("[DEBUG] The resource type is %s", rType)
 	switch rType {
 	case ResourceTypeServer:
 		result, err = buildAssociateResourcesForServer(rType, resources.List())
 	case ResourceTypeDisk, ResourceTypeTurbo:
 		result, err = buildAssociateResourcesForDisk(rType, resources.List())
 	default:
-		err = fmtp.Errorf("The vault type only support server, disk and turbo.")
+		err = fmt.Errorf("the vault type only support server, disk and turbo")
 	}
 	return result, err
 }
@@ -245,20 +248,20 @@ func buildDissociateResourcesForDisk(rType string, resources []interface{}) []st
 func buildDissociateResources(vType string, resources *schema.Set) ([]string, error) {
 	rType, ok := ResourceType[vType]
 	if !ok {
-		return nil, fmtp.Errorf("Invalid resource type: %s", vType)
+		return nil, fmt.Errorf("invalid resource type: %s", vType)
 	}
-	logp.Printf("[DEBUG] The resource type is %s", rType)
+	log.Printf("[DEBUG] The resource type is %s", rType)
 	switch rType {
 	case ResourceTypeServer:
 		return buildDissociateResourcesForServer(rType, resources.List()), nil
 	case ResourceTypeDisk, ResourceTypeTurbo:
 		return buildDissociateResourcesForDisk(rType, resources.List()), nil
 	default:
-		return nil, fmtp.Errorf("The vault type only support server, disk and turbo.")
+		return nil, fmt.Errorf("the vault type only support server, disk and turbo")
 	}
 }
 
-func buildCBRVaultBilling(d *schema.ResourceData) *vaults.BillingCreate {
+func buildBillingStructure(d *schema.ResourceData) *vaults.BillingCreate {
 	billing := &vaults.BillingCreate{
 		ObjectType:      d.Get("type").(string),
 		ConsistentLevel: d.Get("consistent_level").(string),
@@ -269,16 +272,16 @@ func buildCBRVaultBilling(d *schema.ResourceData) *vaults.BillingCreate {
 	return billing
 }
 
-func resourceCBRVaultV3Create(d *schema.ResourceData, meta interface{}) error {
+func resourceVaultCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR v3 client: %s", err)
+		return diag.Errorf("error creating CBR v3 client: %s", err)
 	}
 
 	resources, err := buildAssociateResources(d.Get("type").(string), d.Get("resources").(*schema.Set))
 	if err != nil {
-		return fmtp.Errorf("Error building vault resources: %s", err)
+		return diag.Errorf("error building vault resources: %s", err)
 	}
 	opts := vaults.CreateOpts{
 		Name:                d.Get("name").(string),
@@ -286,31 +289,31 @@ func resourceCBRVaultV3Create(d *schema.ResourceData, meta interface{}) error {
 		BackupPolicyID:      d.Get("policy_id").(string),
 		EnterpriseProjectID: config.GetEnterpriseProjectID(d),
 		Resources:           resources,
-		Billing:             buildCBRVaultBilling(d),
+		Billing:             buildBillingStructure(d),
 	}
 
-	logp.Printf("[DEBUG] The createOpts is: %+v", opts)
+	log.Printf("[DEBUG] The createOpts is: %+v", opts)
 	vault, err := vaults.Create(client, opts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error creating vaults: %s", err)
+		return diag.Errorf("error creating vaults: %s", err)
 	}
 	d.SetId(vault.ID)
 
 	if policy, ok := d.GetOk("policy_id"); ok {
 		_, err := vaults.BindPolicy(client, d.Id(), vaults.BindPolicyOpts{PolicyID: policy.(string)}).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error binding policy to vault: %s", err)
+			return diag.Errorf("error binding policy to vault: %s", err)
 		}
 	}
 
 	if err := utils.UpdateResourceTags(client, d, "vault", d.Id()); err != nil {
-		return fmtp.Errorf("Error setting tags of CBR vault: %s", err)
+		return diag.Errorf("error setting tags of CBR vault: %s", err)
 	}
 
-	return resourceCBRVaultV3Read(d, meta)
+	return resourceVaultRead(ctx, d, meta)
 }
 
-func makeCbrVaultResourcesForServer(resources []vaults.ResourceResp) []map[string]interface{} {
+func makeVaultResourcesForServer(resources []vaults.ResourceResp) []map[string]interface{} {
 	results := make([]map[string]interface{}, len(resources))
 	for i, res := range resources {
 		result := map[string]interface{}{
@@ -332,8 +335,8 @@ func makeCbrVaultResourcesForServer(resources []vaults.ResourceResp) []map[strin
 	return results
 }
 
-// MakeCbrVaultResourcesForDisk is a method for constructing a map list based on the resources response of the server.
-func MakeCbrVaultResourcesForDisk(resources []vaults.ResourceResp) []map[string]interface{} {
+// MakeVaultResourcesForDisk is a method for constructing a map list based on the resources response of the server.
+func MakeVaultResourcesForDisk(resources []vaults.ResourceResp) []map[string]interface{} {
 	includeVolumes := make([]string, len(resources))
 	for i, res := range resources {
 		includeVolumes[i] = res.ID
@@ -345,37 +348,37 @@ func MakeCbrVaultResourcesForDisk(resources []vaults.ResourceResp) []map[string]
 	}
 }
 
-func makeCbrVaultResources(vType string, resources []vaults.ResourceResp) []map[string]interface{} {
+func makeVaultResources(vType string, resources []vaults.ResourceResp) []map[string]interface{} {
 	var result []map[string]interface{}
 	switch vType {
 	case VaultTypeServer:
-		result = makeCbrVaultResourcesForServer(resources)
+		result = makeVaultResourcesForServer(resources)
 	case VaultTypeDisk, VaultTypeTurbo:
-		result = MakeCbrVaultResourcesForDisk(resources)
+		result = MakeVaultResourcesForDisk(resources)
 	}
 	return result
 }
 
-func setCbrResources(d *schema.ResourceData, vType string, resources []vaults.ResourceResp) error {
-	result := makeCbrVaultResources(vType, resources)
+func setResources(d *schema.ResourceData, vType string, resources []vaults.ResourceResp) error {
+	result := makeVaultResources(vType, resources)
 	if len(result) != 0 {
 		return d.Set("resources", result)
 	}
 	return nil
 }
 
-func getCbrPolicyByVaultId(client *golangsdk.ServiceClient, vaultId string) (string, error) {
+func getPolicyByVaultId(client *golangsdk.ServiceClient, vaultId string) (string, error) {
 	listOpts := policies.ListOpts{
 		VaultID: vaultId,
 	}
 	allPages, err := policies.List(client, listOpts).AllPages()
 	if err != nil {
-		return "", fmtp.Errorf("Error getting policy by vault ID (%s): %s", vaultId, err)
+		return "", fmt.Errorf("error getting policy by vault ID (%s): %s", vaultId, err)
 	}
 
 	policyList, err := policies.ExtractPolicies(allPages)
 	if err != nil {
-		return "", fmtp.Errorf("error getting policy by vault ID (%s): %s", vaultId, err)
+		return "", fmt.Errorf("error extracting vault list: %s", err)
 	}
 
 	if len(policyList) >= 1 {
@@ -390,24 +393,24 @@ func getNumberInGB(megaBytes float64) float64 {
 	return math.Trunc(float64(megaBytes) / denominator * 1e2 * 1e-2)
 }
 
-func setCbrPolicyId(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
-	policyId, err := getCbrPolicyByVaultId(client, d.Id())
+func setPolicyId(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	policyId, err := getPolicyByVaultId(client, d.Id())
 	if err != nil {
 		return err
 	}
 	return d.Set("policy_id", policyId)
 }
 
-func resourceCBRVaultV3Read(d *schema.ResourceData, meta interface{}) error {
+func resourceVaultRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR v3 client: %s", err)
+		return diag.Errorf("error creating CBR v3 client: %s", err)
 	}
 
 	resp, err := vaults.Get(client, d.Id()).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error getting vault details: %s", err)
+		return diag.Errorf("error getting vault details: %s", err)
 	}
 
 	mErr := multierror.Append(
@@ -420,8 +423,8 @@ func resourceCBRVaultV3Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("auto_expand", resp.AutoExpand),
 		d.Set("enterprise_project_id", resp.EnterpriseProjectID),
 		d.Set("tags", utils.TagsToMap(resp.Tags)),
-		setCbrResources(d, resp.Billing.ObjectType, resp.Resources),
-		setCbrPolicyId(d, client),
+		setResources(d, resp.Billing.ObjectType, resp.Resources),
+		setPolicyId(d, client),
 		// Computed
 		// The result of 'allocated' and 'used' is in MB, and now we need to use GB as the unit.
 		d.Set("allocated", getNumberInGB(float64(resp.Billing.Allocated))),
@@ -431,7 +434,7 @@ func resourceCBRVaultV3Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("storage", resp.Billing.StorageUnit),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.Errorf("Error setting vault fields: %s", err)
+		return diag.Errorf("error setting vault fields: %s", err)
 	}
 
 	return nil
@@ -446,15 +449,15 @@ func updateResources(d *schema.ResourceData, client *golangsdk.ServiceClient) er
 	if delRaws.Len() > 0 {
 		resources, err := buildDissociateResources(d.Get("type").(string), delRaws)
 		if err != nil {
-			return fmtp.Errorf("Error building dissociate list of vault resources: %s", err)
+			return fmt.Errorf("error building dissociate list of vault resources: %s", err)
 		}
 		dissociateOpt := vaults.DissociateResourcesOpts{
 			ResourceIDs: resources,
 		}
-		logp.Printf("[DEBUG] The dissociate opt is: %+v", dissociateOpt)
+		log.Printf("[DEBUG] The dissociate opt is: %+v", dissociateOpt)
 		_, err = vaults.DissociateResources(client, d.Id(), dissociateOpt).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error dissociating resources: %s", err)
+			return fmt.Errorf("error dissociating resources: %s", err)
 		}
 	}
 
@@ -462,15 +465,15 @@ func updateResources(d *schema.ResourceData, client *golangsdk.ServiceClient) er
 	if addRaws.Len() > 0 {
 		resources, err := buildAssociateResources(d.Get("type").(string), addRaws)
 		if err != nil {
-			return fmtp.Errorf("Error building associate list of vault resources: %s", err)
+			return fmt.Errorf("error building associate list of vault resources: %s", err)
 		}
 		associateOpt := vaults.AssociateResourcesOpts{
 			Resources: resources,
 		}
-		logp.Printf("[DEBUG] The associate opt is: %+v", associateOpt)
+		log.Printf("[DEBUG] The associate opt is: %+v", associateOpt)
 		_, err = vaults.AssociateResources(client, d.Id(), associateOpt).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error binding resources: %s", err)
+			return fmt.Errorf("error binding resources: %s", err)
 		}
 	}
 
@@ -485,24 +488,24 @@ func updatePolicy(d *schema.ResourceData, client *golangsdk.ServiceClient) error
 			PolicyID: newP.(string),
 		}).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error binding policy to vault: %s", err)
+			return fmt.Errorf("error binding policy to vault: %s", err)
 		}
 	} else {
 		_, err := vaults.UnbindPolicy(client, d.Id(), vaults.BindPolicyOpts{
 			PolicyID: oldP.(string),
 		}).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error unbinding policy from vault: %s", err)
+			return fmt.Errorf("error unbinding policy from vault: %s", err)
 		}
 	}
 	return nil
 }
 
-func resourceCBRVaultV3Update(d *schema.ResourceData, meta interface{}) error {
+func resourceVaultUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR v3 client: %s", err)
+		return diag.Errorf("error creating CBR v3 client: %s", err)
 	}
 
 	if d.HasChanges("name", "size", "auto_expand") {
@@ -516,39 +519,39 @@ func resourceCBRVaultV3Update(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := vaults.Update(client, d.Id(), opts).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error updating the vault: %s", err)
+			return diag.Errorf("error updating the vault: %s", err)
 		}
 	}
 
 	if d.HasChange("resources") {
 		if err := updateResources(d, client); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if d.HasChange("policy_id") {
 		if err := updatePolicy(d, client); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	if d.HasChange("tags") {
 		if err = utils.UpdateResourceTags(client, d, "vault", d.Id()); err != nil {
-			return fmtp.Errorf("Failed to update tags: %s", err)
+			return diag.Errorf("failed to update tags: %s", err)
 		}
 	}
 
-	return resourceCBRVaultV3Read(d, meta)
+	return resourceVaultRead(ctx, d, meta)
 }
 
-func resourceCBRVaultV3Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceVaultDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	client, err := config.CbrV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR v3 client: %s", err)
+		return diag.Errorf("error creating CBR v3 client: %s", err)
 	}
 
 	if err := vaults.Delete(client, d.Id()).ExtractErr(); err != nil {
-		return fmtp.Errorf("Error deleting CBR v3 vault: %s", err)
+		return diag.Errorf("error deleting CBR v3 vault: %s", err)
 	}
 
 	d.SetId("")

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/vaults/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/vaults/results.go
@@ -81,6 +81,27 @@ func (r commonResult) Extract() (*Vault, error) {
 	return s.Vault, err
 }
 
+type OrderResp struct {
+	ErrText string  `json:"errText"`
+	ErrCode string  `json:"error_code"`
+	RetCode int     `json:"retCode"`
+	Orders  []Order `json:"orders"`
+}
+
+type Order struct {
+	CloudServiceId     string   `json:"cloudServiceId"`
+	ID                 string   `json:"orderId"`
+	ReserveInstanceIds []string `json:"reserveInstanceIds"`
+	ResourceId         string   `json:"resourceId"`
+	SubscribeResult    string   `json:"subscribeResult"`
+}
+
+func (r CreateResult) ExtractOrder() (*OrderResp, error) {
+	var s OrderResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
 type AssociateResourcesResult struct {
 	golangsdk.Result
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Adjust the funtion formats and error returns for CBR vault resource and data source.
- The vault API supports prepaid creation and deletion.
  - charging_mode
  - period
  - period_unit
  - auto_renew
  - auto_pay
- Cannot update size and configure auto_expend if the vault is `prepaid` mode.
- Currently, only region `cn-south-1` support the prepaid vaults creation. If the user is using an unsupported region, the provider will throw a warning to display the information.
- Differently, the period number of yearly prepaid vault is range from 1  to 5.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the funtion formats and error returns.
2. support prepaid vault creation.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccVault_prePaidServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccVault_prePaidServer -timeout 360m -parallel 4
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== CONT  TestAccVault_prePaidServer
--- PASS: TestAccVault_prePaidServer (332.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       332.375s
```
The informations when creating a vault in an unsupported region
```
huaweicloud_cbr_vault.default: Creating...
╷
│ Warning: Unsupported Region
│ 
│   with huaweicloud_cbr_vault.default,
│   on main.tf line 137, in resource "huaweicloud_cbr_vault" "default":
│  137: resource "huaweicloud_cbr_vault" "default" {
│ 
│ The API does not support prepaid creation in this region (cn-north-4), because of the
│ API response does not include vault ID. You cannot manage it accept using import
│ operation by terraform. The order has been created, if you don't want it, you can
│ unsubscribe in the console. You cannot create a vault with the same configuration until
│ you unsubscribe.
╵
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to huaweicloud_cbr_vault.default, provider
│ "provider[\"local-registry/huaweicloud/huaweicloud\"]" produced an unexpected new value:
│ Root resource was present, but now absent.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue
│ tracker.
```

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccVaults'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccVaults -timeout 360m -parallel 4
=== RUN   TestAccVaults_BasicServer
=== PAUSE TestAccVaults_BasicServer
=== RUN   TestAccVaults_ReplicaServer
=== PAUSE TestAccVaults_ReplicaServer
=== RUN   TestAccVaults_BasicVolume
=== PAUSE TestAccVaults_BasicVolume
=== RUN   TestAccVaults_BasicTurbo
=== PAUSE TestAccVaults_BasicTurbo
=== RUN   TestAccVaults_ReplicaTurbo
=== PAUSE TestAccVaults_ReplicaTurbo
=== CONT  TestAccVaults_BasicServer
=== CONT  TestAccVaults_BasicTurbo
=== CONT  TestAccVaults_BasicVolume
=== CONT  TestAccVaults_ReplicaServer
--- PASS: TestAccVaults_ReplicaServer (21.36s)
=== CONT  TestAccVaults_ReplicaTurbo
--- PASS: TestAccVaults_ReplicaTurbo (16.00s)
--- PASS: TestAccVaults_BasicVolume (235.29s)
--- PASS: TestAccVaults_BasicServer (236.17s)
--- PASS: TestAccVaults_BasicTurbo (349.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       350.065s
```
