### PR TITLE
docs(eip/associate): rename associate resource

### DIFF
--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -27,7 +27,7 @@ resource "huaweicloud_lb_loadbalancer" "lb_1" {
   vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
 }
 
-resource "huaweicloud_networking_eip_associate" "eip_1" {
+resource "huaweicloud_vpc_eip_associate" "eip_1" {
   public_ip = "1.2.3.4"
   port_id   = huaweicloud_lb_loadbalancer.lb_1.vip_port_id
 }

--- a/examples/elb/basic/main.tf
+++ b/examples/elb/basic/main.tf
@@ -72,7 +72,7 @@ resource "huaweicloud_lb_loadbalancer" "elb_1" {
 }
 
 # associate eip with loadbalancer
-resource "huaweicloud_networking_eip_associate" "associate_1" {
+resource "huaweicloud_vpc_eip_associate" "associate_1" {
   public_ip = huaweicloud_vpc_eip.eip_1.address
   port_id   = huaweicloud_lb_loadbalancer.elb_1.vip_port_id
 }

--- a/examples/rds/mysql-with-eip/main.tf
+++ b/examples/rds/mysql-with-eip/main.tf
@@ -75,7 +75,7 @@ data "huaweicloud_networking_port" "rds_port" {
   fixed_ip   = huaweicloud_rds_instance.myinstance.private_ips[0]
 }
 
-resource "huaweicloud_networking_eip_associate" "associated" {
+resource "huaweicloud_vpc_eip_associate" "associated" {
   public_ip = huaweicloud_vpc_eip.myeip.address
   port_id   = data.huaweicloud_networking_port.rds_port.id
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Rename eip associate resource.
After ver.1.33.0 provider is released, the associate resource name is change to `huaweicloud_vpc_eip_associate`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rename eip associate resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run=TestAccEIPAssociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run=TestAccEIPAssociate -timeout 360m -parallel 4
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== RUN   TestAccEIPAssociate_port
=== PAUSE TestAccEIPAssociate_port
=== RUN   TestAccEIPAssociate_compatible
=== PAUSE TestAccEIPAssociate_compatible
=== CONT  TestAccEIPAssociate_basic
=== CONT  TestAccEIPAssociate_compatible
=== CONT  TestAccEIPAssociate_port
--- PASS: TestAccEIPAssociate_port (89.61s)
--- PASS: TestAccEIPAssociate_basic (93.37s)
--- PASS: TestAccEIPAssociate_compatible (94.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       95.067s
```
