### PR TITLE
bugfix(mrs): SetNewComputed does not support nested attributes

### DIFF
--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
@@ -1,7 +1,6 @@
 package mrs
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -254,24 +253,6 @@ func ResourceMRSClusterV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-		},
-
-		CustomizeDiff: func(c context.Context, rd *schema.ResourceDiff, i interface{}) error {
-			nodeGroupNameArray := [6]string{"master_nodes", "analysis_core_nodes", "analysis_task_nodes",
-				"streaming_core_nodes", "streaming_task_nodes", "custom_nodes"}
-
-			for _, nodeGroupName := range nodeGroupNameArray {
-				checkKey := fmt.Sprintf("%s.0.node_number", nodeGroupName)
-				changeKey := fmt.Sprintf("%s.0.host_ips", nodeGroupName)
-				if rd.HasChange(checkKey) {
-					logp.Printf("[DEBUG] nodeGroup=%s change,triger host_ips SetNewComputed", nodeGroupName)
-					err := rd.SetNewComputed(changeKey)
-					if err != nil {
-						return err
-					}
-				}
-			}
-			return nil
 		},
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

the **SetNewComputed** in schema package does not support nested attributes.
An error will be raised when we call **SetNewComputed("master_nodes.0.host_ips")**

```
Error: SetNewComputed: invalid key: master_nodes.0.host_ips
```

the source code as follows:
```
// SetNewComputed functions like SetNew, except that it blanks out a new value
// and marks it as computed.
//
// This function is only allowed on computed attributes.
func (d *ResourceDiff) SetNewComputed(key string) error {
	if err := d.checkKey(key, "SetNewComputed", false); err != nil {
		return err
	}

	return d.setDiff(key, nil, true)
}

// checkKey checks the key to make sure it exists and is computed.
func (d *ResourceDiff) checkKey(key, caller string, nested bool) error {
	var schema *Schema
	if nested {
		keyParts := strings.Split(key, ".")
		schemaL := addrToSchema(keyParts, d.schema)
		if len(schemaL) > 0 {
			schema = schemaL[len(schemaL)-1]
		}
	} else {
		s, ok := d.schema[key]
		if ok {
			schema = s
		}
	}
	if schema == nil {
		return fmt.Errorf("%s: invalid key: %s", caller, key)
	}
	if !schema.Computed {
		return fmt.Errorf("%s only operates on computed keys - %s is not one", caller, key)
	}
	return nil
}
```

so we should delete the **CustomizeDiff** block.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run TestAccMrsMapReduceCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_basic
=== PAUSE TestAccMrsMapReduceCluster_basic
=== RUN   TestAccMrsMapReduceCluster_keypair
=== PAUSE TestAccMrsMapReduceCluster_keypair
=== RUN   TestAccMrsMapReduceCluster_analysis
=== PAUSE TestAccMrsMapReduceCluster_analysis
=== RUN   TestAccMrsMapReduceCluster_stream
=== PAUSE TestAccMrsMapReduceCluster_stream
=== RUN   TestAccMrsMapReduceCluster_hybrid
=== PAUSE TestAccMrsMapReduceCluster_hybrid
=== RUN   TestAccMrsMapReduceCluster_custom_compact
=== PAUSE TestAccMrsMapReduceCluster_custom_compact
=== RUN   TestAccMrsMapReduceCluster_custom_seperate
=== PAUSE TestAccMrsMapReduceCluster_custom_seperate
=== RUN   TestAccMrsMapReduceCluster_custom_fullsize
=== PAUSE TestAccMrsMapReduceCluster_custom_fullsize
=== RUN   TestAccMrsMapReduceCluster_Eip_id
=== PAUSE TestAccMrsMapReduceCluster_Eip_id
=== RUN   TestAccMrsMapReduceCluster_Eip_publicIp
=== PAUSE TestAccMrsMapReduceCluster_Eip_publicIp
=== CONT  TestAccMrsMapReduceCluster_basic
=== CONT  TestAccMrsMapReduceCluster_custom_seperate
=== CONT  TestAccMrsMapReduceCluster_Eip_publicIp
=== CONT  TestAccMrsMapReduceCluster_Eip_id
=== CONT  TestAccMrsMapReduceCluster_custom_seperate
    acceptance.go:382: HW_MAPREDUCE_CUSTOM must be set for acceptance tests:custom type cluster of map reduce
--- SKIP: TestAccMrsMapReduceCluster_custom_seperate (0.00s)
=== CONT  TestAccMrsMapReduceCluster_custom_fullsize
    acceptance.go:382: HW_MAPREDUCE_CUSTOM must be set for acceptance tests:custom type cluster of map reduce
--- SKIP: TestAccMrsMapReduceCluster_custom_fullsize (0.00s)
=== CONT  TestAccMrsMapReduceCluster_stream
--- PASS: TestAccMrsMapReduceCluster_Eip_publicIp (766.40s)
=== CONT  TestAccMrsMapReduceCluster_custom_compact
    acceptance.go:382: HW_MAPREDUCE_CUSTOM must be set for acceptance tests:custom type cluster of map reduce
--- SKIP: TestAccMrsMapReduceCluster_custom_compact (0.00s)
=== CONT  TestAccMrsMapReduceCluster_analysis
--- PASS: TestAccMrsMapReduceCluster_Eip_id (904.35s)
=== CONT  TestAccMrsMapReduceCluster_hybrid
--- PASS: TestAccMrsMapReduceCluster_basic (910.52s)
=== CONT  TestAccMrsMapReduceCluster_keypair
--- PASS: TestAccMrsMapReduceCluster_keypair (841.98s)
--- PASS: TestAccMrsMapReduceCluster_stream (1874.69s)
--- PASS: TestAccMrsMapReduceCluster_analysis (2298.09s)

--- PASS: TestAccMrsMapReduceCluster_hybrid (3349.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs     4253.968s
```
