### PR TITLE
fix(cci/namespace): fix the index out of range panic

### DIFF
--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
@@ -46,6 +46,26 @@ func TestAccDataCciNamespaces_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataCciNamespaces_noNetwork(t *testing.T) {
+	dataSourceName := "data.huaweicloud_cci_namespaces.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCciNamespaces_noNetwork(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "namespaces.0.type", "general-computing"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataCciNamespaces_base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
@@ -92,4 +112,17 @@ data "huaweicloud_cci_namespaces" "test" {
   type = "general-computing"
 }
 `, testAccDataCciNamespaces_base(rName), rName)
+}
+
+func testAccDataCciNamespaces_noNetwork(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cci_namespace" "test" {
+  name = "%[1]s"
+  type = "general-computing"
+}
+
+data "huaweicloud_cci_namespaces" "test" {
+  name = huaweicloud_cci_namespace.test.name
+}
+`, rName)
 }

--- a/huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go
+++ b/huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go
@@ -157,7 +157,12 @@ func isNamespaceParamMatch(d *schema.ResourceData, ns namespaces.Namespace) bool
 	return true
 }
 
-func flattenVpcNetwork(network networks.Network) []map[string]interface{} {
+func flattenVpcNetwork(networkList []networks.Network) []map[string]interface{} {
+	if len(networkList) < 1 {
+		return nil
+	}
+
+	network := networkList[0]
 	return []map[string]interface{}{
 		{
 			"name":              network.Metadata.Name,
@@ -196,7 +201,7 @@ func filterDataCciNamespaces(d *schema.ResourceData, client *golangsdk.ServiceCl
 				"rbac_enabled":              ns.Metadata.Labels.RbacEnable,
 				"created_at":                ns.Metadata.CreationTimestamp,
 				"status":                    ns.Status.Phase,
-				"network":                   flattenVpcNetwork(netList[0]),
+				"network":                   flattenVpcNetwork(netList),
 			}
 
 			result = append(result, nsParams)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The data source will panic when search for a CCI namespace and it does not have network.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2187 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the panic which array index out of bound.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cci' TESTARGS='-run=TestAccDataNamespaces_noNetwork'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run=TestAccDataNamespaces_noNetwork -timeout 360m -parallel 4
=== RUN   TestAccDataNamespaces_noNetwork
=== PAUSE TestAccDataNamespaces_noNetwork
=== CONT  TestAccDataNamespaces_noNetwork
--- PASS: TestAccDataNamespaces_noNetwork (29.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       29.412s
```
