### PR TITLE
fix(RDS): read replica resource does not support autopay

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -537,7 +537,7 @@ func resourceRdsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	if err := updateRdsInstanceFlavor(d, config, client, instanceID); err != nil {
+	if err := updateRdsInstanceFlavor(d, config, client, instanceID, true); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -726,7 +726,8 @@ func updateRdsInstanceName(d *schema.ResourceData, client *golangsdk.ServiceClie
 	return nil
 }
 
-func updateRdsInstanceFlavor(d *schema.ResourceData, config *config.Config, client *golangsdk.ServiceClient, instanceID string) error {
+func updateRdsInstanceFlavor(d *schema.ResourceData, config *config.Config, client *golangsdk.ServiceClient,
+	instanceID string, isSupportAutoPay bool) error {
 	if !d.HasChange("flavor") {
 		return nil
 	}
@@ -734,7 +735,7 @@ func updateRdsInstanceFlavor(d *schema.ResourceData, config *config.Config, clie
 	resizeFlavor := instances.SpecCode{
 		Speccode: d.Get("flavor").(string),
 	}
-	if d.Get("auto_pay").(string) != "false" {
+	if isSupportAutoPay && d.Get("auto_pay").(string) != "false" {
 		resizeFlavor.IsAutoPay = true
 	}
 	var resizeFlavorOpts instances.ResizeFlavorOpts

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -286,7 +286,7 @@ func resourceRdsReadReplicaInstanceUpdate(ctx context.Context, d *schema.Resourc
 	}
 
 	instanceID := d.Id()
-	if err := updateRdsInstanceFlavor(d, config, client, instanceID); err != nil {
+	if err := updateRdsInstanceFlavor(d, config, client, instanceID, false); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. the read replica resource does not support autopay
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run=TestAccReadReplicaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run=TestAccReadReplicaInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_basic
--- PASS: TestAccReadReplicaInstance_basic (1045.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1045.143s
```
