### PR TITLE
acceptance: delete CheckDestroy for data source

### DIFF
--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -21,7 +21,6 @@ func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_serverBasic(randName),
@@ -56,7 +55,6 @@ func TestAccCbrVaultsV3_ReplicaServer(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_serverReplication(randName),
@@ -86,7 +84,6 @@ func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_volumeBasic(randName),
@@ -119,7 +116,6 @@ func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_turboBasic(randName),
@@ -152,7 +148,6 @@ func TestAccCbrVaultsV3_ReplicaTurbo(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_turboReplication(randName),

--- a/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_flavors_test.go
+++ b/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_flavors_test.go
@@ -16,7 +16,6 @@ func TestAccCssFlavorsDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceCssFlavors_basic,
@@ -51,7 +50,6 @@ func TestAccCssFlavorsDataSource_all(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceCssFlavors_all,

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_bandwidth_test.go
@@ -19,7 +19,6 @@ func TestAccBandWidthDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBandWidthDataSource_basic(randName),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_test.go
@@ -18,7 +18,6 @@ func TestAccVpcEipDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcEipConfig_basic(randName),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
@@ -18,7 +18,6 @@ func TestAccVpcEipsDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcEips_basic(randName),
@@ -55,7 +54,6 @@ func TestAccVpcEipsDataSource_byTag(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcEips_byTag(randName),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -26,7 +26,7 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_fgs_function.test"
 
-	dc := acceptance.InitResourceCheck(
+	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&f,
 		getResourceObj,
@@ -35,12 +35,12 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
@@ -49,7 +49,7 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 			{
 				Config: testAccFgsV2Function_update(randName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "description", "fuction test update"),
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
@@ -74,7 +74,7 @@ func TestAccFgsV2Function_withEpsId(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_fgs_function.test"
 
-	dc := acceptance.InitResourceCheck(
+	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&f,
 		getResourceObj,
@@ -86,12 +86,12 @@ func TestAccFgsV2Function_withEpsId(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_withEpsId(randName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
 						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -115,7 +115,7 @@ func TestAccFgsV2Function_text(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_fgs_function.test"
 
-	dc := acceptance.InitResourceCheck(
+	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&f,
 		getResourceObj,
@@ -124,12 +124,12 @@ func TestAccFgsV2Function_text(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_text(randName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 				),
 			},
 			{
@@ -151,7 +151,7 @@ func TestAccFgsV2Function_agency(t *testing.T) {
 	randName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_fgs_function.test"
 
-	dc := acceptance.InitResourceCheck(
+	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&f,
 		getResourceObj,
@@ -160,12 +160,12 @@ func TestAccFgsV2Function_agency(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_agency(randName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "agency", randName),
 					resource.TestCheckResourceAttr(resourceName, "func_mounts.0.mount_type", "sfs"),
 					resource.TestCheckResourceAttr(resourceName, "func_mounts.0.status", "active"),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
@@ -16,7 +16,6 @@ func TestAccGaussDBNoSQLFlavors_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_default(),
@@ -46,7 +45,6 @@ func TestAccGaussDBNoSQLFlavors_mongodb(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_mongodb(),
@@ -68,7 +66,6 @@ func TestAccGaussDBNoSQLFlavors_influxdb(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_influxdb(),
@@ -90,7 +87,6 @@ func TestAccGaussDBNoSQLFlavors_redis(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_redis(),
@@ -112,7 +108,6 @@ func TestAccGaussDBNoSQLFlavors_vcpus(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_vcpus(),
@@ -133,7 +128,6 @@ func TestAccGaussDBNoSQLFlavors_memory(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_memory(),
@@ -154,7 +148,6 @@ func TestAccGaussDBNoSQLFlavors_az(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBNoSQLFlavors_az(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
@@ -22,7 +22,6 @@ func TestAccDataSourceDatasetVersions_basic(t *testing.T) {
 			acceptance.TestAccPreCheckOBS(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceDatasetVersions_basic(name, obsName),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
@@ -19,7 +19,6 @@ func TestAccDataSourceDatasets_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceDatasets_basic(name, obsName),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
@@ -17,7 +17,6 @@ func TestAccNotebookImages_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceImages_basic("BUILD_IN", "x86_64"),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_engine_versions_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_engine_versions_test.go
@@ -17,7 +17,6 @@ func TestAccRdsEngineVersionsV3DataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRdsEngineVersionsV3DataSource_basic,

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_flavors_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_flavors_test.go
@@ -17,7 +17,6 @@ func TestAccRdsFlavorDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRdsFlavorDataSource_basic,
@@ -50,7 +49,6 @@ func TestAccRdsFlavorDataSource_all(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRdsFlavorDataSource_all,

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_instances_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_instances_test.go
@@ -20,7 +20,6 @@ func TestAccRdsInstanceDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRdsInstanceDataSource_basic(rName),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_ids_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_ids_test.go
@@ -18,7 +18,6 @@ func TestAccVpcIdsDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcIds_basic(randName),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connection_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connection_test.go
@@ -18,7 +18,6 @@ func TestAccVpcPeeringConnectionDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcPeeringConnectionDataSource_basic(randName),
@@ -41,7 +40,6 @@ func TestAccVpcPeeringConnectionDataSource_byVpcId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcPeeringConnectionDataSource_byVpcId(randName),
@@ -64,7 +62,6 @@ func TestAccVpcPeeringConnectionDataSource_byPeerVpcId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcPeeringConnectionDataSource_byPeerVpcId(randName),
@@ -87,7 +84,6 @@ func TestAccVpcPeeringConnectionDataSource_byVpcIds(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcPeeringConnectionDataSource_byVpcIds(randName),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_ids_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_ids_test.go
@@ -20,7 +20,6 @@ func TestAccVpcRouteIdsDataSource_basic(t *testing.T) {
 			acceptance.TestAccPreCheckDeprecated(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteIdsDataSource_basic(randName),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test.go
@@ -16,7 +16,6 @@ func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceRouteTable_base(rName),
@@ -24,6 +23,7 @@ func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceRouteTable_default(rName),
 				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "default", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "1"),
 				),
@@ -31,6 +31,7 @@ func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceRouteTable_custom(rName),
 				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "default", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "0"),
 				),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_test.go
@@ -19,7 +19,6 @@ func TestAccVpcSubnetDataSource_ipv4Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetDataSource_ipv4Basic(randName, randCidr, randGatewayIp),
@@ -50,7 +49,6 @@ func TestAccVpcSubnetDataSource_ipv4ByCidr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetDataSource_ipv4ByCidr(randName, randCidr, randGatewayIp),
@@ -81,7 +79,6 @@ func TestAccVpcSubnetDataSource_ipv4ByName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetDataSource_ipv4ByName(randName, randCidr, randGatewayIp),
@@ -112,7 +109,6 @@ func TestAccVpcSubnetDataSource_ipv4ByVpcId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetDataSource_ipv4ByVpcId(randName, randCidr, randGatewayIp),
@@ -143,7 +139,6 @@ func TestAccVpcSubnetDataSource_ipv6Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetDataSource_ipv6Basic(randName, randCidr, randGatewayIp),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnets_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnets_test.go
@@ -19,7 +19,6 @@ func TestAccVpcSubnetsDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetsDataSource_Basic(randName, randCidr, randGatewayIp),
@@ -60,7 +59,6 @@ func TestAccVpcSubnetsDataSource_ipv4ByCidr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetsDataSource_ipv4ByCidr(randName, randCidr, randGatewayIp),
@@ -101,7 +99,6 @@ func TestAccVpcSubnetsDataSource_ipv4ByName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetsDataSource_ipv4ByName(randName, randCidr, randGatewayIp),
@@ -142,7 +139,6 @@ func TestAccVpcSubnetsDataSource_ipv4ByVpcId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetsDataSource_ipv4ByVpcId(randName, randCidr, randGatewayIp),
@@ -183,7 +179,6 @@ func TestAccVpcSubnetsDataSource_ipv6Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcSubnetsDataSource_ipv6Basic(randName, randCidr, randGatewayIp),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test.go
@@ -19,7 +19,6 @@ func TestAccVpcDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpc_basic(randName, randCidr),
@@ -45,7 +44,6 @@ func TestAccVpcDataSource_byCidr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpc_byCidr(randName, randCidr),
@@ -71,7 +69,6 @@ func TestAccVpcDataSource_byName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpc_byName(randName, randCidr),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
@@ -19,7 +19,6 @@ func TestAccVpcsDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcs_basic(randName, randCidr),
@@ -65,7 +64,6 @@ func TestAccVpcsDataSource_byCidr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcs_byCidr(randName, randCidr),
@@ -105,7 +103,6 @@ func TestAccVpcsDataSource_byName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcs_byName(randName, randCidr),
@@ -150,7 +147,6 @@ func TestAccVpcsDataSource_byAll(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcs_byAll(randName, randCidr, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
@@ -198,7 +194,6 @@ func TestAccVpcsDataSource_tags(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVpcs_tags(randName1, randName2),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**CheckDestroy** will always be **nil** if we use resourceCheck.CheckResourceDestroy()
```
// CheckResourceDestroy check whether resources destroyed in HuaweiCloud.
func (rc *resourceCheck) CheckResourceDestroy() resource.TestCheckFunc {
	if strings.Compare(rc.resourceType, dataSourceTypeCode) == 0 {
		logp.Printf("Error, you built a resourceCheck with 'InitDataSourceCheck', " +
			"it cannot run CheckResourceDestroy().")
		return nil
	}
	...
}
```

It's safe to delete them.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCssFlavorsDataSource_basic
=== PAUSE TestAccCssFlavorsDataSource_basic
=== CONT  TestAccCssFlavorsDataSource_basic
--- PASS: TestAccCssFlavorsDataSource_basic (37.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css     37.796s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteTableDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteTableDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTableDataSource_basic
=== PAUSE TestAccVpcRouteTableDataSource_basic
=== CONT  TestAccVpcRouteTableDataSource_basic
--- PASS: TestAccVpcRouteTableDataSource_basic (106.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc     106.426s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcsDataSource_basic'  ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_basic
--- PASS: TestAccVpcsDataSource_basic (51.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc     51.751s
```
