### PR TITLE
test(OpenGauss): add required security group ports

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -62,7 +62,9 @@ The following arguments are supported:
   new resource.
 
 * `security_group_id` - (Optional, String, ForceNew) Specifies the security group ID. Changing this parameter will
-  create a new resource.
+  create a new resource. Ensure that the TCP ports in the inbound rule of security group
+  include `20050`,`5000`,`5001`,`2379`,`2380`,`6000`,`6500`,`40000`-`60480` and `database port`-`database port plus 100`.
+  (For example, if the database port is `8000`, the TCP port must include `8000-8100`.)
 
 * `volume` - (Required, List) Specifies the volume storage information. Structure is documented below.
 
@@ -121,8 +123,8 @@ The `backup_strategy` block supports:
 
 * `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
   backup time window. It must be a valid value in the "hh:mm-HH:MM" format. The current time is in the UTC format. The
-  HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to 00, 15, 30
-  or 45. Example value: 08:15-09:15, 23:00-00:00.
+  HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to 00.
+  Example value: 08:00-09:00, 23:00-00:00.
 
 * `keep_days` - (Optional, Int) Specifies the number of days to retain the generated backup files. The value ranges from
   0 to 732. If this parameter is set to 0, the automated backup policy is not set. If this parameter is not transferred,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. add required ports to the security group
2.  the backup_strategy.start_time  valid value is changed in API.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb' TESTARGS='-run=TestAccOpenGaussInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run=TestAccOpenGaussInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstancesDataSource_basic
=== PAUSE TestAccOpenGaussInstancesDataSource_basic
=== CONT  TestAccOpenGaussInstancesDataSource_basic
--- PASS: TestAccOpenGaussInstancesDataSource_basic (1566.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1566.473s
```
