### PR TITLE
fix(evs/attach): add error parsing for delete check function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3
+	github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7
+	github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3 h1:DOm/4fDXWETTs4hbmsiEVkL3HZAOtaoULHbAl7G6lMA=
 github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7 h1:wrz2cfSpjeMOnzWC9qbH4giqIFpUmlfgfYnDJfnw29U=
+github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3 h1:DOm/4fDXWETTs4h
 github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7 h1:wrz2cfSpjeMOnzWC9qbH4giqIFpUmlfgfYnDJfnw29U=
 github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25 h1:tQ+Zteb311U0w1vc3n1DkxOPuC83I3mXrxCm13qkWMc=
+github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices/results.go
@@ -64,3 +64,15 @@ func (r GetResult) Extract() (*VolumeAttachment, error) {
 func (r GetResult) ExtractInto(v interface{}) error {
 	return r.Result.ExtractIntoStructPtr(v, "volumeAttachment")
 }
+
+type ErrorResponse struct {
+	// Response error.
+	Error Error `json:"error"`
+}
+
+type Error struct {
+	// Error code.
+	Code string `json:"code"`
+	// Error message.
+	Message string `json:"message"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/trigger/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/trigger/results.go
@@ -58,3 +58,10 @@ func ExtractList(r pagination.Page) ([]Trigger, error) {
 	err := (r.(TriggerPage)).ExtractInto(&s)
 	return s, err
 }
+
+type Error struct {
+	// Error code, e.g. "FSS.0500"
+	Code string `json:"error_code"`
+	// Error message, e.g. "Error getting associated function"
+	Message string `json:"error_msg"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3
+# github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7
+# github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a function to parsing 404 not found error.
Since the ECS API response is 400, we should support a function to parse and translate it into a 404 error.

For FunctionGraph API response, the status code is 500, and the error content is:
```
Error: error retrieving FunctionGraph trigger: Internal Server Error: [GET [https://functiongraph.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/fgs/triggers/urn:fss:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:function:default:script_fgs_triggers_function]](https://functiongraph.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/fgs/triggers/urn:fss:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:function:default:script_fgs_triggers_function%5D), error message: {
│ "error_code": "FSS.0500",
│ "error_msg": "Error getting associated function"
│ }
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2194 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new error parsing function.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 Warning: Resource not found
│ 
│   with huaweicloud_compute_volume_attach.flash_ecs1_attachments[0],
│   on main.tf line 239, in resource "huaweicloud_compute_volume_attach" "flash_ecs1_attachments":
│  239: resource "huaweicloud_compute_volume_attach" "flash_ecs1_attachments" {
│ 
│ the resource edfeee55-748f-4d44-98de-5b2b657b2e0d/a21bc4a2-57c9-4f02-b995-1baeee583dea is
│ gone and will be removed in Terraform state.
│ 
│ (and one more similar warning elsewhere)
```
