### PR TITLE
acceptance/ci: use ProviderFactories instead of Providers in service dir

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -26,8 +26,8 @@ func TestAccApigAPIV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigAPIDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigAPIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigAPI_basic(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
@@ -26,8 +26,8 @@ func TestAccApigApplicationV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigApplicationDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigApplicationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigApplication_basic(rName, acctest.RandString(64)),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -26,8 +26,8 @@ func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigCustomAuthorizerDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigCustomAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigCustomAuthorizer_front(rName),
@@ -74,8 +74,8 @@ func TestAccApigCustomAuthorizerV2_backend(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigCustomAuthorizerDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigCustomAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigCustomAuthorizer_backend(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
@@ -26,8 +26,8 @@ func TestAccApigEnvironmentV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigEnvironmentDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigEnvironment_basic(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
@@ -25,8 +25,8 @@ func TestAccApigGroupV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigGroupDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigGroup_basic(rName),
@@ -67,8 +67,8 @@ func TestAccApigGroupV2_variables(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigGroupDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigGroup_basic(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -23,8 +23,8 @@ func TestAccApigInstanceV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigInstanceDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigInstance_basic(rName),
@@ -71,8 +71,8 @@ func TestAccApigInstanceV2_egress(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigInstanceDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigInstance_basic(rName),
@@ -135,8 +135,8 @@ func TestAccApigInstanceV2_ingress(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigInstanceDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigInstance_basic(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go
@@ -25,8 +25,8 @@ func TestAccApigResponseV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigResponseDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigResponseDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigResponse_basic(rName),
@@ -65,8 +65,8 @@ func TestAccApigResponseV2_customRules(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigResponseDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigResponseDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigResponse_basic(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
@@ -27,8 +27,8 @@ func TestAccApigThrottlingPolicyV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigThrottlingPolicyDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigThrottlingPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigThrottlingPolicy_basic(rName),
@@ -83,8 +83,8 @@ func TestAccApigThrottlingPolicyV2_spec(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigThrottlingPolicyDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigThrottlingPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigThrottlingPolicy_basic(rName),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
@@ -26,8 +26,8 @@ func TestAccApigVpcChannelV2_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigVpcChannelDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigVpcChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigVpcChannel_basic(rName),
@@ -78,8 +78,8 @@ func TestAccApigVpcChannelV2_withEipMembers(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckApigVpcChannelDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigVpcChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigVpcChannel_withEipMembers(rName),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -20,8 +20,8 @@ func TestAccCbrVaultsV3_BasicServer(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_serverBasic(randName),
@@ -55,8 +55,8 @@ func TestAccCbrVaultsV3_ReplicaServer(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_serverReplication(randName),
@@ -85,8 +85,8 @@ func TestAccCbrVaultsV3_BasicVolume(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_volumeBasic(randName),
@@ -118,8 +118,8 @@ func TestAccCbrVaultsV3_BasicTurbo(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_turboBasic(randName),
@@ -151,8 +151,8 @@ func TestAccCbrVaultsV3_ReplicaTurbo(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCbrVaultsV3_turboReplication(randName),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_policy_test.go
@@ -31,9 +31,9 @@ func TestAccCBRV3Policy_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testCBRV3Policy_basic(randName),
@@ -82,9 +82,9 @@ func TestAccCBRV3Policy_retention(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testCBRV3Policy_retention(randName),
@@ -146,8 +146,8 @@ func TestAccCBRV3Policy_replication(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckReplication(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testCBRV3Policy_replication(randName),

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -36,8 +36,8 @@ func TestAccCBRV3Vault_BasicServer(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCBRV3Vault_serverBasic(randName),
@@ -98,8 +98,8 @@ func TestAccCBRV3Vault_ReplicaServer(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCBRV3Vault_serverReplication(randName),
@@ -137,8 +137,8 @@ func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCBRV3Vault_volumeBasic(randName),
@@ -196,8 +196,8 @@ func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCBRV3Vault_turboBasic(randName),
@@ -251,8 +251,8 @@ func TestAccCBRV3Vault_ReplicaTurbo(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCBRV3Vault_turboReplication(randName),

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_pvc_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_pvc_test.go
@@ -42,8 +42,8 @@ func TestAccCcePersistentVolumeClaimsV1_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCcePersistentVolumeClaimsV1_basic(randName),
@@ -84,8 +84,8 @@ func TestAccCcePersistentVolumeClaimsV1_obs(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCcePersistentVolumeClaimsV1_obs(randName),
@@ -117,8 +117,8 @@ func TestAccCcePersistentVolumeClaimsV1_sfs(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCcePersistentVolumeClaimsV1_sfs(randName),

--- a/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
+++ b/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
@@ -33,9 +33,9 @@ func TestAccCloudtableCluster_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudtableCluster_basic(rName),

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
@@ -53,9 +53,9 @@ func TestAccCssCluster_security(t *testing.T) {
 	resourceName := "huaweicloud_css_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckCssClusterDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssClusterDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCssCluster_security(rName, 1, "bar"),

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_certificate_test.go
@@ -20,8 +20,8 @@ func TestAccDataSourceELbCertificateV3_basic(t *testing.T) {
 	dataSourceName := "data.huaweicloud_elb_certificate.cert_1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccELbCertDataSourceV3_conf(name),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
@@ -13,8 +13,8 @@ func TestAccFunctionGraphDependencies_basic(t *testing.T) {
 	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphDependencies_basic(),
@@ -30,8 +30,8 @@ func TestAccFunctionGraphDependencies_name(t *testing.T) {
 	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphDependencies_name(),
@@ -49,8 +49,8 @@ func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
 	dataSourceName := "data.huaweicloud_fgs_dependencies.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphDependencies_runtime(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -33,9 +33,9 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_basic(randName),
@@ -85,8 +85,8 @@ func TestAccFgsV2Function_withEpsId(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_withEpsId(randName),
@@ -122,9 +122,9 @@ func TestAccFgsV2Function_text(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_text(randName),
@@ -158,9 +158,9 @@ func TestAccFgsV2Function_agency(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFgsV2Function_agency(randName),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go
@@ -35,9 +35,9 @@ func TestAccFunctionGraphTrigger_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphTimingTrigger_basic(randName),
@@ -83,9 +83,9 @@ func TestAccFunctionGraphTrigger_cronTimer(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphTimingTrigger_cron(randName),
@@ -133,9 +133,9 @@ func TestAccFunctionGraphTrigger_obs(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphObsTrigger_basic(randName),
@@ -169,9 +169,9 @@ func TestAccFunctionGraphTrigger_dis(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphDisTrigger_basic(randName),
@@ -221,9 +221,9 @@ func TestAccFunctionGraphTrigger_smn(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphSmnTrigger_basic(randName),
@@ -255,9 +255,9 @@ func TestAccFunctionGraphTrigger_kafka(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFunctionGraphKafkaTrigger_basic(randName, adminPass),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances_test.go
@@ -16,8 +16,8 @@ func TestAccOpenGaussInstancesDataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.TestAccPreCheck(t) },
-		Providers: acceptance.TestAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOpenGaussInstancesDataSource_basic(rName),

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_job_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_job_test.go
@@ -23,9 +23,9 @@ func TestAccMrsMapReduceJob_basic(t *testing.T) {
 		acctest.RandIntRange(0, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckMRSV2JobDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2JobDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMrsMapReduceJobConfig_basic(rName, pwd),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test.go
@@ -14,9 +14,9 @@ func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: dc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceRouteTable_base(rName),

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_test.go
@@ -33,9 +33,9 @@ func TestAccVpcRouteTable_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcRouteTable_basic(rName),
@@ -88,9 +88,9 @@ func TestAccVpcRouteTable_multiRoutes(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcRouteTable_multiRoutes(rName),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceWafCertificateV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers: acceptance.TestAccProviders,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafCertificateListV1_conf(name),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceWafPoliciesV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers: acceptance.TestAccProviders,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafPoliciesV1_conf(name),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -36,8 +36,8 @@ func TestAccWafCertificateV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafCertificateV1_conf(name),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -22,8 +22,8 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckWafDedicatedDomainV1Destroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedDomainV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafDedicatedDomainV1_basic(randName),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -37,8 +37,8 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafDomainV1_basic(randName, domainName),
@@ -88,8 +88,8 @@ func TestAccWafDomainV1_policy(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: rc.CheckResourceDestroy(),
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafDomainV1_policy(randName, domainName),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
@@ -24,8 +24,8 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckWafPolicyV1Destroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafPolicyV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafPolicyV1_basic(randName),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
@@ -22,8 +22,8 @@ func TestAccWafReferenceTableV1_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckWafReferenceTableV1Destroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafReferenceTableV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafReferenceTableV1_conf(name),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -24,8 +24,8 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckWafRuleBlackListDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafRuleBlackListDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleBlackList_basic(randName),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -30,8 +30,8 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckWafRuleDataMaskingDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafRuleDataMaskingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleDataMasking_basic(policyName),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -27,8 +27,8 @@ func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafWafRuleWebTamperProtectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleWebTamperProtection_basic(randName),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Providers** is marked as deprecated and we should update it to **ProviderFactories**.
Terraform Plugin SDK version 2 uses TestCase.ProviderFactories but supports this value in TestCase.Providers for backwards compatibility.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run TestAccApigAPIV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccApigAPIV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigAPIV2_basic
=== PAUSE TestAccApigAPIV2_basic
=== CONT  TestAccApigAPIV2_basic
--- PASS: TestAccApigAPIV2_basic (522.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig    522.341s

$ make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run TestAccApigGroupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccApigGroupV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigGroupV2_basic
=== PAUSE TestAccApigGroupV2_basic
=== CONT  TestAccApigGroupV2_basic
--- PASS: TestAccApigGroupV2_basic (488.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig    488.264s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcRouteTable_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTable_basic
=== PAUSE TestAccVpcRouteTable_basic
=== CONT  TestAccVpcRouteTable_basic
--- PASS: TestAccVpcRouteTable_basic (138.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc     138.597s
```
