### PR TITLE
test(gaussdb_mysql_proxy): add timeout for subnet in the test case

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy_test.go
@@ -70,6 +70,10 @@ resource "huaweicloud_vpc_subnet" "test" {
   vpc_id     = huaweicloud_vpc.test.id
   gateway_ip = "192.168.0.1"
   cidr       = "192.168.0.0/24"
+
+  timeouts {
+    delete = "20m"
+  }
 }
 
 resource "huaweicloud_gaussdb_mysql_instance" "test" {
@@ -86,8 +90,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
 
 resource "huaweicloud_gaussdb_mysql_proxy" "test" {
   instance_id = huaweicloud_gaussdb_mysql_instance.test.id
-  flavor = "gaussdb.proxy.xlarge.arm.2"
-  node_num = 3
+  flavor      = "gaussdb.proxy.xlarge.arm.2"
+  node_num    = 3
 }
 `, rName, rName, rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When the instance in deleted, the subnet will still be occupied for a while.
So add a deleting timeout in the subnet resource to avoid test failing.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add timeout for subnet in the test case
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb' TESTARGS='-run TestAccGaussDBProxy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBProxy_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBProxy_basic
=== PAUSE TestAccGaussDBProxy_basic
=== CONT  TestAccGaussDBProxy_basic
--- PASS: TestAccGaussDBProxy_basic (1509.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1510.058s
```
