### PR TITLE
acceptance: ignore HW_AVAILABILITY_ZONE environment variable

### DIFF
--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go
@@ -41,20 +41,21 @@ func TestAccCciNetwork_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", acceptance.HW_AVAILABILITY_ZONE),
 					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "namespace",
-						"${huaweicloud_cci_namespace.test.name}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "network_id",
-						"${huaweicloud_vpc_subnet.test.id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "subnet_id",
-						"${huaweicloud_vpc_subnet.test.subnet_id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "security_group_id",
-						"${huaweicloud_networking_secgroup.test.id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "vpc_id",
-						"${huaweicloud_vpc.test.id}"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr"),
+					resource.TestCheckResourceAttrPair(resourceName, "namespace",
+						"huaweicloud_cci_namespace.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "network_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
+						"huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
 				),
 			},
 			{
@@ -74,7 +75,7 @@ func testAccCciNetworkImportStateFunc(name string) resource.ImportStateIdFunc {
 			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
 		}
 		if rs.Primary.ID == "" || rs.Primary.Attributes["namespace"] == "" {
-			return "", fmt.Errorf("The namespace name (%s) or network ID (%s) is nil.",
+			return "", fmt.Errorf("the namespace name (%s) or network ID (%s) is nil",
 				rs.Primary.Attributes["namespace"], rs.Primary.ID)
 		}
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["namespace"], rs.Primary.ID), nil
@@ -112,12 +113,14 @@ func testAccCciNetwork_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
+data "huaweicloud_availability_zones" "test" {}
+
 resource "huaweicloud_cci_network" "test" {
   name              = "%s"
-  availability_zone = "%s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
   namespace         = huaweicloud_cci_namespace.test.name
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
 }
-`, testAccCciNetwork_base(rName), rName, acceptance.HW_AVAILABILITY_ZONE)
+`, testAccCciNetwork_base(rName), rName)
 }

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
@@ -153,7 +153,8 @@ func TestAccGaussDBNoSQLFlavors_az(t *testing.T) {
 				Config: testAccGaussDBNoSQLFlavors_az(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.availability_zones.0", acceptance.HW_AVAILABILITY_ZONE),
+					resource.TestCheckResourceAttrPair(dataSourceName, "flavors.0.availability_zones.0",
+						"data.huaweicloud_availability_zones.test", "names.0"),
 				),
 			},
 		},
@@ -216,8 +217,10 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 
 func testAccGaussDBNoSQLFlavors_az() string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
-  availability_zone = "%s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
 }
-`, acceptance.HW_AVAILABILITY_ZONE)
+`)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**HW_AVAILABILITY_ZONE** is not set in the CI
we should use `data.huaweicloud_availability_zones.test` instead of it.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cci' TESTARGS='-run TestAccCciNetwork_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccCciNetwork_basic -timeout 360m -parallel 4
=== RUN   TestAccCciNetwork_basic
=== PAUSE TestAccCciNetwork_basic
=== CONT  TestAccCciNetwork_basic
--- PASS: TestAccCciNetwork_basic (89.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci     89.152s

make testacc TEST='./huaweicloud/services/acceptance/gaussdb' TESTARGS='-run TestAccGaussDBNoSQLFlavors_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_basic
=== PAUSE TestAccGaussDBNoSQLFlavors_basic
=== CONT  TestAccGaussDBNoSQLFlavors_basic
--- PASS: TestAccGaussDBNoSQLFlavors_basic (44.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb 44.460s
```
