### PR TITLE
feat(kms): support to config key rotation

### DIFF
--- a/docs/data-sources/kms_key.md
+++ b/docs/data-sources/kms_key.md
@@ -4,8 +4,7 @@ subcategory: "Data Encryption Workshop (DEW)"
 
 # huaweicloud_kms_key
 
-Use this data source to get the ID of an available HuaweiCloud KMS key. This is an alternative
-to `huaweicloud_kms_key_v1`
+Use this data source to get the ID of an available HuaweiCloud KMS key.
 
 ## Example Usage
 
@@ -53,3 +52,6 @@ In addition to all arguments above, the following attributes are exported:
 * `expiration_time` - Expiration time.
 * `creation_date` - Creation time (time stamp) of a key.
 * `tags` - The key/value pairs to associate with the kms key.
+* `rotation_enabled` - Indicates whether the key rotation is enabled or not.
+* `rotation_interval` - The key rotation interval. It's valid when rotation is enabled.
+* `rotation_number` - The total number of key rotations. It's valid when rotation is enabled.

--- a/docs/resources/kms_key.md
+++ b/docs/resources/kms_key.md
@@ -39,6 +39,11 @@ The following arguments are supported:
 * `is_enabled` - (Optional, Bool) Specifies whether the key is enabled. Defaults to true. Changing this updates the
   state of existing key.
 
+* `rotation_enabled` - (Optional, Bool) Specifies whether the key rotation is enabled. Defaults to false.
+
+* `rotation_interval` - (Optional, Int) Specifies the key rotation interval. The valid value is range from 30 to 365,
+  defaults to 365.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the kms key. Changing this creates
   a new key.
 
@@ -56,6 +61,7 @@ In addition to all arguments above, the following attributes are exported:
 * `domain_id` - ID of a user domain for the key.
 * `expiration_time` - Expiration time.
 * `creation_date` - Creation time (time stamp) of a key.
+* `rotation_number` - The total number of key rotations.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25
+	github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,12 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3 h1:DOm/4fDXWETTs4hbmsiEVkL3HZAOtaoULHbAl7G6lMA=
-github.com/chnsz/golangsdk v0.0.0-20220603110123-28e919c98ab3/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7 h1:wrz2cfSpjeMOnzWC9qbH4giqIFpUmlfgfYnDJfnw29U=
-github.com/chnsz/golangsdk v0.0.0-20220610013408-f8d5b79fe4a7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25 h1:tQ+Zteb311U0w1vc3n1DkxOPuC83I3mXrxCm13qkWMc=
-github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040 h1:9rkxND2IVrOzVpCfkWx8bxE4340D/Nqytro8S4iFu2s=
+github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
+++ b/huaweicloud/data_source_huaweicloud_kms_key_v1_test.go
@@ -25,6 +25,7 @@ func TestAccKmsKeyDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKmsKeyDataSourceID(datasourceName),
 					resource.TestCheckResourceAttr(datasourceName, "key_alias", keyAlias),
+					resource.TestCheckResourceAttr(datasourceName, "rotation_enabled", "false"),
 					resource.TestCheckResourceAttr(datasourceName, "region", HW_REGION_NAME),
 				),
 			},

--- a/huaweicloud/resource_huaweicloud_kms_key_v1.go
+++ b/huaweicloud/resource_huaweicloud_kms_key_v1.go
@@ -1,6 +1,8 @@
 package huaweicloud
 
 import (
+	"fmt"
+	"log"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -12,8 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 const (
@@ -124,7 +124,7 @@ func resourceKmsKeyValidation(d *schema.ResourceData) error {
 	_, hasInterval := d.GetOk("rotation_interval")
 
 	if !rotationEnabled && hasInterval {
-		return fmtp.Errorf("invalid arguments: rotation_interval is only valid when rotation is enabled")
+		return fmt.Errorf("invalid arguments: rotation_interval is only valid when rotation is enabled")
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	kmsKeyV1Client, err := config.KmsKeyV1Client(GetRegion(d, config))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud kms key client: %s", err)
+		return fmt.Errorf("error creating KMS client: %s", err)
 	}
 
 	if err := resourceKmsKeyValidation(d); err != nil {
@@ -147,17 +147,17 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
 	}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	v, err := keys.Create(kmsKeyV1Client, createOpts).ExtractKeyInfo()
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud key: %s", err)
+		return fmt.Errorf("error creating KMS key: %s", err)
 	}
 
 	// Store the key ID
 	d.SetId(v.KeyID)
 
 	// Wait for the key to become enabled.
-	logp.Printf("[DEBUG] Waiting for key (%s) to become enabled", v.KeyID)
+	log.Printf("[DEBUG] Waiting for KMS key (%s) to become enabled", v.KeyID)
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{WaitingForEnableState, DisabledState},
 		Target:     []string{EnabledState},
@@ -169,19 +169,19 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for key (%s) to become ready: %s",
+		return fmt.Errorf(
+			"error waiting for KMS key (%s) to become ready: %s",
 			v.KeyID, err)
 	}
 
 	if !d.Get("is_enabled").(bool) {
 		key, err := keys.DisableKey(kmsKeyV1Client, v.KeyID).ExtractKeyInfo()
 		if err != nil {
-			return fmtp.Errorf("Error disabling key: %s.", err)
+			return fmt.Errorf("error disabling KMS key: %s", err)
 		}
 
 		if key.KeyState != DisabledState {
-			return fmtp.Errorf("Error disabling key, the key state is: %s", key.KeyState)
+			return fmt.Errorf("error disabling KMS key, the key state is: %s", key.KeyState)
 		}
 	}
 
@@ -190,7 +190,7 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 		taglist := utils.ExpandResourceTags(tagRaw)
 		tagErr := tags.Create(kmsKeyV1Client, "kms", v.KeyID, taglist).ExtractErr()
 		if tagErr != nil {
-			logp.Printf("Error creating tags for kms key(%s): %s", v.KeyID, err)
+			return fmt.Errorf("error creating tags of KMS key(%s): %s", v.KeyID, tagErr)
 		}
 	}
 
@@ -201,7 +201,7 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 		}
 		err := rotation.Enable(kmsKeyV1Client, rotationOpts).ExtractErr()
 		if err != nil {
-			return fmtp.Errorf("failed to enable key rotation: %s", err)
+			return fmt.Errorf("failed to enable KMS key rotation: %s", err)
 		}
 
 		if i, ok := d.GetOk("rotation_interval"); ok {
@@ -211,7 +211,7 @@ func resourceKmsKeyV1Create(d *schema.ResourceData, meta interface{}) error {
 			}
 			err := rotation.Update(kmsKeyV1Client, intervalOpts).ExtractErr()
 			if err != nil {
-				return fmtp.Errorf("failed to change key rotation interval: %s", err)
+				return fmt.Errorf("failed to change KMS key rotation interval: %s", err)
 			}
 		}
 	}
@@ -224,7 +224,7 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	kmsRegion := GetRegion(d, config)
 	kmsKeyV1Client, err := config.KmsKeyV1Client(kmsRegion)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud kms key client: %s", err)
+		return fmt.Errorf("error creating KMS key client: %s", err)
 	}
 
 	v, err := keys.Get(kmsKeyV1Client, d.Id()).ExtractKeyInfo()
@@ -232,9 +232,9 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 		return CheckDeleted(d, err, "failed to retrieve key")
 	}
 
-	logp.Printf("[DEBUG] Kms key %s: %+v", d.Id(), v)
+	log.Printf("[DEBUG] Kms key %s: %+v", d.Id(), v)
 	if v.KeyState == PendingDeletionState {
-		logp.Printf("[WARN] Removing KMS key %s because it's already gone", d.Id())
+		log.Printf("[WARN] Removing KMS key %s because it's already gone", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -257,10 +257,10 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 	if resourceTags, err := tags.Get(kmsKeyV1Client, "kms", d.Id()).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return fmtp.Errorf("Error saving tags to state for kms key(%s): %s", d.Id(), err)
+			return fmt.Errorf("error saving tags to state for KMS key(%s): %s", d.Id(), err)
 		}
 	} else {
-		logp.Printf("[WARN] Error fetching tags of kms key(%s): %s", d.Id(), err)
+		log.Printf("[WARN] error fetching tags of KMS key(%s): %s", d.Id(), err)
 	}
 
 	// Set KMS rotation
@@ -273,7 +273,7 @@ func resourceKmsKeyV1Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("rotation_interval", r.Interval)
 		d.Set("rotation_number", r.NumberOfRotations)
 	} else {
-		logp.Printf("[WARN] Error fetching details about key rotation: %s", err)
+		log.Printf("[WARN] error fetching details about KMS key rotation: %s", err)
 	}
 
 	return nil
@@ -283,7 +283,7 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	kmsKeyV1Client, err := config.KmsKeyV1Client(GetRegion(d, config))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud kms key client: %s", err)
+		return fmt.Errorf("error creating KMS key client: %s", err)
 	}
 
 	if err := resourceKmsKeyValidation(d); err != nil {
@@ -298,7 +298,7 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err = keys.UpdateAlias(kmsKeyV1Client, updateAliasOpts).ExtractKeyInfo()
 		if err != nil {
-			return fmtp.Errorf("Error updating HuaweiCloud key: %s", err)
+			return fmt.Errorf("error updating KMS key: %s", err)
 		}
 	}
 
@@ -309,33 +309,33 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err = keys.UpdateDes(kmsKeyV1Client, updateDesOpts).ExtractKeyInfo()
 		if err != nil {
-			return fmtp.Errorf("Error updating HuaweiCloud key: %s", err)
+			return fmt.Errorf("error updating KMS key: %s", err)
 		}
 	}
 
 	if d.HasChange("is_enabled") {
 		v, err := keys.Get(kmsKeyV1Client, keyID).ExtractKeyInfo()
 		if err != nil {
-			return fmtp.Errorf("DescribeKey got an error: %s.", err)
+			return fmt.Errorf("describeKey got an error: %s", err)
 		}
 
 		if d.Get("is_enabled").(bool) && v.KeyState == DisabledState {
 			key, err := keys.EnableKey(kmsKeyV1Client, keyID).ExtractKeyInfo()
 			if err != nil {
-				return fmtp.Errorf("Error enabling key: %s.", err)
+				return fmt.Errorf("error enabling key: %s", err)
 			}
 			if key.KeyState != EnabledState {
-				return fmtp.Errorf("Error enabling key, the key state is: %s", key.KeyState)
+				return fmt.Errorf("error enabling key, the key state is: %s", key.KeyState)
 			}
 		}
 
 		if !d.Get("is_enabled").(bool) && v.KeyState == EnabledState {
 			key, err := keys.DisableKey(kmsKeyV1Client, keyID).ExtractKeyInfo()
 			if err != nil {
-				return fmtp.Errorf("Error disabling key: %s.", err)
+				return fmt.Errorf("error disabling key: %s", err)
 			}
 			if key.KeyState != DisabledState {
-				return fmtp.Errorf("Error disabling key, the key state is: %s", key.KeyState)
+				return fmt.Errorf("error disabling key, the key state is: %s", key.KeyState)
 			}
 		}
 	}
@@ -343,7 +343,7 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags") {
 		tagErr := utils.UpdateResourceTags(kmsKeyV1Client, d, "kms", keyID)
 		if tagErr != nil {
-			return fmtp.Errorf("Error updating tags of kms:%s, err:%s", keyID, err)
+			return fmt.Errorf("error updating tags of kms: %s, err: %s", keyID, err)
 		}
 	}
 
@@ -360,7 +360,7 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if rotationErr != nil {
-			return fmtp.Errorf("failed to update key rotation status: %s", err)
+			return fmt.Errorf("failed to update key rotation status: %s", err)
 		}
 	}
 
@@ -371,7 +371,7 @@ func resourceKmsKeyV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 		err := rotation.Update(kmsKeyV1Client, intervalOpts).ExtractErr()
 		if err != nil {
-			return fmtp.Errorf("failed to change key rotation interval: %s", err)
+			return fmt.Errorf("failed to change key rotation interval: %s", err)
 		}
 	}
 
@@ -382,7 +382,7 @@ func resourceKmsKeyV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
 	kmsKeyV1Client, err := config.KmsKeyV1Client(GetRegion(d, config))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud kms key client: %s", err)
+		return fmt.Errorf("error creating KMS key client: %s", err)
 	}
 
 	v, err := keys.Get(kmsKeyV1Client, d.Id()).ExtractKeyInfo()
@@ -407,11 +407,11 @@ func resourceKmsKeyV1Delete(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if v.KeyState != PendingDeletionState {
-			return fmtp.Errorf("failed to delete key")
+			return fmt.Errorf("failed to delete KMS key")
 		}
 	}
 
-	logp.Printf("[DEBUG] KMS Key %s deactivated.", d.Id())
+	log.Printf("[DEBUG] KMS Key %s deactivated", d.Id())
 	d.SetId("")
 	return nil
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/rotation/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/rotation/requests.go
@@ -1,0 +1,94 @@
+package rotation
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+type RotationOptsBuilder interface {
+	ToKeyRotationMap() (map[string]interface{}, error)
+}
+
+type UpdateOptsBuilder interface {
+	ToKeyRotationIntervalMap() (map[string]interface{}, error)
+}
+
+type RotationOpts struct {
+	// ID of a CMK
+	KeyID string `json:"key_id" required:"true"`
+	// 36-byte sequence number of a request message
+	Sequence string `json:"sequence,omitempty"`
+}
+
+type IntervalOpts struct {
+	// ID of a CMK
+	KeyID string `json:"key_id" required:"true"`
+	// Rotation interval. The value is an integer in the range 30 to 365.
+	// Set the interval based on how often a CMK is used.
+	// If it is frequently used, set a short interval; otherwise, set a long one.
+	Interval int `json:"rotation_interval" required:"true"`
+	// 36-byte sequence number of a request message
+	Sequence string `json:"sequence,omitempty"`
+}
+
+// ToKeyRotationMap assembles a request body based on the contents of a
+// RotationOpts.
+func (opts RotationOpts) ToKeyRotationMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// ToKeyRotationIntervalMap assembles a request body based on the contents of a
+// IntervalOpts.
+func (opts IntervalOpts) ToKeyRotationIntervalMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Enable will enable rotation for a CMK based on the values in RotationOpts.
+// The default rotation interval is 365 days.
+// CMKs created using imported key materials and Default Master Keys do not support rotation.
+func Enable(client *golangsdk.ServiceClient, opts RotationOptsBuilder) (r golangsdk.ErrResult) {
+	b, err := opts.ToKeyRotationMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(enableURL(client), b, &r.Body, nil)
+	return
+}
+
+// Disable will disable rotation for a CMK based on the values in RotationOpts.
+func Disable(client *golangsdk.ServiceClient, opts RotationOptsBuilder) (r golangsdk.ErrResult) {
+	b, err := opts.ToKeyRotationMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(disableURL(client), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves the key with the provided ID. To extract the key object
+// from the response, call the Extract method on the GetResult.
+func Get(client *golangsdk.ServiceClient, opts RotationOptsBuilder) (r GetResult) {
+	b, err := opts.ToKeyRotationMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(getURL(client), &b, &r.Body, nil)
+	return
+}
+
+// Update will change the rotation interval for a CMK
+func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder) (r golangsdk.ErrResult) {
+	b, err := opts.ToKeyRotationIntervalMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(intervalURL(client), b, &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/rotation/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/rotation/results.go
@@ -1,0 +1,28 @@
+package rotation
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	golangsdk.Result
+}
+
+// Rotation is the response body of Get method
+type Rotation struct {
+	// Key rotation status. The default value is false, indicating that key rotation is disabled.
+	Enabled bool `json:"key_rotation_enabled"`
+	// Rotation interval. The value is an integer in the range 30 to 365.
+	Interval int `json:"rotation_interval"`
+	// Last key rotation time. The timestamp indicates the total microseconds past the start of the epoch date (January 1, 1970).
+	LastRotationTime string `json:"last_rotation_time"`
+	// Number of key rotations.
+	NumberOfRotations int `json:"number_of_rotations"`
+}
+
+func (r GetResult) Extract() (Rotation, error) {
+	var s Rotation
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/rotation/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/rotation/urls.go
@@ -1,0 +1,23 @@
+package rotation
+
+import "github.com/chnsz/golangsdk"
+
+const (
+	resourcePath = "kms"
+)
+
+func enableURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, "enable-key-rotation")
+}
+
+func disableURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, "disable-key-rotation")
+}
+
+func intervalURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, "update-key-rotation-interval")
+}
+
+func getURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, "get-key-rotation-status")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25
+# github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -189,6 +189,7 @@ github.com/chnsz/golangsdk/openstack/imageservice/v2/images
 github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages
 github.com/chnsz/golangsdk/openstack/ims/v2/tags
 github.com/chnsz/golangsdk/openstack/kms/v1/keys
+github.com/chnsz/golangsdk/openstack/kms/v1/rotation
 github.com/chnsz/golangsdk/openstack/lts/huawei/loggroups
 github.com/chnsz/golangsdk/openstack/lts/huawei/logstreams
 github.com/chnsz/golangsdk/openstack/maas/v1/task


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- huaweicloud_kms_key: support to config key rotation;
- data.huaweicloud_kms_key: Add attributes of key rotation;

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccKmsKey_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccKmsKey_Basic -timeout 360m -parallel 4
=== RUN   TestAccKmsKey_Basic
=== PAUSE TestAccKmsKey_Basic
=== CONT  TestAccKmsKey_Basic
--- PASS: TestAccKmsKey_Basic (71.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       71.925s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccKmsKey_rotation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccKmsKey_rotation -timeout 360m -parallel 4
=== RUN   TestAccKmsKey_rotation
=== PAUSE TestAccKmsKey_rotation
=== CONT  TestAccKmsKey_rotation
--- PASS: TestAccKmsKey_rotation (99.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       99.579s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccKmsKeyDataSource_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccKmsKeyDataSource_Basic -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyDataSource_Basic
=== PAUSE TestAccKmsKeyDataSource_Basic
=== CONT  TestAccKmsKeyDataSource_Basic
--- PASS: TestAccKmsKeyDataSource_Basic (37.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       37.255s
```
