### PR TITLE
feat(IoTDA): add a resource to manage AMQP queue

### DIFF
--- a/docs/resources/iotda_amqp.md
+++ b/docs/resources/iotda_amqp.md
@@ -1,0 +1,40 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_amqp
+
+Manages an IoTDA AMQP queue within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_iotda_amqp" "queue" {
+  name = "queue_name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA AMQP queue resource.
+If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the AMQP queue name, which contains 8 to 128 characters.
+Only letters, digits, hyphens (-), underscores (_), dots (.) and colons (:) are allowed.
+Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+AMQP queues can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_iotda_amqp.test 10022532f4f94f26b01daa1e424853e1
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -680,6 +680,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device":              iotda.ResourceDevice(),
 			"huaweicloud_iotda_device_group":        iotda.ResourceDeviceGroup(),
 			"huaweicloud_iotda_dataforwarding_rule": iotda.ResourceDataForwardingRule(),
+			"huaweicloud_iotda_amqp":                iotda.ResourceAmqp(),
 
 			"huaweicloud_kms_key":     ResourceKmsKeyV1(),
 			"huaweicloud_kps_keypair": dew.ResourceKeypair(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
@@ -1,0 +1,69 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getAmqpResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	detail, err := client.ShowQueue(&model.ShowQueueRequest{QueueId: state.Primary.ID})
+	// When the queue does not exist, it still returns a empty struct
+	if detail == nil || detail.QueueId == nil {
+		return nil, fmt.Errorf("error retrieving IoTDA AMQP queue")
+	}
+
+	return detail, err
+}
+
+func TestAccAmqp_basic(t *testing.T) {
+	var obj model.ShowQueueResponse
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_amqp.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAmqpResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAmqp_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAmqp_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iotda_amqp" "test" {
+  name = "%s"
+}
+`, name)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
@@ -1,0 +1,120 @@
+package iotda
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceAmqp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAmqpCreate,
+		ReadContext:   resourceAmqpRead,
+		DeleteContext: resourceAmqpDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(8, 128),
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_0-9.:]*$`),
+						"Only letters, digits, hyphens (-), underscores (_), dots (.) and colons (:) are allowed"),
+				),
+			},
+		},
+	}
+}
+
+func resourceAmqpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	createOpts := model.AddQueueRequest{
+		Body: &model.QueueInfo{
+			QueueName: d.Get("name").(string),
+		},
+	}
+	log.Printf("[DEBUG] Create IoTDA AMQP queue params: %#v", createOpts)
+
+	resp, err := client.AddQueue(&createOpts)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA AMQP queue: %s", err)
+	}
+
+	if resp.QueueId == nil {
+		return diag.Errorf("error creating IoTDA AMQP queue: id is not found in API response")
+	}
+
+	d.SetId(*resp.QueueId)
+	return resourceAmqpRead(ctx, d, meta)
+}
+
+func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	detail, err := client.ShowQueue(&model.ShowQueueRequest{QueueId: d.Id()})
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA AMQP queue")
+	}
+
+	// When the queue does not exist, it still returns a empty struct
+	if detail == nil || detail.QueueId == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving IoTDA AMQP queue")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", detail.QueueName),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAmqpDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	deleteOpts := &model.DeleteQueueRequest{
+		QueueId: d.Id(),
+	}
+	_, err = client.DeleteQueue(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting IoTDA AMQP queue: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a resource to manage AMQP queue

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run=TestAccAmqp_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run=TestAccAmqp_basic -timeout 360m -parallel 4
=== RUN   TestAccAmqp_basic
--- PASS: TestAccAmqp_basic (13.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     13.283s
```
