### PR TITLE
feat(IoTDA): add a resource to manage device certificate

### DIFF
--- a/docs/resources/iotda_device_certificate.md
+++ b/docs/resources/iotda_device_certificate.md
@@ -1,0 +1,82 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_device_certificate
+
+Manages an IoTDA device CA certificate within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "certificateContent" {}
+
+resource "huaweicloud_iotda_device_certificate" "test" {
+  content  = var.certificateContent
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA device CA certificate
+resource. If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `content` - (Required, String, ForceNew) Specifies the content of device CA certificate.
+Changing this parameter will create a new resource. Create a private CA certificate,
+please following [reference](https://support.huaweicloud.com/usermanual-iothub/iot_01_0104.html)
+
+* `space_id` - (Optional, String, ForceNew) Specifies the resource space ID to which the device CA certificate belongs.
+If omitted, the certificate will belong to the default resource space.
+Changing this parameter will create a new resource.
+
+* `verify_content` - (Optional, String) Specifies the content of verification certificate. Can only be used to verify
+the validity of the device CA certificate after creation. Get the verification certificate,
+please following [reference](https://support.huaweicloud.com/usermanual-iothub/iot_01_0106.html)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `cn` - The CN name of the device CA certificate.
+
+* `owner` - The owner of the device CA certificate.
+
+* `status` - The status of the device CA certificate. The valid values are **Unverified** and **Verified**.
+
+* `verify_code` - The verify code of the device CA certificate.
+
+* `effective_date` - The effective date of the device CA certificate.
+The format is: **yyyyMMdd'T'HHmmss'Z'**, e.g., **20151212T121212Z**.
+
+* `expiry_date` - The expiry date of the device CA certificate.
+The format is: **yyyyMMdd'T'HHmmss'Z'**, e.g., **20151212T121212Z**.
+
+## Import
+
+Device CA certificates can be imported by `id`, e.g.
+
+```
+$ terraform import huaweicloud_iotda_device_certificate.test 62b3cec5558d4b703f064534
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `content`, `space_id`, `verify_content`.
+It is generally recommended running `terraform plan` after importing the resource. You can then decide if changes should
+be applied to the resource, or the resource definition should be updated to align with the group. Also you can ignore
+changes as below.
+
+```
+resource "huaweicloud_iotda_device_certificate" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      content, space_id, verify_content
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -684,6 +684,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device_group":        iotda.ResourceDeviceGroup(),
 			"huaweicloud_iotda_dataforwarding_rule": iotda.ResourceDataForwardingRule(),
 			"huaweicloud_iotda_amqp":                iotda.ResourceAmqp(),
+			"huaweicloud_iotda_device_certificate":  iotda.ResourceDeviceCertificate(),
 
 			"huaweicloud_kms_key":     ResourceKmsKeyV1(),
 			"huaweicloud_kps_keypair": dew.ResourceKeypair(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
@@ -1,0 +1,87 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
+)
+
+func getDeviceCertificateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+	return iotda.QueryDeviceCertificate(client, state.Primary.ID, nil)
+}
+
+func TestAccDeviceCertificate_basic(t *testing.T) {
+	var obj model.CertificatesRspDto
+	rName := "huaweicloud_iotda_device_certificate.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceCertificateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceCertificate_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cn", "huaweiIoT"),
+					resource.TestCheckResourceAttr(rName, "status", "Unverified"),
+					resource.TestCheckResourceAttrSet(rName, "verify_code"),
+					resource.TestCheckResourceAttrSet(rName, "effective_date"),
+					resource.TestCheckResourceAttrSet(rName, "expiry_date"),
+					resource.TestCheckResourceAttrSet(rName, "owner"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"content"},
+			},
+		},
+	})
+}
+
+const testDeviceCertificate_basic = `
+resource "huaweicloud_iotda_device_certificate" "test" {
+  content  = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDlTCCAn0CFDksqsC4D2sWd5aIJ/3kveD9bi1VMA0GCSqGSIb3DQEBCwUAMIGF
+MQswCQYDVQQGEwJDTjEQMA4GA1UECAwHYmVpamluZzEQMA4GA1UEBwwHYmVpamlu
+ZzEPMA0GA1UECgwGaHVhd2VpMQ4wDAYDVQQLDAVjbG91ZDESMBAGA1UEAwwJaHVh
+d2VpSW9UMR0wGwYJKoZIhvcNAQkBFg54eHhAaHVhd2VpLmNvbTAgFw0yMjA2MjIw
+MjAyNTVaGA8yMTU5MDUxNTAyMDI1NVowgYUxCzAJBgNVBAYTAkNOMRAwDgYDVQQI
+DAdiZWlqaW5nMRAwDgYDVQQHDAdiZWlqaW5nMQ8wDQYDVQQKDAZodWF3ZWkxDjAM
+BgNVBAsMBWNsb3VkMRIwEAYDVQQDDAlodWF3ZWlJb1QxHTAbBgkqhkiG9w0BCQEW
+Dnh4eEBodWF3ZWkuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+wKVJ6SpnhcBj3A5AEBrykKgZHSnU6+EqmTHoKGHFLjIMQuVr8cv8a8j7gDINc0gQ
+L+UE3D3JdnIxarUH7/WWLjqKqqzTkcNOFi5Mue6JVtGKLJ/3mEsTFAlEz9ArRz+0
+SCYgMJDQ9Z7EYY82NSjpVf8/0YyqOZeQMOGn58i/yxAxqzK4ux1l410JOH55kz7k
+bwW9oXmnyTaZqfvT4JsQ4U9JwkdkRcJlzxR8w24t/s+qE4/KM7avlCw1oMvTnkTO
+uJy9UEWCTCOVyC7+CB9QmysjkK3DZgH/ER2Q6sjSmzIEkpcqJpt4cYTcFL3nDLC7
+TfIr5SmDZ4Q3Z2CYqI6/oQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCffi7j5Zsz
+LTCJsvwplZqjXPnTHSzqvMoD96mf7qSObqsdVh9KaM9sjg49wYtKANqIa4l/oO+t
+qtu+C7evY9M4X4EBOdDTG6OH7U8YOoIPAUgVZ81zhvFmXbCUb+ekOLwBWlccIwtN
+l4223PfNnA8HZhQjpAtfT0DS5pAEmQZ8X2ByqAXXMWgWGgQRh4vyvbd7MMTCr6fp
+zTZSnp58+Rqlf3Sqjps3BJydjxURvLpoB+WvByWhafXoxeOu3yEZQrZF+rzu6yaB
+BWlaAkI9PmPD+h2ozFiXH7nzABrAXFOk1AaRFM+cAJLnuVyWjX/hv5rz9Z4FfWJu
+RQocSUkUw0EW
+-----END CERTIFICATE-----
+EOT
+}
+`

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
@@ -1,0 +1,213 @@
+package iotda
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
+	v5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDeviceCertificate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeviceCertificateCreate,
+		ReadContext:   resourceDeviceCertificateRead,
+		UpdateContext: resourceDeviceCertificateUpdate,
+		DeleteContext: resourceDeviceCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"verify_content": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"cn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"verify_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"effective_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"expiry_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDeviceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	createOpts := model.AddCertificateRequest{
+		Body: &model.CreateCertificateDto{
+			Content: d.Get("content").(string),
+			AppId:   utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+		},
+	}
+
+	resp, err := client.AddCertificate(&createOpts)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA device CA certificate: %s", err)
+	}
+
+	if resp.CertificateId == nil {
+		return diag.Errorf("error creating IoTDA device CA certificate: id is not found in API response")
+	}
+
+	d.SetId(*resp.CertificateId)
+	return resourceDeviceCertificateRead(ctx, d, meta)
+}
+
+func resourceDeviceCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	detail, err := QueryDeviceCertificate(client, d.Id(), utils.StringIgnoreEmpty(d.Get("space_id").(string)))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA device CA certificate")
+	}
+
+	status := "Unverified"
+	if detail.Status != nil && *detail.Status {
+		status = "Verified"
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("cn", detail.CnName),
+		d.Set("owner", detail.Owner),
+		d.Set("status", status),
+		d.Set("verify_code", detail.VerifyCode),
+		d.Set("effective_date", detail.EffectiveDate),
+		d.Set("expiry_date", detail.ExpiryDate),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDeviceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	opts := model.CheckCertificateRequest{
+		CertificateId: d.Id(),
+		ActionId:      "verify",
+		Body: &model.VerifyCertificateDto{
+			VerifyContent: d.Get("verify_content").(string),
+		},
+	}
+
+	_, err = client.CheckCertificate(&opts)
+	if err != nil {
+		return diag.Errorf("error verifing IoTDA device CA certificate: %s", err)
+	}
+
+	return resourceDeviceCertificateRead(ctx, d, meta)
+}
+
+func resourceDeviceCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcIoTdaV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	deleteOpts := &model.DeleteCertificateRequest{
+		CertificateId: d.Id(),
+	}
+	_, err = client.DeleteCertificate(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting IoTDA device CA certificate: %s", err)
+	}
+
+	return nil
+}
+
+func QueryDeviceCertificate(client *v5.IoTDAClient, id string, spaceId *string) (*model.CertificatesRspDto, error) {
+	var marker *string
+	for {
+		resp, err := client.ListCertificates(&model.ListCertificatesRequest{
+			AppId:  spaceId,
+			Limit:  utils.Int32(50),
+			Marker: marker,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		if resp.Certificates == nil || len(*resp.Certificates) == 0 {
+			break
+		}
+
+		for _, v := range *resp.Certificates {
+			if utils.StringValue(v.CertificateId) == id {
+				return &v, nil
+			}
+		}
+		marker = resp.Page.Marker
+	}
+
+	return nil, &sdkerr.ServiceResponseError{StatusCode: http.StatusNotFound}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a resource t o manage device certificate

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run=TestAccDeviceCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run=TestAccDeviceCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceCertificate_basic
--- PASS: TestAccDeviceCertificate_basic (14.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.745s
```
