### PR TITLE
feat(apig/environment): add new data source support

### DIFF
--- a/docs/data-sources/apig_environments.md
+++ b/docs/data-sources/apig_environments.md
@@ -1,0 +1,50 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_environments
+
+Use this data source to query the environment list under the APIG instance within Huaweicloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "environment_name" {}
+
+data "huaweicloud_apig_environments" "test" {
+  instance_id = var.instance_id
+  name        = var.environment_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the APIG environment list.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies an ID of the APIG dedicated instance to which the API
+  environment belongs.
+
+* `name` - (Optional, String) Specifies the name of the API environment. The API environment name consists of 3 to 64
+  characters, starting with a letter. Only letters, digits and underscores (_) are allowed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `environments` - List of APIG environment details. The structure is documented below.
+
+The `environments` block supports:
+
+* `id` - ID of the APIG environment.
+
+* `name` - The environment name.
+
+* `description` - The description about the API environment.
+
+* `create_time` - Time when the APIG environment was created, in RFC-3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -339,7 +339,10 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"huaweicloud_antiddos":           dataSourceAntiDdosV1(),
+			"huaweicloud_antiddos": dataSourceAntiDdosV1(),
+
+			"huaweicloud_apig_environments": apig.DataSourceEnvironments(),
+
 			"huaweicloud_availability_zones": DataSourceAvailabilityZones(),
 
 			"huaweicloud_bms_flavors": bms.DataSourceBmsFlavors(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_environments_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_environments_test.go
@@ -1,0 +1,52 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEnvironments_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_apig_environments.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		rName          = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEnvironments_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "environments.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataEnvironments_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_environment" "test" {
+  name        = "%s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+}
+
+data "huaweicloud_apig_environments" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = huaweicloud_apig_environment.test.name
+}
+`, testAccApigApplication_base(rName), rName)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_environments.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_environments.go
@@ -1,0 +1,112 @@
+package apig
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+)
+
+func DataSourceEnvironments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEnvironmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z](\w+)?$`),
+						"The name can only consist of letters, digits and underscores (_), and must start with a letter."),
+					validation.StringLenBetween(3, 64),
+				),
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenEnvironments(envList []environments.Environment) ([]map[string]interface{}, []string) {
+	if len(envList) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(envList))
+	ids := make([]string, len(envList))
+	for i, env := range envList {
+		result[i] = map[string]interface{}{
+			"id":          env.Id,
+			"name":        env.Name,
+			"description": env.Description,
+			"create_time": env.CreateTime,
+		}
+		ids[i] = env.Id
+	}
+	return result, ids
+}
+
+func dataSourceEnvironmentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	opt := environments.ListOpts{
+		Name: d.Get("name").(string),
+	}
+	pages, err := environments.List(client, d.Get("instance_id").(string), opt).AllPages()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	resp, err := environments.ExtractEnvironments(pages)
+	if err != nil {
+		return diag.Errorf("unable to get the environment list form server: %v", err)
+	}
+
+	envResult, ids := flattenEnvironments(resp)
+	d.SetId(hashcode.Strings(ids))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("environments", envResult),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the terraform, we can obtain the environment information only through resource attributes currently.
Perhaps we can support a data-source to support the APIG environments obtain.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccDataEnvironments_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccDataEnvironments_basic -timeout 360m -parallel 4
=== RUN   TestAccDataEnvironments_basic
=== PAUSE TestAccDataEnvironments_basic
=== CONT  TestAccDataEnvironments_basic
--- PASS: TestAccDataEnvironments_basic (459.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig     460.158s
```
