### PR TITLE
fix(cbr/policy): update require validate method

### DIFF
--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -89,7 +89,7 @@ The following arguments are supported:
   deletes the earliest backups. By default, the system automatically clears data every other day.
 
 * `time_zone` - (Optional, String) Specifies the UTC time zone, e.g.: `UTC+08:00`.
-  Required if `long_term_retention` is set.
+  Only avaiable if `long_term_retention` is set.
 
 <a name="cbr_policy_backup_cycle"></a>
 The `backup_cycle` block supports:

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
@@ -211,9 +211,11 @@ func resourceCBRPolicyV3Read(d *schema.ResourceData, meta interface{}) error {
 	if operationDefinition.MaxBackups != -1 {
 		mErr = multierror.Append(mErr,
 			d.Set("backup_quantity", operationDefinition.MaxBackups),
-			d.Set("time_zone", operationDefinition.Timezone),
 			setCBRPolicyV3LongTermRetention(d, operationDefinition),
 		)
+		if operationDefinition.Timezone != "" {
+			mErr = multierror.Append(mErr, d.Set("time_zone", operationDefinition.Timezone))
+		}
 	}
 	if operationDefinition.RetentionDurationDays != -1 {
 		mErr = multierror.Append(mErr, d.Set("time_period", operationDefinition.RetentionDurationDays))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The time zone parameter is only valid for the `long_term_retention` parameter, the current `RequiredWith` function is wrong.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the require validate method logic,
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccCBRV3Policy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccCBRV3Policy_basic -timeout 360m -parallel 4
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== CONT  TestAccCBRV3Policy_basic
--- PASS: TestAccCBRV3Policy_basic (23.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       23.478s
```
