### PR TITLE
refactor(client): move client function to public package

### DIFF
--- a/huaweicloud/common/config.go
+++ b/huaweicloud/common/config.go
@@ -15,14 +15,18 @@ import (
 // URLs will be assembled according to the endpoints array, separated each element by slashes.
 // for example, array ["https://www.example.com", "v2", "test", ...] will form the address
 // "https://www.example.com/v2/test/.../".
-// NOTE: This client will skip the SSL certificate check.
-func NewCustomClient(endpoints ...string) *golangsdk.ServiceClient {
+// NOTE: You can decide whether to skip the SSL certificate check with the insecure parameter.
+func NewCustomClient(insecure bool, endpoints ...string) *golangsdk.ServiceClient {
 	p := new(golangsdk.ProviderClient)
 	p.HTTPClient = http.Client{
 		Transport: &config.LogRoundTripper{
 			Rt: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					// The version fields of the TLS ver.1.2 and ver.1.3 are filled with 0x0303 (ver.1.2)
+					MinVersion:         tls.VersionTLS12,
+					InsecureSkipVerify: insecure, // Pay attention to the security risks after skip verify.
+				},
 			},
 			OsDebug: logging.IsDebugOrHigher(),
 		},

--- a/huaweicloud/common/config.go
+++ b/huaweicloud/common/config.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// NewCustomClient creates a custom client assembled from user-provided endpoints.
+// URLs will be assembled according to the endpoints array, separated each element by slashes.
+// for example, array ["https://www.example.com", "v2", "test", ...] will form the address
+// "https://www.example.com/v2/test/.../".
+// NOTE: This client will skip the SSL certificate check.
+func NewCustomClient(endpoints ...string) *golangsdk.ServiceClient {
+	p := new(golangsdk.ProviderClient)
+	p.HTTPClient = http.Client{
+		Transport: &config.LogRoundTripper{
+			Rt: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+			OsDebug: logging.IsDebugOrHigher(),
+		},
+		Timeout: 30 * time.Minute,
+	}
+
+	return &golangsdk.ServiceClient{
+		ProviderClient: p,
+		ResourceBase:   strings.Join(endpoints, "/") + "/",
+	}
+}

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/instances"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
@@ -20,7 +21,7 @@ func getMicroserviceInstanceFunc(conf *config.Config, state *terraform.ResourceS
 		return nil, err
 	}
 
-	client := cse.NewCustomClient(state.Primary.Attributes["connect_address"], "v4", "default")
+	client := common.NewCustomClient(state.Primary.Attributes["connect_address"], "v4", "default")
 	return instances.Get(client, state.Primary.Attributes["microservice_id"], state.Primary.ID, token)
 }
 

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -21,7 +21,7 @@ func getMicroserviceInstanceFunc(conf *config.Config, state *terraform.ResourceS
 		return nil, err
 	}
 
-	client := common.NewCustomClient(state.Primary.Attributes["connect_address"], "v4", "default")
+	client := common.NewCustomClient(true, state.Primary.Attributes["connect_address"], "v4", "default")
 	return instances.Get(client, state.Primary.Attributes["microservice_id"], state.Primary.ID, token)
 }
 

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
@@ -21,7 +21,7 @@ func getMicroserviceFunc(conf *config.Config, state *terraform.ResourceState) (i
 		return nil, err
 	}
 
-	client := common.NewCustomClient(state.Primary.Attributes["connect_address"], "v4", "default")
+	client := common.NewCustomClient(true, state.Primary.Attributes["connect_address"], "v4", "default")
 	return services.Get(client, state.Primary.ID, token)
 }
 

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
@@ -20,7 +21,7 @@ func getMicroserviceFunc(conf *config.Config, state *terraform.ResourceState) (i
 		return nil, err
 	}
 
-	client := cse.NewCustomClient(state.Primary.Attributes["connect_address"], "v4", "default")
+	client := common.NewCustomClient(state.Primary.Attributes["connect_address"], "v4", "default")
 	return services.Get(client, state.Primary.ID, token)
 }
 

--- a/huaweicloud/services/cse/config.go
+++ b/huaweicloud/services/cse/config.go
@@ -29,6 +29,6 @@ func GetAuthorizationToken(connAddr, username, password string) (string, error) 
 	if username == "" {
 		return "", nil
 	}
-	client := common.NewCustomClient(connAddr, "v4")
+	client := common.NewCustomClient(true, connAddr, "v4")
 	return getAuthorizationToken(client, username, password)
 }

--- a/huaweicloud/services/cse/config.go
+++ b/huaweicloud/services/cse/config.go
@@ -1,41 +1,12 @@
 package cse
 
 import (
-	"crypto/tls"
 	"fmt"
-	"net/http"
-	"strings"
-	"time"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/auth"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 )
-
-// NewCustomClient creates a custom client assembled from user-provided endpoints.
-// URLs will be assembled according to the endpoints array, separated each element by slashes.
-// for example, array ["https://www.example.com", "v2", "test", ...] will form the address
-// "https://www.example.com/v2/test/.../".
-// NOTE: This client will skip the SSL certificate check.
-func NewCustomClient(endpoints ...string) *golangsdk.ServiceClient {
-	p := new(golangsdk.ProviderClient)
-	p.HTTPClient = http.Client{
-		Transport: &config.LogRoundTripper{
-			Rt: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-			OsDebug: logging.IsDebugOrHigher(),
-		},
-		Timeout: 30 * time.Minute,
-	}
-
-	return &golangsdk.ServiceClient{
-		ProviderClient: p,
-		ResourceBase:   strings.Join(endpoints, "/") + "/",
-	}
-}
 
 // getAuthorizationToken is a method to request the CSE API and get the authorization token.
 // The format of is "Bearer {token}".
@@ -58,6 +29,6 @@ func GetAuthorizationToken(connAddr, username, password string) (string, error) 
 	if username == "" {
 		return "", nil
 	}
-	client := NewCustomClient(connAddr, "v4")
+	client := common.NewCustomClient(connAddr, "v4")
 	return getAuthorizationToken(client, username, password)
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 )
 
 func ResourceMicroservice() *schema.Resource {
@@ -114,7 +115,7 @@ func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	client := NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	createOpts := buildMicroserviceCreateOpts(d)
 	log.Printf("[DEBUG] The createOpts of the Microservice is: %v", createOpts)
 	resp, err := services.Create(client, createOpts, token)
@@ -133,7 +134,7 @@ func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ inter
 		return diag.FromErr(err)
 	}
 
-	client := NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	resp, err := services.Get(client, d.Id(), token)
 	if err != nil {
 		return diag.Errorf("error getting dedicated microservice (%s): %s", d.Id(), err)
@@ -164,7 +165,7 @@ func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ int
 	deleteOpts := services.DeleteOpts{
 		Force: true,
 	}
-	client := NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	err = services.Delete(client, deleteOpts, d.Id(), token)
 	if err != nil {
 		return diag.Errorf("error deleting dedicated microservice (%s): %s", d.Id(), err)

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -189,7 +189,7 @@ func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	client := NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(d.Get("connect_address").(string), "v4", "default")
 	createOpts := buildInstanceCreateOpts(d)
 	log.Printf("[DEBUG] The createOpts of the Microservice instance is: %v", createOpts)
 	resp, err := instances.Create(client, createOpts, d.Get("microservice_id").(string), token)
@@ -239,7 +239,7 @@ func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	client := NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(d.Get("connect_address").(string), "v4", "default")
 	resp, err := instances.Get(client, d.Get("microservice_id").(string), d.Id(), token)
 	if err != nil {
 		return common.CheckDeletedDiag(d, parseMicroserviceInstanceError(err), "error retrieving Microservice instance")
@@ -265,7 +265,7 @@ func resourceMicroserviceInstanceDelete(_ context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	client := NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(d.Get("connect_address").(string), "v4", "default")
 	err = instances.Delete(client, d.Get("microservice_id").(string), d.Id(), token)
 	if err != nil {
 		return diag.Errorf("error deleting dedicated microservice instance (%s): %s", d.Id(), err)

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -189,7 +189,7 @@ func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	client := common.NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	createOpts := buildInstanceCreateOpts(d)
 	log.Printf("[DEBUG] The createOpts of the Microservice instance is: %v", createOpts)
 	resp, err := instances.Create(client, createOpts, d.Get("microservice_id").(string), token)
@@ -239,7 +239,7 @@ func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	client := common.NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	resp, err := instances.Get(client, d.Get("microservice_id").(string), d.Id(), token)
 	if err != nil {
 		return common.CheckDeletedDiag(d, parseMicroserviceInstanceError(err), "error retrieving Microservice instance")
@@ -265,7 +265,7 @@ func resourceMicroserviceInstanceDelete(_ context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	client := common.NewCustomClient(d.Get("connect_address").(string), "v4", "default")
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	err = instances.Delete(client, d.Get("microservice_id").(string), d.Id(), token)
 	if err != nil {
 		return diag.Errorf("error deleting dedicated microservice instance (%s): %s", d.Id(), err)


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Move client function to public package and limit the minimum of TLS protocol version.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. move client function to public package
2. limit the tls min version
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cse' TESTARGS='-run=TestAccMicroservice_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse -v -run=TestAccMicroservice_basic -timeout 360m -parallel 4
=== RUN   TestAccMicroservice_basic
=== PAUSE TestAccMicroservice_basic
=== CONT  TestAccMicroservice_basic
--- PASS: TestAccMicroservice_basic (853.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       853.916s
```
