### PR TITLE
fix(servicestage/instance): fix what causes ecs deployment to fail

### DIFF
--- a/docs/resources/servicestage_component_instance.md
+++ b/docs/resources/servicestage_component_instance.md
@@ -267,11 +267,7 @@ The `env_variable` block supports:
   The name can contain `1` to `64` characters, only letters, digits, hyphens (-), underscores (_) and dots (.) are
   allowed. The name cannot start with a digit.
 
-* `value` - (Required, String) Specifies the variable value. After the instance is created, the system will
-  automatically add a series of environment variables to it. We have filtered the system parameters, please be careful
-  not to set the parameters of the following styles:
-  + Starting with the feature keyword: **PAAS_**, **CAS_**, and **AOM_**.
-  + Specific variable name: **servicecomb_engine_name**.
+* `value` - (Required, String) Specifies the variable value.
 
 <a name="servicestage_storages"></a>
 The `storage` block supports:

--- a/docs/resources/servicestage_component_instance.md
+++ b/docs/resources/servicestage_component_instance.md
@@ -8,7 +8,7 @@ This resource is used to deploy a component under specified application within H
 
 ## Example Usage
 
-### Deploy a component with specified SWR image
+### Deploy a component in the container with specified SWR image
 
 ```hcl
 variable "app_id" {}
@@ -58,6 +58,55 @@ resource "huaweicloud_servicestage_component_instance" "default" {
     env_variable {
       name  = "TZ"
       value = "Asia/Shanghai"
+    }
+  }
+}
+```
+
+### Deploy a component in the ECS instance with specified jar package
+
+```hcl
+variable "app_id" {}
+variable "component_id" {}
+variable "env_id" {}
+variable "instance_name" {}
+variable "flavor_id" {}
+variable "component_name" {}
+variable "jar_url" {}
+variable "obs_bucket_name" {}
+variable "obs_bucket_endpoint" {}
+variable "obs_object_key" {}
+variable "ecs_instance_id" {}
+
+resource "huaweicloud_servicestage_component_instance" "test" {
+  application_id = var.app_id
+  component_id   = var.component_id
+  environment_id = var.env_id
+
+  name      = var.instance_name
+  version   = "1.0.0"
+  replica   = 1
+  flavor_id = var.flavor_id
+
+  artifact {
+    name      = var.component_name
+    auth_type = "iam"
+    type      = "package"
+    storage   = "obs"
+    url       = var.jar_url
+
+    properties {
+      bucket   = var.obs_bucket_name
+      endpoint = var.obs_bucket_endpoint
+      key      = var.obs_object_key
+    }
+  }
+
+  refer_resource {
+    type = "ecs"
+    id   = "Default"
+    parameters = {
+      hosts = "[\"${var.ecs_instance_id}\"]"
     }
   }
 }
@@ -146,11 +195,11 @@ The `refer_resource` block supports:
   The valid values are: **distributed_session**, **distributed_cache** and **distributed_session, distributed_cache**.
   Defaults to **distributed_session, distributed_cache**.
 
-* `parameters` - (Optional, String) Specifies the reference resource parameter.
+* `parameters` - (Optional, Map) Specifies the reference resource parameter.
   + When `type` is set to **cce**, this parameter is mandatory, and need to specify the namespace of the cluster where
   the component is to be deployed, such as **{"namespace": "default"}**.
   + When `type` is set to **ecs**, this parameter is mandatory, and need to specify the hosts where the component is to
-  be deployed, such as **{"hosts":["04d9f887-9860-4029-91d1-7d3102903a69", "04d9f887-9860-4029-91d1-7d3102903a70"]}}**.
+  be deployed, such as **{"hosts":"[\"04d9f887-9860-4029-91d1-7d3102903a69\", \"04d9f887-9860-4029-91d1-7d3102903a70\"]"}**.
 
 <a name="servicestage_artifact"></a>
 The `artifact` block supports:
@@ -173,6 +222,19 @@ The `artifact` block supports:
   The valid values are **iam** and **none**. Defaults to **iam**.
 
 * `version` - (Optional, String) Specifies the version number.
+
+* `properties` - (Optional, List) Specifies the properties of the OBS object.
+  This parameter is available only `storage` is **obs**.
+  The [object](#servicestage_properties) structure is documented below.
+
+<a name="servicestage_properties"></a>
+The `properties` block supports:
+
+* `bucket` - (Optional, String) Specifies the OBS bucket name.
+
+* `endpoint` - (Optional, String) Specifies the OBS bucket endpoint.
+
+* `key` - (Optional, String) Specifies the key name of the OBS object.
 
 <a name="servicestage_configuration"></a>
 The `configuration` block supports:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41
+	github.com/chnsz/golangsdk v0.0.0-20220701061130-f5ff51d74f49
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220625020635-39bb1ee32cb0
+	github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,10 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41 h1:2rUmKwJAmpFwDb52tmWjur21MOLRwPE7mQKFQQHiH5o=
 github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220630062755-85a1fa99168c h1:czWH29Ei2iwmBIzBaK3l5oAFTWMvkLcTajxlbqGO2NI=
+github.com/chnsz/golangsdk v0.0.0-20220630062755-85a1fa99168c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220701061130-f5ff51d74f49 h1:sOEiD9DiwqfFOgb0udZzgETtEPTSKzw0cx7sjW1LKJE=
+github.com/chnsz/golangsdk v0.0.0-20220701061130-f5ff51d74f49/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040 h1:9rkxND2IVrOzVpCfkWx8bxE4340D/Nqytro8S4iFu2s=
-github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20220625020635-39bb1ee32cb0 h1:tpa2N3f85N0iO4nBk0hWMUHSC0hHJNMvwOvuMA4tIPU=
-github.com/chnsz/golangsdk v0.0.0-20220625020635-39bb1ee32cb0/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41 h1:2rUmKwJAmpFwDb52tmWjur21MOLRwPE7mQKFQQHiH5o=
+github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
@@ -63,8 +63,6 @@ func TestAccComponentInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "artifact.0.url", acceptance.HW_BUILD_IMAGE_URL),
 					resource.TestCheckResourceAttr(resourceName, "artifact.0.auth_type", "iam"),
 					resource.TestCheckResourceAttr(resourceName, "refer_resource.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.name", "TZ"),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.value", "Asia/Shanghai"),
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 				),
 			},
@@ -75,6 +73,8 @@ func TestAccComponentInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "version", "1.0.2"),
 					resource.TestCheckResourceAttr(resourceName, "flavor_id", "CUSTOM-15G:500m-500m:1Gi-1Gi"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.name", "TZ"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.value", "Asia/Shanghai"),
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 				),
 			},
@@ -259,19 +259,6 @@ resource "huaweicloud_servicestage_component_instance" "test" {
     type = "cse"
     id   = "default"
   }
-
-  configuration {
-    env_variable {
-      name  = "TZ"
-      value = "Asia/Shanghai"
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      configuration[0].env_variable,
-    ]
-  }
 }
 `, testAccComponentInstance_base(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
 }
@@ -318,12 +305,6 @@ resource "huaweicloud_servicestage_component_instance" "test" {
       name  = "TZ"
       value = "Asia/Shanghai"
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      configuration[0].env_variable,
-    ]
   }
 }
 `, testAccComponentInstance_base(rName), rName, acceptance.HW_BUILD_IMAGE_URL)

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
@@ -2,6 +2,7 @@ package servicestage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
@@ -304,7 +305,31 @@ func ResourceComponentInstance() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
-						// Currently, we don't know how to configure the properties.
+						"properties": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bucket": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"endpoint": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -560,21 +585,31 @@ func buildArtifactStructure(artifacts *schema.Set) map[string]instances.Artifact
 	result := make(map[string]instances.Artifact)
 	for _, val := range artifacts.List() {
 		artifact := val.(map[string]interface{})
-		result[artifact["name"].(string)] = instances.Artifact{
+		s := instances.Artifact{
 			Type:    artifact["type"].(string),
 			Storage: artifact["storage"].(string),
 			URL:     artifact["url"].(string),
 			Auth:    artifact["auth_type"].(string),
 			Version: artifact["version"].(string),
 		}
+		properties := artifact["properties"].([]interface{})
+		if len(properties) > 0 {
+			property := properties[0].(map[string]interface{})
+			s.Properties = map[string]interface{}{
+				"bucket":   property["bucket"].(string),
+				"endpoint": property["endpoint"].(string),
+				"key":      property["key"].(string),
+			}
+		}
+		result[artifact["name"].(string)] = s
 	}
 
 	return result
 }
 
-func buildReferResourcesList(resources *schema.Set) []instances.ReferResource {
+func buildReferResourcesList(resources *schema.Set) ([]instances.ReferResource, error) {
 	if resources.Len() < 1 {
-		return nil
+		return nil, nil
 	}
 
 	result := make([]instances.ReferResource, resources.Len())
@@ -585,13 +620,32 @@ func buildReferResourcesList(resources *schema.Set) []instances.ReferResource {
 			ID:         res["id"].(string),
 			ReferAlias: res["alias"].(string),
 		}
+		pResult := make(map[string]interface{})
 		if param, ok := res["parameters"]; ok {
-			refer.Parameters = param.(map[string]interface{})
+			p := param.(map[string]interface{})
+			for k, v := range p {
+				if k == "hosts" {
+					var r []string
+					err := json.Unmarshal([]byte(v.(string)), &r)
+					if err != nil {
+						return nil, fmt.Errorf("The format of the host value is not right: %#v", v)
+					}
+					log.Printf("The host value is %v", r)
+					log.Printf("The length of host is %#v", len(r))
+					pResult[k] = &r
+					continue
+				}
+				pResult[k] = v
+			}
+
+			refer.Parameters = pResult
 		}
+
+		log.Printf("The parameter map is %v", pResult)
 		result[i] = refer
 	}
 
-	return result
+	return result, nil
 }
 
 func buildEnvVariables(variables *schema.Set) []instances.Variable {
@@ -808,18 +862,18 @@ func buildProbeStructure(probes []interface{}) (*instances.Probe, error) {
 	}, nil
 }
 
-func buildConfigurationStructure(configs []interface{}) (*instances.Configuration, error) {
+func buildConfigurationStructure(configs []interface{}) (instances.Configuration, error) {
 	if len(configs) < 1 {
-		return nil, nil
+		return instances.Configuration{}, nil
 	}
 
 	config := configs[0].(map[string]interface{})
 	probe, err := buildProbeStructure(config["probe"].([]interface{}))
 	if err != nil {
-		return nil, err
+		return instances.Configuration{}, err
 	}
 
-	return &instances.Configuration{
+	return instances.Configuration{
 		EnvVariables: buildEnvVariables(config["env_variable"].(*schema.Set)),
 		Storages:     buildStoragesList(config["storage"].(*schema.Set)),
 		Strategy:     buildStrategyStructure(config["strategy"].([]interface{})),
@@ -849,16 +903,21 @@ func buildExternalAccessList(accesses *schema.Set) []instances.ExternalAccess {
 
 func buildInstanceCreateOpts(d *schema.ResourceData) (instances.CreateOpts, error) {
 	result := instances.CreateOpts{
-		EnvId:            d.Get("environment_id").(string),
-		Name:             d.Get("name").(string),
-		Version:          d.Get("version").(string),
-		Replica:          d.Get("replica").(int),
-		FlavorId:         d.Get("flavor_id").(string),
-		Description:      d.Get("description").(string),
-		Artifacts:        buildArtifactStructure(d.Get("artifact").(*schema.Set)),
-		ReferResources:   buildReferResourcesList(d.Get("refer_resource").(*schema.Set)),
+		EnvId:       d.Get("environment_id").(string),
+		Name:        d.Get("name").(string),
+		Version:     d.Get("version").(string),
+		Replica:     d.Get("replica").(int),
+		FlavorId:    d.Get("flavor_id").(string),
+		Description: d.Get("description").(string),
+		Artifacts:   buildArtifactStructure(d.Get("artifact").(*schema.Set)),
+
 		ExternalAccesses: buildExternalAccessList(d.Get("external_access").(*schema.Set)),
 	}
+	referRes, err := buildReferResourcesList(d.Get("refer_resource").(*schema.Set))
+	if err != nil {
+		return result, err
+	}
+	result.ReferResources = referRes
 
 	conf, err := buildConfigurationStructure(d.Get("configuration").([]interface{}))
 	if err != nil {
@@ -909,20 +968,42 @@ func resourceComponentInstanceCreate(ctx context.Context, d *schema.ResourceData
 	return resourceComponentInstanceRead(ctx, d, meta)
 }
 
-func flattenArtifact(artifacts map[string]instances.Artifact) (result []map[string]interface{}) {
+func flattenProperties(properties map[string]interface{}) []map[string]interface{} {
+	result := make(map[string]interface{})
+	if bucket, ok := properties["bucket"]; ok {
+		result["bucket"] = bucket
+	}
+	if endpoint, ok := properties["endpoint"]; ok {
+		result["endpoint"] = endpoint
+	}
+	if key, ok := properties["key"]; ok {
+		result["key"] = key
+	}
+	if len(result) < 1 {
+		return nil
+	}
+	return []map[string]interface{}{result}
+}
+
+func flattenArtifact(artifacts map[string]instances.Artifact) []map[string]interface{} {
 	if len(artifacts) < 1 {
 		return nil
 	}
 
+	result := make([]map[string]interface{}, 0, len(artifacts))
 	for key, val := range artifacts {
-		result = append(result, map[string]interface{}{
+		s := map[string]interface{}{
 			"name":      key,
 			"type":      val.Type,
 			"storage":   val.Storage,
 			"url":       val.URL,
 			"auth_type": val.Auth,
 			"version":   val.Version,
-		})
+		}
+		if p := flattenProperties(val.Properties); p != nil {
+			s["properties"] = p
+		}
+		result = append(result, s)
 	}
 
 	log.Printf("[DEBUG] The artifacts result is %#v", result)
@@ -935,12 +1016,24 @@ func flattenReferResources(resources []instances.ReferResource) (result []map[st
 	}
 
 	for _, val := range resources {
-		result = append(result, map[string]interface{}{
-			"type":       val.Type,
-			"id":         val.ID,
-			"parameters": val.Parameters,
-			"alias":      val.ReferAlias,
-		})
+		s := map[string]interface{}{
+			"type":  val.Type,
+			"id":    val.ID,
+			"alias": val.ReferAlias,
+		}
+		params := make(map[string]interface{})
+		for k, v := range val.Parameters {
+			if _, ok := v.([]interface{}); ok {
+				jsonByte, _ := json.Marshal(v.([]interface{}))
+				params[k] = string(jsonByte)
+				continue
+			}
+			params[k] = v
+		}
+		if len(params) > 0 {
+			s["parameters"] = params
+		}
+		result = append(result, s)
 	}
 
 	log.Printf("[DEBUG] The resources result is %#v", result)
@@ -1285,9 +1378,14 @@ func buildInstanceUpdateOpts(d *schema.ResourceData) (instances.UpdateOpts, erro
 		FlavorId:         d.Get("flavor_id").(string),
 		Description:      &desc,
 		Artifacts:        buildArtifactStructure(d.Get("artifact").(*schema.Set)),
-		ReferResources:   buildReferResourcesList(d.Get("refer_resource").(*schema.Set)),
 		ExternalAccesses: buildExternalAccessList(d.Get("external_access").(*schema.Set)),
 	}
+
+	referRes, err := buildReferResourcesList(d.Get("refer_resource").(*schema.Set))
+	if err != nil {
+		return result, err
+	}
+	result.ReferResources = referRes
 
 	conf, err := buildConfigurationStructure(d.Get("configuration").([]interface{}))
 	if err != nil {

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/requests.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 	Artifacts map[string]Artifact `json:"artifacts,omitempty"`
 	// Configuration parameters, such as environment variables, deployment configurations, and O&M monitoring.
 	// By default, this parameter is left blank.
-	Configuration *Configuration `json:"configuration,omitempty"`
+	Configuration Configuration `json:"configuration,omitempty"`
 	// Description. The value can contain up to 128 characters.
 	Description string `json:"description,omitempty"`
 	// External network access.
@@ -354,7 +354,7 @@ type UpdateOpts struct {
 	Artifacts map[string]Artifact `json:"artifacts,omitempty"`
 	// Configuration parameters, such as environment variables, deployment configurations, and O&M monitoring.
 	// By default, this parameter is left blank.
-	Configuration *Configuration `json:"configuration,omitempty"`
+	Configuration Configuration `json:"configuration,omitempty"`
 	// Description. The value can contain up to 128 characters.
 	Description *string `json:"description,omitempty"`
 	// External network access.

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/results.go
@@ -47,17 +47,30 @@ type Instance struct {
 // ConfigurationResp is an object represents the configuration details of the deployment.
 type ConfigurationResp struct {
 	// Environment variable.
-	EnvVariables []Variable `json:"env,omitempty"`
+	EnvVariables []VariableResp `json:"env"`
 	// Data storage configuration.
-	Storages []StorageResp `json:"storage,omitempty"`
+	Storages []StorageResp `json:"storage"`
 	// Upgrade policy.
-	Strategy StrategyResp `json:"strategy,omitempty"`
+	Strategy StrategyResp `json:"strategy"`
 	// Lifecycle.
-	Lifecycle LifecycleResp `json:"lifecycle,omitempty"`
+	Lifecycle LifecycleResp `json:"lifecycle"`
 	// Scheduling policy.
-	Scheduler SchedulerResp `json:"scheduler,omitempty"`
+	Scheduler SchedulerResp `json:"scheduler"`
 	// Health check.
-	Probe ProbeResp `json:"probes,omitempty"`
+	Probe ProbeResp `json:"probes"`
+}
+
+// VariableResp is an object represents the detail of the environment variable.
+
+type VariableResp struct {
+	// Whether variable is internal variable.
+	Internal bool `json:"internal"`
+	// Environment variable name.
+	// The value contains 1 to 64 characters, including letters, digits, underscores (_), hyphens (-), and dots (.),
+	// and cannot start with a digit.
+	Name string `json:"name"`
+	// Environment variable value.
+	Value string `json:"value"`
 }
 
 // StorageResp is an object represents the storage configuration of the deployment.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220625020635-39bb1ee32cb0
+# github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220630062244-9f47bb8d5e41
+# github.com/chnsz/golangsdk v0.0.0-20220701061130-f5ff51d74f49
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The value type of host ID list is interface list, not string.
Without properties parameter, the componet will fail if we using obs package to deploy component.
Due to servicestage serivce API's problem, the configuration structure cannot be omited.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using json marshal and unmarshal function to fix the format error.
2. add obs properties parameter.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
