### PR TITLE
chore(IoTDA): remove the project_id from dataforward rule

### DIFF
--- a/docs/resources/iotda_dataforwarding_rule.md
+++ b/docs/resources/iotda_dataforwarding_rule.md
@@ -10,10 +10,8 @@ Manages an IoTDA data forwarding rule within HuaweiCloud.
 
 ```hcl
 variable "disRegion" {}
-variable "disProjectId" {}
 variable "disStreamId" {}
 variable "obsRegion" {}
-variable "obsProjectId" {}
 variable "obsbucket" {}
 
 resource "huaweicloud_iotda_dataforwarding_rule" "test" {
@@ -24,9 +22,8 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
   targets {
     type = "DIS_FORWARDING"
     dis_forwarding {
-      region     = var.disRegion
-      project_id = var.disProjectId
-      stream_id  = var.disStreamId
+      region    = var.disRegion
+      stream_id = var.disStreamId
     }
   }
 
@@ -40,9 +37,8 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
   targets {
     type = "OBS_FORWARDING"
     obs_forwarding {
-      region     = var.obsRegion
-      project_id = var.obsProjectId
-      bucket     = var.obsbucket
+      region = var.obsRegion
+      bucket = var.obsbucket
     }
   }
 }
@@ -53,10 +49,10 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA data forwarding rule
-resource. If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+  resource. If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `name` - (Required, String) Specifies the name of data forwarding rule. The name contains a maximum of 256 characters.
- Only letters, Chinese characters, digits, hyphens (-), underscores (_) and the following specail characters are
+  Only letters, Chinese characters, digits, hyphens (-), underscores (_) and the following specail characters are
   allowed: `?'#().,&%@!`.
 
 * `trigger` - (Required, String, ForceNew) Specifies the trigger event. The options are as follows:
@@ -73,27 +69,27 @@ resource. If omitted, the provider-level region will be used. Changing this para
   + **product:update**: Product updated.
   + **device.command.status:update**: Update of the device asynchronous command status.
 
-Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `description` - (Optional, String) Specifies the description of data forwarding rule. The description contains
-a maximum of 256 characters.
+  a maximum of 256 characters.
 
 * `space_id` - (Optional, String, ForceNew) Specifies the resource space ID which uses the data forwarding rule.
-If omitted, all resource space will use the data forwarding rule. Changing this parameter will create a new resource.
+  If omitted, all resource space will use the data forwarding rule. Changing this parameter will create a new resource.
 
 * `select` - (Optional, String) Specifies the SQL SELECT statement which contains a maximum of 500 characters.
 
 * `where` - (Optional, String) Specifies the SQL WHERE statement which contains a maximum of 500 characters.
 
 * `targets` - (Optional, List) Specifies the list of the targets (HUAWEI CLOUD services or private servers) to which you
-want to forward the data. The [targets](#IoTDA_targets) structure is documented below.
+  want to forward the data. The [targets](#IoTDA_targets) structure is documented below.
 
 -> The IoTDA supports connection with other cloud services of HUAWEI CLOUD. When creating a rule for connecting to
-DIS, OBS, Kafka, ROMA Connect service, and SMN for the first time, you need to create a agency which can access the
-target cloud services. The default agency is `iotda_admin_trust`.
+  DIS, OBS, Kafka, ROMA Connect service, and SMN for the first time, you need to create a agency which can access the
+  target cloud services. The default agency is `iotda_admin_trust`.
 
 * `enabled` - (Optional, Bool) Specifies whether to enable the data forwarding rule. Defaults to `false`.
-Can not enable without `targets`.
+  Can not enable without `targets`.
 
 <a name="IoTDA_targets"></a>
 The `targets` block supports:
@@ -113,19 +109,19 @@ The `targets` block supports:
    and traffic balancing.
 
 * `http_forwarding` - (Optional, List) Specifies the detail of the HTTP forwards. It is required when type
-is `HTTP_FORWARDING`. The [http_forwarding](#IoTDA_http_forwarding) structure is documented below.
+  is `HTTP_FORWARDING`. The [http_forwarding](#IoTDA_http_forwarding) structure is documented below.
 
 * `dis_forwarding` - (Optional, List) Specifies the detail of the DIS forwards. It is required when type
-is `DIS_FORWARDING`. The [dis_forwarding](#IoTDA_dis_forwarding) structure is documented below.
+  is `DIS_FORWARDING`. The [dis_forwarding](#IoTDA_dis_forwarding) structure is documented below.
 
 * `obs_forwarding` - (Optional, List) Specifies the detail of the OBS forwards. It is required when type
-is `OBS_FORWARDING`. The [obs_forwarding](#IoTDA_obs_forwarding) structure is documented below.
+  is `OBS_FORWARDING`. The [obs_forwarding](#IoTDA_obs_forwarding) structure is documented below.
 
 * `amqp_forwarding` - (Optional, List) Specifies the detail of AMQP forwards. It is required when type
-is `AMQP_FORWARDING`. The [amqp_forwarding](#IoTDA_amqp_forwarding) structure is documented below.
+  is `AMQP_FORWARDING`. The [amqp_forwarding](#IoTDA_amqp_forwarding) structure is documented below.
 
 * `kafka_forwarding` - (Optional, List) Specifies the detail of the KAFKA forwards. It is required when type
-is `DMS_KAFKA_FORWARDING`. The [properties](#IoTDA_kafka_forwarding) structure is documented below.
+  is `DMS_KAFKA_FORWARDING`. The [properties](#IoTDA_kafka_forwarding) structure is documented below.
 
 <a name="IoTDA_http_forwarding"></a>
 The `http_forwarding` block supports:
@@ -137,18 +133,20 @@ The `dis_forwarding` block supports:
 
 * `region` - (Required, String) Specifies the region to which the DIS stream belongs.
 
-* `project_id` - (Required, String) Specifies the project ID to which the DIS stream belongs.
-
 * `stream_id` - (Required, String) Specifies the DIS stream ID.
+
+* `project_id` - (Optional, String) Specifies the project ID to which the DIS stream belongs.
+If omitted, the default project in the region will be used.
 
 <a name="IoTDA_obs_forwarding"></a>
 The `obs_forwarding` block supports:
 
 * `region` - (Required, String) Specifies the region to which the OBS belongs.
 
-* `project_id` - (Required, String) Specifies the project ID to which the OBS belongs.
-
 * `bucket` - (Required, String) Specifies the OBS Bucket.
+
+* `project_id` - (Optional, String) Specifies the project ID to which the OBS belongs.
+  If omitted, the default project in the region will be used.
 
 * `custom_directory` - (Optional, String) Specifies the custom directory for storing channel files. The ID contains a
  maximum of 256 characters. Multi-level directories can be separated by (/), and cannot start or end with a slash (/),
@@ -167,12 +165,13 @@ The `kafka_forwarding` block supports:
 
 * `region` - (Required, String) Specifies the region to which the KAFKA belongs.
 
-* `project_id` - (Required, String) Specifies the project ID to which the KAFKA belongs.
-
 * `topic` - (Required, String) Specifies the topic.
 
 * `addresses` - (Required, List) Specifies the list of the connected service addresses.
 The [addresses](#IoTDA_forwarding_addresses) structure is documented below.
+
+* `project_id` - (Optional, String) Specifies the project ID to which the KAFKA belongs.
+If omitted, the default project in the region will be used.
 
 * `user_name` - (Optional, String) Specifies the SASL user name.
 

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
@@ -34,7 +34,7 @@ func TestAccDataForwardingRule_basic(t *testing.T) {
 		getDataForwardingRuleResourceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -53,7 +53,7 @@ func TestAccDataForwardingRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testDataForwardingRule_dis(updateName, acceptance.HW_REGION_NAME, acceptance.HW_PROJECT_ID),
+				Config: testDataForwardingRule_dis(updateName, acceptance.HW_REGION_NAME),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "trigger", "product:delete"),
@@ -93,7 +93,7 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
 `, name)
 }
 
-func testDataForwardingRule_dis(name, region, projectId string) string {
+func testDataForwardingRule_dis(name, region string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dis_stream" "test" {
   stream_name     = "%s"
@@ -108,13 +108,10 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
   targets {
     type = "DIS_FORWARDING"
     dis_forwarding {
-      region     = "%s"
-      project_id = "%s"
-      stream_id  = huaweicloud_dis_stream.test.id
+      region    = "%s"
+      stream_id = huaweicloud_dis_stream.test.id
     }
   }
-
-
 }
-`, name, name, region, projectId)
+`, name, name, region)
 }

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
@@ -155,14 +155,15 @@ func ResourceDataForwardingRule() *schema.Resource {
 										Required: true,
 									},
 
-									"project_id": {
+									"stream_id": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
 
-									"stream_id": {
+									"project_id": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
+										Computed: true,
 									},
 								},
 							},
@@ -180,14 +181,15 @@ func ResourceDataForwardingRule() *schema.Resource {
 										Required: true,
 									},
 
-									"project_id": {
+									"bucket": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
 
-									"bucket": {
+									"project_id": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
+										Computed: true,
 									},
 
 									"custom_directory": {
@@ -235,11 +237,6 @@ func ResourceDataForwardingRule() *schema.Resource {
 										Required: true,
 									},
 
-									"project_id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
 									"addresses": {
 										Type:     schema.TypeList,
 										Required: true,
@@ -266,6 +263,12 @@ func ResourceDataForwardingRule() *schema.Resource {
 									"topic": {
 										Type:     schema.TypeString,
 										Required: true,
+									},
+
+									"project_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
 									},
 
 									"user_name": {
@@ -301,6 +304,7 @@ func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
 
+	projectId := c.RegionProjectIDMap[region]
 	createOpts := buildDataForwardingRuleCreateParams(d)
 	log.Printf("[DEBUG] Create IoTDA data forwarding rule params: %#v", createOpts)
 
@@ -316,7 +320,7 @@ func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceDat
 	d.SetId(*resp.RuleId)
 	m := d.Get("targets").(*schema.Set)
 	// create action rule
-	targets, err := buildActionTargets(m.List(), d.Id())
+	targets, err := buildActionTargets(m.List(), d.Id(), projectId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -379,6 +383,8 @@ func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
 
+	projectId := c.RegionProjectIDMap[region]
+
 	if d.HasChange("targets") {
 		o, n := d.GetChange("targets")
 		oldTargetSet := o.(*schema.Set)
@@ -397,7 +403,7 @@ func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceDat
 		for _, v := range newTargetSet.List() {
 			target := v.(map[string]interface{})
 			channel := target["type"].(string)
-			channelDetail, err := buildChannelDetail(target, channel)
+			channelDetail, err := buildChannelDetail(target, channel, projectId)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -496,12 +502,12 @@ func buildDataForwardingRuleCreateParams(d *schema.ResourceData) *model.CreateRo
 	return &req
 }
 
-func buildActionTargets(raw []interface{}, ruleId string) ([]model.CreateRuleActionRequest, error) {
+func buildActionTargets(raw []interface{}, ruleId, projectId string) ([]model.CreateRuleActionRequest, error) {
 	rst := make([]model.CreateRuleActionRequest, len(raw))
 	for i, v := range raw {
 		target := v.(map[string]interface{})
 		channel := target["type"].(string)
-		channelDetail, err := buildChannelDetail(target, channel)
+		channelDetail, err := buildChannelDetail(target, channel, projectId)
 		if err != nil {
 			return nil, err
 		}
@@ -517,7 +523,7 @@ func buildActionTargets(raw []interface{}, ruleId string) ([]model.CreateRuleAct
 	return rst, nil
 }
 
-func buildChannelDetail(target map[string]interface{}, channel string) (*model.ChannelDetail, error) {
+func buildChannelDetail(target map[string]interface{}, channel, projectId string) (*model.ChannelDetail, error) {
 	switch channel {
 	case "HTTP_FORWARDING":
 		forward := target["http_forwarding"].([]interface{})
@@ -538,11 +544,14 @@ func buildChannelDetail(target map[string]interface{}, channel string) (*model.C
 			return nil, fmt.Errorf("dis_forwarding is Required when the target type is DIS_FORWARDING")
 		}
 		f := forward[0].(map[string]interface{})
-
+		projectIdStr := f["project_id"].(string)
+		if projectIdStr == "" {
+			projectIdStr = projectId
+		}
 		d := model.ChannelDetail{
 			DisForwarding: &model.DisForwarding{
 				RegionName: f["region"].(string),
-				ProjectId:  f["project_id"].(string),
+				ProjectId:  projectIdStr,
 				StreamId:   utils.String(f["stream_id"].(string)),
 			},
 		}
@@ -554,10 +563,14 @@ func buildChannelDetail(target map[string]interface{}, channel string) (*model.C
 			return nil, fmt.Errorf("obs_forwarding is Required when the target type is OBS_FORWARDING")
 		}
 		f := forward[0].(map[string]interface{})
+		projectIdStr := f["project_id"].(string)
+		if projectIdStr == "" {
+			projectIdStr = projectId
+		}
 		d := model.ChannelDetail{
 			ObsForwarding: &model.ObsForwarding{
 				RegionName: f["region"].(string),
-				ProjectId:  f["project_id"].(string),
+				ProjectId:  projectIdStr,
 				BucketName: f["bucket"].(string),
 				FilePath:   utils.StringIgnoreEmpty(f["custom_directory"].(string)),
 			},
@@ -593,10 +606,15 @@ func buildChannelDetail(target map[string]interface{}, channel string) (*model.C
 				Domain: utils.String(item["domain"].(string)),
 			}
 		}
+
+		projectIdStr := f["project_id"].(string)
+		if projectIdStr == "" {
+			projectIdStr = projectId
+		}
 		d := model.ChannelDetail{
 			DmsKafkaForwarding: &model.DmsKafkaForwarding{
 				RegionName: f["region"].(string),
-				ProjectId:  f["project_id"].(string),
+				ProjectId:  projectIdStr,
 				Topic:      f["topic"].(string),
 				Username:   utils.String(f["user_name"].(string)),
 				Password:   utils.String(f["password"].(string)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
As all regions have been loaded in client init, so remove the project_id from the data forward rule, and get it by region.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run=TestAccDataForwardingRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run=TestAccDataForwardingRule_basic -timeout 360m -parallel 4
=== RUN   TestAccDataForwardingRule_basic
--- PASS: TestAccDataForwardingRule_basic (27.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     27.268s
```
