### PR TITLE
chore(config): specifies the minimum TLS version to 1.2

### DIFF
--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -62,7 +62,11 @@ func buildClient(c *Config) error {
 }
 
 func generateTLSConfig(c *Config) (*tls.Config, error) {
-	config := &tls.Config{}
+	config := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: c.Insecure,
+	}
+
 	if c.CACertFile != "" {
 		caCert, _, err := pathorcontents.Read(c.CACertFile)
 		if err != nil {
@@ -72,10 +76,6 @@ func generateTLSConfig(c *Config) (*tls.Config, error) {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM([]byte(caCert))
 		config.RootCAs = caCertPool
-	}
-
-	if c.Insecure {
-		config.InsecureSkipVerify = true
 	}
 
 	if c.ClientCertFile != "" && c.ClientKeyFile != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

when run gosec, we got a high severity error:

```
[./huaweicloud/config/auth.go:65] - G402 (CWE-295): TLS MinVersion too low. (Confidence: HIGH, Severity: HIGH)
    64: func generateTLSConfig(c *Config) (*tls.Config, error) {
  > 65:         config := &tls.Config{}
    66:         if c.CACertFile != "" {
```

we should set `MinVersion` to TLS1.2 for security.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic

--- PASS: TestAccVpcV1_basic (42.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       42.279s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLogTankGroupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLogTankGroupV2_basic -timeout 360m -parallel 4
=== RUN   TestAccLogTankGroupV2_basic
=== PAUSE TestAccLogTankGroupV2_basic
=== CONT  TestAccLogTankGroupV2_basic
--- PASS: TestAccLogTankGroupV2_basic (20.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       20.646s
```
