### PR TITLE
feat: refactor: test(dms/kafka): support new product format

### DIFF
--- a/docs/data-sources/dms_kafka_flavors.md
+++ b/docs/data-sources/dms_kafka_flavors.md
@@ -1,0 +1,143 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_flavors
+
+Use this data source to get the list of available flavor details within HuaweiCloud.
+
+## Example Usage
+
+### Query the list of kafka flavors for cluster type
+
+```hcl
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type = "cluster"
+}
+```
+
+### Query the kafka flavor details of the specified ID
+
+```hcl
+data "huaweicloud_dms_kafka_flavors" "test" {
+  flavor_id = "c6.2u4g.cluster"
+}
+```
+
+### Query list of kafka flavors that available in the availability zone list
+
+```hcl
+variable "az1" {}
+variable "az2" {}
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  availability_zones = [
+    var.az1,
+    var.az2,
+  ]
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the dms kafka flavors.
+  If omitted, the provider-level region will be used.
+
+* `flavor_id` - (Optional, String) Specifies the DMS flvaor ID, e.g. **c6.2u4g.cluster**.
+
+* `storage_spec_code` - (Optional, String) Specifies the disk IO encoding.
+  + **dms.physical.storage.high.v2**: Type of the disk that uses high I/O.
+  + **dms.physical.storage.ultra.v2**: Type of the disk that uses ultra-high I/O.
+
+* `type` - (Optional, String) Specifies flavor type. The valid values are **single** and **cluster**.
+
+* `arch_type` - (Optional, String) Specifies the type of CPU architecture, e.g. **X86**.
+
+* `availability_zones` - (Optional, List) Specifies the list of availability zones with available resources.
+
+* `charging_mode` - (Optional, String) Specifies the flavor billing mode.
+  The valid valus are **prePaid** and **postPaid**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `versions` - The supported flavor versions.
+
+* `flavors` - The list of flavor details.
+  The [object](#dms_kafka_flavors) structure is documented below.
+
+<a name="dms_kafka_flavors"></a>
+The `flavors` block supports:
+
+* `id` - The flavor ID.
+
+* `type` - The flavor type.
+
+* `vm_specification` - The underlying VM specification.
+
+* `arch_types` - The list of supported CPU architectures.
+
+* `charging_modes` - The list of supported billing modes.
+
+* `ios` - The list of supported disk IO types.
+  The [object](#dms_kafka_flavor_ios) structure is documented below.
+
+* `support_features` - The list of features supported by the current specification.
+  The [object](#dms_kafka_flavor_support_features) structure is documented below.
+
+* `properties` - The properties of the current specification.
+  The [object](#dms_kafka_flavor_properties) structure is documented below.
+
+<a name="dms_kafka_flavor_ios"></a>
+The `ios` block supports:
+
+* `storage_spec_code` - The disk IO encoding.
+
+* `type` - The disk type.
+
+* `availability_zones` - The list of availability zones with available resources.
+
+* `unavailability_zones` - The list of unavailability zones with available resources.
+
+<a name="dms_kafka_flavor_support_features"></a>
+The `support_features` block supports:
+
+* `name` - The function name, e.g. **connector_obs**.
+
+* `properties` - The function property details.
+  The [object](#dms_kafka_flavor_support_feature_properties) structure is documented below.
+
+<a name="dms_kafka_flavor_support_feature_properties"></a>
+The `properties` block supports:
+
+* `max_task` - The maximum number of tasks for the dump function.
+
+* `min_task` - The minimum number of tasks for the dump function.
+
+* `max_node` - The maximum number of nodes for the dump function.
+
+* `min_node` - The minimum number of nodes for the dump function.
+
+<a name="dms_kafka_flavor_properties"></a>
+The `properties` block supports:
+
+* `max_broker` - The maximum number of brokers.
+
+* `min_broker` - The minimum number of brokers.
+
+* `max_bandwidth_per_broker` - The maximum bandwidth per broker.
+
+* `max_consumer_per_broker` - The maximum number of consumers per broker.
+
+* `max_partition_per_broker` - The maximum number of partitions per broker.
+
+* `max_tps_per_broker` - The maximum TPS per broker.
+
+* `max_storage_per_node` - The maximum storage per node. The unit is GB.
+
+* `min_storage_per_node` - The minimum storage per node. The unit is GB.
+
+* `flavor_alias` - The flavor ID alias.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220705081403-19cda7d0379b
+	github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220705081403-19cda7d0379b h1:bfECicNlEyKtv8zClkGEcJLr2m6mYl6vUscJfyLO4aQ=
-github.com/chnsz/golangsdk v0.0.0-20220705081403-19cda7d0379b/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c h1:nypZgt4qDK+8HxcVoC3SWxoeDwSdKf9OfOjnX+bYBFw=
+github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -377,6 +377,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_flavors": dds.DataSourceDDSFlavorV3(),
 
 			"huaweicloud_dms_az":              deprecated.DataSourceDmsAZ(),
+			"huaweicloud_dms_kafka_flavors":   dms.DataSourceKafkaFlavors(),
 			"huaweicloud_dms_kafka_instances": dms.DataSourceDmsKafkaInstances(),
 			"huaweicloud_dms_product":         dms.DataSourceDmsProduct(),
 			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_flavors_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_flavors_test.go
@@ -1,0 +1,74 @@
+package dms
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKafkaFlavorsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_dms_kafka_flavors.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestMatchResourceAttr(dataSourceName, "flavors.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("type_validation", "true"),
+					resource.TestCheckOutput("arch_types_validation", "true"),
+					resource.TestCheckOutput("charging_modes_validation", "true"),
+					resource.TestCheckOutput("storage_spec_code_validation", "true"),
+					resource.TestCheckOutput("availability_zones_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccKafkaFlavorsDataSource_basic = `
+data "huaweicloud_dms_kafka_flavors" "baisc" {
+  type = "cluster"
+}
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type               = local.test_refer.type
+  arch_type          = local.test_refer.arch_types[0]
+  charging_mode      = local.test_refer.charging_modes[0]
+  storage_spec_code  = local.test_refer.ios[0].storage_spec_code
+  availability_zones = local.test_refer.ios[0].availability_zones
+}
+
+locals {
+  test_refer   = data.huaweicloud_dms_kafka_flavors.baisc.flavors[0]
+  test_results = data.huaweicloud_dms_kafka_flavors.test
+}
+
+output "type_validation" {
+  value = contains(local.test_results.flavors[*].type, local.test_refer.type)
+}
+
+output "arch_types_validation" {
+  value = !contains([for a in local.test_results.flavors[*].arch_types : contains(a, local.test_refer.arch_types[0])], false)
+}
+
+output "charging_modes_validation" {
+  value = !contains([for c in local.test_results.flavors[*].charging_modes : contains(c, local.test_refer.charging_modes[0])], false)
+}
+
+output "storage_spec_code_validation" {
+  value = !contains([for ios in local.test_results.flavors[*].ios : !contains([for io in ios : io.storage_spec_code == local.test_refer.ios[0].storage_spec_code], false)], false)
+}
+
+output "availability_zones_validation" {
+  value = !contains([for ios in local.test_results.flavors[*].ios : !contains([for io in ios : length(setintersection(io.availability_zones, local.test_refer.ios[0].availability_zones)) == length(local.test_refer.ios[0].availability_zones)], false)], false)
+}
+`

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_instances_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_instances_test.go
@@ -79,5 +79,5 @@ data "huaweicloud_dms_kafka_instances" "query_4" {
 
   status = "RUNNING"
 }
-`, testAccDmsKafkaInstance_basic(rName))
+`, testAccKafkaInstance_basic(rName))
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
@@ -119,7 +119,7 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   partitions  = 10
   aging_time  = 36
 }
-`, testAccDmsKafkaInstance_basic(rName), rName)
+`, testAccKafkaInstance_base(rName), rName)
 }
 
 func testAccDmsKafkaTopic_update_part1(rName string) string {
@@ -132,7 +132,7 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   partitions  = 20
   aging_time  = 72
 }
-`, testAccDmsKafkaInstance_basic(rName), rName)
+`, testAccKafkaInstance_base(rName), rName)
 }
 
 func testAccDmsKafkaTopic_update_part2(rName string) string {
@@ -147,5 +147,5 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   sync_flushing    = true
   sync_replication = true
 }
-`, testAccDmsKafkaInstance_basic(rName), rName)
+`, testAccKafkaInstance_base(rName), rName)
 }

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_flavors.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_flavors.go
@@ -1,0 +1,429 @@
+package dms
+
+import (
+	"context"
+	"log"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/dms/v2/products"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+type InstanceType string
+type ChargingMode string
+
+var (
+	InstanceTypeSingle  InstanceType = "single"
+	InstanceTypeCluster InstanceType = "cluster"
+
+	ChargingModePrePaid  ChargingMode = "prePaid"
+	ChargingModePostPaid ChargingMode = "postPaid"
+
+	ChargingModesMap map[string]ChargingMode = map[string]ChargingMode{
+		"hourly":  ChargingModePrePaid,
+		"monthly": ChargingModePostPaid,
+	}
+)
+
+func DataSourceKafkaFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKafkaFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// We call the product as flavor.
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"storage_spec_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(InstanceTypeSingle), string(InstanceTypeCluster),
+				}, false),
+			},
+			"arch_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"charging_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(ChargingModePrePaid), string(ChargingModePostPaid),
+				}, false),
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vm_specification": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"arch_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"charging_modes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"ios": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"storage_spec_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"availability_zones": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"unavailability_zones": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"support_features": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"properties": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max_task": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"min_task": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"max_node": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"min_node": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"properties": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"max_broker": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"min_broker": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max_bandwidth_per_broker": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max_consumer_per_broker": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max_partition_per_broker": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max_tps_per_broker": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max_storage_per_node": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"min_storage_per_node": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"flavor_alias": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type ios []products.IOEntity
+
+func (s ios) Len() int {
+	return len(s)
+}
+
+func (s ios) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ios) Less(i, j int) bool {
+	return strings.ToLower(s[i].IoSpec) < strings.ToLower(s[j].IoSpec)
+}
+
+func filterFlavors(d *schema.ResourceData, flavorList []products.Product) ([]products.Product, []string) {
+	if len(flavorList) < 1 {
+		return nil, nil
+	}
+
+	result := make([]products.Product, 0, len(flavorList))
+	ids := make([]string, 0, len(flavorList))
+
+	t, tOk := d.GetOk("type")
+	cm, cmOk := d.GetOk("charging_mode")
+	at, atOk := d.GetOk("arch_type")
+	sc, scOk := d.GetOk("storage_spec_code")
+	azs := d.Get("availability_zones").([]interface{})
+
+	for i, flavor := range flavorList {
+		if tOk && flavor.Type != t.(string) {
+			continue
+		}
+		if cmOk && !utils.StrSliceContains(flavor.ChargingModes, parseChargingMode(cm.(string))) {
+			continue
+		}
+		if atOk && !utils.StrSliceContains(flavor.ArchTypes, at.(string)) {
+			continue
+		}
+		validIOs := make([]products.IOEntity, 0, len(flavor.IOs))
+		for _, io := range flavor.IOs {
+			if scOk && io.IoSpec != sc.(string) {
+				continue
+			}
+			if utils.StrSliceContainsAnother(io.AvailableZones, utils.ExpandToStringList(azs)) {
+				validIOs = append(validIOs, io)
+			}
+		}
+		if len(validIOs) < 1 {
+			continue
+		}
+		sort.Sort(ios(validIOs))
+		// The element "flavor" is just a copy.
+		flavorList[i].IOs = validIOs
+		result = append(result, flavorList[i])
+		ids = append(ids, flavor.ProductId)
+	}
+
+	return result, ids
+}
+
+func flattenIOs(ios []products.IOEntity) []map[string]interface{} {
+	if len(ios) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(ios))
+
+	for i, io := range ios {
+		result[i] = map[string]interface{}{
+			"storage_spec_code":    io.IoSpec,
+			"type":                 io.Type,
+			"availability_zones":   io.AvailableZones,
+			"unavailability_zones": io.UnavailableZones,
+		}
+	}
+
+	log.Printf("[DEBUG] The result of IO list is: %#v", result)
+	return result
+}
+
+func convertStringNumberIgnoreErr(strNum string) int {
+	result, _ := strconv.Atoi(strNum)
+	return result
+}
+
+func flattenSupportFeatures(features []products.SupportFeatureEntity) []map[string]interface{} {
+	if len(features) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(features))
+
+	for i, feature := range features {
+		result[i] = map[string]interface{}{
+			"name": feature.Name,
+			"properties": []map[string]interface{}{
+				{
+					"max_task": convertStringNumberIgnoreErr(feature.Properties.MaxTask),
+					"min_task": convertStringNumberIgnoreErr(feature.Properties.MinTask),
+					"max_node": convertStringNumberIgnoreErr(feature.Properties.MaxNode),
+					"min_node": convertStringNumberIgnoreErr(feature.Properties.MinNode),
+				},
+			},
+		}
+	}
+
+	log.Printf("[DEBUG] The support features result is: %#v", result)
+	return result
+}
+
+func flattenProperties(properties products.PropertiesEntity) []map[string]interface{} {
+	if reflect.DeepEqual(properties, products.PropertiesEntity{}) {
+		return nil
+	}
+
+	result := []map[string]interface{}{
+		{
+			"max_partition_per_broker": convertStringNumberIgnoreErr(properties.MaxPartitionPerBroker),
+			"max_broker":               convertStringNumberIgnoreErr(properties.MaxBroker),
+			"max_storage_per_node":     convertStringNumberIgnoreErr(properties.MaxStoragePerNode),
+			"max_consumer_per_broker":  convertStringNumberIgnoreErr(properties.MaxConsumerPerBroker),
+			"min_broker":               convertStringNumberIgnoreErr(properties.MinBroker),
+			"max_bandwidth_per_broker": convertStringNumberIgnoreErr(properties.MaxBandwidthPerBroker),
+			"min_storage_per_node":     convertStringNumberIgnoreErr(properties.MinStoragePerNode),
+			"max_tps_per_broker":       convertStringNumberIgnoreErr(properties.MaxTpsPerBroker),
+			"flavor_alias":             properties.ProductAlias,
+		},
+	}
+
+	log.Printf("[DEBUG] The properties result is: %#v", result)
+	return result
+}
+
+func parseChargingMode(chargingMode string) string {
+	if chargingMode == string(ChargingModePostPaid) {
+		return "hourly"
+	}
+	return "monthly"
+}
+
+func parseChargingModesResp(chargingModes []string) []interface{} {
+	result := make([]interface{}, len(chargingModes))
+	for i, val := range chargingModes {
+		if cm, ok := ChargingModesMap[val]; ok {
+			result[i] = cm
+		} else {
+			result[i] = val
+		}
+	}
+	return result
+}
+
+func flattenFlavors(flavorList []products.Product) []map[string]interface{} {
+	if len(flavorList) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(flavorList))
+
+	for i, val := range flavorList {
+		result[i] = map[string]interface{}{
+			"id":               val.ProductId,
+			"type":             val.Type,
+			"vm_specification": val.EcsFlavorId,
+			"arch_types":       val.ArchTypes,
+			"charging_modes":   parseChargingModesResp(val.ChargingModes),
+			"ios":              flattenIOs(val.IOs),
+			"support_features": flattenSupportFeatures(val.SupportFeatures),
+			"properties":       flattenProperties(val.Properties),
+		}
+	}
+
+	log.Printf("[DEBUG] The result of DMS flavor list is: %#v", result)
+	return result
+}
+
+func dataSourceKafkaFlavorsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return dataSourceFlavorsRead(ctx, d, meta, "kafka")
+}
+
+func dataSourceFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}, engine string) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.DmsV2Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error getting DMS v2 client: %v", err)
+	}
+
+	opt := products.ListOpts{
+		ProductId: d.Get("flavor_id").(string),
+	}
+	resp, err := products.List(client, engine, opt)
+	if err != nil {
+		return diag.Errorf("error getting %s flavor list: %v", engine, err)
+	}
+	log.Printf("[DEBUG] The response of DMS %s flavor list request is: %#v", engine, resp)
+
+	filtered, ids := filterFlavors(d, resp.Products)
+	log.Printf("[DEBUG] The filtered list of DMS %s flavors is: %#v", engine, filtered)
+	d.SetId(hashcode.Strings(ids))
+
+	mErr := multierror.Append(nil,
+		d.Set("versions", resp.Versions),
+		d.Set("flavors", flattenFlavors(filtered)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -61,11 +62,6 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"storage_space": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
 			"storage_spec_code": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -85,19 +81,6 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"availability_zones": {
-				// There is a problem with order of elements in Availability Zone list returned by Kafka API.
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"product_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
 			"manager_user": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -108,6 +91,36 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 				Required:  true,
 				Sensitive: true,
 				ForceNew:  true,
+			},
+			"availability_zones": {
+				// There is a problem with order of elements in Availability Zone list returned by Kafka API.
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"flavor_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"product_id"},
+				RequiredWith: []string{"broker_num", "storage_space"},
+			},
+			"broker_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"storage_space": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
 			},
 			"access_user": {
 				Type:     schema.TypeString,
@@ -284,8 +297,8 @@ func resourceDmsKafkaPublicIpIDs(d *schema.ResourceData, bandwidth string) (stri
 	return strings.Join(publicIpIDs, ","), nil
 }
 
-func getProductDetail(config *config.Config, d *schema.ResourceData, instanceType string) (*products.Detail, error) {
-	productRsp, err := getProducts(config, config.GetRegion(d), instanceType)
+func getProductDetail(config *config.Config, d *schema.ResourceData, engineType string) (*products.Detail, error) {
+	productRsp, err := getProducts(config, config.GetRegion(d), engineType)
 	if err != nil {
 		return nil, fmtp.Errorf("error querying product detail, please check product_id, error: %s", err)
 	}
@@ -299,11 +312,11 @@ func getProductDetail(config *config.Config, d *schema.ResourceData, instanceTyp
 		}
 		for _, v := range ps.Values {
 			for _, p := range v.Details {
-				if instanceType == "kafka" {
+				if engineType == "kafka" {
 					if p.ProductID == productID {
 						return &p, nil
 					}
-				} else if instanceType == "rabbitmq" {
+				} else if engineType == "rabbitmq" {
 					for _, pi := range p.ProductInfos {
 						if pi.ProductID == productID {
 							p.ProductInfos = []products.ProductInfo{pi}
@@ -319,6 +332,119 @@ func getProductDetail(config *config.Config, d *schema.ResourceData, instanceTyp
 }
 
 func resourceDmsKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if _, ok := d.GetOk("flavor_id"); ok {
+		return newKafkaInstanceCreate(ctx, d, meta)
+	}
+	return oldKafkaInstanceCreate(ctx, d, meta)
+}
+
+func newKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.DmsV2Client(region)
+	if err != nil {
+		return fmtp.DiagErrorf("error creating HuaweiCloud DMS instance client: %s", err)
+	}
+
+	createOpts := &instances.CreateOps{
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		Engine:              "kafka",
+		EngineVersion:       d.Get("engine_version").(string),
+		AccessUser:          d.Get("access_user").(string),
+		VPCID:               d.Get("vpc_id").(string),
+		SecurityGroupID:     d.Get("security_group_id").(string),
+		SubnetID:            d.Get("network_id").(string),
+		ProductID:           d.Get("flavor_id").(string),
+		KafkaManagerUser:    d.Get("manager_user").(string),
+		MaintainBegin:       d.Get("maintain_begin").(string),
+		MaintainEnd:         d.Get("maintain_end").(string),
+		RetentionPolicy:     d.Get("retention_policy").(string),
+		ConnectorEnalbe:     d.Get("dumping").(bool),
+		EnableAutoTopic:     d.Get("enable_auto_topic").(bool),
+		StorageSpecCode:     d.Get("storage_spec_code").(string),
+		StorageSpace:        d.Get("storage_space").(int),
+		BrokerNum:           d.Get("broker_num").(int),
+		EnterpriseProjectID: common.GetEnterpriseProjectID(d, conf),
+	}
+
+	if ids, ok := d.GetOk("public_ip_ids"); ok {
+		createOpts.EnablePublicIP = true
+		createOpts.PublicIpID = strings.Join(utils.ExpandToStringList(ids.([]interface{})), ",")
+	}
+
+	sslEnable := false
+	if d.Get("access_user").(string) != "" && d.Get("password").(string) != "" {
+		sslEnable = true
+	}
+	createOpts.SslEnable = sslEnable
+
+	var availableZones []string
+	zoneIDs, ok := d.GetOk("available_zones")
+	if ok {
+		availableZones = utils.ExpandToStringList(zoneIDs.([]interface{}))
+	} else {
+		// convert the codes of the availability zone into ids
+		azCodes := d.Get("availability_zones").(*schema.Set)
+		availableZones, err = getAvailableZoneIDByCode(conf, region, azCodes.List())
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	createOpts.AvailableZones = availableZones
+
+	//set tags
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		taglist := utils.ExpandResourceTags(tagRaw)
+		createOpts.Tags = taglist
+	}
+
+	logp.Printf("[DEBUG] Create DMS Kafka instance options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
+	createOpts.KafkaManagerPassword = d.Get("manager_password").(string)
+
+	v, err := instances.Create(client, createOpts).Extract()
+	if err != nil {
+		return fmtp.DiagErrorf("error creating HuaweiCloud DMS kafka instance: %s", err)
+	}
+	logp.Printf("[INFO] instance ID: %s", v.InstanceID)
+
+	// Store the instance ID now
+	d.SetId(v.InstanceID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"CREATING"},
+		Target:       []string{"RUNNING"},
+		Refresh:      DmsKafkaInstanceStateRefreshFunc(client, v.InstanceID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        300 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmtp.DiagErrorf("error waiting for instance (%s) to become ready: %s", v.InstanceID, err)
+	}
+
+	// After the kafka instance is created, wait for the access port to complete the binding.
+	stateConf = &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"BOUND"},
+		Refresh:      portsBindStatusRefreshFunc(client, d.Id()),
+		Timeout:      5 * time.Minute,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Failed to bind cross-VPC ports: %v", err)
+	}
+
+	return resourceDmsKafkaInstanceRead(ctx, d, meta)
+}
+
+func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	region := config.GetRegion(d)
 	dmsV2Client, err := config.DmsV2Client(region)
@@ -489,6 +615,14 @@ func flattenConnectPorts(strInfos string) ([]map[string]interface{}, error) {
 	return result, nil
 }
 
+func setKafkaFlavorId(d *schema.ResourceData, flavorId string) error {
+	re := regexp.MustCompile(`^[a-z0-9]+\.\d+u\d+g\.cluster|single$`)
+	if re.MatchString(flavorId) {
+		return d.Set("flavor_id", flavorId)
+	}
+	return d.Set("product_id", flavorId)
+}
+
 func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	region := config.GetRegion(d)
@@ -516,6 +650,7 @@ func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, met
 
 	mErr = multierror.Append(mErr,
 		d.Set("region", config.GetRegion(d)),
+		setKafkaFlavorId(d, v.ProductID),
 		d.Set("name", v.Name),
 		d.Set("description", v.Description),
 		d.Set("engine", v.Engine),
@@ -530,7 +665,7 @@ func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("network_id", v.SubnetID),
 		d.Set("available_zones", availableZoneIDs),
 		d.Set("availability_zones", availableZoneCodes),
-		d.Set("product_id", v.ProductID),
+		d.Set("broker_num", v.BrokerNum),
 		d.Set("manager_user", v.KafkaManagerUser),
 		d.Set("maintain_begin", v.MaintainBegin),
 		d.Set("maintain_end", v.MaintainEnd),
@@ -603,7 +738,7 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if d.HasChanges("storage_space", "product_id") {
+	if d.HasChanges("storage_space", "product_id", "flavor_id") {
 		err = resizeInstance(ctx, d, meta, "kafka")
 		if err != nil {
 			e := fmtp.Errorf("error resizing HuaweiCloud DMS kafka Instance: %s", err)
@@ -626,28 +761,31 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	return resourceDmsKafkaInstanceRead(ctx, d, meta)
 }
 
-func resizeInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, instanceType string) error {
+func resizeInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, engineType string) error {
 	config := meta.(*config.Config)
 	dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("error creating HuaweiCloud DMS instance client: %s", err)
 	}
 
-	product, err := getProductDetail(config, d, instanceType)
-	if err != nil || product == nil {
-		return fmtp.Errorf("change storage_space failed, error querying product detail: %s", err)
-	}
-	logp.Printf("[DEBUG] Get DMS product detail: %#v", product)
+	opts := instances.ResizeInstanceOpts{}
+	if _, ok := d.GetOk("product_id"); ok {
+		product, err := getProductDetail(config, d, engineType)
+		if err != nil || product == nil {
+			return fmtp.Errorf("change storage_space failed, error querying product detail: %s", err)
+		}
+		logp.Printf("[DEBUG] Get DMS product detail: %#v", product)
 
-	storage := d.Get("storage_space").(int)
-	specCode := product.SpecCode
-	if instanceType == "rabbitmq" {
-		specCode = product.ProductInfos[0].SpecCode
+		opts.NewStorageSpace = d.Get("storage_space").(int)
+		opts.NewSpecCode = product.SpecCode
+		if engineType == "rabbitmq" {
+			opts.NewSpecCode = product.ProductInfos[0].SpecCode
+		}
+	} else {
+		opts.NewSpecCode = d.Get("storage_spec_code").(string)
+		opts.NewStorageSpace = d.Get("storage_space").(int)
 	}
-	opts := instances.ResizeInstanceOpts{
-		NewSpecCode:     specCode,
-		NewStorageSpace: storage,
-	}
+
 	logp.Printf("[DEBUG] Resize DMS storage capacity option : %#v", opts)
 
 	_, err = instances.Resize(dmsV2Client, d.Id(), opts)
@@ -655,11 +793,16 @@ func resizeInstance(ctx context.Context, d *schema.ResourceData, meta interface{
 		return fmtp.Errorf("resize failed, error: %s", err)
 	}
 
-	productID := d.Get("product_id").(string)
+	var flavorId string
+	if productId, ok := d.GetOk("product_id"); ok {
+		flavorId = productId.(string)
+	} else {
+		flavorId = d.Get("flavor_id").(string)
+	}
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"EXTENDING", "REFRESHING"},
 		Target:       []string{"RUNNING"},
-		Refresh:      refreshResizeProductIDFunc(dmsV2Client, d.Id(), productID),
+		Refresh:      refreshResizeProductIDFunc(dmsV2Client, d.Id(), flavorId),
 		Timeout:      d.Timeout(schema.TimeoutUpdate),
 		Delay:        300 * time.Second,
 		PollInterval: 15 * time.Second,

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -163,6 +163,20 @@ func StrSliceContains(haystack []string, needle string) bool {
 	return IsStrContainsSliceElement(needle, haystack, false, true)
 }
 
+// StrSliceContainsAnother checks whether a string slice (b) contains another string slice (s).
+func StrSliceContainsAnother(b []string, s []string) bool {
+	// The empty set is the subset of any set.
+	if len(s) < 1 {
+		return true
+	}
+	for _, v := range s {
+		if !StrSliceContains(b, v) {
+			return false
+		}
+	}
+	return true
+}
+
 // IsStrContainsSliceElement returns true if the string exists in given slice or contains in one of slice elements when
 // open exact flag. Also you can ignore case for this check.
 func IsStrContainsSliceElement(str string, sl []string, ignoreCase, isExcat bool) bool {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -34,15 +34,18 @@ type CreateOps struct {
 	// Indicates the version of a message engine.
 	EngineVersion string `json:"engine_version" required:"true"`
 
-	//Indicates the baseline bandwidth of a Kafka instance, that is,
-	//the maximum amount of data transferred per unit time. Unit: byte/s.
-	Specification string `json:"specification" required:"true"`
-
 	// Indicates the message storage space.
 	StorageSpace int `json:"storage_space" required:"true"`
 
-	//Indicates the maximum number of topics in a Kafka instance.
-	PartitionNum int `json:"partition_num" required:"true"`
+	// Indicates the baseline bandwidth of a Kafka instance, that is,
+	// the maximum amount of data transferred per unit time. Unit: byte/s.
+	Specification string `json:"specification,omitempty"`
+
+	// Indicates the maximum number of brokers in a Kafka instance.
+	BrokerNum int `json:"broker_num,omitempty"`
+
+	// Indicates the maximum number of topics in a Kafka instance.
+	PartitionNum int `json:"partition_num,omitempty"`
 
 	// Indicates a username.
 	// A username consists of 1 to 64 characters

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
@@ -42,6 +42,7 @@ type Instance struct {
 	Specification              string             `json:"specification"`
 	StorageSpace               int                `json:"storage_space"`
 	PartitionNum               string             `json:"partition_num"`
+	BrokerNum                  int                `json:"broker_num"`
 	UsedStorageSpace           int                `json:"used_storage_space"`
 	ConnectAddress             string             `json:"connect_address"`
 	Port                       int                `json:"port"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/requests.go
@@ -7,6 +7,9 @@ import (
 )
 
 // Get products
+//
+// Deprecated: Please use the GetFlavor method to query product (new format) details of DMS kafka.
+// The old format is '00300-30308-0--0', but the new that we recommanded is 'c6.2u4g.cluster'.
 func Get(client *golangsdk.ServiceClient, engine string) (*GetResponse, error) {
 	if len(engine) == 0 {
 		return nil, fmt.Errorf("The parameter \"engine\" cannot be empty, it is required.")
@@ -22,4 +25,26 @@ func Get(client *golangsdk.ServiceClient, engine string) (*GetResponse, error) {
 		return &r, err
 	}
 	return nil, err
+}
+
+type ListOpts struct {
+	// The product ID.
+	ProductId string `q:"product_id"`
+}
+
+// List is a method to query the list of product details using given parameters.
+func List(c *golangsdk.ServiceClient, engineType string, opts ListOpts) (*ListResp, error) {
+	url := listURL(c, engineType)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var r ListResp
+	_, err = c.Get(url, &r, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/results.go
@@ -56,3 +56,92 @@ type IO struct {
 	UnavailableZones []string `json:"unavailable_zones"`
 	VolumeType       string   `json:"volume_type"`
 }
+
+// ListResp is the structure that represents the request response of List method.
+type ListResp struct {
+	// The engine type of the DMS products.
+	Engine string `json:"engine"`
+	// The supported product version types.
+	Versions []string `json:"versions"`
+	// The list of product details.
+	Products []Product `json:"products"`
+}
+
+// Product is the structure that represents the details of the product specification.
+type Product struct {
+	// product type. The current product types are stand-alone and cluster.
+	Type string `json:"type"`
+	// Product ID.
+	ProductId string `json:"product_id"`
+	// The underlying resource type.
+	EcsFlavorId string `json:"ecs_flavor_id"`
+	// Billing type.
+	BillingCode string `json:"billing_code"`
+	// List of supported CPU architectures.
+	ArchTypes []string `json:"arch_types"`
+	// List of supported billing modes.
+	//   monthly: yearly/monthly type.
+	//   hourly: On-demand type.
+	ChargingModes []string `json:"charging_mode"`
+	// List of supported disk IO types.
+	IOs []IOEntity `json:"ios"`
+	// A list of features supported by the current specification instance.
+	SupportFeatures []SupportFeatureEntity `json:"support_features"`
+	// Properties of the current specification instance.
+	Properties PropertiesEntity `json:"properties"`
+}
+
+// IOEntity is the structure that represents the disk IO type information.
+type IOEntity struct {
+	// Disk IO encoding.
+	IoSpec string `json:"io_spec"`
+	// Disk type.
+	Type string `json:"type"`
+	// Availability Zone.
+	AvailableZones []string `json:"available_zones"`
+	// Unavailable zone.
+	UnavailableZones []string `json:"unavailable_zones"`
+}
+
+// SupportFeatureEntity is the structure that represents the features supported by the instance.
+type SupportFeatureEntity struct {
+	// function name.
+	Name string `json:"name"`
+	// Description of the function properties supported by the instance.
+	Properties SupportFeaturePropertiesEntity `json:"properties"`
+}
+
+// SupportFeaturePropertiesEntity is the structure that represents the description of the functional properties
+// supported by the instance.
+type SupportFeaturePropertiesEntity struct {
+	// The maximum number of tasks for the dump function.
+	MaxTask string `json:"max_task"`
+	// Minimum number of tasks for dump function.
+	MinTask string `json:"min_task"`
+	// Maximum number of nodes for dump function.
+	MaxNode string `json:"max_node"`
+	// Minimum number of nodes for dump function.
+	MinNode string `json:"min_node"`
+}
+
+// PropertiesEntity is the structure that represents the properties of the current specification instance.
+type PropertiesEntity struct {
+	// Maximum number of partitions per broker.
+	MaxPartitionPerBroker string `json:"max_partition_per_broker"`
+	// The maximum number of brokers.
+	MaxBroker string `json:"max_broker"`
+	// Maximum storage per node. The unit is GB.
+	MaxStoragePerNode string `json:"max_storage_per_node"`
+	// Maximum number of consumers per broker.
+	MaxConsumerPerBroker string `json:"max_consumer_per_broker"`
+	// The minimum number of brokers.
+	MinBroker string `json:"min_broker"`
+	// Maximum bandwidth per broker.
+	MaxBandwidthPerBroker string `json:"max_bandwidth_per_broker"`
+	// Minimum storage per node. The unit is GB.
+	MinStoragePerNode string `json:"min_storage_per_node"`
+	// Maximum TPS per Broker.
+	MaxTpsPerBroker string `json:"max_tps_per_broker"`
+	// Product ID alias.
+	ProductAlias string `json:"product_alias"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/urls.go
@@ -10,3 +10,7 @@ const resourcePath = "products"
 func getURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(resourcePath)
 }
+
+func listURL(client *golangsdk.ServiceClient, engineType string) string {
+	return client.ServiceURL(engineType, resourcePath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220705081403-19cda7d0379b
+# github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Support a new data-source to query products of the new format. (the old format is `00300-30308-0--0`, the new format is `c6.2u4g.cluster`).
- Add a new parameters `flavor_id` and `broker_num` to support the creation of kafka instances with new format products.
- Adjust the scripts and check lists.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new data-source to query product list of new format.
2. adjust the test methods and scripts.
3. support for creating instances with new product ids.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run=TestAccKafkaInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run=TestAccKafkaInstance_ -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_withEpsId
=== CONT  TestAccKafkaInstance_compatible
--- PASS: TestAccKafkaInstance_compatible (530.29s)
--- PASS: TestAccKafkaInstance_withEpsId (606.82s)
--- PASS: TestAccKafkaInstance_newFormat (659.36s)
--- PASS: TestAccKafkaInstance_basic (1129.44s)
PASS
PASS    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1129.516s
```
```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run=TestAccProductsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run=TestAccProductsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccProductsDataSource_basic
=== PAUSE TestAccProductsDataSource_basic
=== CONT  TestAccProductsDataSource_basic
--- PASS: TestAccProductsDataSource_basic (14.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       14.104s
```
