### PR TITLE
feat: support new region in Europe

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1031,7 +1031,7 @@ func init() {
 
 func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersion string) (interface{},
 	diag.Diagnostics) {
-	var tenantName, tenantID, delegated_project, identityEndpoint string
+	var tenantName, tenantID, delegatedProject, identityEndpoint string
 	region := d.Get("region").(string)
 	cloud := d.Get("cloud").(string)
 
@@ -1054,9 +1054,9 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 
 	// Use region as delegated_project if it's not set
 	if v, ok := d.GetOk("delegated_project"); ok && v.(string) != "" {
-		delegated_project = v.(string)
+		delegatedProject = v.(string)
 	} else {
-		delegated_project = region
+		delegatedProject = region
 	}
 
 	// use auth_url as identityEndpoint if provided
@@ -1091,7 +1091,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 		UserID:              d.Get("user_id").(string),
 		AgencyName:          d.Get("agency_name").(string),
 		AgencyDomainName:    d.Get("agency_domain_name").(string),
-		DelegatedProject:    delegated_project,
+		DelegatedProject:    delegatedProject,
 		Cloud:               cloud,
 		MaxRetries:          d.Get("max_retries").(int),
 		EnterpriseProjectID: d.Get("enterprise_project_id").(string),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

the domain in Europe region is **myhuaweicloud.eu**, we should update the default domain when region begions with **eu-west-1xx**

Also, the regions in Europe are isolated from other regions, we don't need to update the domain when getting service client.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ export HW_REGION_NAME=eu-west-101
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccServiceEndpoints_Compute'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_Compute -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_Compute
2022/07/13 14:56:02 [DEBUG] customer endpoints: map[]
2022/07/13 14:56:02 [DEBUG] init region and project map: map[string]string{"eu-west-101":"0970dd7a1300f5672ff2c003c60ae115"}
2022/07/13 14:56:02 [WARN] get domain id failed: List domains failed, err=Get "https://iam.myhuaweicloud.eu/v3/auth/domains": dial tcp: lookup iam.myhuaweicloud.eu on 100.125.3.250:53: no such host
    endpoints_test.go:1152: ecs v1 endpoint:     https://ecs.eu-west-101.myhuaweicloud.eu/v1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: ecs v1.1 endpoint:   https://ecs.eu-west-101.myhuaweicloud.eu/v1.1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: ecs v2.1 endpoint:   https://ecs.eu-west-101.myhuaweicloud.eu/v2.1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: autoscaling v1 endpoint:     https://as.eu-west-101.myhuaweicloud.eu/autoscaling-api/v1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: image v2 endpoint:   https://ims.eu-west-101.myhuaweicloud.eu/v2/
    endpoints_test.go:1152: cce v3 endpoint:     https://cce.eu-west-101.myhuaweicloud.eu/api/v3/projects/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: cceAddon v3 endpoint:        https://cce.eu-west-101.myhuaweicloud.eu/api/v3/
    endpoints_test.go:1152: cci v1 endpoint:     https://cci.eu-west-101.myhuaweicloud.eu/api/v1/
    endpoints_test.go:1152: cci v1 beta endpoint:        https://cci.eu-west-101.myhuaweicloud.eu/apis/networking.cci.io/v1beta1/
    endpoints_test.go:1152: fgs v2 endpoint:     https://functiongraph.eu-west-101.myhuaweicloud.eu/v2/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: swr v2 endpoint:     https://swr-api.eu-west-101.myhuaweicloud.eu/v2/
    endpoints_test.go:1152: bms v1 endpoint:     https://bms.eu-west-101.myhuaweicloud.eu/v1/0970dd7a1300f5672ff2c003c60ae115/
--- PASS: TestAccServiceEndpoints_Compute (0.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.827s


$ export HW_REGION_NAME=cn-north-4
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccServiceEndpoints_Compute'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_Compute -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_Compute
2022/07/13 14:59:43 [DEBUG] customer endpoints: map[]
2022/07/13 14:59:44 [DEBUG] init region and project map: map[string]string{"cn-north-4":"0970dd7a1300f5672ff2c003c60ae115"}
    endpoints_test.go:1152: ecs v1 endpoint:     https://ecs.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: ecs v1.1 endpoint:   https://ecs.cn-north-4.myhuaweicloud.com/v1.1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: ecs v2.1 endpoint:   https://ecs.cn-north-4.myhuaweicloud.com/v2.1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: autoscaling v1 endpoint:     https://as.cn-north-4.myhuaweicloud.com/autoscaling-api/v1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: image v2 endpoint:   https://ims.cn-north-4.myhuaweicloud.com/v2/
    endpoints_test.go:1152: cce v3 endpoint:     https://cce.cn-north-4.myhuaweicloud.com/api/v3/projects/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: cceAddon v3 endpoint:        https://cce.cn-north-4.myhuaweicloud.com/api/v3/
    endpoints_test.go:1152: cci v1 endpoint:     https://cci.cn-north-4.myhuaweicloud.com/api/v1/
    endpoints_test.go:1152: cci v1 beta endpoint:        https://cci.cn-north-4.myhuaweicloud.com/apis/networking.cci.io/v1beta1/
    endpoints_test.go:1152: fgs v2 endpoint:     https://functiongraph.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:1152: swr v2 endpoint:     https://swr-api.cn-north-4.myhuaweicloud.com/v2/
    endpoints_test.go:1152: bms v1 endpoint:     https://bms.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/
--- PASS: TestAccServiceEndpoints_Compute (0.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.905s
```
