### PR TITLE
fix(rds/database): update validatefunc of database name

### DIFF
--- a/docs/resources/rds_database.md
+++ b/docs/resources/rds_database.md
@@ -29,9 +29,9 @@ The following arguments are supported:
 * `instance_id` - (Required, String, ForceNew) Specifies the RDS instance ID. Changing this will create a new resource.
 
 * `name` - (Required, String, ForceNew) Specifies the database name. The database name contains **1** to **64**
-  characters. The name can only consist of letters, digits, hyphens (-), underscores (_) and dollar signs ($).
-  The total number of hyphens (-) and dollar signs ($) cannot exceed **10**. RDS for **MySQL 8.0** does not support
-  dollar signs ($). Changing this will create a new resource.
+  characters. The name can only consist of lowercase letters, digits, hyphens (-), underscores (_) and dollar signs
+  ($). The total number of hyphens (-) and dollar signs ($) cannot exceed **10**. RDS for **MySQL 8.0** does not
+  support dollar signs ($). Changing this will create a new resource.
 
 * `character_set` - (Required, String, ForceNew) Specifies the character set used by the database, For example **utf8**,
   **gbk**, **ascii**, etc. Changing this will create a new resource.

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_database.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_database.go
@@ -47,8 +47,8 @@ func ResourceRdsDatabase() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.StringMatch(regexp.MustCompile(`^[\$\w-]+$`),
-						"the name can only consist of letters, digits, hyphens (-), underscores (_) and dollar signs ($)"),
+					validation.StringMatch(regexp.MustCompile(`^[\$a-z0-9-_]+$`),
+						"the name can only consist of lowercase letters, digits, hyphens (-), underscores (_) and dollar signs ($)"),
 					func(v interface{}, k string) (ws []string, errors []error) {
 						re := regexp.MustCompile(`-|\$`)
 						if len(re.FindAllString(v.(string), -1)) > 10 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

the rds service accepts database name with uppercase letters but returns the name in lowercase, this will make the terraform can't find the database in Get func(name different).
So update the validatefunc of database name to avoid error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update validatefunc of database name
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccRdsDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccRdsDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsDatabase_basic
=== PAUSE TestAccRdsDatabase_basic
=== CONT  TestAccRdsDatabase_basic
--- PASS: TestAccRdsDatabase_basic (661.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       661.703s
```
