### PR TITLE
feat(meeting): add new resource support

### DIFF
--- a/docs/resources/meeting_admin_assignment.md
+++ b/docs/resources/meeting_admin_assignment.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Meeting"
+---
+
+# huaweicloud_meeting_admin_assignment
+
+Using this resource to assign an administrator role to a user within HuaweiCloud.
+
+## Example Usage
+
+### Assign an administrator role to a user
+
+```hcl
+variable "app_id" {}
+variable "app_key" {}
+variable "user_account" {}
+
+resource "huaweicloud_meeting_admin_assignment" "test" {
+  app_id  = var.app_id
+  app_key = var.app_key
+
+  account = var.user_account
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_name` - (Optional, String, ForceNew) Specifies the (HUAWEI Cloud meeting) user account name to which the
+  default administrator belongs. Changing this parameter will create a new resource.
+
+* `account_password` - (Optional, String, ForceNew) Specifies the user password.
+  Required if `account_name` is set. Changing this parameter will create a new resource.
+
+* `app_id` - (Optional, String, ForceNew) Specifies the ID of the Third-party application.
+  Changing this parameter will create a new resource.
+
+  -> You can apply for an application and obtain the App ID and App Key in the console.
+
+* `app_key` - (Optional, String, ForceNew) Specifies the Key information of the Third-party APP.
+  Required if `app_id` is set. Changing this parameter will create a new resource.
+
+-> Exactly one of account authorization and application authorization you must select.
+
+* `account` - (Required, String) Specifies the user account to be assigned the administrator role.
+  The value can contain **1** to **64** characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (user account).
+
+## Import
+
+The assignment relationships can be imported using their `id` and authorization parameters, separated by slashes, e.g.
+
+Import an administrator assignment and authenticated by account.
+
+```
+$ terraform import huaweicloud_meeting_admin_assignment.test &ltid&gt/&ltaccount_name&gt/&ltaccount_password&gt
+```
+
+Import an administrator assignment and authenticated by `APP ID`/`APP Key`.
+
+```
+$ terraform import huaweicloud_meeting_admin_assignment.test &ltid&gt/&ltapp_id&gt/&ltapp_key&gt/&ltcorp_id&gt/&ltuser_id&gt
+```
+
+For this resource, the `corp_id` and `user_id` are never used, you can omit them but the slashes cannot be missing.

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220715095639-bc543e91c4b0 h1:Szm/uKc5daXFKHiq/ATrg9VLDSA1b/NEhHOBoRI/TQ8=
-github.com/chnsz/golangsdk v0.0.0-20220715095639-bc543e91c4b0/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220726083100-cebcc3a0547c h1:EC9PtS6lsNDvxDE9HkXOTYye1IyGmWuFodhHMlWcV50=
 github.com/chnsz/golangsdk v0.0.0-20220726083100-cebcc3a0547c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -722,8 +722,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_mapreduce_cluster": mrs.ResourceMRSClusterV2(),
 			"huaweicloud_mapreduce_job":     mrs.ResourceMRSJobV2(),
 
-			"huaweicloud_meeting_conference": meeting.ResourceConference(),
-			"huaweicloud_meeting_user":       meeting.ResourceUser(),
+			"huaweicloud_meeting_admin_assignment": meeting.ResourceAdminAssignment(),
+			"huaweicloud_meeting_conference":       meeting.ResourceConference(),
+			"huaweicloud_meeting_user":             meeting.ResourceUser(),
 
 			"huaweicloud_modelarts_dataset":                modelarts.ResourceDataset(),
 			"huaweicloud_modelarts_dataset_version":        modelarts.ResourceDatasetVersion(),

--- a/huaweicloud/services/acceptance/meeting/resoruce_huaweicloud_meeting_admin_assignment_test.go
+++ b/huaweicloud/services/acceptance/meeting/resoruce_huaweicloud_meeting_admin_assignment_test.go
@@ -1,0 +1,99 @@
+package meeting
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/meeting/v1/assignments"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAdminAssignment_basic(t *testing.T) {
+	var (
+		administrator assignments.Administrator
+		resourceName  = "huaweicloud_meeting_admin_assignment.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&administrator,
+		getUserFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAppAuth(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAdminAssignment_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "app_id", acceptance.HW_MEETING_APP_ID),
+					resource.TestCheckResourceAttr(resourceName, "app_key", acceptance.HW_MEETING_APP_KEY),
+					resource.TestCheckResourceAttrPair(resourceName, "account", "huaweicloud_meeting_user.test", "account"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAdminAssignmentImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccAdminAssignmentImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var (
+			accountName, password string
+			appId, appKey         string
+			account               string
+		)
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_meeting_admin_assignment" {
+				accountName = rs.Primary.Attributes["account_name"]
+				password = rs.Primary.Attributes["account_password"]
+				appId = rs.Primary.Attributes["app_id"]
+				appKey = rs.Primary.Attributes["app_key"]
+				account = rs.Primary.ID
+			}
+		}
+		if account != "" && accountName != "" && password != "" {
+			return fmt.Sprintf("%s/%s/%s", account, accountName, password), nil
+		}
+		if account != "" && appId != "" && appKey != "" {
+			return fmt.Sprintf("%s/%s/%s//", account, appId, appKey), nil
+		}
+		return "", fmt.Errorf("resource not found: %s", account)
+	}
+}
+
+func testAccAdminAssignment_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_meeting_user" "test" {
+  app_id  = "%[1]s"
+  app_key = "%[2]s"
+
+  name     = "Test Name"
+  password = "HuaweiTest@123"
+  country  = "chinaPR"
+  email    = "123456789@example.com"
+  phone    = "+8612345678987"
+}
+
+resource "huaweicloud_meeting_admin_assignment" "test" {
+  app_id  = "%[1]s"
+  app_key = "%[2]s"
+
+  account = huaweicloud_meeting_user.test.account
+}
+`, acceptance.HW_MEETING_APP_ID, acceptance.HW_MEETING_APP_KEY)
+}

--- a/huaweicloud/services/meeting/config.go
+++ b/huaweicloud/services/meeting/config.go
@@ -45,35 +45,51 @@ const (
 )
 
 func buildTokenEnvKey(d *schema.ResourceData) string {
+	var corpId, userId string
+	if val, ok := d.GetOk("corp_id"); ok {
+		corpId = val.(string)
+	}
+	if val, ok := d.GetOk("user_id"); ok {
+		userId = val.(string)
+	}
 	elements := []byte(d.Get("account_name").(string) + ":" + d.Get("account_password").(string) + ":" +
-		d.Get("app_id").(string) + ":" + d.Get("app_key").(string) + ":" + d.Get("corp_id").(string) + ":" +
-		d.Get("user_id").(string))
+		d.Get("app_id").(string) + ":" + d.Get("app_key").(string) + ":" + corpId + ":" + userId)
 	return base64.StdEncoding.EncodeToString(elements)
 }
 
 func buildAuthOpts(d *schema.ResourceData) AuthOpts {
-	return AuthOpts{
+	result := AuthOpts{
 		AccountName:        d.Get("account_name").(string),
 		Password:           d.Get("account_password").(string),
 		AppId:              d.Get("app_id").(string),
 		AppKey:             d.Get("app_key").(string),
-		CorpId:             d.Get("corp_id").(string),
-		UserId:             d.Get("user_id").(string),
 		TokenEffectiveTime: 12,
 		CurrentToken:       GetTokenFromEnv(buildTokenEnvKey(d)),
 	}
+	if val, ok := d.GetOk("corp_id"); ok {
+		result.CorpId = val.(string)
+	}
+	if val, ok := d.GetOk("user_id"); ok {
+		result.UserId = val.(string)
+	}
+	return result
 }
 
 func buildAuthOptsByState(state *terraform.ResourceState) AuthOpts {
-	return AuthOpts{
+	result := AuthOpts{
 		AccountName:        state.Primary.Attributes["account_name"],
 		Password:           state.Primary.Attributes["account_password"],
 		AppId:              state.Primary.Attributes["app_id"],
 		AppKey:             state.Primary.Attributes["app_key"],
-		CorpId:             state.Primary.Attributes["corp_id"],
-		UserId:             state.Primary.Attributes["user_id"],
 		TokenEffectiveTime: 12,
 	}
+	if val, ok := state.Primary.Attributes["corp_id"]; ok {
+		result.CorpId = val
+	}
+	if val, ok := state.Primary.Attributes["user_id"]; ok {
+		result.UserId = val
+	}
+	return result
 }
 
 // GetTokenFromEnv is a method to obtain token from global map using given key.

--- a/huaweicloud/services/meeting/resource_huaweicloud_meeting_admin_assignment.go
+++ b/huaweicloud/services/meeting/resource_huaweicloud_meeting_admin_assignment.go
@@ -1,0 +1,169 @@
+package meeting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/meeting/v1/assignments"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceAdminAssignment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAdminAssignmentCreate,
+		ReadContext:   resourceAdminAssignmentRead,
+		DeleteContext: resourceAdminAssignmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAdminAssignmentImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			// Authorization arguments
+			"account_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"account_password"},
+			},
+			"account_password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+			"app_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"app_key"},
+				ExactlyOneOf: []string{"account_name"},
+			},
+			"app_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+
+			// Arguments
+			"account": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+		},
+	}
+}
+
+func resourceAdminAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	token, err := NewMeetingToken(conf, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	account := d.Get("account").(string)
+	opt := assignments.CreateOpts{
+		Account: d.Get("account").(string),
+		// Authorization token.
+		Token: token,
+	}
+	err = assignments.Create(NewMeetingV1Client(conf), opt)
+	if err != nil {
+		return diag.Errorf("error assign the administrator role to a cloud meeting user: %s", err)
+	}
+
+	d.SetId(account)
+	return resourceAdminAssignmentRead(ctx, d, meta)
+}
+
+func parseAdministratorNotFoundError(respErr error) error {
+	var apiErr assignments.ErrResponse
+	if errCode, ok := respErr.(golangsdk.ErrDefault400); ok && errCode.Body != nil {
+		pErr := json.Unmarshal(errCode.Body, &apiErr)
+		if pErr == nil && apiErr.Code == "USG.201040000" {
+			return golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Body: []byte("the user does not exist"),
+				},
+			}
+		}
+	}
+	return respErr
+}
+
+func resourceAdminAssignmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	token, err := NewMeetingToken(conf, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	opt := assignments.GetOpts{
+		Token:   token,
+		Account: d.Id(),
+	}
+	resp, err := assignments.Get(NewMeetingV1Client(conf), opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, parseAdministratorNotFoundError(err),
+			"error retrieving administrator information")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("account", resp.Account),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAdminAssignmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	token, err := NewMeetingToken(conf, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	opt := assignments.DeleteOpts{
+		Token:    token,
+		Accounts: []string{d.Id()},
+	}
+	err = assignments.BatchDelete(NewMeetingV1Client(conf), opt)
+	if err != nil {
+		return diag.Errorf("unassigned admin role failed: %s", err)
+	}
+	return nil
+}
+
+func resourceAdminAssignmentImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+	error) {
+	var mErr *multierror.Error
+	parts := strings.Split(d.Id(), "/")
+	switch len(parts) {
+	case 3:
+		d.SetId(parts[0])
+		mErr = multierror.Append(mErr,
+			d.Set("account_name", parts[1]),
+			d.Set("account_password", parts[2]),
+		)
+	case 5:
+		d.SetId(parts[0])
+		mErr = multierror.Append(mErr,
+			d.Set("app_id", parts[1]),
+			d.Set("app_key", parts[2]),
+		)
+	default:
+		return nil, fmt.Errorf("the imported ID specifies an invalid format, must be " +
+			"<id>/<account_name>/<account_password> or <id>/<app_id>/<app_key>/<corp_id>/<user_id>.")
+	}
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to assign the administrator role for an account.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new resource: 
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/meeting' TESTARGS='-run=TestAccAdminAssignment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/meeting -v -run=TestAccAdminAssignment_basic -timeout 360m -parallel 4
=== RUN   TestAccAdminAssignment_basic
=== PAUSE TestAccAdminAssignment_basic
=== CONT  TestAccAdminAssignment_basic
--- PASS: TestAccAdminAssignment_basic (30.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/meeting   32.105s
```
To be merged with the PR of the conference user and golangsdk.