### PR TITLE
feat(cbr/vault): add auto_bind support

### DIFF
--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -139,6 +139,10 @@ The following arguments are supported:
 
   -> You cannot configure `auto_expand` if the vault is **prePaid** mode.
 
+* `auto_bind` - (Optional, Bool) Specifies whether automatic association is enabled. Defaults to **false**.
+
+* `bind_rules` - (Optional, Map) Specifies the tags to filter resources for automatic association with **auto_bind**.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies a unique ID in UUID format of enterprise project.
   Changing this will create a new vault.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
SFS Trubo doesn't support auto_bind currently.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/cbr/ TESTARGS='-run=TestAccVault'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr/ -v -run=TestAccVault -timeout 360m -parallel 4
=== RUN   TestAccVaults_BasicServer
=== PAUSE TestAccVaults_BasicServer
=== RUN   TestAccVaults_ReplicaServer
=== PAUSE TestAccVaults_ReplicaServer
=== RUN   TestAccVaults_BasicVolume
=== PAUSE TestAccVaults_BasicVolume
=== RUN   TestAccVaults_BasicTurbo
=== PAUSE TestAccVaults_BasicTurbo
=== RUN   TestAccVaults_ReplicaTurbo
=== PAUSE TestAccVaults_ReplicaTurbo
=== RUN   TestAccVault_BasicServer
=== PAUSE TestAccVault_BasicServer
=== RUN   TestAccVault_ReplicaServer
=== PAUSE TestAccVault_ReplicaServer
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== RUN   TestAccVault_BasicVolume
=== PAUSE TestAccVault_BasicVolume
=== RUN   TestAccVault_BasicTurbo
=== PAUSE TestAccVault_BasicTurbo
=== RUN   TestAccVault_ReplicaTurbo
=== PAUSE TestAccVault_ReplicaTurbo
=== RUN   TestAccVault_AutoBind
=== PAUSE TestAccVault_AutoBind
=== CONT  TestAccVaults_BasicServer
=== CONT  TestAccVaults_BasicTurbo
=== CONT  TestAccVault_BasicTurbo
=== CONT  TestAccVault_AutoBind
--- PASS: TestAccVault_AutoBind (106.64s)
=== CONT  TestAccVault_ReplicaServer
--- PASS: TestAccVault_ReplicaServer (59.68s)
=== CONT  TestAccVault_BasicVolume
--- PASS: TestAccVaults_BasicServer (318.71s)
=== CONT  TestAccVault_prePaidServer
    acceptance.go:232: This environment does not support prepaid tests
--- SKIP: TestAccVault_prePaidServer (0.00s)
=== CONT  TestAccVault_ReplicaTurbo
--- PASS: TestAccVault_ReplicaTurbo (60.57s)
=== CONT  TestAccVault_BasicServer
--- PASS: TestAccVaults_BasicTurbo (382.02s)
=== CONT  TestAccVaults_ReplicaTurbo
--- PASS: TestAccVaults_ReplicaTurbo (64.74s)
=== CONT  TestAccVaults_ReplicaServer
--- PASS: TestAccVaults_ReplicaServer (53.77s)
=== CONT  TestAccVaults_BasicVolume
--- PASS: TestAccVault_BasicVolume (433.05s)
--- PASS: TestAccVaults_BasicVolume (336.41s)
--- PASS: TestAccVault_BasicTurbo (838.73s)
--- PASS: TestAccVault_BasicServer (461.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       841.256s
```
