### PR TITLE
fix(secgroup): replace default group with resource reference

### DIFF
--- a/docs/resources/compute_interface_attach.md
+++ b/docs/resources/compute_interface_attach.md
@@ -11,16 +11,18 @@ Attaches a Network Interface to an Instance. This is an alternative to `huaweicl
 ### Basic Attachment
 
 ```hcl
+variable "security_group_id" {}
+
 data "huaweicloud_vpc_subnet" "mynet" {
   name = "subnet-default"
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
+  name               = "instance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.security_group_id]
   availability_zone = "cn-north-4a"
 
   network {
@@ -37,17 +39,19 @@ resource "huaweicloud_compute_interface_attach" "attached" {
 ### Attachment Specifying a Fixed IP
 
 ```hcl
+variable "security_group_id" {}
+
 data "huaweicloud_vpc_subnet" "mynet" {
   name = "subnet-default"
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "instance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.security_group_id]
+  availability_zone  = "cn-north-4a"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -64,6 +68,8 @@ resource "huaweicloud_compute_interface_attach" "attached" {
 ### Attachment Using an Existing Port
 
 ```hcl
+variable "security_group_id" {}
+
 data "huaweicloud_vpc_subnet" "mynet" {
   name = "subnet-default"
 }
@@ -74,12 +80,12 @@ data "huaweicloud_networking_port" "myport" {
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "instance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.security_group_id]
+  availability_zone  = "cn-north-4a"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"

--- a/docs/resources/compute_volume_attach.md
+++ b/docs/resources/compute_volume_attach.md
@@ -11,6 +11,8 @@ Attaches a volume to an ECS Instance.
 ### Basic attachment of a single volume to a single instance
 
 ```hcl
+variable "security_group_id" {}
+
 resource "huaweicloud_evs_volume" "myvol" {
   name              = "volume"
   availability_zone = "cn-north-4a"
@@ -19,12 +21,12 @@ resource "huaweicloud_evs_volume" "myvol" {
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "instance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.security_group_id]
+  availability_zone  = "cn-north-4a"
 
   network {
     uuid = "55534eaa-533a-419d-9b40-ec427ea7195a"
@@ -40,6 +42,8 @@ resource "huaweicloud_compute_volume_attach" "attached" {
 ### Attaching multiple volumes to a single instance
 
 ```hcl
+variable "security_group_id" {}
+
 resource "huaweicloud_evs_volume" "myvol" {
   count             = 2
   name              = "volume_1"
@@ -49,12 +53,12 @@ resource "huaweicloud_evs_volume" "myvol" {
 }
 
 resource "huaweicloud_compute_instance" "myinstance" {
-  name              = "instance"
-  image_id          = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id         = "s6.small.1"
-  key_pair          = "my_key_pair_name"
-  security_groups   = ["default"]
-  availability_zone = "cn-north-4a"
+  name               = "instance"
+  image_id           = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor_id          = "s6.small.1"
+  key_pair           = "my_key_pair_name"
+  security_group_ids = [var.security_group_id]
+  availability_zone  = "cn-north-4a"
 }
 
 resource "huaweicloud_compute_volume_attach" "attachments" {

--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -13,6 +13,8 @@ Manages a ECS instance resource within HuaweiCloud.
 ### Basic Instance
 
 ```hcl
+variable "security_group_name" {}
+
 resource "huaweicloud_ecs_instance_v1" "basic" {
   name     = "server_1"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
@@ -25,13 +27,15 @@ resource "huaweicloud_ecs_instance_v1" "basic" {
 
   availability_zone = "cn-north-1a"
   key_name          = "KeyPair-test"
-  security_groups   = ["default"]
+  security_groups   = [var.security_group_name]
 }
 ```
 
 ### Instance with Data Disks
 
 ```hcl
+variable "security_group_name" {}
+
 resource "huaweicloud_ecs_instance_v1" "basic" {
   name     = "server_1"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
@@ -57,13 +61,15 @@ resource "huaweicloud_ecs_instance_v1" "basic" {
   delete_disks_on_termination = true
   availability_zone           = "cn-north-1a"
   key_name                    = "KeyPair-test"
-  security_groups             = ["default"]
+  security_groups             = [var.security_group_name]
 }
 ```
 
 ### Instance With Attached Volume
 
 ```hcl
+variable "security_group_name" {}
+
 resource "huaweicloud_blockstorage_volume_v2" "myvol" {
   name = "myvol"
   size = 1
@@ -81,7 +87,7 @@ resource "huaweicloud_ecs_instance_v1" "basic" {
 
   availability_zone = "cn-north-1a"
   key_name          = "KeyPair-test"
-  security_groups   = ["default"]
+  security_groups   = [var.security_group_name]
 }
 
 resource "huaweicloud_compute_volume_attach" "attached" {
@@ -93,6 +99,8 @@ resource "huaweicloud_compute_volume_attach" "attached" {
 ### Instance With Multiple Networks
 
 ```hcl
+variable "security_group_name" {}
+
 resource "huaweicloud_networking_floatingip_v2" "myip" {
 }
 
@@ -112,7 +120,7 @@ resource "huaweicloud_ecs_instance_v1" "multi-net" {
 
   availability_zone = "cn-north-1a"
   key_name          = "KeyPair-test"
-  security_groups   = ["default"]
+  security_groups   = [var.security_group_name]
 }
 
 resource "huaweicloud_compute_eip_associate" "myip" {
@@ -125,6 +133,8 @@ resource "huaweicloud_compute_eip_associate" "myip" {
 ### Instance with User Data (cloud-init)
 
 ```hcl
+variable "security_group_name" {}
+
 resource "huaweicloud_ecs_instance_v1" "basic" {
   name     = "server_1"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
@@ -137,7 +147,7 @@ resource "huaweicloud_ecs_instance_v1" "basic" {
 
   user_data       = "#cloud-config\nhostname: server_1.example.com\nfqdn: server_1.example.com"
   key_name        = "KeyPair-test"
-  security_groups = ["default"]
+  security_groups = [var.security_group_name]
 }
 ```
 

--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -11,6 +11,7 @@ Manages an Image resource within HuaweiCloud IMS.
 ### Creating an image from ECS
 
 ```hcl
+variable "security_group_id" {}
 variable "instance_name" {}
 variable "image_name" {}
 
@@ -21,10 +22,10 @@ data "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_compute_instance" "test" {
-  name              = var.instance_name
-  image_name        = "Ubuntu 18.04 server 64bit"
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = var.instance_name
+  image_name         = "Ubuntu 18.04 server 64bit"
+  security_group_ids = [var.security_group_id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_eip_associate_test.go
@@ -337,7 +337,7 @@ data "huaweicloud_images_image" "image_1" {
 }
 
 resource "huaweicloud_vpc" "vpc_1" {
-  name = "%s"
+  name = "%[1]s"
   cidr = "172.16.0.0/16"
 }
 
@@ -349,12 +349,16 @@ resource "huaweicloud_vpc_subnet" "subnet_1" {
   ipv6_enable = true
 }
 
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_id          = data.huaweicloud_images_image.image_1.id
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  flavor_id         = "c6.large.2"
-  security_groups   = ["default"]
+  name               = "%[1]s"
+  image_id           = data.huaweicloud_images_image.image_1.id
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  flavor_id          = "c6.large.2"
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
 
   network {
     uuid        = huaweicloud_vpc_subnet.subnet_1.id
@@ -363,7 +367,7 @@ resource "huaweicloud_compute_instance" "test" {
 }
 
 resource "huaweicloud_vpc_bandwidth" "bandwidth_1" {
-  name = "%s"
+  name = "%[1]s"
   size = 5
 }
 
@@ -372,5 +376,5 @@ resource "huaweicloud_compute_eip_associate" "test" {
   instance_id  = huaweicloud_compute_instance.test.id
   fixed_ip     = huaweicloud_compute_instance.test.access_ip_v6
 }
-`, rName, rName, rName)
+`, rName)
 }

--- a/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
+++ b/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
@@ -149,12 +149,16 @@ data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
 
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
 resource "huaweicloud_compute_instance" "vm_1" {
-  name              = "ecs-%s"
-  image_id          = data.huaweicloud_images_image.test.id
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "ecs-%[1]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -162,10 +166,10 @@ resource "huaweicloud_compute_instance" "vm_1" {
 }
 
 resource "huaweicloud_smn_topic" "topic_1" {
-  name         = "smn-%s"
+  name         = "smn-%[1]s"
   display_name = "The display name of smn topic"
 }
-`, rName, rName)
+`, rName)
 }
 
 func testCESAlarmRule_basic(rName string) string {

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
@@ -130,12 +130,16 @@ data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
 
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
 resource "huaweicloud_compute_instance" "test" {
-  name              = "%s"
-  image_name        = "Ubuntu 18.04 server 64bit"
-  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups   = ["default"]
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%[1]s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
     uuid = data.huaweicloud_vpc_subnet.test.id
@@ -143,7 +147,7 @@ resource "huaweicloud_compute_instance" "test" {
 }
 
 resource "huaweicloud_images_image" "test" {
-  name        = "%s"
+  name        = "%[1]s"
   instance_id = huaweicloud_compute_instance.test.id
   description = "created by Terraform AccTest"
 
@@ -152,7 +156,7 @@ resource "huaweicloud_images_image" "test" {
     key = "value"
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccImsImageDataSource_queryName(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Due to API changes, the default security group name has now changed from **default** to **sys-default**.
Therefore, considering possible API modifications in the future, hardcoding should be replaced.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace the hard coding of default security group with resource reference.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeEIPAssociate_bandwidth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeEIPAssociate_bandwidth -timeout 360m -parallel 4
=== RUN   TestAccComputeEIPAssociate_bandwidth
=== PAUSE TestAccComputeEIPAssociate_bandwidth
=== CONT  TestAccComputeEIPAssociate_bandwidth
--- PASS: TestAccComputeEIPAssociate_bandwidth (215.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       215.707s
```
```
make testacc TEST='./huaweicloud/services/acceptance/ims' TESTARGS='-run=TestAccImsImageDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run=TestAccImsImageDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccImsImageDataSource_basic
=== PAUSE TestAccImsImageDataSource_basic
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_basic
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_basic (32.38s)
--- PASS: TestAccImsImageDataSource_testQueries (421.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       421.971s
```
```
make testacc TEST='./huaweicloud/services/acceptance/ces' TESTARGS='-run=TestAccCESAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run=TestAccCESAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_basic
=== PAUSE TestAccCESAlarmRule_basic
=== CONT  TestAccCESAlarmRule_basic
--- PASS: TestAccCESAlarmRule_basic (202.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       202.689s
```
