### PR TITLE
refactor(log): fix incorrect log level setting

### DIFF
--- a/huaweicloud/common/config.go
+++ b/huaweicloud/common/config.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -28,7 +27,6 @@ func NewCustomClient(insecure bool, endpoints ...string) *golangsdk.ServiceClien
 					InsecureSkipVerify: insecure, // Pay attention to the security risks after skip verify.
 				},
 			},
-			OsDebug: logging.IsDebugOrHigher(),
 		},
 		Timeout: 30 * time.Minute,
 	}

--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	huaweisdk "github.com/chnsz/golangsdk/openstack"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	iam_model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3/model"
 	"github.com/jmespath/go-jmespath"
 	"github.com/mitchellh/go-homedir"
@@ -121,7 +120,6 @@ func genClient(c *Config, ao golangsdk.AuthOptionsProvider) (*golangsdk.Provider
 	client.HTTPClient = http.Client{
 		Transport: &LogRoundTripper{
 			Rt:         transport,
-			OsDebug:    logging.IsDebugOrHigher(),
 			MaxRetries: c.MaxRetries,
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -13,9 +13,10 @@ import (
 	"github.com/chnsz/golangsdk/openstack/identity/v3/projects"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/users"
 	"github.com/chnsz/golangsdk/openstack/obs"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 const (
@@ -171,7 +172,7 @@ func (c *Config) ObjectStorageClientWithSignature(region string) (*obs.ObsClient
 	}
 
 	// init log
-	if logging.IsDebugOrHigher() {
+	if utils.IsDebugOrHigher() {
 		if err := obs.InitLog(obsLogFile, obsLogFileSize10MB, 10, obs.LEVEL_DEBUG, false); err != nil {
 			log.Printf("[WARN] initial obs sdk log failed: %s", err)
 		}
@@ -191,7 +192,7 @@ func (c *Config) ObjectStorageClient(region string) (*obs.ObsClient, error) {
 	}
 
 	// init log
-	if logging.IsDebugOrHigher() {
+	if utils.IsDebugOrHigher() {
 		if err := obs.InitLog(obsLogFile, obsLogFileSize10MB, 10, obs.LEVEL_DEBUG, false); err != nil {
 			log.Printf("[WARN] initial obs sdk log failed: %s", err)
 		}

--- a/huaweicloud/config/hc_config.go
+++ b/huaweicloud/config/hc_config.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/basic"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/global"
 	hcconfig "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/config"
@@ -300,10 +299,6 @@ func getProxyFromEnv() string {
 }
 
 func logRequestHandler(request http.Request) {
-	if !logging.IsDebugOrHigher() {
-		return
-	}
-
 	log.Printf("[DEBUG] API Request URL: %s %s", request.Method, request.URL)
 	log.Printf("[DEBUG] API Request Headers:\n%s", FormatHeaders(request.Header, "\n"))
 	if request.Body != nil {
@@ -314,10 +309,6 @@ func logRequestHandler(request http.Request) {
 }
 
 func logResponseHandler(response http.Response) {
-	if !logging.IsDebugOrHigher() {
-		return
-	}
-
 	log.Printf("[DEBUG] API Response Code: %d", response.StatusCode)
 	log.Printf("[DEBUG] API Response Headers:\n%s", FormatHeaders(response.Header, "\n"))
 

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -388,3 +388,33 @@ func RandomString(n int, allowedChars ...[]rune) (result string) {
 	result = string(b)
 	return
 }
+
+// IsDebugOrHigher returns a bool type parameter, which specifies whether to print log
+var validLevels = []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+
+func IsDebugOrHigher() bool {
+	logLevel := os.Getenv("TF_LOG_PROVIDER")
+	if logLevel == "" {
+		logLevel = os.Getenv("TF_LOG")
+	}
+
+	if logLevel != "" {
+		if isValidLogLevel(logLevel) {
+			logLevel = strings.ToUpper(logLevel)
+			return logLevel == "DEBUG" || logLevel == "TRACE"
+		} else {
+			log.Printf("[WARN] Invalid log level: %q. Valid levels are: %+v", logLevel, validLevels)
+		}
+	}
+	return false
+}
+
+func isValidLogLevel(level string) bool {
+	for _, l := range validLevels {
+		if strings.ToUpper(level) == string(l) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 )
 
 func main() {
+	// Remove any date and time prefix in log package function output to
+	// prevent duplicate timestamp and incorrect log level setting
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: huaweicloud.Provider})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently all logs defined in our provider are automatically set to [INFO] level, this makes filter logs with TF_LOG not working.
This PR fixs incorrect log level setting.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix incorrect log level setting
2. remove some no longer needed IsDebugOrHigher check
3. remove OsDebug in LogRoundTripper
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Example logs after fix

```
2022-08-02T11:18:16.095+0800 [DEBUG] provider.terraform-provider-huaweicloud: API Request URL: GET https://vpc.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/vpcs/3a30c1e7-d51b-489a-954a-011a8575b15e: timestamp=2022-08-02T11:18:16.095+0800
2022-08-02T11:18:16.095+0800 [DEBUG] provider.terraform-provider-huaweicloud: API Request Headers:
Accept: application/json
Authorization: ***
Host: vpc.cn-north-4.myhuaweicloud.com
User-Agent: terraform-provider-iac golangsdk/2.0.0
X-Project-Id: 0970dd7a1300f5672ff2c003c60ae115
X-Sdk-Date: 20220802T031816Z: timestamp=2022-08-02T11:18:16.095+0800
2022-08-02T11:18:16.486+0800 [DEBUG] provider.terraform-provider-huaweicloud: API Response Code: 200: timestamp=2022-08-02T11:18:16.486+0800
2022-08-02T11:18:16.486+0800 [DEBUG] provider.terraform-provider-huaweicloud: API Response Headers:
Accept-Ranges: bytes
Connection: keep-alive
Content-Type: application/json
Date: Tue, 02 Aug 2022 03:18:16 GMT
Server: api-gateway
Strict-Transport-Security: max-age=31536000; includeSubdomains;
Vary: Accept-Charset, Accept-Encoding, Accept-Language, Accept
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Request-Id: b878f7c3a22737254b2bde3b465fbc08
X-Xss-Protection: 1; mode=block;: timestamp=2022-08-02T11:18:16.486+0800
2022-08-02T11:18:16.486+0800 [DEBUG] provider.terraform-provider-huaweicloud: API Response Body: {
  "vpc": {
    "cidr": "172.17.0.0/16",
    "description": "",
    "enterprise_project_id": "0",
    "id": "3a30c1e7-d51b-489a-954a-011a8575b15e",
    "name": "zhangjishu-test",
    "routes": [],
    "status": "OK"
  }
}: timestamp=2022-08-02T11:18:16.486+0800
2022-08-02T11:18:16.487+0800 [INFO]  provider.terraform-provider-huaweicloud: xxxx no level message: timestamp=2022-08-02T11:18:16.486+0800
2022-08-02T11:18:16.487+0800 [TRACE] provider.terraform-provider-huaweicloud: xxxx trace message: timestamp=2022-08-02T11:18:16.486+0800
2022-08-02T11:18:16.487+0800 [DEBUG] provider.terraform-provider-huaweicloud: xxxx debug message: timestamp=2022-08-02T11:18:16.487+0800
2022-08-02T11:18:16.487+0800 [INFO]  provider.terraform-provider-huaweicloud: xxxx info message: timestamp=2022-08-02T11:18:16.487+0800
2022-08-02T11:18:16.487+0800 [WARN]  provider.terraform-provider-huaweicloud: xxxx warn message: timestamp=2022-08-02T11:18:16.487+0800
2022-08-02T11:18:16.487+0800 [ERROR] provider.terraform-provider-huaweicloud: xxxx error message: timestamp=2022-08-02T11:18:16.487+0800
```
