### PR TITLE
fix(rds): avoid BACKING_UP state issue

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -367,6 +367,8 @@ func resourceRdsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 			Timeout:      d.Timeout(schema.TimeoutCreate),
 			Delay:        20 * time.Second,
 			PollInterval: 10 * time.Second,
+			// Ensure that the instance is 'ACTIVE', not going to enter 'BACKING UP'.
+			ContinuousTargetOccurence: 2,
 		}
 		if _, err = stateConf.WaitForState(); err != nil {
 			return diag.Errorf("error waiting for RDS instance (%s) creation completed: %s", instanceID, err)


### PR DESCRIPTION
Adds ContinuousTargetOccurence for sate check of Create to avoid
the instance to go BACKING UP state after ACTIVE.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds TESTARGS='-run=TestAccRdsInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run=TestAccRdsInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_basic
--- PASS: TestAccRdsInstance_basic (1148.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1148.351s
```
