### PR TITLE
feat(instance): support collection policy parameter

### DIFF
--- a/docs/resources/servicestage_component_instance.md
+++ b/docs/resources/servicestage_component_instance.md
@@ -59,6 +59,16 @@ resource "huaweicloud_servicestage_component_instance" "default" {
       name  = "TZ"
       value = "Asia/Shanghai"
     }
+
+    log_collection_policy {
+      host_path = "/tmp"
+
+      container_mounting {
+        path             = "/attached/01"
+        host_extend_path = "None"
+        aging_period     = "Hourly"
+      }
+    }
   }
 }
 ```
@@ -251,6 +261,9 @@ The `configuration` block supports:
 * `lifecycle` - (Optional, List) Specifies the lifecycle.
   The [object](#servicestage_lifecycle) structure is documented below.
 
+* `log_collection_policy` - (Optional, List) Specifies the policies of the log collection.
+  The [object](#servicestage_log_collection_policies) structure is documented below.
+
 * `scheduler` - (Optional, List) Specifies the scheduling policy.
   The key indicates the component name. In the Docker container scenario, key indicates the container name.
   If the source parameters of a component specify the software package source, this parameter is optional, and the
@@ -325,6 +338,31 @@ The `lifecycle` block supports:
 
 * `pre_stop` - (Required, List) Specifies the pre-stop processing.
   The [object](#servicestage_lifecycle_process) structure is documented below.
+
+<a name="servicestage_log_collection_policies"></a>
+The `log_collection_policy` block supports:
+
+* `container_mounting` - (Required, List) Specifies the configurations of the container mounting.
+  The [object](#servicestage_container_mounting) structure is documented below.
+
+* `host_path` - (Optional, String) Specifies the The host path that will be mounted to the specified container path.
+
+<a name="servicestage_container_mounting"></a>
+The `container_mounting` block supports:
+
+* `path` - (Required, String) Specifies the path of the container mounting.
+
+* `host_extend_path` - (Optional, String) Specifies the extended host path.
+  This parameter can be configured only when `host_path` is configured.
+  The valid values are as follows:
+  + **None**
+  + **PodUID**
+  + **PodName**
+  + **PodUID/ContainerName**
+  + **PodName/ContainerName**
+
+* `aging_period` - (Optional, String) Specifies the aging period.
+  The valid values are **Hourly**, **Daily** and **Weekly**. The default value is **Hourly**.
 
 <a name="servicestage_entrypoint"></a>
 The `entrypoint` block supports:

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_instance_test.go
@@ -64,6 +64,7 @@ func TestAccComponentInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "artifact.0.auth_type", "iam"),
 					resource.TestCheckResourceAttr(resourceName, "refer_resource.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.log_collection_policy.#", "2"),
 				),
 			},
 			{
@@ -76,6 +77,7 @@ func TestAccComponentInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.name", "TZ"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.env_variable.0.value", "Asia/Shanghai"),
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.log_collection_policy.#", "1"),
 				),
 			},
 			{
@@ -259,6 +261,52 @@ resource "huaweicloud_servicestage_component_instance" "test" {
     type = "cse"
     id   = "default"
   }
+
+  configuration {
+    log_collection_policy {
+      host_path = "/tmp"
+
+      container_mounting {
+        path             = "/tmp/01"
+        host_extend_path = "None"
+        aging_period     = "Hourly"
+      }
+      container_mounting {
+        path             = "/tmp/02"
+        host_extend_path = "None"
+        aging_period     = "Daily"
+      }
+      container_mounting {
+        path             = "/tmp/03"
+        host_extend_path = "None"
+        aging_period     = "Weekly"
+      }
+      container_mounting {
+        path             = "/tmp/04"
+        host_extend_path = "PodUID"
+        aging_period     = "Weekly"
+      }
+      container_mounting {
+        path             = "/tmp/05"
+        host_extend_path = "PodName"
+        aging_period     = "Weekly"
+      }
+      container_mounting {
+        path             = "/tmp/06"
+        host_extend_path = "PodUID/ContainerName"
+        aging_period     = "Weekly"
+      }
+    }
+    log_collection_policy {
+      host_path = "/mytest"
+
+      container_mounting {
+        path             = "/mytest/01"
+        host_extend_path = "None"
+        aging_period     = "Hourly"
+      }
+    }
+  }
 }
 `, testAccComponentInstance_base(rName), rName, acceptance.HW_BUILD_IMAGE_URL)
 }
@@ -304,6 +352,13 @@ resource "huaweicloud_servicestage_component_instance" "test" {
     env_variable {
       name  = "TZ"
       value = "Asia/Shanghai"
+    }
+
+    log_collection_policy {
+      container_mounting {
+        path         = "/tmp"
+        aging_period = "Hourly"
+      }
     }
   }
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/requests.go
@@ -95,6 +95,8 @@ type Configuration struct {
 	Strategy *Strategy `json:"strategy,omitempty"`
 	// Lifecycle.
 	Lifecycle *Lifecycle `json:"lifecycle,omitempty"`
+	// Policy list of log collection.
+	LogCollectionPolicies []LogCollectionPolicy `json:"log,omitempty"`
 	// Scheduling policy.
 	Scheduler *Scheduler `json:"scheduler,omitempty"`
 	// Health check.
@@ -190,6 +192,24 @@ type ProcessParams struct {
 	Path string `json:"path,omitempty"`
 	// Defaults to the IP address of the POD instance. You can also specify it yourself. Applies to http type.
 	Host string `json:"host,omitempty"`
+}
+
+// LogCollectionPolicy is an object that specifies the policy of the log collection.
+type LogCollectionPolicy struct {
+	// Container mounting path.
+	LogPath string `json:"logPath" required:"ture"`
+	// Aging period.
+	AgingPeriod string `json:"rotate" required:"ture"`
+	// The extended host path, the valid values are as follows:
+	//	None
+	//	PodUID
+	//	PodName
+	//	PodUID/ContainerName
+	//	PodName/ContainerName
+	// If omited, means container mounting.
+	HostExtendPath string `json:"hostExtendPath,omitempty"`
+	// Host mounting path.
+	HostPath string `json:"hostPath,omitempty"`
 }
 
 // Scheduler is an object that specifies the scheduling policy.

--- a/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/servicestage/v2/instances/results.go
@@ -54,6 +54,8 @@ type ConfigurationResp struct {
 	Strategy StrategyResp `json:"strategy"`
 	// Lifecycle.
 	Lifecycle LifecycleResp `json:"lifecycle"`
+	// Policy list of log collection.
+	LogCollectionPolicy []LogCollectionPolicyResp `json:"log"`
 	// Scheduling policy.
 	Scheduler SchedulerResp `json:"scheduler"`
 	// Health check.
@@ -121,6 +123,24 @@ type ProcessResp struct {
 	Type string `json:"type" required:"true"`
 	// Start post-processing or stop pre-processing parameters.
 	Parameters ProcessParams `json:"parameters" required:"true"`
+}
+
+// LogCollectionPolicyResp is an object represents the details of the log collection policy.
+type LogCollectionPolicyResp struct {
+	// Container mounting path.
+	LogPath string `json:"logPath"`
+	// The extend host path, the valid values are as follows:
+	//	None
+	//	PodUID
+	//	PodName
+	//	PodUID/ContainerName
+	//	PodName/ContainerName
+	// If omited, means container mounting.
+	HostExtendPath string `json:"hostExtendPath"`
+	// Aging period.
+	AgingPeriod string `json:"rotate"`
+	// Host mounting path.
+	HostPath string `json:"hostPath"`
 }
 
 // SchedulerResp is an object represents the scheduling policy.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new parameter to provide the host mounting and container mounting.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new parameter to support policy list setting for the log collection.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS
='-run=TestAccComponentInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccComponentInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComponentInstance_basic
=== PAUSE TestAccComponentInstance_basic
=== CONT  TestAccComponentInstance_basic
--- PASS: TestAccComponentInstance_basic (985.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage       989.755s
```
