### PR TITLE
fix(cce/node_pool): change type of extend_param elements before setting

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/resource_huaweicloud_cce_node_pool.go
@@ -2,6 +2,7 @@ package huaweicloud
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -421,7 +422,26 @@ func resourceCCENodePoolRead(_ context.Context, d *schema.ResourceData, meta int
 	var extendParam = s.Spec.NodeTemplate.ExtendParam
 	mErr = multierror.Append(mErr, d.Set("max_pods", extendParam["maxPods"]))
 	delete(extendParam, "maxPods")
-	mErr = multierror.Append(mErr, d.Set("extend_param", extendParam))
+
+	extendParamToSet := map[string]string{}
+	for k, v := range extendParam {
+		switch v := v.(type) {
+		case string:
+			extendParamToSet[k] = v
+		case int:
+			extendParamToSet[k] = strconv.Itoa(v)
+		case int32:
+			extendParamToSet[k] = strconv.FormatInt(int64(v), 10)
+		case float64:
+			extendParamToSet[k] = strconv.FormatFloat(v, 'f', -1, 64)
+		case bool:
+			extendParamToSet[k] = strconv.FormatBool(v)
+		default:
+			logp.Printf("[WARN] can not set %s to extend_param, the value is %v", k, v)
+		}
+	}
+
+	mErr = multierror.Append(mErr, d.Set("extend_param", extendParamToSet))
 
 	if s.Spec.NodeTemplate.RunTime != nil {
 		mErr = multierror.Append(mErr, d.Set("runtime", s.Spec.NodeTemplate.RunTime.Name))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

change type of extend_param elements before setting

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
change type of extend_param elements before setting
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1394.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1394.280s
```
