### PR TITLE
refactor(networking): move data_source networking port to services path

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -433,7 +433,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_certificate": elb.DataSourceELBCertificateV3(),
 
 			"huaweicloud_nat_gateway":          DataSourceNatGatewayV2(),
-			"huaweicloud_networking_port":      DataSourceNetworkingPortV2(),
+			"huaweicloud_networking_port":      vpc.DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":  DataSourceNetworkingSecGroup(),
 			"huaweicloud_networking_secgroups": vpc.DataSourceNetworkingSecGroups(),
 
@@ -480,7 +480,7 @@ func Provider() *schema.Provider {
 
 			// Legacy
 			"huaweicloud_images_image_v2":        ims.DataSourceImagesImageV2(),
-			"huaweicloud_networking_port_v2":     DataSourceNetworkingPortV2(),
+			"huaweicloud_networking_port_v2":     vpc.DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup_v2": DataSourceNetworkingSecGroup(),
 
 			"huaweicloud_kms_key_v1":      DataSourceKmsKeyV1(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_port_v2_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_port_v2_test.go
@@ -1,18 +1,19 @@
-package huaweicloud
+package vpc
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccNetworkingV2PortDataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_networking_port.gw_port"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkingV2PortDataSource_basic(),

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package vpc
 
 import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -102,7 +102,7 @@ func DataSourceNetworkingPortV2() *schema.Resource {
 
 func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
 	}
@@ -212,7 +212,7 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("mac_address", port.MACAddress)
 	d.Set("device_owner", port.DeviceOwner)
 	d.Set("device_id", port.DeviceID)
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", config.GetRegion(d))
 	d.Set("all_security_group_ids", port.SecurityGroups)
 	d.Set("all_fixed_ips", expandNetworkingPortFixedIPToStringSlice(port.FixedIPs))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

move data_source networking port to services path

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
move data_source networking port to services path
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkingV2PortDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingV2PortDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (13.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       13.877s
```
