### PR TITLE
feat(cse/engine): add a new parameter 'version'

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -56,6 +56,9 @@ The following arguments are supported:
     After security authentication is disabled, all users who use the engine can use the engine without using the account
     and password, and have the same operation permissions on all services.
 
+* `version` - (Optional, String, ForceNew) Specifies the version of the dedicated microservice engine. The value can be:
+  **CSE2**. Defaults to: **CSE2**. Changing this will create a new engine.
+
 * `admin_pass` - (Optional, String, ForceNew) Specifies the account password. The corresponding account name is **root**.
   Required if `auth_type` is **RBAC**. Changing this will create a new engine.
   The password format must meet the following conditions:

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -24,6 +24,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var DefaultVersion = "CSE2"
+
 func ResourceMicroserviceEngine() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMicroserviceEngineCreate,
@@ -80,6 +82,12 @@ func ResourceMicroserviceEngine() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"RBAC", "NONE",
 				}, false),
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  DefaultVersion,
 			},
 			"admin_pass": {
 				Type:      schema.TypeString,
@@ -175,7 +183,7 @@ func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceDat
 	authType := d.Get("auth_type").(string)
 	createOpts := engines.CreateOpts{
 		Payment:             "1",
-		SpecType:            "CSE2",
+		SpecType:            d.Get("version").(string),
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
 		Flavor:              d.Get("flavor").(string),
@@ -272,6 +280,7 @@ func resourceMicroserviceEngineRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("flavor", resp.Flavor),
 		d.Set("availability_zones", resp.Reference.AzList),
 		d.Set("auth_type", resp.AuthType),
+		d.Set("version", resp.SpecType),
 		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
 		d.Set("network_id", resp.Reference.NetworkId),
 		d.Set("description", resp.Description),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add a new parameter 'version', so the engine version can be specified

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new parameter 'version', so the engine version can be specified
2. put the default value as package variable so it can be changed when the resource is refered in other cloud
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cse' TESTARGS='-run TestAccMicroserviceEngine_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse -v -run TestAccMicroserviceEngine_basic -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_basic
--- PASS: TestAccMicroserviceEngine_basic (816.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       816.363s
```
