### PR TITLE
fix(cse/instance): ignore internal parameters

### DIFF
--- a/docs/resources/cse_microservice_instance.md
+++ b/docs/resources/cse_microservice_instance.md
@@ -105,6 +105,8 @@ The following arguments are supported:
 * `properties` - (Optional, String, ForceNew) Specifies the extended attributes.
   Changing this will create a new microservice instance.
 
+  -> The internal key-value pair cannot be configured or overwritten, such as **engineID** and **engineName**.
+
 * `health_check` - (Optional, List, ForceNew) Specifies the health check configuration.
   The [object](#microservice_instance_health_check) structure is documented below.
   Changing this will create a new microservice instance.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After creation completed for the microservice instance, the properties will return some internal key-value pairs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore internal parameters.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cse' TESTARGS='-run=TestAccMicroserviceInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse -v -run=TestAccMicroserviceInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceInstance_basic
=== PAUSE TestAccMicroserviceInstance_basic
=== CONT  TestAccMicroserviceInstance_basic
--- PASS: TestAccMicroserviceInstance_basic (874.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse   874.436s
```
