### PR TITLE
refactor(eip/list): set enterprise_project_id to all_granted_eps if it's not specified

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -53,9 +53,10 @@ func GetEnterpriseProjectID(d *schema.ResourceData, config *config.Config) strin
 }
 
 // GetEipIDbyAddress returns the EIP ID of address when success.
-func GetEipIDbyAddress(client *golangsdk.ServiceClient, address string) (string, error) {
+func GetEipIDbyAddress(client *golangsdk.ServiceClient, address, epsID string) (string, error) {
 	listOpts := &eips.ListOpts{
-		PublicIp: []string{address},
+		PublicIp:            []string{address},
+		EnterpriseProjectId: epsID,
 	}
 	pages, err := eips.List(client, listOpts).AllPages()
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -1807,7 +1807,8 @@ func calcUnsubscribeResources(d *schema.ResourceData, cfg *config.Config) ([]str
 		}
 
 		eipAddr := d.Get("public_ip").(string)
-		if eipID, err := common.GetEipIDbyAddress(eipClient, eipAddr); err == nil {
+		epsID := "all_granted_eps"
+		if eipID, err := common.GetEipIDbyAddress(eipClient, eipAddr, epsID); err == nil {
 			mainResources = append(mainResources, eipID)
 		} else {
 			return nil, fmt.Errorf("error fetching EIP ID of ECS (%s): %s", d.Id(), err)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -290,7 +290,8 @@ func setApigIngressAccess(d *schema.ResourceData, config *config.Config, resp in
 			return fmtp.Errorf("Error creating VPC client: %s", err)
 		}
 		opt := eips.ListOpts{
-			PublicIp: []string{publicAddress},
+			PublicIp:            []string{publicAddress},
+			EnterpriseProjectId: "all_granted_eps",
 		}
 		allPages, err := eips.List(client, opt).AllPages()
 		if err != nil {

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -472,7 +472,8 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 			return fmtp.DiagErrorf("Error creating networking client: %s", err)
 		}
 
-		if eipID, err := common.GetEipIDbyAddress(eipClient, publicIP); err == nil {
+		epsID := "all_granted_eps"
+		if eipID, err := common.GetEipIDbyAddress(eipClient, publicIP, epsID); err == nil {
 			resourceIDs = append(resourceIDs, eipID)
 		} else {
 			return fmtp.DiagErrorf("Error fetching EIP ID of BMS server (%s): %s", d.Id(), err)

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_associate.go
@@ -127,7 +127,8 @@ func resourceEIPAssociateCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	publicIP := d.Get("public_ip").(string)
-	publicID, err := getEIPByAddress(vpcClient, publicIP)
+	epsID := "all_granted_eps"
+	publicID, err := common.GetEipIDbyAddress(vpcClient, publicIP, epsID)
 	if err != nil {
 		return fmtp.DiagErrorf("Unable to get ID of public IP %s: %s", publicIP, err)
 	}
@@ -222,27 +223,6 @@ func resourceEIPAssociateDelete(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	return nil
-}
-
-func getEIPByAddress(client *golangsdk.ServiceClient, address string) (string, error) {
-	listOpts := eips.ListOpts{
-		PublicIp: []string{address},
-	}
-
-	pages, err := eips.List(client, listOpts).AllPages()
-	if err != nil {
-		return "", err
-	}
-	allEips, err := eips.ExtractPublicIPs(pages)
-	if err != nil {
-		return "", fmtp.Errorf("Unable to retrieve EIPs: %s ", err)
-	}
-
-	if len(allEips) != 1 {
-		return "", fmtp.Errorf("unable to determine the ID of %s", address)
-	}
-
-	return allEips[0].ID, nil
 }
 
 func bindPort(client *golangsdk.ServiceClient, eipID, portID string, timeout time.Duration) error {

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
@@ -522,7 +522,8 @@ func resourceMRSClusterV2Create(d *schema.ResourceData, meta interface{}) error 
 		return fmtp.Errorf("Error creating networking client: %s", err)
 	}
 
-	eipId, publicIp, err := queryEipInfo(networkingClient, d.Get("eip_id").(string), d.Get("public_ip").(string))
+	epsID := "all_granted_eps"
+	eipId, publicIp, err := queryEipInfo(networkingClient, d.Get("eip_id").(string), d.Get("public_ip").(string), epsID)
 	if err != nil {
 		return fmtp.Errorf("Unable to find the eip_id=%s,public_ip=%s on the server: %s", d.Get("eip_id").(string),
 			d.Get("public_ip").(string), err)
@@ -581,12 +582,14 @@ func resourceMRSClusterV2Create(d *schema.ResourceData, meta interface{}) error 
 	return resourceMRSClusterV2Read(d, meta)
 }
 
-func queryEipInfo(client *golangsdk.ServiceClient, eipId, PublicIp string) (string, string, error) {
+func queryEipInfo(client *golangsdk.ServiceClient, eipId, PublicIp, epsID string) (string, string, error) {
 	if eipId == "" && PublicIp == "" {
 		return "", "", nil
 	}
 
-	var listOpts eips.ListOpts
+	listOpts := eips.ListOpts{
+		EnterpriseProjectId: epsID,
+	}
 	if eipId != "" {
 		listOpts.Id = []string{eipId}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

set enterprise_project_id to all_granted_eps if it's not specified

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
set enterprise_project_id to all_granted_eps if it's not specified
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccEIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== CONT  TestAccEIPAssociate_basic
--- PASS: TestAccEIPAssociate_basic (224.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       224.693s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeEIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeEIPAssociate_basic
=== PAUSE TestAccComputeEIPAssociate_basic
=== CONT  TestAccComputeEIPAssociate_basic
--- PASS: TestAccComputeEIPAssociate_basic (174.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       174.561s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (865.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       865.770s

make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_prePaid (172.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       172.809s

make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run TestAccMrsMapReduceCluster_Eip_publicIp'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster_Eip_publicIp -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_Eip_publicIp
=== PAUSE TestAccMrsMapReduceCluster_Eip_publicIp
=== CONT  TestAccMrsMapReduceCluster_Eip_publicIp
--- PASS: TestAccMrsMapReduceCluster_Eip_publicIp (792.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       792.379s
```