### PR TITLE
test(acc/param): use subnet id to create turbo cluster

### DIFF
--- a/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/resource_huaweicloud_cce_cluster_v3_test.go
@@ -391,9 +391,8 @@ resource "huaweicloud_cce_cluster" "test" {
   vpc_id                 = huaweicloud_vpc.test.id
   subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "eni"
-  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.id
+  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.subnet_id
   eni_subnet_cidr        = huaweicloud_vpc_subnet.eni_test.cidr
-
 }
 
 `, testAccCCEClusterV3_Base(rName), rName, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It is correct to use the subnet ID to create the turbo cluster, not the network ID.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using subnet id to create turbo cluster.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccCCEClusterV3_turbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccCCEClusterV3_turbo -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_turbo
=== PAUSE TestAccCCEClusterV3_turbo
=== CONT  TestAccCCEClusterV3_turbo
--- PASS: TestAccCCEClusterV3_turbo (533.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       533.320s
```
