### PR TITLE
feat(test): add precheck for internal acceptance tests

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -37,6 +37,7 @@ var (
 	HW_OBS_BUCKET_NAME       = os.Getenv("HW_OBS_BUCKET_NAME")
 
 	HW_DEPRECATED_ENVIRONMENT = os.Getenv("HW_DEPRECATED_ENVIRONMENT")
+	HW_INTERNAL_USED          = os.Getenv("HW_INTERNAL_USED")
 
 	HW_WAF_ENABLE_FLAG = os.Getenv("HW_WAF_ENABLE_FLAG")
 
@@ -134,6 +135,13 @@ func TestAccPreCheckDeprecated(t *testing.T) {
 	}
 
 	preCheckRequiredEnvVars(t)
+}
+
+// lintignore:AT003
+func TestAccPreCheckInternal(t *testing.T) {
+	if HW_INTERNAL_USED == "" {
+		t.Skip("HW_INTERNAL_USED must be set for internal acceptance tests")
+	}
 }
 
 // lintignore:AT003

--- a/huaweicloud/services/acceptance/cmdb/resource_huaweicloud_aom_application_test.go
+++ b/huaweicloud/services/acceptance/cmdb/resource_huaweicloud_aom_application_test.go
@@ -3,13 +3,14 @@ package cmdb
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"testing"
 )
 
 func getAppResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -46,7 +47,10 @@ func TestAccAomApp_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckInternal(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cmdb/resource_huaweicloud_aom_component_test.go
+++ b/huaweicloud/services/acceptance/cmdb/resource_huaweicloud_aom_component_test.go
@@ -3,13 +3,14 @@ package cmdb
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"testing"
 )
 
 func getCompResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -46,7 +47,10 @@ func TestAccAomComp_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckInternal(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cmdb/resource_huaweicloud_aom_environment_test.go
+++ b/huaweicloud/services/acceptance/cmdb/resource_huaweicloud_aom_environment_test.go
@@ -3,13 +3,14 @@ package cmdb
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"testing"
 )
 
 func getEnvResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -46,7 +47,10 @@ func TestAccAomEnv_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckInternal(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

for internal-used resources, we must add a pre-check to run the acceptance tests.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
```
$ make testacc TEST='./huaweicloud/services/acceptance/cmdb' TESTARGS='-run TestAccAomEnv_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cmdb -v -run TestAccAomEnv_basic -timeout 360m -parallel 4
=== RUN   TestAccAomEnv_basic
=== PAUSE TestAccAomEnv_basic
=== CONT  TestAccAomEnv_basic
    acceptance.go:143: HW_INTERNAL_USED must be set for internal acceptance tests
--- SKIP: TestAccAomEnv_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cmdb      0.080s
```
