### PR TITLE
feat(dew): add new data source keypairs

### DIFF
--- a/docs/data-sources/kps_keypairs.md
+++ b/docs/data-sources/kps_keypairs.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# huaweicloud_kps_keypairs
+
+Use this data source to get a list of keypairs.
+
+## Example Usage
+
+```hcl
+variable "keypair_name" {}
+
+data "huaweicloud_kps_keypairs" "test" {
+  name = var.keypair_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the keypairs. If omitted, the provider-level region will
+  be used.
+
+* `name` - (Optional, String) Specifies the name of the keypair.
+
+* `public_key` - (Optional, String) Specifies the imported OpenSSH-formatted public key.
+
+* `fingerprint` - (Optional, String) Specifies the fingerprint of the keypair.
+
+* `is_managed` - (Optional, Bool) Specifies whether the private key is managed by HuaweiCloud.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `keypairs` - Indicates a list of all keypairs found. Structure is documented below.
+
+The `keypairs` block contains:
+
+* `name` - Indicates the name of the keypair.
+
+* `scope` - Indicates the scope of key pair. The value can be **account**or **user**.
+
+* `public_key` - Indicates the imported OpenSSH-formatted public key.
+
+* `fingerprint` - Indicates the fingerprint information about an key pair.
+
+* `is_managed` - Indicates whether the private key is managed by HuaweiCloud.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -429,6 +429,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_kms_key":      DataSourceKmsKeyV1(),
 			"huaweicloud_kms_data_key": DataSourceKmsDataKeyV1(),
+			"huaweicloud_kps_keypairs": dew.DataSourceKeypairs(),
 
 			"huaweicloud_lb_loadbalancer": lb.DataSourceELBV2Loadbalancer(),
 			"huaweicloud_lb_certificate":  lb.DataSourceLBCertificateV2(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kps_keypairs_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_kps_keypairs_test.go
@@ -1,0 +1,52 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataKpsKeypairs_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "data.huaweicloud_kps_keypairs.test"
+	publicKey, _, _ := acctest.RandSSHKeyPair("Generated-by-AccTest")
+
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataKpsKeypairs_basic(rName, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "keypairs.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "keypairs.0.public_key", publicKey),
+					resource.TestCheckResourceAttrPair(resourceName, "keypairs.0.scope",
+						"huaweicloud_kps_keypair.test", "scope"),
+					resource.TestCheckResourceAttrPair(resourceName, "keypairs.0.fingerprint",
+						"huaweicloud_kps_keypair.test", "fingerprint"),
+					resource.TestCheckResourceAttrPair(resourceName, "keypairs.0.is_managed",
+						"huaweicloud_kps_keypair.test", "is_managed"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataKpsKeypairs_basic(rName, key string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_kps_keypairs" "test" {
+  name = huaweicloud_kps_keypair.test.name
+
+  depends_on = [huaweicloud_kps_keypair.test]
+}
+`, testKeypair_publicKey(rName, key))
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_kps_keypairs.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_kps_keypairs.go
@@ -1,0 +1,165 @@
+package dew
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceKeypairs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceKeypairsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"public_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"fingerprint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"is_managed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"keypairs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"scope": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"public_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"fingerprint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"is_managed": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKeypairsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	region := c.GetRegion(d)
+	client, err := c.HcKmsV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating KMS v3 client: %s", err)
+	}
+
+	var marker string
+	var allKeypairs []model.Keypair
+	for {
+		response, err := client.ListKeypairs(&model.ListKeypairsRequest{Marker: utils.StringIgnoreEmpty(marker)})
+		if err != nil {
+			return diag.Errorf("error fetching keypair: %s", err)
+		}
+
+		if response.Keypairs != nil {
+			for _, k := range *response.Keypairs {
+				allKeypairs = append(allKeypairs, *k.Keypair)
+			}
+		}
+
+		if response.PageInfo.NextMarker != nil {
+			marker = *response.PageInfo.NextMarker
+		} else {
+			break
+		}
+	}
+
+	filter := map[string]interface{}{
+		"Name":            d.Get("name"),
+		"PublicKey":       d.Get("public_key"),
+		"Fingerprint":     d.Get("fingerprint"),
+		"IsKeyProtection": d.Get("is_managed"),
+	}
+
+	filterKeypairs, err := utils.FilterSliceWithField(allKeypairs, filter)
+	if err != nil {
+		return diag.Errorf("erroring filting keypair list: %s", err)
+	}
+
+	keypairsToSet, ids, err := flattenKaypairs(filterKeypairs)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+
+	mErr := d.Set("keypairs", keypairsToSet)
+	if mErr != nil {
+		return diag.Errorf("set keypairs err:%s", mErr)
+	}
+
+	return nil
+}
+
+func flattenKaypairs(keypairs []interface{}) ([]map[string]interface{}, []string, error) {
+	result := make([]map[string]interface{}, len(keypairs))
+	ids := make([]string, len(keypairs))
+
+	for i, item := range keypairs {
+		val := item.(model.Keypair)
+		keypair := map[string]interface{}{
+			"name":        val.Name,
+			"public_key":  val.PublicKey,
+			"fingerprint": val.Fingerprint,
+			"is_managed":  val.IsKeyProtection,
+		}
+
+		scope, err := parseEncodeValue(val.Scope.MarshalJSON())
+		if err != nil {
+			return nil, nil, fmt.Errorf("can not parse the value of %q from response: %s", "scope", err)
+		}
+		if scope == scopeDomainValue {
+			scope = scopeDomainLabel
+		}
+
+		keypair["scope"] = scope
+
+		result[i] = keypair
+		ids[i] = *val.Name
+	}
+
+	return result, ids, nil
+}

--- a/huaweicloud/utils/filter.go
+++ b/huaweicloud/utils/filter.go
@@ -61,8 +61,13 @@ func filterSliceWithFieldRaw(all interface{}, filter map[string]interface{}, ign
 				return nil, fmt.Errorf("get slice field %s failed: %s", key, err)
 			}
 
-			if actual != val {
-				log.Printf("[DEBUG] can not match slice[%d] field %s: expect %v, but got %v", i, key, val, actual)
+			actualVal := reflect.ValueOf(actual)
+			if actualVal.Kind() == reflect.Ptr {
+				actualVal = actualVal.Elem()
+			}
+
+			if actualVal.Interface() != val {
+				log.Printf("[DEBUG] can not match slice[%d] field %s: expect %v, but got %v", i, key, val, actualVal)
 				matched = false
 				break
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new data source keypairs

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source keypairs
2. improve the common filter in utils package to make it support pointer type
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccDataKpsKeypairs_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataKpsKeypairs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataKpsKeypairs_basic
=== PAUSE TestAccDataKpsKeypairs_basic
=== CONT  TestAccDataKpsKeypairs_basic
--- PASS: TestAccDataKpsKeypairs_basic (12.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       13.004s
```
