### PR TITLE
docs(cce): add note when using kms_key_id

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -4,7 +4,7 @@ subcategory: "Cloud Container Engine (CCE)"
 
 # huaweicloud_cce_node
 
-Add a node to a CCE cluster. This is an alternative to `huaweicloud_cce_node_v3`
+Add a node to a CCE cluster.
 
 ## Basic Usage
 
@@ -232,6 +232,9 @@ The following arguments are supported:
     Changing this parameter will create a new resource.
   + `kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key. This is used to encrypt the volume.
     Changing this parameter will create a new resource.
+
+    -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time
+    ever. The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.
 
 * `storage` - (Optional, List, ForceNew) Specifies the disk initialization management parameter.
   If omitted, disks are managed based on the DockerLVMConfigOverride parameter in extendParam.

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -146,6 +146,9 @@ The `data_volumes` block supports:
 * `kms_key_id` - (Optional, String, ForceNew) Specifies the KMS key ID. This is used to encrypt the volume.
   Changing this parameter will create a new resource.
 
+  -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time ever.
+  The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.
+
 The `taints` block supports:
 
 * `key` - (Required, String) A key must contain 1 to 63 characters starting with a letter or digit. Only letters,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

We need to create an agency (EVSAccessKMS) when disk encryption is used with `kms_key_id` in the current project for the first time ever.
The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
