### PR TITLE
fix(ecs/password): use v1 api to reset the password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d
+	github.com/chnsz/golangsdk v0.0.0-20220820052301-8604be71395a
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter v1.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d h1:kwcXHIQP7ebq/AmYjYr83Ee0Z67/qvrd8wesBhjIinA=
-github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220820052301-8604be71395a h1:Ob4ERabSbEo6P+sPqB4OPJA+E3WIfzeSEUmLfLXcMw0=
+github.com/chnsz/golangsdk v0.0.0-20220820052301-8604be71395a/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -1059,7 +1059,7 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange("admin_pass") {
 		if newPwd, ok := d.Get("admin_pass").(string); ok {
-			err := servers.ChangeAdminPassword(computeClient, d.Id(), newPwd).ExtractErr()
+			err := cloudservers.ChangeAdminPassword(ecsClient, d.Id(), newPwd).ExtractErr()
 			if err != nil {
 				return diag.Errorf("error changing admin password of server (%s): %s", d.Id(), err)
 			}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -374,3 +374,15 @@ func Resize(client *golangsdk.ServiceClient, opts ResizeOptsBuilder, serverId st
 	_, r.Err = client.Post(resizeURL(client, serverId), reqBody, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
 	return
 }
+
+// ChangeAdminPassword alters the administrator or root password for a specified
+// server.
+func ChangeAdminPassword(client *golangsdk.ServiceClient, id, newPassword string) (r PasswordResult) {
+	b := map[string]interface{}{
+		"reset-password": map[string]string{
+			"new_password": newPassword,
+		},
+	}
+	_, r.Err = client.Put(passwordURL(client, id), b, nil, &golangsdk.RequestOpts{OkCodes: []int{204}})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
@@ -11,6 +11,10 @@ type cloudServerResult struct {
 	golangsdk.Result
 }
 
+type PasswordResult struct {
+	golangsdk.ErrResult
+}
+
 type Flavor struct {
 	Disk  string `json:"disk"`
 	Vcpus string `json:"vcpus"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/urls.go
@@ -33,3 +33,7 @@ func orderURL(sc *golangsdk.ServiceClient, orderId string) string {
 func deleteOrderURL(sc *golangsdk.ServiceClient) string {
 	return sc.ServiceURL(sc.DomainID, "common/order-mgr/resources/delete")
 }
+
+func passwordURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL("cloudservers", id, "os-reset-password")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/snapshots/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/snapshots/results.go
@@ -118,5 +118,5 @@ type Link struct {
 type PagedList struct {
 	Count     int        `json:"count"`
 	Snapshots []Snapshot `json:"snapshots"`
-	Links     Link       `json:"snapshots_links"`
+	Links     []Link     `json:"snapshots_links"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220816121712-c2c3003e9e4d
+# github.com/chnsz/golangsdk v0.0.0-20220820052301-8604be71395a
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

the v2 api for resetting password is not available any more, so use v1 api to reset the password

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
use v1 api to reset the password
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (194.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       194.525s
```
