### PR TITLE
feat(rds/flavors): support group type parameter

### DIFF
--- a/docs/data-sources/rds_flavors.md
+++ b/docs/data-sources/rds_flavors.md
@@ -42,6 +42,22 @@ SQLServer| 2008_R2_EE <br>2008_R2_WEB <br>2012_SE <br>2014_SE <br>2016_SE <br>20
 
 * `memory` - (Optional, Int) Specifies the memory size(GB) in the RDS flavor.
 
+* `group_type` - (Optional, String) Specifies the performance specification, the valid values are as follows:
+  + **normal**: General enhanced.
+  + **normal2**: General enhanced type II.
+  + **armFlavors**: KunPeng general enhancement.
+  + **dedicatedNormal**: (dedicatedNormalLocalssd): Dedicated for x86.
+  + **armLocalssd**: KunPeng general type.
+  + **normalLocalssd**: x86 general type.
+  + **general**: General type.
+  + **dedicated**:  
+    For MySQL engine: Dedicated type.  
+    For PostgreSQL and SQL Server engines: Dedicated type, only supported by cloud disk SSD.
+  + **rapid**:  
+    For MySQL engine: Dedicated (discontinued).  
+    For PostgreSQL and SQL Server engines: Dedicated, only supported by ultra-fast SSDs.
+  + **bigmem**: Large memory type.
+
 * `availability_zone` - (Optional, String) Specifies the availability zone which the RDS flavor belongs to.
 
 ## Attributes Reference
@@ -58,6 +74,7 @@ The `flavors` block contains:
 * `name` - The name of the rds flavor.
 * `vcpus` - The CPU size.
 * `memory` - The memory size in GB.
+* `group_type` - The performance specification.
 * `instance_mode` - The mode of instance.
 * `availability_zones` - The availability zones which the RDS flavor belongs to.
 * `db_versions` - The Available versions of the database.

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_flavors.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_flavors.go
@@ -51,6 +51,10 @@ func DataSourceRdsFlavor() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"group_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -74,6 +78,10 @@ func DataSourceRdsFlavor() *schema.Resource {
 						},
 						"memory": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"group_type": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"mode": {
@@ -125,6 +133,7 @@ func dataSourceRdsFlavorRead(_ context.Context, d *schema.ResourceData, meta int
 	mode := d.Get("instance_mode").(string)
 	az := d.Get("availability_zone").(string)
 	version := d.Get("db_version").(string)
+	groupType := d.Get("group_type").(string)
 
 	var vcpus string
 	if v, ok := d.GetOk("vcpus"); ok {
@@ -134,6 +143,7 @@ func dataSourceRdsFlavorRead(_ context.Context, d *schema.ResourceData, meta int
 	filter := map[string]interface{}{
 		"Vcpus":        vcpus,
 		"Instancemode": mode,
+		"GroupType":    groupType,
 	}
 	if mem, ok := d.GetOk("memory"); ok {
 		filter["Ram"] = mem.(int)
@@ -195,6 +205,7 @@ func flattenRdsFlavor(flavor flavors.Flavors, azList, versionList []string) map[
 		"name":               flavor.Speccode,
 		"vcpus":              vcpus,
 		"memory":             flavor.Ram,
+		"group_type":         flavor.GroupType,
 		"instance_mode":      flavor.Instancemode,
 		"mode":               flavor.Instancemode,
 		"availability_zones": azList,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support the new parameter: group_type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run=TestAccRdsFlavorDataSource_groupType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run=TestAccRdsFlavorDataSource_groupType -timeout 360m -parallel 4
=== RUN   TestAccRdsFlavorDataSource_groupType
=== PAUSE TestAccRdsFlavorDataSource_groupType
=== CONT  TestAccRdsFlavorDataSource_groupType
--- PASS: TestAccRdsFlavorDataSource_groupType (41.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       41.929s
```
