### PR TITLE
refactor(vpc/vip): move vip associate to services path

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -756,7 +756,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_secgroup":      ResourceNetworkingSecGroup(),
 			"huaweicloud_networking_secgroup_rule": ResourceNetworkingSecGroupRule(),
 			"huaweicloud_networking_vip":           vpc.ResourceNetworkingVip(),
-			"huaweicloud_networking_vip_associate": resourceNetworkingVIPAssociateV2(),
+			"huaweicloud_networking_vip_associate": vpc.ResourceNetworkingVIPAssociateV2(),
 
 			"huaweicloud_obs_bucket":        ResourceObsBucket(),
 			"huaweicloud_obs_bucket_object": ResourceObsBucketObject(),
@@ -942,7 +942,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_queue_v1":                dli.ResourceDliQueue(),
 			"huaweicloud_cs_route_v1":                 deprecated.ResourceCsRouteV1(),
 			"huaweicloud_networking_vip_v2":           vpc.ResourceNetworkingVip(),
-			"huaweicloud_networking_vip_associate_v2": resourceNetworkingVIPAssociateV2(),
+			"huaweicloud_networking_vip_associate_v2": vpc.ResourceNetworkingVIPAssociateV2(),
 			"huaweicloud_fgs_function_v2":             fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_cdn_domain_v1":               resourceCdnDomainV1(),
 

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package vpc
 
 import (
 	"fmt"
@@ -8,11 +8,12 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 )
 
-func resourceNetworkingVIPAssociateV2() *schema.Resource {
+func ResourceNetworkingVIPAssociateV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNetworkingVIPAssociateV2Create,
 		Update: resourceNetworkingVIPAssociateV2Update,
@@ -122,7 +123,7 @@ func updateNetworkingVIPAssociate(client *golangsdk.ServiceClient, vipID string,
 
 func resourceNetworkingVIPAssociateV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -146,7 +147,7 @@ func resourceNetworkingVIPAssociateV2Create(d *schema.ResourceData, meta interfa
 
 func resourceNetworkingVIPAssociateV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -168,7 +169,7 @@ func resourceNetworkingVIPAssociateV2Update(d *schema.ResourceData, meta interfa
 
 func resourceNetworkingVIPAssociateV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -177,7 +178,7 @@ func resourceNetworkingVIPAssociateV2Read(d *schema.ResourceData, meta interface
 	vipID := d.Get("vip_id").(string)
 	vip, err := ports.Get(networkingClient, vipID).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "vip")
+		return common.CheckDeleted(d, err, "vip")
 	}
 
 	var allPorts []string
@@ -221,7 +222,7 @@ func resourceNetworkingVIPAssociateV2Read(d *schema.ResourceData, meta interface
 
 func resourceNetworkingVIPAssociateV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating networking client: %s", err)
 	}
@@ -230,7 +231,7 @@ func resourceNetworkingVIPAssociateV2Delete(d *schema.ResourceData, meta interfa
 	vipID := d.Get("vip_id").(string)
 	_, err = ports.Get(networkingClient, vipID).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "vip")
+		return common.CheckDeleted(d, err, "vip")
 	}
 
 	// disassociate all allowed address pairs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

move vip associate to services path

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
move vip associate to services path
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkingV2VIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingV2VIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIPAssociate_basic
=== PAUSE TestAccNetworkingV2VIPAssociate_basic
=== CONT  TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (193.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       194.016s
```
