### PR TITLE
feat(lb/pool): add persistence.timeout support

### DIFF
--- a/docs/resources/lb_pool.md
+++ b/docs/resources/lb_pool.md
@@ -61,6 +61,11 @@ The `persistence` argument supports:
 * `cookie_name` - (Optional, String, ForceNew) The name of the cookie if persistence mode is set appropriately. Required
   if `type = APP_COOKIE`.
 
+* `timeout` - (Optional, Int, ForceNew) Specifies the sticky session timeout duration in minutes. This parameter is
+  invalid when type is set to APP_COOKIE. The value range varies depending on the protocol of the backend server group:
+  + When the protocol of the backend server group is TCP or UDP, the value ranges from 1 to 60.
+  + When the protocol of the backend server group is HTTP or HTTPS, the value ranges from 1 to 1440.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/lb/ TESTARGS='-run=TestAccLBV2Pool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run=TestAccLBV2Pool_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (219.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        219.514s
```
