### PR TITLE
feat(eps): add skip_disable_on_destory support

### DIFF
--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -31,6 +31,9 @@ resource "huaweicloud_enterprise_project" "test" {
 
 * `enable` - (Optional, Bool) Specifies whether to enable the enterprise project. Default to *true*.
 
+* `skip_disable_on_destroy` - (Optional, Bool) Specifies whether to skip disable the enterprise project on destroy.
+  Default to *false*.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go
+++ b/huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go
@@ -2,6 +2,7 @@ package eps
 
 import (
 	"context"
+	"log"
 	"regexp"
 	"time"
 
@@ -58,6 +59,10 @@ func ResourceEnterpriseProject() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+			"skip_disable_on_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"status": {
 				Type:     schema.TypeInt,
@@ -181,6 +186,11 @@ func resourceEnterpriseProjectDelete(_ context.Context, d *schema.ResourceData, 
 
 	if err != nil {
 		return fmtp.DiagErrorf("Unable to create HuaweiCloud EPS client : %s", err)
+	}
+
+	if d.Get("skip_disable_on_destroy").(bool) {
+		log.Printf("[DEBUG] Skip disable on destroy for %s", d.Id())
+		return nil
 	}
 
 	actionOpts := enterpriseprojects.ActionOpts{


### PR DESCRIPTION
Adds skip_disable_on_destroy to make it possible for users to
keep eps enable after destroy on terraform side.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/eps/ TESTARGS='-run=TestAccEnterpriseProject_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eps/ -v -run=TestAccEnterpriseProject_basic -timeout 360m -parallel 4
=== RUN   TestAccEnterpriseProject_basic
=== PAUSE TestAccEnterpriseProject_basic
=== CONT  TestAccEnterpriseProject_basic
--- PASS: TestAccEnterpriseProject_basic (60.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       60.523s
```
