### PR TITLE
feat(sfs/turbos): add new data source support

### DIFF
--- a/docs/data-sources/sfs_turbos.md
+++ b/docs/data-sources/sfs_turbos.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Scalable File Service (SFS)"
+---
+
+# huaweicloud_sfs_turbos
+
+Use this data source to get the list of the available SFS turbos.
+
+## Example Usage
+
+```hcl
+variable "sfs_turbo_name" {}
+
+data "huaweicloud_sfs_turbos" "test" {
+  name = var.sfs_turbo_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the SFS turbo file systems.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the SFS turbo file system.
+
+* `size` - (Optional, Int) Specifies the capacity of the SFS turbo file system, in GB.
+  The value ranges from `500` to `32,768`, and must be large than `10,240` for an enhanced file system.
+
+* `share_proto` - (Optional, String) Specifies the protocol of the SFS turbo file system. The valid value is **NFS**.
+
+* `share_type` - (Optional, String) Specifies the type of the SFS turbo file system.
+  The valid values are **STANDARD** and **PERFORMANCE**.
+
+* `enterprise_project_id` - (Optional, String) The enterprise project ID of the SFS turbo file system.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `turbos` - The list of the SFS turbo file systems. The [object](#turbo) structure is documented below.
+
+<a name="turbo"></a>
+The `turbos` block supports:
+
+* `id` - The resource ID of the SFS turbo file system.
+
+* `name` - The name of the SFS turbo file system.
+
+* `size` - The capacity of the SFS turbo file system.
+
+* `share_proto` - The protocol of the SFS turbo file system.
+
+* `share_type` - The type of the SFS turbo file system.
+
+* `enterprise_project_id` - The enterprise project ID of the SFS turbo file system.
+
+* `version` - The version of the SFS turbo file system.
+
+* `enhanced` - Whether the SFS turbo file system is enhanced.
+
+* `availability_zone` - The availability zone where the SFS turbo file system is located.
+
+* `available_capacity` - The available capacity of the SFS turbo file system, in GB.
+
+* `export_location` - The mount point of the SFS turbo file system.
+
+* `crypt_key_id` - The ID of a KMS key to encrypt the SFS turbo file system.
+
+* `vpc_id` - The ID of the VPC to which the SFS turbo belongs.
+
+* `subnet_id` - The **network ID** of the subnet to which the SFS turbo belongs.
+
+* `security_group_id` - The ID of the security group to which the SFS turbo belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -57,6 +57,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/smn"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
@@ -455,7 +456,9 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_sms_source_servers": sms.DataSourceServers(),
 
-			"huaweicloud_sfs_file_system":   DataSourceSFSFileSystemV2(),
+			"huaweicloud_sfs_file_system": DataSourceSFSFileSystemV2(),
+			"huaweicloud_sfs_turbos":      sfs.DataSourceTurbos(),
+
 			"huaweicloud_vbs_backup_policy": dataSourceVBSBackupPolicyV2(),
 			"huaweicloud_vbs_backup":        dataSourceVBSBackupV2(),
 

--- a/huaweicloud/services/acceptance/sfs/data_source_huaweicloud_sfs_turbos_test.go
+++ b/huaweicloud/services/acceptance/sfs/data_source_huaweicloud_sfs_turbos_test.go
@@ -1,0 +1,146 @@
+package sfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTurbosDataSource_basic(t *testing.T) {
+	var (
+		rName         = acceptance.RandomAccResourceNameWithDash()
+		dcByName      = acceptance.InitDataSourceCheck("data.huaweicloud_sfs_turbos.by_name")
+		dcBySize      = acceptance.InitDataSourceCheck("data.huaweicloud_sfs_turbos.by_size")
+		dcByShareType = acceptance.InitDataSourceCheck("data.huaweicloud_sfs_turbos.by_share_type")
+		dcByEpsId     = acceptance.InitDataSourceCheck("data.huaweicloud_sfs_turbos.by_eps_id")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTurbosDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_query_result_validation", "true"),
+					dcBySize.CheckResourceExists(),
+					resource.TestCheckOutput("size_query_result_validation", "true"),
+					dcByShareType.CheckResourceExists(),
+					resource.TestCheckOutput("share_type_query_result_validation", "true"),
+					dcByEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("eps_id_query_result_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTurbosDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+variable "turbo_configuration" {
+  type = list(object({
+    size        = number
+    share_type  = string
+    eps_enabled = bool
+  }))
+
+  default = [
+    {size = 100, share_type = "PERFORMANCE", eps_enabled = false},
+    {size = 200, share_type = "STANDARD", eps_enabled = false},
+    {size = 200, share_type = "PERFORMANCE", eps_enabled = true},
+  ]
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id = huaweicloud_vpc.test.id
+
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  count = length(var.turbo_configuration)
+
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+
+  name                  = "%[1]s-${count.index}"
+  size                  = var.turbo_configuration[count.index]["size"]
+  share_proto           = "NFS"
+  share_type            = var.turbo_configuration[count.index]["share_type"]
+  enterprise_project_id = var.turbo_configuration[count.index]["eps_enabled"] ? "%[2]s" : "0"
+}
+
+data "huaweicloud_sfs_turbos" "by_name" {
+  depends_on = [huaweicloud_sfs_turbo.test]
+
+  name = huaweicloud_sfs_turbo.test[0].name
+}
+
+data "huaweicloud_sfs_turbos" "by_size" {
+  depends_on = [huaweicloud_sfs_turbo.test]
+
+  size = var.turbo_configuration[0]["size"]
+}
+
+data "huaweicloud_sfs_turbos" "by_share_type" {
+  depends_on = [huaweicloud_sfs_turbo.test]
+
+  share_type = var.turbo_configuration[1]["share_type"]
+}
+
+data "huaweicloud_sfs_turbos" "by_eps_id" {
+  depends_on = [huaweicloud_sfs_turbo.test]
+
+  enterprise_project_id = "%[2]s"
+}
+
+output "name_query_result_validation" {
+  value = contains(data.huaweicloud_sfs_turbos.by_name.turbos[*].id,
+  huaweicloud_sfs_turbo.test[0].id) && !contains(data.huaweicloud_sfs_turbos.by_name.turbos[*].id,
+  huaweicloud_sfs_turbo.test[1].id) && !contains(data.huaweicloud_sfs_turbos.by_name.turbos[*].id,
+  huaweicloud_sfs_turbo.test[2].id)
+}
+
+output "size_query_result_validation" {
+  value = contains(data.huaweicloud_sfs_turbos.by_size.turbos[*].id,
+  huaweicloud_sfs_turbo.test[0].id) && !contains(data.huaweicloud_sfs_turbos.by_size.turbos[*].id,
+  huaweicloud_sfs_turbo.test[1].id) && !contains(data.huaweicloud_sfs_turbos.by_size.turbos[*].id,
+  huaweicloud_sfs_turbo.test[2].id)
+}
+
+output "share_type_query_result_validation" {
+  value = contains(data.huaweicloud_sfs_turbos.by_share_type.turbos[*].id,
+  huaweicloud_sfs_turbo.test[1].id) && !contains(data.huaweicloud_sfs_turbos.by_share_type.turbos[*].id,
+  huaweicloud_sfs_turbo.test[0].id) && !contains(data.huaweicloud_sfs_turbos.by_share_type.turbos[*].id,
+  huaweicloud_sfs_turbo.test[2].id)
+}
+
+output "eps_id_query_result_validation" {
+  value = contains(data.huaweicloud_sfs_turbos.by_eps_id.turbos[*].id,
+  huaweicloud_sfs_turbo.test[2].id) && !contains(data.huaweicloud_sfs_turbos.by_eps_id.turbos[*].id,
+  huaweicloud_sfs_turbo.test[0].id) && !contains(data.huaweicloud_sfs_turbos.by_eps_id.turbos[*].id,
+  huaweicloud_sfs_turbo.test[1].id)
+}
+`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/sfs/data_source_huaweicloud_sfs_turbos.go
+++ b/huaweicloud/services/sfs/data_source_huaweicloud_sfs_turbos.go
@@ -1,0 +1,212 @@
+package sfs
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceTurbos() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTurbosRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"share_proto": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"share_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"turbos": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"share_proto": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"share_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enhanced": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"available_capacity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"export_location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"crypt_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func filterTurbosBySize(turbos []interface{}, size int) []interface{} {
+	if len(turbos) < 1 {
+		return nil
+	}
+	result := make([]interface{}, 0, len(turbos))
+	for _, val := range turbos {
+		if turbo, ok := val.(shares.Turbo); ok {
+			re := regexp.MustCompile(fmt.Sprintf(`^%d+(\.\d+)?$`, size))
+			if re.MatchString(turbo.Size) {
+				result = append(result, turbo)
+			}
+		}
+	}
+	return result
+}
+
+func flattenTurbos(turbos []interface{}) ([]map[string]interface{}, []string) {
+	if len(turbos) < 1 {
+		return nil, nil
+	}
+	result := make([]map[string]interface{}, len(turbos))
+	ids := make([]string, len(turbos))
+	for i, val := range turbos {
+		if turbo, ok := val.(shares.Turbo); ok {
+			rm := map[string]interface{}{
+				"id":                    turbo.ID,
+				"name":                  turbo.Name,
+				"share_proto":           turbo.ShareProto,
+				"share_type":            turbo.ShareType,
+				"enterprise_project_id": turbo.EnterpriseProjectId,
+				"version":               turbo.Version,
+				"availability_zone":     turbo.AvailabilityZone,
+				"available_capacity":    turbo.AvailCapacity,
+				"export_location":       turbo.ExportLocation,
+				"crypt_key_id":          turbo.CryptKeyID,
+				"vpc_id":                turbo.VpcID,
+				"subnet_id":             turbo.SubnetID,
+				"security_group_id":     turbo.SecurityGroupID,
+			}
+
+			if turbo.ExpandType == "bandwidth" {
+				rm["enhanced"] = true
+			} else {
+				rm["enhanced"] = false
+			}
+
+			// High-precision to low-precision, discarding digits after the dot (.).
+			floatSize, _ := strconv.ParseFloat(turbo.Size, 64)
+			rm["size"] = int(floatSize)
+
+			result[i] = rm
+			ids[i] = turbo.ID
+		}
+	}
+	return result, ids
+}
+
+func dataSourceTurbosRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	resp, err := shares.List(client)
+	if err != nil {
+		return diag.Errorf("error getting SFS turbo list: %s", err)
+	}
+
+	filter := map[string]interface{}{
+		"Name":                d.Get("name"),
+		"ShareProto":          d.Get("share_proto"),
+		"ShareType":           d.Get("share_type"),
+		"EnterpriseProjectId": d.Get("enterprise_project_id"),
+	}
+
+	result, err := utils.FilterSliceWithField(resp, filter)
+	if err != nil {
+		return diag.Errorf("error filtering SFS turbo list: %s", err)
+	}
+	if size, ok := d.GetOk("size"); ok {
+		result = filterTurbosBySize(result, size.(int))
+	}
+	tflog.Debug(ctx, fmt.Sprintf("the filter result of STS turbo list is: %s", result))
+
+	turbos, ids := flattenTurbos(result)
+	d.SetId(hashcode.Strings(ids))
+	if err := d.Set("turbos", turbos); err != nil {
+		return diag.Errorf("error setting field of SFS turbo list: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The SFS service is missing the turbo data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source support.
2. add related document and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/sfs' TESTARGS='-run=TestAccTurbosDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfs -v -run=TestAccTurbosDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccTurbosDataSource_basic
=== PAUSE TestAccTurbosDataSource_basic
=== CONT  TestAccTurbosDataSource_basic
--- PASS: TestAccTurbosDataSource_basic (425.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfs       425.717s
```
