### PR TITLE
fix(apig/instance): ignore the error if ingress address is not found

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -300,10 +300,11 @@ func setApigIngressAccess(d *schema.ResourceData, config *config.Config, resp in
 		if err != nil {
 			return err
 		}
-		if len(publicIps) == 0 {
-			return fmtp.Errorf("Error getting eip id from server by ip address (%s): %s", publicAddress, err)
+		if len(publicIps) > 0 {
+			return d.Set("eip_id", publicIps[0].ID)
 		}
-		return d.Set("eip_id", publicIps[0].ID)
+		logp.Printf("[WARN] The instance does not synchronize EIP information, got (%s), but not found on the server",
+			publicAddress)
 	}
 	return d.Set("eip_id", nil)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After an EIP is unbound, the APIG instance does not synchronize the IP address about the unbound EIP. So, we need to manually ignore the EIP IP address.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore the error if ingress address is not found.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
PENDING
```
