### PR TITLE
fix(acceptance): ignore delete_eip_on_termination to make test happy

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -217,6 +217,7 @@ func TestAccComputeInstance_powerAction(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"stop_before_destroy",
+					"delete_eip_on_termination",
 					"power_action",
 				},
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstance -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== RUN   TestAccComputeInstancesDataSource_basic
=== PAUSE TestAccComputeInstancesDataSource_basic
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== RUN   TestAccComputeInstance_disks
=== PAUSE TestAccComputeInstance_disks
=== RUN   TestAccComputeInstance_tags
=== PAUSE TestAccComputeInstance_tags
=== RUN   TestAccComputeInstance_powerAction
=== PAUSE TestAccComputeInstance_powerAction
=== CONT  TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstance_powerAction
=== CONT  TestAccComputeInstance_tags
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstanceDataSource_basic (197.18s)
=== CONT  TestAccComputeInstance_disks
--- PASS: TestAccComputeInstance_tags (352.95s)
=== CONT  TestAccComputeInstancesDataSource_basic
--- PASS: TestAccComputeInstance_basic (228.41s)
--- PASS: TestAccComputeInstance_disks (262.40s)
--- PASS: TestAccComputeInstancesDataSource_basic (172.18s)
--- PASS: TestAccComputeInstance_powerAction (570.60s)
PASS
ok    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       570.682s

$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_prePaid (198.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       198.944s
```
