### PR TITLE
feat(ecs/instance): the auto-renew param can be updated

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -289,8 +289,8 @@ The following arguments are supported:
   ranges from 1 to 3. This parameter is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a
   new resource.
 
-* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
-  Valid values are *true* and *false*. Defaults to *false*. Changing this creates a new resource.
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
+  Valid values are *true* and *false*. Defaults to *false*.
 
 * `auto_pay` - (Optional, String, ForceNew) Specifies whether auto pay is enabled.
   Valid values are *true* and *false*. Defaults to *true*. If you set this to *false*, you need to pay the order
@@ -400,7 +400,7 @@ Note that the imported state may not be identical to your resource definition, d
 API response, security or some other reason.
 The missing attributes include: `admin_pass`, `user_data`, `data_disks`, `scheduler_hints`, `stop_before_destroy`,
 `delete_disks_on_termination`, `delete_eip_on_termination`, `network/access_network`, `bandwidth`, `eip_type`,
-`power_action` and arguments for pre-paid.
+`power_action` and arguments for pre-paid (expect for `auto_renew`).
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to
 align with the instance. Also you can ignore changes as below.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0
+	github.com/chnsz/golangsdk v0.0.0-20220831020503-4997d76976f9
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter v1.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0 h1:ca2Lkp9MUxCGZHpmmRhBONU7jutrHggRhJTF2qV75ho=
-github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220831020503-4997d76976f9 h1:giv2oeKKypAg2wYd9uaBGvJFqNoec6DtgpvtYoY9J/E=
+github.com/chnsz/golangsdk v0.0.0-20220831020503-4997d76976f9/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/bss/v2/orders"
+	"github.com/chnsz/golangsdk/openstack/bss/v2/resources"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -196,4 +197,11 @@ func GetAutoPay(d *schema.ResourceData) string {
 		return "false"
 	}
 	return "true"
+}
+
+func UpdateAutoRenew(c *golangsdk.ServiceClient, enabled, resourceId string) error {
+	if enabled == "true" {
+		return resources.EnableAutoRenew(c, resourceId)
+	}
+	return resources.DisableAutoRenew(c, resourceId)
 }

--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -82,6 +82,19 @@ func SchemaAutoRenew(conflicts []string) *schema.Schema {
 	return &resourceSchema
 }
 
+func SchemaNewAutoRenew(conflicts []string) *schema.Schema {
+	resourceSchema := schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"true", "false",
+		}, false),
+		ConflictsWith: conflicts,
+	}
+
+	return &resourceSchema
+}
+
 func SchemaAutoPay(conflicts []string) *schema.Schema {
 	resourceSchema := schema.Schema{
 		Type:     schema.TypeString,

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/bss/v2/resources"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/keypairs"
@@ -350,7 +352,7 @@ func ResourceComputeInstanceV2() *schema.Resource {
 			"charging_mode": schemaChargingMode(novaConflicts),
 			"period_unit":   schemaPeriodUnit(novaConflicts),
 			"period":        schemaPeriod(novaConflicts),
-			"auto_renew":    schemaAutoRenew(novaConflicts),
+			"auto_renew":    common.SchemaNewAutoRenew(novaConflicts),
 			"auto_pay":      schemaAutoPay(novaConflicts),
 
 			"user_id": { // required if in prePaid charging mode with key_pair.
@@ -802,6 +804,10 @@ func resourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return diag.Errorf("error creating image client: %s", err)
 	}
+	bssClient, err := config.BssV2Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("error creating BSS V2 client: %s", err)
+	}
 
 	server, err := cloudservers.Get(ecsClient, d.Id()).Extract()
 	if err != nil {
@@ -951,6 +957,15 @@ func resourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, me
 		}
 	} else {
 		logp.Printf("[WARN] Error fetching tags of compute instance (%s): %s", d.Id(), err)
+	}
+
+	resp, err := resources.Get(bssClient, d.Id(), true)
+	if err != nil {
+		return diag.Errorf("error getting the auto_renew value: %s", err)
+	}
+	err = d.Set("auto_renew", strconv.FormatBool(resp.ExpirePolicy == 3))
+	if err != nil {
+		return diag.Errorf("error setting auto_renew field: %s", err)
 	}
 
 	return nil
@@ -1180,6 +1195,16 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 		action := d.Get("power_action").(string)
 		if err = doPowerAction(ecsClient, d, action); err != nil {
 			return diag.Errorf("Doing power action (%s) for instance (%s) failed: %s", action, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("auto_renew") {
+		bssClient, err := config.BssV2Client(GetRegion(d, config))
+		if err != nil {
+			return diag.Errorf("error creating BSS V2 client: %s", err)
+		}
+		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/huaweicloud/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance_test.go
@@ -103,6 +103,14 @@ func TestAccComputeInstance_prePaid(t *testing.T) {
 					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "delete_eip_on_termination", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_prePaidUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
 				),
 			},
 		},
@@ -424,6 +432,37 @@ resource "huaweicloud_compute_instance" "test" {
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = 1
+  auto_renew    = "true"
+}
+`, testAccCompute_data, rName)
+}
+
+func testAccComputeInstance_prePaidUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = data.huaweicloud_vpc_subnet.test.id
+  }
+
+  eip_type = "5_bgp"
+  bandwidth {
+    share_type  = "PER"
+    size        = 5
+    charge_mode = "bandwidth"
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "false"
 }
 `, testAccCompute_data, rName)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/requests.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/chnsz/golangsdk"
+)
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// List of resource IDs.
+	ResourceIds []string `json:"resource_ids,omitempty"`
+	// Order ID.
+	OrderId string `json:"order_id,omitempty"`
+	// Whether to query only the main resource, this parameter is invalid when the request parameter is the ID of the
+	// sub-resource. If the resource_ids is the ID of the sub-resource, it can only query itself.
+	OnlyMainResource int `json:"only_main_resource,omitempty"`
+	// resource status.
+	StatusList []int `json:"status_list,omitempty"`
+	// Query the list of resources that have expired within the specified time period, the start time of the time
+	// period, and the UTC time.
+	ExpireTimeBegin string `json:"expire_time_begin,omitempty"`
+	// Query the list of resources that have expired within the specified time period, the end time of the time period,
+	// and the UTC time.
+	ExpireTimeEnd string `json:"expire_time_end,omitempty"`
+}
+
+// Get is a method to retrieves a particular resource based on its unique ID.
+func Get(c *golangsdk.ServiceClient, resourceId string, onlyMainRes bool) (*Resource, error) {
+	opts := ListOpts{
+		ResourceIds: []string{resourceId},
+	}
+	if onlyMainRes {
+		opts.OnlyMainResource = 1
+	}
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r QueryResp
+	_, err = c.Post(queryURL(c), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if r.TotalCount < 1 {
+		return nil, fmt.Errorf("unabled to find the resource (%s) from the server.", resourceId)
+	}
+	resList := r.Resources
+	return &resList[0], nil
+}
+
+// EnableAutoRenew is a method to enable the auto-renew of the prepaid resource.
+func EnableAutoRenew(c *golangsdk.ServiceClient, resourceId string) error {
+	_, err := c.Post(autoRenewURL(c, resourceId), nil, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+		OkCodes:     []int{204},
+	})
+	return err
+}
+
+// DisableAutoRenew is a method to disable the auto-renew of the prepaid resource.
+func DisableAutoRenew(c *golangsdk.ServiceClient, resourceId string) error {
+	_, err := c.Delete(autoRenewURL(c, resourceId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+		OkCodes:     []int{204},
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/results.go
@@ -1,0 +1,64 @@
+package resources
+
+// QueryResp is the structure that represents the API response of 'Get' method.
+type QueryResp struct {
+	// Error code.
+	ErrorCode string `json:"error_code"`
+	// Error message.
+	ErrorMsg string `json:"error_msg"`
+	// List of the prepaid resources.
+	Resources []Resource `json:"data"`
+	// The total number of resources queried.
+	TotalCount int `json:"total_count"`
+}
+
+// Resource is the structure that represents the detail of the prepaid resource.
+type Resource struct {
+	// The internal ID of the resource to be activated. The ID generated after the resource is activated is resource_id.
+	ID string `json:"id"`
+	// Resource ID.
+	ResourceId string `json:"resource_id"`
+	// Resource name.
+	ResourceName string `json:"resource_name"`
+	// Cloud service area code, for example: "cn-north-1".
+	Region string `json:"region_code"`
+	// Cloud service type code, for example: the cloud service type code of OBS is "hws.service.type.obs".
+	ServiceTypeCode string `json:"service_type_code"`
+	// Resource type name, for example: the VM of ECS is "hws.resource.type.vm".
+	ServieTypeName string `json:"service_type_name"`
+	// Resource specifications for cloud service. If it is a resource specification of a VM, the specification will
+	// contain ".win" or ".linux", such as "s2.small.1.linux".
+	ResourceTypeCode string `json:"resource_type_code"`
+	// Cloud service type name, for example: the name of the cloud service type of ECS is "弹性云服务器".
+	ResourceTypeName string `json:"resource_type_name"`
+	// Resource type name, for example: the resource type name of ECS is "云主机".
+	ResourceSpecCode string `json:"resource_spec_code"`
+	// Project ID.
+	ProjectId string `json:"project_id"`
+	// Product ID.
+	ProductId string `json:"product_id"`
+	// Parent resource ID.
+	ParentResourceId string `json:"parent_resource_id"`
+	// Whether it is the main resource.
+	// + 0: non-primary resource
+	// + 1: Main resource
+	IsMainResource int `json:"is_main_resource"`
+	// Status code.
+	// + 2: in use
+	// + 3: Closed (the page does not display this state)
+	// + 4: Frozen
+	// + 5: Expired
+	Status int `json:"status"`
+	// Resource effective time.
+	EffectiveTime string `json:"effective_time"`
+	// Resource expire time.
+	ExpireTime string `json:"expire_time"`
+	// Resource expire policy.
+	// + 0: Expires into the grace period
+	// + 1: Expired to on-demand
+	// + 2: Automatic deletion after expiration (direct deletion from effective)
+	// + 3: Automatic renewal after expiration
+	// + 4: Freeze after expiration
+	// + 5: Delete after expiration (delete from retention period)
+	ExpirePolicy int `json:"expire_policy"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/urls.go
@@ -1,0 +1,11 @@
+package resources
+
+import "github.com/chnsz/golangsdk"
+
+func queryURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("orders/suscriptions/resources/query")
+}
+
+func autoRenewURL(c *golangsdk.ServiceClient, resourceId string) string {
+	return c.ServiceURL("orders/subscriptions/resources/autorenew", resourceId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20220826060937-d49168741ce0
+# github.com/chnsz/golangsdk v0.0.0-20220831020503-4997d76976f9
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -44,6 +44,7 @@ github.com/chnsz/golangsdk/openstack/blockstorage/v2/volumes
 github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers
 github.com/chnsz/golangsdk/openstack/bms/v1/flavors
 github.com/chnsz/golangsdk/openstack/bss/v2/orders
+github.com/chnsz/golangsdk/openstack/bss/v2/resources
 github.com/chnsz/golangsdk/openstack/cbr/v3/policies
 github.com/chnsz/golangsdk/openstack/cbr/v3/vaults
 github.com/chnsz/golangsdk/openstack/cce/v1/namespaces


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update the auto-renew parameter behavior: cancel `ForceNew`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the auto-renew param can be updated
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_prePaid (262.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       262.733s
```
