### PR TITLE
feat(obs/bucket): add a new parameter kms_key_project_id

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -203,7 +203,10 @@ The following arguments are supported:
 
 * `encryption` - (Optional, Bool) Whether enable default server-side encryption of the bucket in SSE-KMS mode.
 
-* `kms_key_id` - (Optional, String) Specifies the ID of a kms key. If omitted, the default master key will be used.
+* `kms_key_id` - (Optional, String) Specifies the ID of a KMS key. If omitted, the default master key will be used.
+
+* `kms_key_project_id` - (Optional, String) Specifies the project ID to which the KMS key belongs. If omitted, the ID
+  of the provider-level project will be used.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the OBS bucket. Changing
   this will create a new bucket.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new parameter kms_key_project_id, this will help the console correctly display the selected kms key.
This will not influence current users.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new parameter kms_key_project_id
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccObsBucket_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccObsBucket_encryption -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (41.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       42.020s
```
