### PR TITLE
fix(elb/loadbalancer): fix the wrong networking client usage

### DIFF
--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/ports"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -232,7 +232,7 @@ func resourceLoadBalancerV2Read(_ context.Context, d *schema.ResourceData, meta 
 			return fmtp.DiagErrorf("Error creating HuaweiCloud networking client: %s", err)
 		}
 
-		port, err := ports.Get(networkingClient, lb.VipPortID).Extract()
+		port, err := ports.Get(networkingClient, lb.VipPortID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -362,13 +362,13 @@ func resourceLoadBalancerV2SecurityGroups(networkingClient *golangsdk.ServiceCli
 	if v, ok := d.GetOk("security_group_ids"); ok {
 		securityGroups := resourcePortSecurityGroupsV2(v.(*schema.Set))
 		updateOpts := ports.UpdateOpts{
-			SecurityGroups: &securityGroups,
+			SecurityGroups: securityGroups,
 		}
 
 		logp.Printf("[DEBUG] Adding security groups to loadbalancer "+
 			"VIP Port %s: %#v", vipPortID, updateOpts)
 
-		_, err := ports.Update(networkingClient, vipPortID, updateOpts).Extract()
+		_, err := ports.Update(networkingClient, vipPortID, updateOpts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The sdk version is incorrect, should be v1 with project, but v2 without project.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong networking client usage.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lb' TESTARGS='-run=TestAccDatasourceListeners_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run=TestAccLBV2LoadBalancer_ -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== RUN   TestAccLBV2LoadBalancer_secGroup
=== PAUSE TestAccLBV2LoadBalancer_secGroup
=== RUN   TestAccLBV2LoadBalancer_withEpsId
=== PAUSE TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_withEpsId (69.36s)
--- PASS: TestAccLBV2LoadBalancer_basic (98.66s)
--- PASS: TestAccLBV2LoadBalancer_secGroup (138.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb139.761s
```
