### PR TITLE
feat(SCM): add a datasource to manage SCM certificate

### DIFF
--- a/docs/data-sources/scm_certificates.md
+++ b/docs/data-sources/scm_certificates.md
@@ -1,0 +1,107 @@
+---
+subcategory: "SSL Certificate Manager (SCM)"
+---
+
+# huaweicloud_scm_certificates
+
+Use this data source to get the list of SCM certificates.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_scm_certificates" "test" {
+  status = "ALL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `status` - (Optional, String) Certificate status.  
+The options are as follows:
+  - ALL: All certificate status.
+  - PAID: The certificate has been paid and needs to be applied for from the CA.
+  - ISSUED: The certificate has been issued.
+  - CHECKING: The certificate application is being reviewed.
+  - CANCELCHECKING: The certificate application cancellation is being reviewed.
+  - UNPASSED: The certificate application fails.
+  - EXPIRED: The certificate has expired.
+  - REVOKING: The certificate revocation application is being reviewed.
+  - REVOKED: The certificate has been revoked.
+  - UPLOAD: The certificate is being managed.
+  - CHECKING_ORG: The organization verification is to be completed.
+  - ISSUING: The certificate is to be issued.
+  - SUPPLEMENTCHECKING: Additional domain names to be added for a multi-domain certificate are being reviewed.
+  
+  Default: ALL
+
+* `enterprise_project_id` - (Optional, String) The enterprise project id of the project.
+
+* `deploy_support` - (Optional, Bool) Whether to support deployment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `certificates` - Certificate list. For details, see Data structure of the Certificate field.
+  The [Certificate](#certificate_Certificates) structure is documented below.
+
+<a name="certificate_Certificates"></a>
+The `Certificates` block supports:
+
+* `id` - Certificate ID.
+
+* `name` - Certificate name.
+
+* `domain` - Domain name associated with the certificate.
+
+* `sans` - Additional domain name associated with the certificate.
+
+* `signature_algorithm` - Signature algorithm.
+
+* `deploy_support` - Whether to support deployment.
+
+* `type` - Certificate type. The value can be: **DV_SSL_CERT**, **DV_SSL_CERT_BASIC**, **EV_SSL_CERT**,
+  **EV_SSL_CERT_PRO**, **OV_SSL_CERT**, **OV_SSL_CERT_PRO**.
+
+* `brand` - Certificate authority. The value can be: **GLOBALSIGN**, **SYMANTEC**, **GEOTRUST**, **CFCA**.
+
+* `expire_time` - Certificate expiration time.
+
+* `domain_type` - Domain name type.  
+The options are as follows:
+  - SINGLE_DOMAIN: Single domain names
+  - WILDCARD: Wildcard domain names
+  - MULTI_DOMAIN: Multiple domain names
+
+* `validity_period` - Certificate validity period, in months.
+
+* `status` - Certificate status.  
+The options are as follows:
+  - ALL: All certificate status.
+  - PAID: The certificate has been paid and needs to be applied for from the CA.
+  - ISSUED: The certificate has been issued.
+  - CHECKING: The certificate application is being reviewed.
+  - CANCELCHECKING: The certificate application cancellation is being reviewed.
+  - UNPASSED: The certificate application fails.
+  - EXPIRED: The certificate has expired.
+  - REVOKING: The certificate revocation application is being reviewed.
+  - REVOKED: The certificate has been revoked.
+  - UPLOAD: The certificate is being managed.
+  - CHECKING_ORG: The organization verification is to be completed.
+  - ISSUING: The certificate is to be issued.
+  - SUPPLEMENTCHECKING: Additional domain names to be added for a multi-domain certificate are being reviewed.
+
+* `domain_count` - Number of domain names that can be associated with the certificate.
+
+* `wildcard_count` - Number of wildcard domain names that can be associated with the certificate.
+
+* `description` - Certificate description.
+
+* `enterprise_project_id` - The enterprise project id of the project.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -463,6 +463,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_sms_source_servers": sms.DataSourceServers(),
 
+			"huaweicloud_scm_certificates": scm.DataSourceCertificates(),
+
 			"huaweicloud_sfs_file_system": DataSourceSFSFileSystemV2(),
 			"huaweicloud_sfs_turbos":      sfs.DataSourceTurbos(),
 

--- a/huaweicloud/services/acceptance/scm/data_source_huaweicloud_scm_certificates_test.go
+++ b/huaweicloud/services/acceptance/scm/data_source_huaweicloud_scm_certificates_test.go
@@ -1,0 +1,42 @@
+package scm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCertificates_basic(t *testing.T) {
+	rName := "data.huaweicloud_scm_certificates.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCertificates_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.domain"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.expire_time"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.domain_count"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.wildcard_count"),
+					resource.TestCheckResourceAttrSet(rName, "certificates.0.enterprise_project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCertificates_basic() string {
+	return `
+data "huaweicloud_scm_certificates" "test" {
+}
+`
+}

--- a/huaweicloud/services/scm/data_source_huaweicloud_scm_certificates.go
+++ b/huaweicloud/services/scm/data_source_huaweicloud_scm_certificates.go
@@ -1,0 +1,251 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product SCM
+// ---------------------------------------------------------------
+
+package scm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceCertificates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceCertificatesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Certificate status.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALL", "PAID", "ISSUED", "CHECKING", "CANCELCHECKING", "UNPASSED", "EXPIRED", "REVOKING", "REVOKED",
+					"UPLOAD", "CHECKING_ORG", "ISSUING", "SUPPLEMENTCHECKING",
+				}, false),
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The enterprise project id of the project.`,
+			},
+			"deploy_support": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to support deployment.`,
+			},
+			"certificates": {
+				Type:        schema.TypeList,
+				Elem:        certificateCertificatesSchema(),
+				Computed:    true,
+				Description: `Certificate list. For details, see Data structure of the Certificate field.`,
+			},
+		},
+	}
+}
+
+func certificateCertificatesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate name.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Domain name associated with the certificate.`,
+			},
+			"sans": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Additional domain name associated with the certificate.`,
+			},
+			"signature_algorithm": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Signature algorithm.`,
+			},
+			"deploy_support": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to support deployment.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate type. The value can be: **DV_SSL_CERT**, **DV_SSL_CERT_BASIC**, **EV_SSL_CERT**, **EV_SSL_CERT_PRO**, **OV_SSL_CERT**, **OV_SSL_CERT_PRO**.`,
+			},
+			"brand": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate authority. The value can be: **GLOBALSIGN**, **SYMANTEC**, **GEOTRUST**, **CFCA**.`,
+			},
+			"expire_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate expiration time.`,
+			},
+			"domain_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Domain name type.`,
+			},
+			"validity_period": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Certificate validity period, in months.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate status.`,
+			},
+			"domain_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Number of domain names that can be associated with the certificate.`,
+			},
+			"wildcard_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Number of wildcard domain names that can be associated with the certificate.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Certificate description.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise project id of the project.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceCertificatesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// listCertificates: Query the List of SCM certificates.
+	var (
+		listCertificatesHttpUrl = "v3/scm/certificates"
+		listCertificatesProduct = "scm"
+	)
+	listCertificatesClient, err := config.NewServiceClient(listCertificatesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Certificate Client: %s", err)
+	}
+
+	listCertificatesPath := listCertificatesClient.Endpoint + listCertificatesHttpUrl
+
+	listCertificatesqueryParams := buildListCertificatesQueryParams(d)
+	listCertificatesPath = listCertificatesPath + listCertificatesqueryParams
+
+	listCertificatesResp, err := pagination.ListAllItems(
+		listCertificatesClient,
+		"offset",
+		listCertificatesPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Certificate")
+	}
+
+	listCertificatesRespJson, err := json.Marshal(listCertificatesResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listCertificatesRespBody interface{}
+	err = json.Unmarshal(listCertificatesRespJson, &listCertificatesRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("certificates", flattenListCertificatesBodyCertificates(listCertificatesRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListCertificatesBodyCertificates(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("certificates", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"name":                  utils.PathSearch("name", v, nil),
+			"domain":                utils.PathSearch("domain", v, nil),
+			"sans":                  utils.PathSearch("sans", v, nil),
+			"signature_algorithm":   utils.PathSearch("signature_algorithm", v, nil),
+			"deploy_support":        utils.PathSearch("deploy_support", v, nil),
+			"type":                  utils.PathSearch("type", v, nil),
+			"brand":                 utils.PathSearch("brand", v, nil),
+			"expire_time":           utils.PathSearch("expire_time", v, nil),
+			"domain_type":           utils.PathSearch("domain_type", v, nil),
+			"validity_period":       utils.PathSearch("validity_period", v, nil),
+			"status":                utils.PathSearch("status", v, nil),
+			"domain_count":          utils.PathSearch("domain_count", v, nil),
+			"wildcard_count":        utils.PathSearch("wildcard_count", v, nil),
+			"description":           utils.PathSearch("description", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildListCertificatesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("deploy_support"); ok {
+		res = fmt.Sprintf("%s&deploy_support=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a datasource to manage SCM certificate

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/scm' TESTARGS='-run=TestAccDatasourceCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/scm -v -run=TestAccDatasourceCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCertificate_basic
=== PAUSE TestAccDatasourceCertificate_basic
=== CONT  TestAccDatasourceCertificate_basic
--- PASS: TestAccDatasourceCertificate_basic (16.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/scm       16.702s
```
