### PR TITLE
fix(eip/prepaid): fix parsing error when updating

### DIFF
--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -137,10 +137,12 @@ func TestAccVpcEIP_WithEpsId(t *testing.T) {
 }
 
 func TestAccVpcEIP_prePaid(t *testing.T) {
-	var eip eips.PublicIp
-
-	randName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_vpc_eip.test"
+	var (
+		eip          eips.PublicIp
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		udpateName   = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_vpc_eip.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -157,7 +159,7 @@ func TestAccVpcEIP_prePaid(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcEip_prePaid(randName),
+				Config: testAccVpcEip_prePaid(randName, 5),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
@@ -165,6 +167,49 @@ func TestAccVpcEIP_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", randName),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
 					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "address"),
+				),
+			},
+			{
+				Config: testAccVpcEip_prePaid(udpateName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
+					resource.TestCheckResourceAttr(resourceName, "publicip.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", udpateName),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "address"),
+				),
+			},
+			{
+				Config: testAccVpcEip_prePaid(udpateName, 6),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
+					resource.TestCheckResourceAttr(resourceName, "publicip.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", udpateName),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "6"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "address"),
+				),
+			},
+			{
+				Config: testAccVpcEip_prePaid(randName, 7),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
+					resource.TestCheckResourceAttr(resourceName, "publicip.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", randName),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "7"),
 					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "address"),
 				),
@@ -321,7 +366,7 @@ resource "huaweicloud_vpc_eip" "test" {
 `, rName)
 }
 
-func testAccVpcEip_prePaid(rName string) string {
+func testAccVpcEip_prePaid(rName string, size int) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc_eip" "test" {
   charging_mode = "prePaid"
@@ -333,11 +378,11 @@ resource "huaweicloud_vpc_eip" "test" {
   }
   bandwidth {
     share_type  = "PER"
-    name        = "%s"
-    size        = 5
+    name        = "%[1]s"
+    size        = %[2]d
   }
 }
-`, rName)
+`, rName, size)
 }
 
 func testAccVpcEip_ipv6(rName string) string {

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -407,15 +407,13 @@ func resourceVpcEIPV1Update(d *schema.ResourceData, meta interface{}) error {
 				return fmtp.Errorf("error updating bandwidth: %s", err)
 			}
 
-			// wait for order success
 			orderData, ok := order.(bandwidthsv2.PrePaid)
-			if !ok {
-				return fmtp.Errorf("error extracting order data")
-			}
-			if orderData.OrderID != "" {
+			if ok {
+				logp.Printf("[DEBUG] The orderData is: %#v", orderData)
+				// wait for order success
 				bssClient, err := config.BssV2Client(config.GetRegion(d))
 				if err != nil {
-					return fmtp.Errorf("error creating bss v2 client: %s", err)
+					return fmtp.Errorf("error creating BSS v2 client: %s", err)
 				}
 				if err := orders.WaitForOrderSuccess(bssClient, int(d.Timeout(schema.TimeoutCreate)/time.Second), orderData.OrderID); err != nil {
 					return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Problem description: When calling the update prepaid EIP API, the response body returned by only updating the name and updating the name and size at the same time is inconsistent:
https://support.huaweicloud.com/api-eip/eip_apisharedbandwidth_0006.html
Update only name:
```
{
  "bandwidth": {
    "bandwidth_type": "bgp",
    "billing_info": "CS2209071448IAB2X:00301-162388-0--0:cn-north-4:0970dd7a1300f5672ff2c003c60ae115",
    "charge_mode": "bandwidth",
    "created_at": "2022-09-07T06:48:58Z",
    "enterprise_project_id": "0",
    "id": "3fb23b40-846f-4110-909c-f827beb90515",
    "name": "script-modules-eip-update-update",
    "public_border_group": "center",
    "publicip_info": [
      {
        "ip_version": 4,
        "publicip_address": "124.70.1.121",
        "publicip_id": "246e5ba2-676c-4c86-aa56-5529312b92e8",
        "publicip_type": "5_bgp"
      }
    ],
    "share_type": "PER",
    "size": 5,
    "status": "NORMAL",
    "tenant_id": "0970dd7a1300f5672ff2c003c60ae115",
    "updated_at": "2022-09-07T06:51:29Z"
  }
}
```

Update name and size at the same time:
```
{
  "order_id": "CS2209071029J1JSB"
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix parsing error when updating
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run=TestAccVpcEIP_prePaid'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run=TestAccVpcEIP_prePaid -timeout 360m -parallel 4
=== RUN   TestAccVpcEIP_prePaid
=== PAUSE TestAccVpcEIP_prePaid
=== CONT  TestAccVpcEIP_prePaid
--- PASS: TestAccVpcEIP_prePaid (327.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       327.963s
```
