### PR TITLE
refactor(obs): move resources and data sources to services dir

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -451,7 +451,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_notebook_images":  modelarts.DataSourceNotebookImages(),
 
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
-			"huaweicloud_obs_bucket_object": DataSourceObsBucketObject(),
+			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
 			"huaweicloud_rds_flavors":         rds.DataSourceRdsFlavor(),
 			"huaweicloud_rds_engine_versions": rds.DataSourceRdsEngineVersionsV3(),
@@ -779,9 +779,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_vip":           vpc.ResourceNetworkingVip(),
 			"huaweicloud_networking_vip_associate": vpc.ResourceNetworkingVIPAssociateV2(),
 
-			"huaweicloud_obs_bucket":        ResourceObsBucket(),
-			"huaweicloud_obs_bucket_object": ResourceObsBucketObject(),
-			"huaweicloud_obs_bucket_policy": ResourceObsBucketPolicy(),
+			"huaweicloud_obs_bucket":        obs.ResourceObsBucket(),
+			"huaweicloud_obs_bucket_object": obs.ResourceObsBucketObject(),
+			"huaweicloud_obs_bucket_policy": obs.ResourceObsBucketPolicy(),
 
 			"huaweicloud_oms_migration_task": oms.ResourceMigrationTask(),
 

--- a/huaweicloud/resource_huaweicloud_cci_pvc_test.go
+++ b/huaweicloud/resource_huaweicloud_cci_pvc_test.go
@@ -50,7 +50,6 @@ func TestAccCCIPersistentVolumeClaims_basic(t *testing.T) {
 
 func TestAccCCIPersistentVolumeClaims_obs(t *testing.T) {
 	var pvc persistentvolumeclaims.ListResp
-	rInt := acctest.RandInt()
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_cci_pvc.test"
 	volumeType := "obs"
@@ -65,7 +64,7 @@ func TestAccCCIPersistentVolumeClaims_obs(t *testing.T) {
 		CheckDestroy: testAccCheckCCIPersistentVolumeClaimsDestroy(volumeType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCIPersistentVolumeClaims_obs(rName, volumeType, rInt),
+				Config: testAccCCIPersistentVolumeClaims_obs(rName, volumeType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCIPersistentVolumeClaimsExists(resourceName, volumeType, &pvc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -235,9 +234,14 @@ resource "huaweicloud_cci_pvc" "test" {
 `, rName, HW_ENTERPRISE_PROJECT_ID_TEST, rName, HW_CCI_NAMESPACE, volumeType)
 }
 
-func testAccCCIPersistentVolumeClaims_obs(rName, volumeType string, suffix int) string {
+func testAccCCIPersistentVolumeClaims_obs(rName, volumeType string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket                = "%s"
+  storage_class         = "STANDARD"
+  acl                   = "private"
+  enterprise_project_id = "%s"
+}
 
 resource "huaweicloud_cci_pvc" "test" {
   name        = "%s"
@@ -245,7 +249,7 @@ resource "huaweicloud_cci_pvc" "test" {
   volume_type = "%s"
   volume_id   = huaweicloud_obs_bucket.bucket.id
 }
-`, testAccObsBucket_epsId(suffix), rName, HW_CCI_NAMESPACE, volumeType)
+`, rName, HW_ENTERPRISE_PROJECT_ID_TEST, rName, HW_CCI_NAMESPACE, volumeType)
 }
 
 func testAccCCIPersistentVolumeClaims_nfs(rName, volumeType string) string {

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -25,8 +25,7 @@ func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckOBS(t)
 		},
-		ProviderFactories:         acceptance.TestAccProviderFactories,
-		PreventPostDestroyRefresh: true,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConf,
@@ -37,7 +36,7 @@ func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 			{
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsObsObjectDataSourceExists(dataSourceName),
+					testAccCheckObsObjectDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "content_type", "binary/octet-stream"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 				),
@@ -54,17 +53,16 @@ func TestAccObsBucketObjectDataSource_source(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	rInt := acctest.RandInt()
-
 	// write test data to the tempfile
 	for i := 0; i < 1024; i++ {
-		_, err := tmpFile.WriteString("test obs object file storage")
+		_, err := tmpFile.WriteString("test obs object file storage\n")
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 	tmpFile.Close()
 
+	rInt := acctest.RandInt()
 	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_source(rInt, tmpFile.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -72,8 +70,7 @@ func TestAccObsBucketObjectDataSource_source(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckOBS(t)
 		},
-		ProviderFactories:         acceptance.TestAccProviderFactories,
-		PreventPostDestroyRefresh: true,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConf,
@@ -84,7 +81,7 @@ func TestAccObsBucketObjectDataSource_source(t *testing.T) {
 			{
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsObsObjectDataSourceExists(dataSourceName),
+					testAccCheckObsObjectDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "content_type", "binary/octet-stream"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 				),
@@ -103,8 +100,7 @@ func TestAccObsBucketObjectDataSource_allParams(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckOBS(t)
 		},
-		ProviderFactories:         acceptance.TestAccProviderFactories,
-		PreventPostDestroyRefresh: true,
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConf,
@@ -115,7 +111,7 @@ func TestAccObsBucketObjectDataSource_allParams(t *testing.T) {
 			{
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsObsObjectDataSourceExists(dataSourceName),
+					testAccCheckObsObjectDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "content_type", "application/unknown"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 				),
@@ -124,7 +120,7 @@ func TestAccObsBucketObjectDataSource_allParams(t *testing.T) {
 	})
 }
 
-func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
+func testAccCheckObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -6,12 +6,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -129,11 +128,11 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find Obs object data source: %s", n)
+			return fmt.Errorf("can't find OBS object data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("Obs object data source ID not set")
+			return fmt.Errorf("OBS object data source ID not set")
 		}
 
 		bucket := rs.Primary.Attributes["bucket"]
@@ -142,7 +141,7 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 		conf := acceptance.TestAccProvider.Meta().(*config.Config)
 		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+			return fmt.Errorf("Error creating OBS client: %s", err)
 		}
 
 		respList, err := obsClient.ListObjects(&obs.ListObjectsInput{
@@ -152,7 +151,7 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 			},
 		})
 		if err != nil {
-			return fmtp.Errorf("Error listing objects of OBS bucket", bucket, err)
+			return fmt.Errorf("Error listing objects of OBS bucket %s: %s", bucket, err)
 		}
 
 		var exist bool
@@ -163,7 +162,7 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 			}
 		}
 		if !exist {
-			return fmtp.Errorf("object %s not found in bucket %s", key, bucket)
+			return fmt.Errorf("object %s not found in bucket %s", key, bucket)
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"fmt"
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccObsBucketObjectDataSource_content(t *testing.T) {
@@ -21,8 +22,11 @@ func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_content(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckOBS(t) },
-		Providers:                 testAccProviders,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories:         acceptance.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
@@ -65,8 +69,11 @@ func TestAccObsBucketObjectDataSource_source(t *testing.T) {
 	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_source(rInt, tmpFile.Name())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckOBS(t) },
-		Providers:                 testAccProviders,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories:         acceptance.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
@@ -93,8 +100,11 @@ func TestAccObsBucketObjectDataSource_allParams(t *testing.T) {
 	resourceConf, dataSourceConf := testAccObsBucketObjectDataSource_allParams(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckOBS(t) },
-		Providers:                 testAccProviders,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories:         acceptance.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
@@ -129,8 +139,8 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 		bucket := rs.Primary.Attributes["bucket"]
 		key := rs.Primary.Attributes["key"]
 
-		config := testAccProvider.Meta().(*config.Config)
-		obsClient, err := config.ObjectStorageClient(HW_REGION_NAME)
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 		}
@@ -142,7 +152,7 @@ func testAccCheckAwsObsObjectDataSourceExists(n string) resource.TestCheckFunc {
 			},
 		})
 		if err != nil {
-			return getObsError("Error listing objects of OBS bucket", bucket, err)
+			return fmtp.Errorf("Error listing objects of OBS bucket", bucket, err)
 		}
 
 		var exist bool

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -16,14 +16,15 @@ import (
 )
 
 func TestAccObsBucketObject_source(t *testing.T) {
+	rInt := acctest.RandInt()
 	resourceName := "huaweicloud_obs_bucket_object.object"
+
 	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(tmpFile.Name())
 
-	rInt := acctest.RandInt()
 	// write some data to the tempfile
 	err = ioutil.WriteFile(tmpFile.Name(), []byte("initial object state"), 0644)
 	if err != nil {

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"fmt"
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccObsBucketObject_source(t *testing.T) {
@@ -31,9 +32,12 @@ func TestAccObsBucketObject_source(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketObjectDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketObjectConfigSource(rInt, tmpFile.Name()),
@@ -69,9 +73,12 @@ func TestAccObsBucketObject_content(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket_object.object"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketObjectDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {},
@@ -87,8 +94,8 @@ func TestAccObsBucketObject_content(t *testing.T) {
 }
 
 func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	obsClient, err := config.ObjectStorageClient(HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}
@@ -138,8 +145,8 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 			return fmtp.Errorf("No OBS Bucket Object ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		obsClient, err := config.ObjectStorageClient(HW_REGION_NAME)
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 		}
@@ -152,7 +159,7 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 
 		resp, err := obsClient.ListObjects(input)
 		if err != nil {
-			return getObsError("Error listing objects of OBS bucket", bucket, err)
+			return fmtp.Errorf("Error listing objects of OBS bucket", bucket, err)
 		}
 
 		var exist bool

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -6,12 +6,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -97,7 +96,7 @@ func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 	conf := acceptance.TestAccProvider.Meta().(*config.Config)
 	obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -116,7 +115,7 @@ func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 			if obsError, ok := err.(obs.ObsError); ok && obsError.Code == "NoSuchBucket" {
 				return nil
 			}
-			return fmtp.Errorf("Error listing objects of OBS bucket %s: %s", bucket, err)
+			return fmt.Errorf("Error listing objects of OBS bucket %s: %s", bucket, err)
 		}
 
 		var exist bool
@@ -127,7 +126,7 @@ func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 			}
 		}
 		if exist {
-			return fmtp.Errorf("Resource %s still exists in bucket %s", rs.Primary.ID, bucket)
+			return fmt.Errorf("Resource %s still exists in bucket %s", rs.Primary.ID, bucket)
 		}
 	}
 
@@ -138,17 +137,17 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not Found: %s", n)
+			return fmt.Errorf("Not Found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No OBS Bucket Object ID is set")
+			return fmt.Errorf("No OBS Bucket Object ID is set")
 		}
 
 		conf := acceptance.TestAccProvider.Meta().(*config.Config)
 		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+			return fmt.Errorf("Error creating OBS client: %s", err)
 		}
 
 		bucket := rs.Primary.Attributes["bucket"]
@@ -159,7 +158,7 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 
 		resp, err := obsClient.ListObjects(input)
 		if err != nil {
-			return fmtp.Errorf("Error listing objects of OBS bucket", bucket, err)
+			return fmt.Errorf("Error listing objects of OBS bucket %s: %s", bucket, err)
 		}
 
 		var exist bool
@@ -170,7 +169,7 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 			}
 		}
 		if !exist {
-			return fmtp.Errorf("Resource %s not found in bucket %s", rs.Primary.ID, bucket)
+			return fmt.Errorf("Resource %s not found in bucket %s", rs.Primary.ID, bucket)
 		}
 
 		return nil
@@ -181,14 +180,14 @@ func testAccObsBucketObjecImportStateIdFunc() resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		bucket, ok := s.RootModule().Resources["huaweicloud_obs_bucket.object_bucket"]
 		if !ok {
-			return "", fmtp.Errorf("Bucket not found: %s", bucket)
+			return "", fmt.Errorf("Bucket not found: %s", bucket)
 		}
 		object, ok := s.RootModule().Resources["huaweicloud_obs_bucket_object.object"]
 		if !ok {
-			return "", fmtp.Errorf("Object not found: %s", object)
+			return "", fmt.Errorf("Object not found: %s", object)
 		}
 		if bucket.Primary.ID == "" || object.Primary.ID == "" {
-			return "", fmtp.Errorf("resource not found: %s/%s", bucket.Primary.ID, object.Primary.ID)
+			return "", fmt.Errorf("resource not found: %s/%s", bucket.Primary.ID, object.Primary.ID)
 		}
 		return fmt.Sprintf("%s/%s", bucket.Primary.ID, object.Primary.ID), nil
 	}

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_policy_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_policy_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"fmt"
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
@@ -22,9 +23,12 @@ func TestAccObsBucketPolicy_basic(t *testing.T) {
 		name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketPolicyConfig(name),
@@ -57,9 +61,12 @@ func TestAccObsBucketPolicy_update(t *testing.T) {
 		name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketPolicyConfig(name),
@@ -91,9 +98,12 @@ func TestAccObsBucketPolicy_s3(t *testing.T) {
 		name, name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketPolicyS3Foramt(name),
@@ -127,12 +137,12 @@ func testAccCheckObsBucketHasPolicy(n string, expectedPolicyText string) resourc
 		var err error
 		var obsClient *obs.ObsClient
 
-		config := testAccProvider.Meta().(*config.Config)
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
 		format := rs.Primary.Attributes["policy_format"]
 		if format == "obs" {
-			obsClient, err = config.ObjectStorageClientWithSignature(HW_REGION_NAME)
+			obsClient, err = conf.ObjectStorageClientWithSignature(acceptance.HW_REGION_NAME)
 		} else {
-			obsClient, err = config.ObjectStorageClient(HW_REGION_NAME)
+			obsClient, err = conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		}
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_policy_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_policy_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccObsBucketPolicy_basic(t *testing.T) {
@@ -127,11 +127,11 @@ func testAccCheckObsBucketHasPolicy(n string, expectedPolicyText string) resourc
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No OBS Bucket ID is set")
+			return fmt.Errorf("No OBS Bucket ID is set")
 		}
 
 		var err error
@@ -145,17 +145,17 @@ func testAccCheckObsBucketHasPolicy(n string, expectedPolicyText string) resourc
 			obsClient, err = conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		}
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+			return fmt.Errorf("Error creating OBS client: %s", err)
 		}
 
 		policy, err := obsClient.GetBucketPolicy(rs.Primary.ID)
 		if err != nil {
-			return fmtp.Errorf("GetBucketPolicy error: %v", err)
+			return fmt.Errorf("GetBucketPolicy error: %v", err)
 		}
 
 		actualPolicyText := policy.Policy
 		if actualPolicyText != expectedPolicyText {
-			return fmtp.Errorf("non-equivalent policy error:\n\nexpected: %s\n\n     got: %s",
+			return fmt.Errorf("non-equivalent policy error:\n\nexpected: %s\n\n     got: %s",
 				expectedPolicyText, actualPolicyText)
 		}
 
@@ -167,7 +167,7 @@ func testAccOBSPolicyImportStateIDFunc() resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		policyRes, ok := s.RootModule().Resources["huaweicloud_obs_bucket_policy.s3_policy"]
 		if !ok {
-			return "", fmtp.Errorf("huaweicloud_obs_bucket_policy resource not found")
+			return "", fmt.Errorf("resource not found")
 		}
 
 		return fmt.Sprintf("%s/s3", policyRes.Primary.ID), nil

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
@@ -16,9 +17,12 @@ func TestAccObsBucket_basic(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucket_basic(rInt),
@@ -31,7 +35,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "multi_az", "false"),
 					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "false"),
 					resource.TestCheckResourceAttr(resourceName, "encryption", "false"),
-					resource.TestCheckResourceAttr(resourceName, "region", HW_REGION_NAME),
+					resource.TestCheckResourceAttr(resourceName, "region", acceptance.HW_REGION_NAME),
 					resource.TestCheckResourceAttr(resourceName, "bucket_version", "3.0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
@@ -65,9 +69,13 @@ func TestAccObsBucket_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucket_epsId(rInt),
@@ -76,7 +84,7 @@ func TestAccObsBucket_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "bucket", testAccObsBucketName(rInt)),
 					resource.TestCheckResourceAttr(
-						resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+						resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -88,9 +96,12 @@ func TestAccObsBucket_multiAZ(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigMultiAZ(rInt),
@@ -113,9 +124,12 @@ func TestAccObsBucket_parallelFS(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigParallelFS(rInt),
@@ -140,9 +154,12 @@ func TestAccObsBucket_encryption(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucket_basic(rInt),
@@ -172,9 +189,12 @@ func TestAccObsBucket_versioning(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigWithVersioning(rInt),
@@ -202,9 +222,12 @@ func TestAccObsBucket_logging(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigWithLogging(rInt),
@@ -222,9 +245,12 @@ func TestAccObsBucket_quota(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigWithQuota(rInt),
@@ -243,9 +269,12 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigWithLifecycle(rInt),
@@ -282,9 +311,12 @@ func TestAccObsBucket_website(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketWebsiteConfigWithRoutingRules(rInt),
@@ -305,9 +337,12 @@ func TestAccObsBucket_cors(t *testing.T) {
 	resourceName := "huaweicloud_obs_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckOBS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccObsBucketConfigWithCORS(rInt),
@@ -330,8 +365,8 @@ func TestAccObsBucket_cors(t *testing.T) {
 }
 
 func testAccCheckObsBucketDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	obsClient, err := config.ObjectStorageClient(HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}
@@ -360,8 +395,8 @@ func testAccCheckObsBucketExists(n string) resource.TestCheckFunc {
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		obsClient, err := config.ObjectStorageClient(HW_REGION_NAME)
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 		}
@@ -381,8 +416,8 @@ func testAccCheckObsBucketLogging(name, target, prefix string) resource.TestChec
 			return fmtp.Errorf("Not found: %s", name)
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		obsClient, err := config.ObjectStorageClient(HW_REGION_NAME)
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 		}
@@ -411,7 +446,7 @@ func testAccObsBucketName(randInt int) string {
 }
 
 func testAccObsBucketDomainName(randInt int) string {
-	return fmt.Sprintf("tf-test-bucket-%d.obs.%s.myhuaweicloud.com", randInt, HW_REGION_NAME)
+	return fmt.Sprintf("tf-test-bucket-%d.obs.%s.myhuaweicloud.com", randInt, acceptance.HW_REGION_NAME)
 }
 
 func testAccObsBucket_basic(randInt int) string {
@@ -474,7 +509,7 @@ resource "huaweicloud_obs_bucket" "bucket" {
   acl                   = "private"
   enterprise_project_id = "%s"
 }
-`, randInt, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, randInt, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccObsBucketConfigMultiAZ(randInt int) string {

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccObsBucket_basic(t *testing.T) {
@@ -368,7 +368,7 @@ func testAccCheckObsBucketDestroy(s *terraform.State) error {
 	conf := acceptance.TestAccProvider.Meta().(*config.Config)
 	obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -378,7 +378,7 @@ func testAccCheckObsBucketDestroy(s *terraform.State) error {
 
 		_, err := obsClient.HeadBucket(rs.Primary.ID)
 		if err == nil {
-			return fmtp.Errorf("HuaweiCloud OBS Bucket %s still exists", rs.Primary.ID)
+			return fmt.Errorf("OBS Bucket %s still exists", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -388,22 +388,22 @@ func testAccCheckObsBucketExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("No ID is set")
 		}
 
 		conf := acceptance.TestAccProvider.Meta().(*config.Config)
 		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+			return fmt.Errorf("Error creating OBS client: %s", err)
 		}
 
 		_, err = obsClient.HeadBucket(rs.Primary.ID)
 		if err != nil {
-			return fmtp.Errorf("HuaweiCloud OBS Bucket not found: %v", err)
+			return fmt.Errorf("OBS Bucket not found: %v", err)
 		}
 		return nil
 	}
@@ -413,26 +413,26 @@ func testAccCheckObsBucketLogging(name, target, prefix string) resource.TestChec
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", name)
 		}
 
 		conf := acceptance.TestAccProvider.Meta().(*config.Config)
 		obsClient, err := conf.ObjectStorageClient(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+			return fmt.Errorf("Error creating OBS client: %s", err)
 		}
 
 		output, err := obsClient.GetBucketLoggingConfiguration(rs.Primary.ID)
 		if err != nil {
-			return fmtp.Errorf("Error getting logging configuration of OBS bucket: %s", err)
+			return fmt.Errorf("Error getting logging configuration of OBS bucket: %s", err)
 		}
 
 		if output.TargetBucket != target {
-			return fmtp.Errorf("%s.logging: Attribute 'target_bucket' expected %s, got %s",
+			return fmt.Errorf("%s.logging: Attribute 'target_bucket' expected %s, got %s",
 				name, output.TargetBucket, target)
 		}
 		if output.TargetPrefix != prefix {
-			return fmtp.Errorf("%s.logging: Attribute 'target_prefix' expected %s, got %s",
+			return fmt.Errorf("%s.logging: Attribute 'target_prefix' expected %s, got %s",
 				name, output.TargetPrefix, prefix)
 		}
 

--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
@@ -1,13 +1,13 @@
 package obs
 
 import (
+	"fmt"
+	"log"
 	"strings"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/obs"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -65,7 +65,7 @@ func dataSourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) err
 	conf := meta.(*config.Config)
 	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -91,10 +91,10 @@ func dataSourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 	if !exist {
-		return fmtp.Errorf("object %s not found in bucket %s", key, bucket)
+		return fmt.Errorf("object %s not found in bucket %s", key, bucket)
 	}
 
-	logp.Printf("[DEBUG] Data Source Reading OBS Bucket Object %s: %#v", key, objectContent)
+	log.Printf("[DEBUG] Data Source Reading OBS Bucket Object %s: %#v", key, objectContent)
 
 	object, err := obsClient.GetObject(&obs.GetObjectInput{
 		GetObjectMetadataInput: obs.GetObjectMetadataInput{
@@ -106,7 +106,7 @@ func dataSourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) err
 		return getObsError("Error get object info of OBS bucket", bucket, err)
 	}
 
-	logp.Printf("[DEBUG] Data Source Reading OBS Bucket Object : %#v", object)
+	log.Printf("[DEBUG] Data Source Reading OBS Bucket Object : %#v", object)
 
 	d.SetId(key)
 	d.Set("size", objectContent.Size)

--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"strings"
@@ -62,8 +62,8 @@ func DataSourceObsBucketObject() *schema.Resource {
 // Attribute parameters are not returned in one interface.
 // Two interfaces need to be called to get all parameters.
 func dataSourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}

--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_buckets.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_buckets.go
@@ -64,8 +64,8 @@ func DataSourceObsBuckets() *schema.Resource {
 }
 
 func dataSourceObsBucketsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ObjectStorageClient(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	client, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud OBS client: %s", err)
 	}
@@ -130,11 +130,4 @@ func queryMetadata(client *obs.ObsClient, name string) (*obs.GetBucketMetadataOu
 		err = golangsdk.ErrDefault404{}
 	}
 	return metadata, getObsError("Error querying OBS bucket metadata", name, err)
-}
-
-func getObsError(action string, bucket string, err error) error {
-	if obsError, ok := err.(obs.ObsError); ok {
-		return fmtp.Errorf("%s %s: %s,\n Reason: %s", action, bucket, obsError.Code, obsError.Message)
-	}
-	return err
 }

--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_buckets.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_buckets.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceObsBuckets() *schema.Resource {
@@ -67,14 +66,14 @@ func dataSourceObsBucketsRead(_ context.Context, d *schema.ResourceData, meta in
 	conf := meta.(*config.Config)
 	client, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud OBS client: %s", err)
+		return diag.Errorf("Error creating OBS client: %s", err)
 	}
 	r, err := client.ListBuckets(&obs.ListBucketsInput{
 		BucketType: obs.OBJECT,
 	})
 
 	if err != nil {
-		return fmtp.DiagErrorf("Error querying OBS buckets: %s", err)
+		return diag.Errorf("Error querying OBS buckets: %s", err)
 	}
 
 	ids := make([]string, 0, len(r.Buckets))
@@ -86,7 +85,7 @@ func dataSourceObsBucketsRead(_ context.Context, d *schema.ResourceData, meta in
 	for _, v := range r.Buckets {
 		metadata, err := queryMetadata(client, v.Name)
 		if err != nil && !errors.As(err, &golangsdk.ErrDefault404{}) {
-			return fmtp.DiagErrorf("Error querying OBS bucket metadata: %s", err)
+			return diag.Errorf("Error querying OBS bucket metadata: %s", err)
 		}
 
 		storageClass, enterpriseProjectID, region := "", "", ""
@@ -116,7 +115,7 @@ func dataSourceObsBucketsRead(_ context.Context, d *schema.ResourceData, meta in
 	d.SetId(hashcode.Strings(ids))
 	err = d.Set("buckets", buckets)
 	if err != nil {
-		return fmtp.DiagErrorf("error setting OBS attributes: %s", err)
+		return diag.Errorf("error setting OBS attributes: %s", err)
 	}
 	return nil
 }

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -4,17 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/url"
 
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceObsBucket() *schema.Resource {
@@ -315,7 +315,7 @@ func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	region := conf.GetRegion(d)
 	obsClient, err := conf.ObjectStorageClient(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -333,7 +333,7 @@ func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.AvailableZone = "3az"
 	}
 
-	logp.Printf("[DEBUG] OBS bucket create opts: %#v", opts)
+	log.Printf("[DEBUG] OBS bucket create opts: %#v", opts)
 	_, err = obsClient.CreateBucket(opts)
 	if err != nil {
 		return getObsError("Error creating bucket", bucket, err)
@@ -349,15 +349,15 @@ func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	region := conf.GetRegion(d)
 	obsClient, err := conf.ObjectStorageClient(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	obsClientWithSignature, err := conf.ObjectStorageClientWithSignature(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client with signature: %s", err)
+		return fmt.Errorf("Error creating OBS client with signature: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Update OBS bucket %s", d.Id())
+	log.Printf("[DEBUG] Update OBS bucket %s", d.Id())
 	if d.HasChange("acl") && !d.IsNewResource() {
 		if err := resourceObsBucketAclUpdate(obsClient, d); err != nil {
 			return err
@@ -436,18 +436,18 @@ func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 	region := conf.GetRegion(d)
 	obsClient, err := conf.ObjectStorageClient(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Read OBS bucket: %s", d.Id())
+	log.Printf("[DEBUG] Read OBS bucket: %s", d.Id())
 	_, err = obsClient.HeadBucket(d.Id())
 	if err != nil {
 		if obsError, ok := err.(obs.ObsError); ok && obsError.StatusCode == 404 {
-			logp.Printf("[WARN] OBS bucket(%s) not found", d.Id())
+			log.Printf("[WARN] OBS bucket(%s) not found", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmtp.Errorf("error reading OBS bucket %s: %s", d.Id(), err)
+		return fmt.Errorf("error reading OBS bucket %s: %s", d.Id(), err)
 	}
 
 	// for import case
@@ -509,7 +509,7 @@ func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 	if format == "obs" {
 		policyClient, err = conf.ObjectStorageClientWithSignature(region)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud OBS policy client: %s", err)
+			return fmt.Errorf("Error creating OBS policy client: %s", err)
 		}
 	}
 	if err := setObsBucketPolicy(policyClient, d); err != nil {
@@ -528,26 +528,26 @@ func resourceObsBucketDelete(d *schema.ResourceData, meta interface{}) error {
 	conf := meta.(*config.Config)
 	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	bucket := d.Id()
-	logp.Printf("[DEBUG] deleting OBS Bucket: %s", bucket)
+	log.Printf("[DEBUG] deleting OBS Bucket: %s", bucket)
 	_, err = obsClient.DeleteBucket(bucket)
 	if err != nil {
 		obsError, ok := err.(obs.ObsError)
 		if ok && obsError.Code == "BucketNotEmpty" {
-			logp.Printf("[WARN] OBS bucket: %s is not empty", bucket)
+			log.Printf("[WARN] OBS bucket: %s is not empty", bucket)
 			if d.Get("force_destroy").(bool) {
 				err = deleteAllBucketObjects(obsClient, bucket)
 				if err == nil {
-					logp.Printf("[WARN] all objects of %s have been deleted, and try again", bucket)
+					log.Printf("[WARN] all objects of %s have been deleted, and try again", bucket)
 					return resourceObsBucketDelete(d, meta)
 				}
 			}
 			return err
 		}
-		return fmtp.Errorf("Error deleting OBS bucket %s, %s", bucket, err)
+		return fmt.Errorf("Error deleting OBS bucket %s, %s", bucket, err)
 	}
 	return nil
 }
@@ -567,7 +567,7 @@ func resourceObsBucketTagsUpdate(obsClient *obs.ObsClient, d *schema.ResourceDat
 	req := &obs.SetBucketTaggingInput{}
 	req.Bucket = bucket
 	req.Tags = tagList
-	logp.Printf("[DEBUG] set tags of OBS bucket %s: %#v", bucket, req)
+	log.Printf("[DEBUG] set tags of OBS bucket %s: %#v", bucket, req)
 
 	_, err := obsClient.SetBucketTagging(req)
 	if err != nil {
@@ -584,7 +584,7 @@ func resourceObsBucketAclUpdate(obsClient *obs.ObsClient, d *schema.ResourceData
 		Bucket: bucket,
 		ACL:    obs.AclType(acl),
 	}
-	logp.Printf("[DEBUG] set ACL of OBS bucket %s: %#v", bucket, i)
+	log.Printf("[DEBUG] set ACL of OBS bucket %s: %#v", bucket, i)
 
 	_, err := obsClient.SetBucketAcl(i)
 	if err != nil {
@@ -601,7 +601,7 @@ func resourceObsBucketPolicyUpdate(obsClient *obs.ObsClient, d *schema.ResourceD
 	policy := d.Get("policy").(string)
 
 	if policy != "" {
-		logp.Printf("[DEBUG] OBS bucket: %s, set policy: %s", bucket, policy)
+		log.Printf("[DEBUG] OBS bucket: %s, set policy: %s", bucket, policy)
 		params := &obs.SetBucketPolicyInput{
 			Bucket: bucket,
 			Policy: policy,
@@ -611,7 +611,7 @@ func resourceObsBucketPolicyUpdate(obsClient *obs.ObsClient, d *schema.ResourceD
 			return getObsError("Error setting OBS bucket policy", bucket, err)
 		}
 	} else {
-		logp.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
+		log.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
 		_, err := obsClient.DeleteBucketPolicy(bucket)
 		if err != nil {
 			return getObsError("Error deleting policy of OBS bucket %s: %s", bucket, err)
@@ -628,7 +628,7 @@ func resourceObsBucketClassUpdate(obsClient *obs.ObsClient, d *schema.ResourceDa
 	input := &obs.SetBucketStoragePolicyInput{}
 	input.Bucket = bucket
 	input.StorageClass = obs.StorageClassType(class)
-	logp.Printf("[DEBUG] set storage class of OBS bucket %s: %#v", bucket, input)
+	log.Printf("[DEBUG] set storage class of OBS bucket %s: %#v", bucket, input)
 
 	_, err := obsClient.SetBucketStoragePolicy(input)
 	if err != nil {
@@ -649,7 +649,7 @@ func resourceObsBucketVersioningUpdate(obsClient *obs.ObsClient, d *schema.Resou
 	} else {
 		input.Status = obs.VersioningStatusSuspended
 	}
-	logp.Printf("[DEBUG] set versioning of OBS bucket %s: %#v", bucket, input)
+	log.Printf("[DEBUG] set versioning of OBS bucket %s: %#v", bucket, input)
 
 	_, err := obsClient.SetBucketVersioning(input)
 	if err != nil {
@@ -674,7 +674,7 @@ func resourceObsBucketEncryptionUpdate(config *config.Config, obsClient *obs.Obs
 			input.ProjectID = config.GetProjectID(config.GetRegion(d))
 		}
 
-		logp.Printf("[DEBUG] enable default encryption of OBS bucket %s: %#v", bucket, input)
+		log.Printf("[DEBUG] enable default encryption of OBS bucket %s: %#v", bucket, input)
 		_, err := obsClient.SetBucketEncryption(input)
 		if err != nil {
 			return getObsError("failed to enable default encryption of OBS bucket", bucket, err)
@@ -705,7 +705,7 @@ func resourceObsBucketLoggingUpdate(obsClient *obs.ObsClient, d *schema.Resource
 			loggingStatus.TargetPrefix = val
 		}
 	}
-	logp.Printf("[DEBUG] set logging of OBS bucket %s: %#v", bucket, loggingStatus)
+	log.Printf("[DEBUG] set logging of OBS bucket %s: %#v", bucket, loggingStatus)
 
 	_, err := obsClient.SetBucketLoggingConfiguration(loggingStatus)
 	if err != nil {
@@ -736,7 +736,7 @@ func resourceObsBucketLifecycleUpdate(obsClient *obs.ObsClient, d *schema.Resour
 	lifecycleRules := d.Get("lifecycle_rule").([]interface{})
 
 	if len(lifecycleRules) == 0 {
-		logp.Printf("[DEBUG] remove all lifecycle rules of bucket %s", bucket)
+		log.Printf("[DEBUG] remove all lifecycle rules of bucket %s", bucket)
 		_, err := obsClient.DeleteBucketLifecycleConfiguration(bucket)
 		if err != nil {
 			return getObsError("Error deleting lifecycle rules of OBS bucket", bucket, err)
@@ -817,7 +817,7 @@ func resourceObsBucketLifecycleUpdate(obsClient *obs.ObsClient, d *schema.Resour
 	opts := &obs.SetBucketLifecycleConfigurationInput{}
 	opts.Bucket = bucket
 	opts.LifecycleRules = rules
-	logp.Printf("[DEBUG] set lifecycle configurations of OBS bucket %s: %#v", bucket, opts)
+	log.Printf("[DEBUG] set lifecycle configurations of OBS bucket %s: %#v", bucket, opts)
 
 	_, err := obsClient.SetBucketLifecycleConfiguration(opts)
 	if err != nil {
@@ -841,7 +841,7 @@ func resourceObsBucketWebsiteUpdate(obsClient *obs.ObsClient, d *schema.Resource
 	} else if len(ws) == 0 {
 		return resourceObsBucketWebsiteDelete(obsClient, d)
 	} else {
-		return fmtp.Errorf("Cannot specify more than one website.")
+		return fmt.Errorf("Cannot specify more than one website.")
 	}
 }
 
@@ -851,7 +851,7 @@ func resourceObsBucketCorsUpdate(obsClient *obs.ObsClient, d *schema.ResourceDat
 
 	if len(rawCors) == 0 {
 		// Delete CORS
-		logp.Printf("[DEBUG] delete CORS rules of OBS bucket: %s", bucket)
+		log.Printf("[DEBUG] delete CORS rules of OBS bucket: %s", bucket)
 		_, err := obsClient.DeleteBucketCors(bucket)
 		if err != nil {
 			return getObsError("Error deleting CORS rules of OBS bucket", bucket, err)
@@ -884,14 +884,14 @@ func resourceObsBucketCorsUpdate(obsClient *obs.ObsClient, d *schema.ResourceDat
 				}
 			}
 		}
-		logp.Printf("[DEBUG] set CORS of OBS bucket %s: %#v", bucket, r)
+		log.Printf("[DEBUG] set CORS of OBS bucket %s: %#v", bucket, r)
 		rules = append(rules, r)
 	}
 
 	corsInput := &obs.SetBucketCorsInput{}
 	corsInput.Bucket = bucket
 	corsInput.CorsRules = rules
-	logp.Printf("[DEBUG] OBS bucket: %s, put CORS: %#v", bucket, corsInput)
+	log.Printf("[DEBUG] OBS bucket: %s, put CORS: %#v", bucket, corsInput)
 
 	_, err := obsClient.SetBucketCors(corsInput)
 	if err != nil {
@@ -918,7 +918,7 @@ func resourceObsBucketWebsitePut(obsClient *obs.ObsClient, d *schema.ResourceDat
 	}
 
 	if indexDocument == "" && redirectAllRequestsTo == "" {
-		return fmtp.Errorf("Must specify either index_document or redirect_all_requests_to.")
+		return fmt.Errorf("Must specify either index_document or redirect_all_requests_to.")
 	}
 
 	websiteConfiguration := &obs.SetBucketWebsiteConfigurationInput{}
@@ -963,7 +963,7 @@ func resourceObsBucketWebsitePut(obsClient *obs.ObsClient, d *schema.ResourceDat
 		websiteConfiguration.RoutingRules = unmarshaledRules
 	}
 
-	logp.Printf("[DEBUG] set website configuration of OBS bucket %s: %#v", bucket, websiteConfiguration)
+	log.Printf("[DEBUG] set website configuration of OBS bucket %s: %#v", bucket, websiteConfiguration)
 	_, err := obsClient.SetBucketWebsiteConfiguration(websiteConfiguration)
 	if err != nil {
 		return getObsError("Error updating website configuration of OBS bucket", bucket, err)
@@ -975,7 +975,7 @@ func resourceObsBucketWebsitePut(obsClient *obs.ObsClient, d *schema.ResourceDat
 func resourceObsBucketWebsiteDelete(obsClient *obs.ObsClient, d *schema.ResourceData) error {
 	bucket := d.Get("bucket").(string)
 
-	logp.Printf("[DEBUG] delete website configuration of OBS bucket %s", bucket)
+	log.Printf("[DEBUG] delete website configuration of OBS bucket %s", bucket)
 	_, err := obsClient.DeleteBucketWebsiteConfiguration(bucket)
 	if err != nil {
 		return getObsError("Error deleting website configuration of OBS bucket", bucket, err)
@@ -988,10 +988,10 @@ func setObsBucketStorageClass(obsClient *obs.ObsClient, d *schema.ResourceData) 
 	bucket := d.Id()
 	output, err := obsClient.GetBucketStoragePolicy(bucket)
 	if err != nil {
-		logp.Printf("[WARN] Error getting storage class of OBS bucket %s: %s", bucket, err)
+		log.Printf("[WARN] Error getting storage class of OBS bucket %s: %s", bucket, err)
 	} else {
 		class := string(output.StorageClass)
-		logp.Printf("[DEBUG] getting storage class of OBS bucket %s: %s", bucket, class)
+		log.Printf("[DEBUG] getting storage class of OBS bucket %s: %s", bucket, class)
 		d.Set("storage_class", normalizeStorageClass(class))
 	}
 
@@ -1007,7 +1007,7 @@ func setObsBucketMetadata(obsClient *obs.ObsClient, d *schema.ResourceData) erro
 	if err != nil {
 		return getObsError("Error getting metadata of OBS bucket", bucket, err)
 	}
-	logp.Printf("[DEBUG] getting metadata of OBS bucket %s: %#v", bucket, output)
+	log.Printf("[DEBUG] getting metadata of OBS bucket %s: %#v", bucket, output)
 
 	d.Set("enterprise_project_id", output.Epid)
 
@@ -1036,14 +1036,14 @@ func setObsBucketPolicy(obsClient *obs.ObsClient, d *schema.ResourceData) error 
 				d.Set("policy", nil)
 				return nil
 			}
-			return fmtp.Errorf("Error getting policy of OBS bucket %s: %s,\n Reason: %s",
+			return fmt.Errorf("Error getting policy of OBS bucket %s: %s,\n Reason: %s",
 				bucket, obsError.Code, obsError.Message)
 		}
 		return err
 	}
 
 	pol := output.Policy
-	logp.Printf("[DEBUG] getting policy of OBS bucket %s: %s", bucket, pol)
+	log.Printf("[DEBUG] getting policy of OBS bucket %s: %s", bucket, pol)
 	d.Set("policy", pol)
 
 	return nil
@@ -1056,7 +1056,7 @@ func setObsBucketVersioning(obsClient *obs.ObsClient, d *schema.ResourceData) er
 		return getObsError("Error getting versioning status of OBS bucket", bucket, err)
 	}
 
-	logp.Printf("[DEBUG] getting versioning status of OBS bucket %s: %s", bucket, output.Status)
+	log.Printf("[DEBUG] getting versioning status of OBS bucket %s: %s", bucket, output.Status)
 	if output.Status == obs.VersioningStatusEnabled {
 		d.Set("versioning", true)
 	} else {
@@ -1077,13 +1077,13 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 				d.Set("kms_key_project_id", nil)
 				return nil
 			}
-			return fmtp.Errorf("Error getting encryption configuration of OBS bucket %s: %s,\n Reason: %s",
+			return fmt.Errorf("Error getting encryption configuration of OBS bucket %s: %s,\n Reason: %s",
 				bucket, obsError.Code, obsError.Message)
 		}
 		return err
 	}
 
-	logp.Printf("[DEBUG] getting encryption configuration of OBS bucket %s: %+v", bucket, output.BucketEncryptionConfiguration)
+	log.Printf("[DEBUG] getting encryption configuration of OBS bucket %s: %+v", bucket, output.BucketEncryptionConfiguration)
 	if output.SSEAlgorithm != "" {
 		d.Set("encryption", true)
 		d.Set("kms_key_id", output.KMSMasterKeyID)
@@ -1114,10 +1114,10 @@ func setObsBucketLogging(obsClient *obs.ObsClient, d *schema.ResourceData) error
 		}
 		lcList = append(lcList, logging)
 	}
-	logp.Printf("[DEBUG] getting logging configuration of OBS bucket %s: %#v", bucket, lcList)
+	log.Printf("[DEBUG] getting logging configuration of OBS bucket %s: %#v", bucket, lcList)
 
 	if err := d.Set("logging", lcList); err != nil {
-		return fmtp.Errorf("Error saving logging configuration of OBS bucket %s: %s", bucket, err)
+		return fmt.Errorf("Error saving logging configuration of OBS bucket %s: %s", bucket, err)
 	}
 
 	return nil
@@ -1130,7 +1130,7 @@ func setObsBucketQuota(obsClient *obs.ObsClient, d *schema.ResourceData) error {
 		return getObsError("Error getting quota of OBS bucket", bucket, err)
 	}
 
-	logp.Printf("[DEBUG] getting quota of OBS bucket %s: %d", bucket, output.Quota)
+	log.Printf("[DEBUG] getting quota of OBS bucket %s: %d", bucket, output.Quota)
 
 	d.Set("quota", output.Quota)
 
@@ -1146,14 +1146,14 @@ func setObsBucketLifecycleConfiguration(obsClient *obs.ObsClient, d *schema.Reso
 				d.Set("lifecycle_rule", nil)
 				return nil
 			}
-			return fmtp.Errorf("Error getting lifecycle configuration of OBS bucket %s: %s,\n Reason: %s",
+			return fmt.Errorf("Error getting lifecycle configuration of OBS bucket %s: %s,\n Reason: %s",
 				bucket, obsError.Code, obsError.Message)
 		}
 		return err
 	}
 
 	rawRules := output.LifecycleRules
-	logp.Printf("[DEBUG] getting original lifecycle configuration of OBS bucket %s, lifecycle: %#v", bucket, rawRules)
+	log.Printf("[DEBUG] getting original lifecycle configuration of OBS bucket %s, lifecycle: %#v", bucket, rawRules)
 
 	rules := make([]map[string]interface{}, 0, len(rawRules))
 	for _, lifecycleRule := range rawRules {
@@ -1211,9 +1211,9 @@ func setObsBucketLifecycleConfiguration(obsClient *obs.ObsClient, d *schema.Reso
 		rules = append(rules, rule)
 	}
 
-	logp.Printf("[DEBUG] saving lifecycle configuration of OBS bucket %s, lifecycle: %#v", bucket, rules)
+	log.Printf("[DEBUG] saving lifecycle configuration of OBS bucket %s, lifecycle: %#v", bucket, rules)
 	if err := d.Set("lifecycle_rule", rules); err != nil {
-		return fmtp.Errorf("Error saving lifecycle configuration of OBS bucket %s: %s", bucket, err)
+		return fmt.Errorf("Error saving lifecycle configuration of OBS bucket %s: %s", bucket, err)
 	}
 
 	return nil
@@ -1228,13 +1228,13 @@ func setObsBucketWebsiteConfiguration(obsClient *obs.ObsClient, d *schema.Resour
 				d.Set("website", nil)
 				return nil
 			}
-			return fmtp.Errorf("Error getting website configuration of OBS bucket %s: %s,\n Reason: %s",
+			return fmt.Errorf("Error getting website configuration of OBS bucket %s: %s,\n Reason: %s",
 				bucket, obsError.Code, obsError.Message)
 		}
 		return err
 	}
 
-	logp.Printf("[DEBUG] getting original website configuration of OBS bucket %s, output: %#v", bucket, output.BucketWebsiteConfiguration)
+	log.Printf("[DEBUG] getting original website configuration of OBS bucket %s, output: %#v", bucket, output.BucketWebsiteConfiguration)
 	var websites []map[string]interface{}
 	w := make(map[string]interface{})
 
@@ -1269,15 +1269,15 @@ func setObsBucketWebsiteConfiguration(obsClient *obs.ObsClient, d *schema.Resour
 	if len(rawRules) > 0 {
 		rr, err := normalizeWebsiteRoutingRules(rawRules)
 		if err != nil {
-			return fmtp.Errorf("Error while marshaling website routing rules: %s", err)
+			return fmt.Errorf("Error while marshaling website routing rules: %s", err)
 		}
 		w["routing_rules"] = rr
 	}
 
 	websites = append(websites, w)
-	logp.Printf("[DEBUG] saving website configuration of OBS bucket %s, website: %#v", bucket, websites)
+	log.Printf("[DEBUG] saving website configuration of OBS bucket %s, website: %#v", bucket, websites)
 	if err := d.Set("website", websites); err != nil {
-		return fmtp.Errorf("Error saving website configuration of OBS bucket %s: %s", bucket, err)
+		return fmt.Errorf("Error saving website configuration of OBS bucket %s: %s", bucket, err)
 	}
 	return nil
 }
@@ -1291,14 +1291,14 @@ func setObsBucketCorsRules(obsClient *obs.ObsClient, d *schema.ResourceData) err
 				d.Set("cors_rule", nil)
 				return nil
 			}
-			return fmtp.Errorf("Error getting CORS configuration of OBS bucket %s: %s,\n Reason: %s",
+			return fmt.Errorf("Error getting CORS configuration of OBS bucket %s: %s,\n Reason: %s",
 				bucket, obsError.Code, obsError.Message)
 		}
 		return err
 	}
 
 	corsRules := output.CorsRules
-	logp.Printf("[DEBUG] getting original CORS rules of OBS bucket %s, CORS: %#v", bucket, corsRules)
+	log.Printf("[DEBUG] getting original CORS rules of OBS bucket %s, CORS: %#v", bucket, corsRules)
 
 	rules := make([]map[string]interface{}, 0, len(corsRules))
 	for _, ruleObject := range corsRules {
@@ -1316,9 +1316,9 @@ func setObsBucketCorsRules(obsClient *obs.ObsClient, d *schema.ResourceData) err
 		rules = append(rules, rule)
 	}
 
-	logp.Printf("[DEBUG] saving CORS rules of OBS bucket %s, CORS: %#v", bucket, rules)
+	log.Printf("[DEBUG] saving CORS rules of OBS bucket %s, CORS: %#v", bucket, rules)
 	if err := d.Set("cors_rule", rules); err != nil {
-		return fmtp.Errorf("Error saving CORS rules of OBS bucket %s: %s", bucket, err)
+		return fmt.Errorf("Error saving CORS rules of OBS bucket %s: %s", bucket, err)
 	}
 
 	return nil
@@ -1333,7 +1333,7 @@ func setObsBucketTags(obsClient *obs.ObsClient, d *schema.ResourceData) error {
 				d.Set("tags", nil)
 				return nil
 			}
-			return fmtp.Errorf("Error getting tags of OBS bucket %s: %s,\n Reason: %s",
+			return fmt.Errorf("Error getting tags of OBS bucket %s: %s,\n Reason: %s",
 				bucket, obsError.Code, obsError.Message)
 		}
 		return err
@@ -1343,9 +1343,9 @@ func setObsBucketTags(obsClient *obs.ObsClient, d *schema.ResourceData) error {
 	for _, tag := range output.Tags {
 		tagmap[tag.Key] = tag.Value
 	}
-	logp.Printf("[DEBUG] getting tags of OBS bucket %s: %#v", bucket, tagmap)
+	log.Printf("[DEBUG] getting tags of OBS bucket %s: %#v", bucket, tagmap)
 	if err := d.Set("tags", tagmap); err != nil {
-		return fmtp.Errorf("Error saving tags of OBS bucket %s: %s", bucket, err)
+		return fmt.Errorf("Error saving tags of OBS bucket %s: %s", bucket, err)
 	}
 	return nil
 }
@@ -1369,13 +1369,13 @@ func deleteAllBucketObjects(obsClient *obs.ObsClient, bucket string) error {
 		Bucket:  bucket,
 		Objects: objects,
 	}
-	logp.Printf("[DEBUG] objects of %s will be deleted: %v", bucket, objects)
+	log.Printf("[DEBUG] objects of %s will be deleted: %v", bucket, objects)
 	output, err := obsClient.DeleteObjects(deleteOpts)
 	if err != nil {
 		return getObsError("Error deleting all objects of OBS bucket", bucket, err)
 	}
 	if len(output.Errors) > 0 {
-		return fmtp.Errorf("Error some objects are still exist in %s: %#v", bucket, output.Errors)
+		return fmt.Errorf("Error some objects are still exist in %s: %#v", bucket, output.Errors)
 	}
 	return nil
 }
@@ -1395,7 +1395,7 @@ func expirationHash(v interface{}) int {
 
 func getObsError(action string, bucket string, err error) error {
 	if obsError, ok := err.(obs.ObsError); ok {
-		return fmtp.Errorf("%s %s: %s,\n Reason: %s", action, bucket, obsError.Code, obsError.Message)
+		return fmt.Errorf("%s %s: %s,\n Reason: %s", action, bucket, obsError.Code, obsError.Message)
 	}
 	return err
 }

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"bytes"
@@ -110,8 +110,8 @@ func resourceObsBucketObjectPut(d *schema.ResourceData, meta interface{}) error 
 	var resp *obs.PutObjectOutput
 	var err error
 
-	config := meta.(*config.Config)
-	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}
@@ -230,8 +230,8 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Put
 }
 
 func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}
@@ -276,8 +276,8 @@ func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceObsBucketObjectDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
 	}

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_policy.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_policy.go
@@ -1,14 +1,15 @@
 package obs
 
 import (
+	"fmt"
+	"log"
 	"strings"
 
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceObsBucketPolicy() *schema.Resource {
@@ -61,12 +62,12 @@ func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error 
 		obsClient, err = conf.ObjectStorageClient(conf.GetRegion(d))
 	}
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	bucket := d.Get("bucket").(string)
 	policy := d.Get("policy").(string)
-	logp.Printf("[DEBUG] OBS bucket: %s, set policy: %s", bucket, policy)
+	log.Printf("[DEBUG] OBS bucket: %s, set policy: %s", bucket, policy)
 
 	params := &obs.SetBucketPolicyInput{
 		Bucket: bucket,
@@ -87,20 +88,20 @@ func resourceObsBucketPolicyRead(d *schema.ResourceData, meta interface{}) error
 	conf := meta.(*config.Config)
 
 	format := d.Get("policy_format").(string)
-	logp.Printf("[DEBUG] obs bucket policy format: %s", format)
+	log.Printf("[DEBUG] obs bucket policy format: %s", format)
 	if format == "obs" {
 		obsClient, err = conf.ObjectStorageClientWithSignature(conf.GetRegion(d))
 	} else {
 		obsClient, err = conf.ObjectStorageClient(conf.GetRegion(d))
 	}
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	// set bucket from the policy id
 	d.Set("bucket", d.Id())
 
-	logp.Printf("[DEBUG] read policy for obs bucket: %s", d.Id())
+	log.Printf("[DEBUG] read policy for obs bucket: %s", d.Id())
 	output, err := obsClient.GetBucketPolicy(d.Id())
 
 	var pol string
@@ -126,12 +127,12 @@ func resourceObsBucketPolicyDelete(d *schema.ResourceData, meta interface{}) err
 		obsClient, err = conf.ObjectStorageClient(conf.GetRegion(d))
 	}
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
+		return fmt.Errorf("Error creating OBS client: %s", err)
 	}
 
 	bucket := d.Get("bucket").(string)
 
-	logp.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
+	log.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
 	_, err = obsClient.DeleteBucketPolicy(bucket)
 	if err != nil {
 		return getObsError("Error deleting policy of OBS bucket %s: %s", bucket, err)

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_policy.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_policy.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package obs
 
 import (
 	"strings"
@@ -52,13 +52,13 @@ func ResourceObsBucketPolicy() *schema.Resource {
 func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	var obsClient *obs.ObsClient
-	config := meta.(*config.Config)
+	conf := meta.(*config.Config)
 
 	format := d.Get("policy_format").(string)
 	if format == "obs" {
-		obsClient, err = config.ObjectStorageClientWithSignature(GetRegion(d, config))
+		obsClient, err = conf.ObjectStorageClientWithSignature(conf.GetRegion(d))
 	} else {
-		obsClient, err = config.ObjectStorageClient(GetRegion(d, config))
+		obsClient, err = conf.ObjectStorageClient(conf.GetRegion(d))
 	}
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
@@ -84,14 +84,14 @@ func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error 
 func resourceObsBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	var obsClient *obs.ObsClient
-	config := meta.(*config.Config)
+	conf := meta.(*config.Config)
 
 	format := d.Get("policy_format").(string)
 	logp.Printf("[DEBUG] obs bucket policy format: %s", format)
 	if format == "obs" {
-		obsClient, err = config.ObjectStorageClientWithSignature(GetRegion(d, config))
+		obsClient, err = conf.ObjectStorageClientWithSignature(conf.GetRegion(d))
 	} else {
-		obsClient, err = config.ObjectStorageClient(GetRegion(d, config))
+		obsClient, err = conf.ObjectStorageClient(conf.GetRegion(d))
 	}
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)
@@ -117,13 +117,13 @@ func resourceObsBucketPolicyRead(d *schema.ResourceData, meta interface{}) error
 func resourceObsBucketPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	var obsClient *obs.ObsClient
-	config := meta.(*config.Config)
+	conf := meta.(*config.Config)
 
 	format := d.Get("policy_format").(string)
 	if format == "obs" {
-		obsClient, err = config.ObjectStorageClientWithSignature(GetRegion(d, config))
+		obsClient, err = conf.ObjectStorageClientWithSignature(conf.GetRegion(d))
 	} else {
-		obsClient, err = config.ObjectStorageClient(GetRegion(d, config))
+		obsClient, err = conf.ObjectStorageClient(conf.GetRegion(d))
 	}
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud OBS client: %s", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_multiAZ
=== PAUSE TestAccObsBucket_multiAZ
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucket_multiAZ
=== CONT  TestAccObsBucketPolicy_basic
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucket_multiAZ (31.22s)
=== CONT  TestAccObsBucketObjectDataSource_allParams
--- PASS: TestAccObsBucketObject_content (31.81s)
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketPolicy_basic (40.11s)
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucketObjectDataSource_content (53.67s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_quota (28.87s)
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucketObjectDataSource_allParams (50.06s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_cors (32.79s)
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucketObject_source (61.45s)
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucket_website (30.46s)
=== CONT  TestAccObsBucketObjectDataSource_source
--- PASS: TestAccObsBucket_lifecycle (31.96s)
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_withEpsId (31.36s)
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_basic (63.49s)
=== CONT  TestAccObsBucketPolicy_s3
--- PASS: TestAccObsBucketObjectDataSource_source (53.08s)
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucket_logging (35.25s)
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_versioning (54.11s)
=== CONT  TestAccObsBucket_parallelFS
--- PASS: TestAccObsBucketPolicy_s3 (36.65s)
--- PASS: TestAccObsBucket_parallelFS (27.34s)
--- PASS: TestAccObsBucketPolicy_update (53.58s)
--- PASS: TestAccObsBucket_encryption (62.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       222.807s
```
