### PR TITLE
feat: support to display content of an object data source with body field

### DIFF
--- a/docs/data-sources/obs_bucket_object.md
+++ b/docs/data-sources/obs_bucket_object.md
@@ -29,13 +29,20 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - the `key` of the resource supplied above.
-* `bucket` - the name of the bucket to put the file in.
-* `key` - the name of the object once it is in the bucket.
+
 * `etag` - the ETag generated for the object (an MD5 sum of the object content). When the object is encrypted on the
   server side, the ETag value is not the MD5 value of the object, but the unique identifier calculated through the
   server-side encryption.
+
 * `size` - the size of the object in bytes.
+
 * `version_id` - a unique version ID value for the object, if bucket versioning is enabled.
+
 * `storage_class` - specifies the storage class of the object.
+
 * `content_type` - a standard MIME type describing the format of the object data, e.g. application/octet-stream. All
   Valid MIME Types are valid for this input.
+
+* `body` - The content of an object which is available only for objects which have a human-readable Content-Type
+  (text/* and application/json) and smaller than **64KB**. This is to prevent printing unsafe characters and
+  potentially downloading large amount of data.

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -96,8 +96,8 @@ $ terraform import huaweicloud_obs_bucket_object.object bucket/key
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `content_type`, `encryption`, `source`,
-`acl`, `sse_kms_key_id` and `version_id`. It is generally recommended running `terraform plan` after importing an object.
+API response, security or some other reason. The missing attributes include: `encryption`, `source`, `acl` and
+`sse_kms_key_id`. It is generally recommended running `terraform plan` after importing an object.
 You can then decide if changes should be applied to the object, or the resource
 definition should be updated to align with the object. Also you can ignore changes as below.
 
@@ -107,7 +107,7 @@ resource "huaweicloud_obs_bucket_object" "object" {
 
   lifecycle {
     ignore_changes = [
-      content_type, encryption, source, acl, sse_kms_key_id, version_id,
+      encryption, source, acl, sse_kms_key_id,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -112,8 +112,9 @@ func TestAccObsBucketObjectDataSource_allParams(t *testing.T) {
 				Config: dataSourceConf,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsObjectDataSourceExists(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "content_type", "application/unknown"),
+					resource.TestCheckResourceAttr(dataSourceName, "content_type", "application/json"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "body"),
 				),
 			},
 		},
@@ -226,7 +227,7 @@ resource "huaweicloud_obs_bucket_object" "object" {
   acl           = "private"
   storage_class = "STANDARD"
   encryption    = true
-  content_type  = "application/unknown"
+  content_type  = "application/json"
   content       = <<CONTENT
     {"msg": "Hi there!"}
 CONTENT

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -61,7 +61,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccObsBucketObjecImportStateIdFunc(),
 				ImportStateVerifyIgnore: []string{
-					"content_type", "encryption", "source", "version_id",
+					"encryption", "source",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- use **GetObjectMetadata** to get more attributes for object resource
- support to display content of an object data source with `body` field

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2264 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObject_content'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObject_content -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (15.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       15.541s

$ make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObjectDataSource_allParams'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObjectDataSource_allParams -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObjectDataSource_allParams
--- PASS: TestAccObsBucketObjectDataSource_allParams (24.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       24.056s
```