### PR TITLE
feat(rds): add new resource database privilege

### DIFF
--- a/docs/resources/rds_database_privilege.md
+++ b/docs/resources/rds_database_privilege.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_database_privilege
+
+Manages RDS Mysql database privilege resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "db_name" {}
+variable "user_name_1" {}
+variable "user_name_2" {}
+
+resource "huaweicloud_rds_database_privilege" "test" {
+  instance_id = var.instance_id
+  db_name     = var.db_name
+
+  users {
+    name     = var.user_name_1
+    readonly = true
+  }
+
+  users {
+    name     = var.user_name_2
+    readonly = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the RDS database privilege resource. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the RDS instance ID. Changing this will create a new resource.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name. Changing this creates a new resource.
+
+* `users` - (Required, String, ForceNew) Specifies the account that associated with the database. This parameter supports
+  a maximum of 50 elements. Structure is documented below. Changing this creates a new resource.
+
+The `users` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the username of the database account. Changing this creates a new resource.
+
+* `readonly` - (Optional, Bool, ForceNew) Specifies the read-only permission. The value can be:
+  + **true**: indicates the read-only permission.
+  + **false**: indicates the read and write permission.
+
+  The default value is **false**. Changing this creates a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of database privilege which is formatted `<instance_id>/<database_name>`.
+
+## Import
+
+RDS database privilege can be imported using the `instance id` and `database name`, e.g.
+
+```
+$ terraform import huaweicloud_rds_database_privilege.test instance_id/database_name
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -790,6 +790,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_rds_account":               rds.ResourceRdsAccount(),
 			"huaweicloud_rds_database":              rds.ResourceRdsDatabase(),
+			"huaweicloud_rds_database_privilege":    rds.ResourceRdsDatabasePrivilege(),
 			"huaweicloud_rds_instance":              rds.ResourceRdsInstance(),
 			"huaweicloud_rds_parametergroup":        rds.ResourceRdsConfiguration(),
 			"huaweicloud_rds_read_replica_instance": rds.ResourceRdsReadReplicaInstance(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_database_privilege_test.go
@@ -1,0 +1,85 @@
+package rds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
+)
+
+func getRdsDatabasePrivilegeFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcRdsV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and database from resource id
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<database_name>")
+	}
+	instanceId := parts[0]
+	dbName := parts[1]
+	return rds.QueryDatabaseUsers(client, instanceId, dbName)
+}
+
+func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_rds_database_privilege.test"
+	var users []model.UserWithPrivilege
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&users,
+		getRdsDatabasePrivilegeFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsDatabasePrivilege_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "users.0.name",
+						"huaweicloud_rds_account.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "users.0.readonly", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRdsDatabasePrivilege_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_rds_account" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = "%s"
+  password    = "Test@12345678"
+}
+
+resource "huaweicloud_rds_database_privilege" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+  db_name     = huaweicloud_rds_database.test.name
+
+  users {
+    name = huaweicloud_rds_account.test.name
+  }
+}
+`, testRdsDatabase_basic(rName, rName), rName)
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_database_privilege.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_database_privilege.go
@@ -1,0 +1,232 @@
+package rds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	v3 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3"
+	rds "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceRdsDatabasePrivilege() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRdsDatabasePrivilegeCreate,
+		DeleteContext: resourceRdsDatabasePrivilegeDelete,
+		ReadContext:   resourceRdsDatabasePrivilegeRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 50,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"readonly": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildUserOpts(rawUsers []interface{}) []rds.UserWithPrivilege {
+	if len(rawUsers) < 1 {
+		return nil
+	}
+
+	usersOpts := make([]rds.UserWithPrivilege, len(rawUsers))
+	for i, v := range rawUsers {
+		user := v.(map[string]interface{})
+		usersOpts[i] = rds.UserWithPrivilege{
+			Name:     user["name"].(string),
+			Readonly: user["readonly"].(bool),
+		}
+	}
+	return usersOpts
+}
+
+func buildRevokeUserOpts(rawUsers []interface{}) []rds.RevokeRequestBodyUsers {
+	if len(rawUsers) < 1 {
+		return nil
+	}
+
+	usersOpts := make([]rds.RevokeRequestBodyUsers, len(rawUsers))
+	for i, v := range rawUsers {
+		user := v.(map[string]interface{})
+		usersOpts[i] = rds.RevokeRequestBodyUsers{
+			Name: user["name"].(string),
+		}
+	}
+	return usersOpts
+}
+
+func resourceRdsDatabasePrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcRdsV3Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	dbName := d.Get("db_name").(string)
+	createOpts := rds.GrantRequest{
+		DbName: d.Get("db_name").(string),
+		Users:  buildUserOpts(d.Get("users").([]interface{})),
+	}
+	tflog.Debug(ctx, "Create RDS database privilege options: %#v", createOpts)
+
+	privilegeReq := rds.AllowDbUserPrivilegeRequest{
+		InstanceId: instanceId,
+		Body:       &createOpts,
+	}
+
+	_, err = client.AllowDbUserPrivilege(&privilegeReq)
+	if err != nil {
+		return diag.Errorf("error creating RDS database privilege: %s", err)
+	}
+
+	id := instanceId + "/" + dbName
+	d.SetId(id)
+	return resourceRdsDatabasePrivilegeRead(ctx, d, meta)
+}
+
+func resourceRdsDatabasePrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcRdsV3Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and database from resource id
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<database_name>")
+	}
+	instanceId := parts[0]
+	dbName := parts[1]
+
+	users, err := QueryDatabaseUsers(client, instanceId, dbName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error listing RDS db authorized users")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", instanceId),
+		d.Set("db_name", dbName),
+		d.Set("users", flattenUsers(users)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting RDS db privilege fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourceRdsDatabasePrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcRdsV3Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	deleteOpts := rds.RevokeRequestBody{
+		DbName: d.Get("db_name").(string),
+		Users:  buildRevokeUserOpts(d.Get("users").([]interface{})),
+	}
+	tflog.Debug(ctx, "Delete RDS database privilege options: %#v", deleteOpts)
+
+	deleteReq := rds.RevokeRequest{
+		InstanceId: d.Get("instance_id").(string),
+		Body:       &deleteOpts,
+	}
+
+	_, err = client.Revoke(&deleteReq)
+	if err != nil {
+		return diag.Errorf("error deleting RDS database privilege: %s", err)
+	}
+
+	return nil
+}
+
+func flattenUsers(users []rds.UserWithPrivilege) []map[string]interface{} {
+	if len(users) < 1 {
+		return nil
+	}
+
+	usersToSet := make([]map[string]interface{}, len(users))
+	for i, v := range users {
+		usersToSet[i] = map[string]interface{}{
+			"name":     v.Name,
+			"readonly": v.Readonly,
+		}
+	}
+	return usersToSet
+}
+
+func QueryDatabaseUsers(client *v3.RdsClient, instanceId, dbName string) ([]rds.UserWithPrivilege, error) {
+	request := rds.ListAuthorizedDbUsersRequest{
+		InstanceId: instanceId,
+		DbName:     dbName,
+		Limit:      int32(100),
+		Page:       int32(1),
+	}
+
+	// List all databases
+	allUsers := []rds.UserWithPrivilege{}
+	for {
+		response, err := client.ListAuthorizedDbUsers(&request)
+		if err != nil {
+			return nil, err
+		}
+		if response.Users == nil || len(*response.Users) == 0 {
+			break
+		}
+
+		users := *response.Users
+		allUsers = append(allUsers, users...)
+		request.Page += 1
+	}
+
+	if len(allUsers) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return allUsers, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new resource database privilege

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource database privilege
2. add lock for instanceId in huaweicloud_rds_account and huaweicloud_rds_database to avoid error
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccRdsDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccRdsDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsDatabasePrivilege_basic
=== PAUSE TestAccRdsDatabasePrivilege_basic
=== CONT  TestAccRdsDatabasePrivilege_basic
--- PASS: TestAccRdsDatabasePrivilege_basic (820.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       821.134s
```
