### PR TITLE
feat(as): support to scale bandwidths

### DIFF
--- a/docs/resources/as_bandwidth_policy.md
+++ b/docs/resources/as_bandwidth_policy.md
@@ -1,0 +1,176 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# huaweicloud_as_bandwidth_policy
+
+Manages an AS bandwidth scaling policy resource within HuaweiCloud.
+
+-> AS cannot scale yearly/monthly bandwidths.
+
+## Example Usage
+
+### AS Recurrence Policy
+
+```hcl
+variable "bandwidth_id" {}
+
+resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
+  scaling_policy_name = "bw_policy"
+  scaling_policy_type = "RECURRENCE"
+  bandwidth_id        = var.bandwidth_id
+  cool_down_time      = 600
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time      = "07:00"
+    recurrence_type  = "Weekly"
+    recurrence_value = "1,3,5"
+    start_time       = "2022-09-30T12:00Z"
+    end_time         = "2022-12-30T12:00Z"
+  }
+}
+```
+
+### AS Scheduled Policy
+
+```hcl
+variable "bandwidth_id" {}
+
+resource "huaweicloud_as_bandwidth_policy" "bw_policy" {
+  scaling_policy_name = "bw_policy"
+  scaling_policy_type = "SCHEDULED"
+  bandwidth_id        = var.bandwidth_id
+  cool_down_time      = 600
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time = "2022-09-30T12:00Z"
+  }
+}
+```
+
+### AS Alarm Policy
+
+```hcl
+variable "bandwidth_id" {}
+variable "alarm_id" {}
+
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "bw_policy"
+  scaling_policy_type = "ALARM"
+  bandwidth_id        = var.bandwidth_id
+  alarm_id            = var.alarm_id
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+    limits    = 300
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `scaling_policy_name` - (Required, String) Specifies the AS policy name.
+  The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
+
+* `scaling_policy_type` - (Required, String) Specifies the AS policy type. The options are as follows:
+  - **ALARM** (corresponding to `alarm_id`): indicates that the scaling action is triggered by an alarm.
+  - **SCHEDULED** (corresponding to `scheduled_policy`): indicates that the scaling action is triggered as scheduled.
+  - **RECURRENCE** (corresponding to `scheduled_policy`): indicates that the scaling action is triggered periodically.
+
+* `bandwidth_id` - (Required, String) Specifies the scaling bandwidth ID.
+
+* `alarm_id` - (Optional, String) Specifies the alarm rule ID.
+  This parameter is mandatory when `scaling_policy_type` is set to ALARM.
+
+* `cool_down_time` - (Optional, Int) Specifies the cooldown period (in seconds).
+  The value ranges from 0 to 86400 and is 300 by default.
+
+* `description` - (Optional, String) Specifies the description of the AS policy.
+  The value can contain 0 to 256 characters.
+
+* `scaling_policy_action` - (Optional, String) Specifies the scaling action of the AS policy.
+  The [object](#ASBandWidthPolicy_ScalingPolicyAction) structure is documented below.
+
+* `scheduled_policy` - (Optional, String) Specifies the periodic or scheduled AS policy.
+  This parameter is mandatory when `scaling_policy_type` is set to SCHEDULED or RECURRENCE.
+  The [object](#ASBandWidthPolicy_ScheduledPolicy) structure is documented below.
+
+<a name="ASBandWidthPolicy_ScalingPolicyAction"></a>
+The `scaling_policy_action` block supports:
+
+* `operation` - (Optional, String) Specifies the operation to be performed. The default operation is ADD.
+  The options are as follows:
+  - **ADD**: indicates adding the bandwidth size.
+  - **REDUCE**: indicates reducing the bandwidth size.
+  - **SET**: indicates setting the bandwidth size to a specified value.
+
+* `size` - (Optional, Int) Specifies the bandwidth (Mbit/s).
+  The value is an integer from 1 to 2000. The default value is 1.
+
+* `limits` - (Optional, Int) Specifies the operation restrictions.
+  - If operation is not SET, this parameter takes effect and the unit is Mbit/s.
+  - If operation is set to ADD, this parameter indicates the maximum bandwidth allowed.
+  - If operation is set to REDUCE, this parameter indicates the minimum bandwidth allowed.
+
+<a name="ASBandWidthPolicy_ScheduledPolicy"></a>
+The `scheduled_policy` block supports:
+
+* `launch_time` - (Required, String) Specifies the time when the scaling action is triggered.
+  The time format complies with UTC.
+  - If scaling_policy_type is set to SCHEDULED, the time format is YYYY-MM-DDThh:mmZ.
+  - If scaling_policy_type is set to RECURRENCE, the time format is hh:mm.
+
+* `recurrence_type` - (Optional, String) Specifies the periodic triggering type.
+  This parameter is mandatory when scaling_policy_type is set to RECURRENCE. The options are as follows:
+  - **Daily**: indicates that the scaling action is triggered once a day.
+  - **Weekly**: indicates that the scaling action is triggered once a week.
+  - **Monthly**: indicates that the scaling action is triggered once a month.
+
+* `recurrence_value` - (Optional, String) Specifies the day when a periodic scaling action is triggered.
+  This parameter is mandatory when scaling_policy_type is set to RECURRENCE.
+  - If recurrence_type is set to Daily, the value is null, indicating that the scaling action is triggered once a day.
+  - If recurrence_type is set to Weekly, the value ranges from 1 (Sunday) to 7 (Saturday).
+    The digits refer to dates in each week and separated by a comma, such as 1,3,5.
+  - If recurrence_type is set to Monthly, the value ranges from 1 to 31.
+    The digits refer to the dates in each month and separated by a comma, such as 1,10,13,28.
+
+* `start_time` - (Optional, String) Specifies the start time of the scaling action triggered periodically.
+  The time format complies with UTC. The default value is the local time.
+  The time format is YYYY-MM-DDThh:mmZ.
+
+* `end_time` - (Optional, String) Specifies the end time of the scaling action triggered periodically.
+  The time format complies with UTC. This parameter is mandatory when scaling_policy_type is set to RECURRENCE.
+  When the scaling action is triggered periodically, the end time cannot be earlier than the current and start time.
+  The time format is YYYY-MM-DDThh:mmZ.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `scaling_resource_type` - The scaling resource type. The value is fixed to **BANDWIDTH**.
+
+* `status` - The AS policy status. The value can be **INSERVICE**, **PAUSED** and **EXECUTING**.
+
+## Import
+
+The bandwidth scaling policies can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_as_bandwidth_policy.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -577,10 +577,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_throttling_policy":           apig.ResourceApigThrottlingPolicyV2(),
 			"huaweicloud_apig_vpc_channel":                 apig.ResourceApigVpcChannelV2(),
 
-			"huaweicloud_as_configuration":  as.ResourceASConfiguration(),
-			"huaweicloud_as_group":          as.ResourceASGroup(),
-			"huaweicloud_as_lifecycle_hook": as.ResourceASLifecycleHook(),
-			"huaweicloud_as_policy":         as.ResourceASPolicy(),
+			"huaweicloud_as_configuration":    as.ResourceASConfiguration(),
+			"huaweicloud_as_group":            as.ResourceASGroup(),
+			"huaweicloud_as_lifecycle_hook":   as.ResourceASLifecycleHook(),
+			"huaweicloud_as_policy":           as.ResourceASPolicy(),
+			"huaweicloud_as_bandwidth_policy": as.ResourceASBandWidthPolicy(),
 
 			"huaweicloud_bms_instance": bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance": resourceBCSInstanceV2(),

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
@@ -1,0 +1,270 @@
+package as
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getASBandWidthPolicyResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getBandwidthPolicy: Query the AS bandwidth scaling policy
+	var (
+		getBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
+		getBandwidthPolicyProduct = "autoscaling"
+	)
+	getBandwidthPolicyClient, err := config.NewServiceClient(getBandwidthPolicyProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ASBandWidthPolicy Client: %s", err)
+	}
+
+	getBandwidthPolicyPath := getBandwidthPolicyClient.Endpoint + getBandwidthPolicyHttpUrl
+	getBandwidthPolicyPath = strings.Replace(getBandwidthPolicyPath, "{project_id}", getBandwidthPolicyClient.ProjectID, -1)
+	getBandwidthPolicyPath = strings.Replace(getBandwidthPolicyPath, "{id}", state.Primary.ID, -1)
+
+	getBandwidthPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getBandwidthPolicyResp, err := getBandwidthPolicyClient.Request("GET", getBandwidthPolicyPath, &getBandwidthPolicyOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving ASBandWidthPolicy: %s", err)
+	}
+	return utils.FlattenResponse(getBandwidthPolicyResp)
+}
+
+func TestAccASBandWidthPolicy_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_as_bandwidth_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getASBandWidthPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testASBandWidthPolicy_scheduled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_resource_type", "BANDWIDTH"),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "300"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.size", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test", "id"),
+				),
+			},
+			{
+				Config: testASBandWidthPolicy_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName+"-updated"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "900"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.limits", "300"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testASBandWidthPolicy_recurrence(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "RECURRENCE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "600"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_policy.0.launch_time", "07:00"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_policy.0.recurrence_type", "Weekly"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccASBandWidthPolicy_alarm(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_as_bandwidth_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getASBandWidthPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testASBandWidthPolicy_alarm(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "ALARM"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_resource_type", "BANDWIDTH"),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "alarm_id", "huaweicloud_ces_alarmrule.alarmrule_1", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testASBandWidthPolicy_scheduled(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s"
+  scaling_policy_type = "SCHEDULED"
+  bandwidth_id        = huaweicloud_vpc_bandwidth.test.id
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time = "2088-09-30T12:00Z"
+  }
+}
+`, name)
+}
+
+func testASBandWidthPolicy_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s-updated"
+  scaling_policy_type = "SCHEDULED"
+  bandwidth_id        = huaweicloud_vpc_bandwidth.test.id
+  cool_down_time      = 900
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 2
+    limits    = 300
+  }
+  scheduled_policy {
+    launch_time = "2099-09-30T12:00Z"
+  }
+}
+`, name)
+}
+
+func testASBandWidthPolicy_recurrence(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s"
+  scaling_policy_type = "RECURRENCE"
+  bandwidth_id        = huaweicloud_vpc_bandwidth.test.id
+  cool_down_time      = 600
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 1
+  }
+  scheduled_policy {
+    launch_time      = "07:00"
+    recurrence_type  = "Weekly"
+    recurrence_value = "1,3,5"
+    start_time       = "2022-09-30T12:00Z"
+    end_time         = "2022-12-30T12:00Z"
+  }
+}
+`, name)
+}
+
+func testASBandWidthPolicy_alarm(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
+  alarm_name           = "rule-%[1]s"
+  alarm_description    = "autoScaling"
+  alarm_action_enabled = true
+  alarm_enabled        = true
+
+  metric {
+    namespace   = "SYS.VPC"
+    metric_name = "downstream_bandwidth"
+
+    dimensions {
+      name  = "bandwidth_id"
+      value = huaweicloud_vpc_bandwidth.test.id
+    }
+  }
+
+  condition  {
+    period              = 300
+    filter              = "max"
+    comparison_operator = ">"
+    value               = 3600
+    unit                = "bit/s"
+    count               = 2
+  }
+
+  alarm_actions {
+    type              = "autoscaling"
+    notification_list = []
+  }
+}
+
+resource "huaweicloud_as_bandwidth_policy" "test" {
+  scaling_policy_name = "%[1]s"
+  scaling_policy_type = "ALARM"
+  bandwidth_id        = huaweicloud_vpc_bandwidth.test.id
+  alarm_id            = huaweicloud_ces_alarmrule.alarmrule_1.id
+
+  scaling_policy_action {
+    operation = "ADD"
+    size      = 2
+    limits    = 300
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
@@ -1,0 +1,460 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product AS
+// ---------------------------------------------------------------
+
+package as
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceASBandWidthPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceASBandWidthPolicyCreate,
+		UpdateContext: resourceASBandWidthPolicyUpdate,
+		ReadContext:   resourceASBandWidthPolicyRead,
+		DeleteContext: resourceASPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"scaling_policy_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  `Specifies the AS policy name.`,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+			"scaling_policy_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the AS policy type.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALARM", "SCHEDULED", "RECURRENCE",
+				}, false),
+			},
+			"bandwidth_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the scaling bandwidth ID.`,
+			},
+			"alarm_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the alarm rule ID.`,
+				ExactlyOneOf: []string{
+					"scheduled_policy",
+				},
+			},
+			"cool_down_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				Description:  `Specifies the cooldown period (in seconds).`,
+				ValidateFunc: validation.IntAtMost(86400),
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the description of the AS policy.`,
+			},
+			"scaling_policy_action": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     ASBandWidthPolicyActionSchema(),
+				Optional: true,
+				Computed: true,
+			},
+			"scheduled_policy": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     ASBandWidthScheduledPolicySchema(),
+				Optional: true,
+				Computed: true,
+				ExactlyOneOf: []string{
+					"alarm_id",
+				},
+			},
+			"scaling_resource_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `the scaling resource type.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `the AS policy status.`,
+			},
+		},
+	}
+}
+
+func ASBandWidthPolicyActionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"operation": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the operation to be performed. The default operation is ADD.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ADD", "REDUCE", "SET",
+				}, false),
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the bandwidth (Mbit/s).`,
+			},
+			"limits": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the operation restrictions.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func ASBandWidthScheduledPolicySchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"launch_time": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the time when the scaling action is triggered. The time format complies with UTC.`,
+			},
+			"recurrence_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the periodic triggering type.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Daily", "Weekly", "Monthly",
+				}, false),
+			},
+			"recurrence_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the day when a periodic scaling action is triggered.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the start time of the scaling action triggered periodically.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the end time of the scaling action triggered periodically.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceASBandWidthPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	// createBandwidthPolicy: create an AS bandwidth scaling policy
+	var (
+		createBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy"
+		createBandwidthPolicyProduct = "autoscaling"
+	)
+	createBandwidthPolicyClient, err := config.NewServiceClient(createBandwidthPolicyProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating ASBandWidthPolicy Client: %s", err)
+	}
+
+	createBandwidthPolicyPath := createBandwidthPolicyClient.Endpoint + createBandwidthPolicyHttpUrl
+	createBandwidthPolicyPath = strings.Replace(createBandwidthPolicyPath, "{project_id}", createBandwidthPolicyClient.ProjectID, -1)
+
+	createBandwidthPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createBandwidthPolicyOpt.JSONBody = utils.RemoveNil(buildCreateBandwidthPolicyBodyParams(d, config))
+	createBandwidthPolicyResp, err := createBandwidthPolicyClient.Request("POST", createBandwidthPolicyPath, &createBandwidthPolicyOpt)
+	if err != nil {
+		return diag.Errorf("error creating ASBandWidthPolicy: %s", err)
+	}
+
+	createBandwidthPolicyRespBody, err := utils.FlattenResponse(createBandwidthPolicyResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("scaling_policy_id", createBandwidthPolicyRespBody)
+	if err != nil {
+		return diag.Errorf("error creating ASBandWidthPolicy: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceASBandWidthPolicyRead(ctx, d, meta)
+}
+
+func buildCreateBandwidthPolicyBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"scaling_policy_name":   utils.ValueIngoreEmpty(d.Get("scaling_policy_name")),
+		"scaling_policy_type":   utils.ValueIngoreEmpty(d.Get("scaling_policy_type")),
+		"scaling_resource_id":   utils.ValueIngoreEmpty(d.Get("bandwidth_id")),
+		"scaling_resource_type": "BANDWIDTH",
+		"alarm_id":              utils.ValueIngoreEmpty(d.Get("alarm_id")),
+		"cool_down_time":        utils.ValueIngoreEmpty(d.Get("cool_down_time")),
+		"description":           utils.ValueIngoreEmpty(d.Get("description")),
+		"scaling_policy_action": buildCreateBandwidthPolicyScalingPolicyActionChildBody(d),
+		"scheduled_policy":      buildCreateBandwidthPolicyScheduledPolicyChildBody(d),
+	}
+	return bodyParams
+}
+
+func buildCreateBandwidthPolicyScalingPolicyActionChildBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("scaling_policy_action").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw := rawParams[0].(map[string]interface{})
+	params := map[string]interface{}{
+		"operation": utils.ValueIngoreEmpty(raw["operation"]),
+		"size":      utils.ValueIngoreEmpty(raw["size"]),
+		"limits":    utils.ValueIngoreEmpty(raw["limits"]),
+	}
+
+	return params
+}
+
+func buildCreateBandwidthPolicyScheduledPolicyChildBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("scheduled_policy").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw := rawParams[0].(map[string]interface{})
+	params := map[string]interface{}{
+		"launch_time":      utils.ValueIngoreEmpty(raw["launch_time"]),
+		"recurrence_type":  utils.ValueIngoreEmpty(raw["recurrence_type"]),
+		"recurrence_value": utils.ValueIngoreEmpty(raw["recurrence_value"]),
+		"start_time":       utils.ValueIngoreEmpty(raw["start_time"]),
+		"end_time":         utils.ValueIngoreEmpty(raw["end_time"]),
+	}
+
+	return params
+}
+
+func resourceASBandWidthPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getBandwidthPolicy: Query the AS bandwidth scaling policy
+	var (
+		getBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
+		getBandwidthPolicyProduct = "autoscaling"
+	)
+	getBandwidthPolicyClient, err := config.NewServiceClient(getBandwidthPolicyProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating ASBandWidthPolicy Client: %s", err)
+	}
+
+	getBandwidthPolicyPath := getBandwidthPolicyClient.Endpoint + getBandwidthPolicyHttpUrl
+	getBandwidthPolicyPath = strings.Replace(getBandwidthPolicyPath, "{project_id}", getBandwidthPolicyClient.ProjectID, -1)
+	getBandwidthPolicyPath = strings.Replace(getBandwidthPolicyPath, "{id}", d.Id(), -1)
+
+	getBandwidthPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getBandwidthPolicyResp, err := getBandwidthPolicyClient.Request("GET", getBandwidthPolicyPath, &getBandwidthPolicyOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ASBandWidthPolicy")
+	}
+
+	getBandwidthPolicyRespBody, err := utils.FlattenResponse(getBandwidthPolicyResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("scaling_policy_name", utils.PathSearch("scaling_policy.scaling_policy_name", getBandwidthPolicyRespBody, nil)),
+		d.Set("scaling_policy_type", utils.PathSearch("scaling_policy.scaling_policy_type", getBandwidthPolicyRespBody, nil)),
+		d.Set("bandwidth_id", utils.PathSearch("scaling_policy.scaling_resource_id", getBandwidthPolicyRespBody, nil)),
+		d.Set("scaling_resource_type", utils.PathSearch("scaling_policy.scaling_resource_type", getBandwidthPolicyRespBody, nil)),
+		d.Set("alarm_id", utils.PathSearch("scaling_policy.alarm_id", getBandwidthPolicyRespBody, nil)),
+		d.Set("cool_down_time", utils.PathSearch("scaling_policy.cool_down_time", getBandwidthPolicyRespBody, nil)),
+		d.Set("description", utils.PathSearch("scaling_policy.description", getBandwidthPolicyRespBody, nil)),
+		d.Set("status", utils.PathSearch("scaling_policy.policy_status", getBandwidthPolicyRespBody, nil)),
+		d.Set("scaling_policy_action", flattenGetBandwidthPolicyResponseBodyScalingPolicyAction(getBandwidthPolicyRespBody)),
+		d.Set("scheduled_policy", flattenGetBandwidthPolicyResponseBodyScheduledPolicy(getBandwidthPolicyRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetBandwidthPolicyResponseBodyScalingPolicyAction(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson, err := jmespath.Search("scaling_policy.scaling_policy_action", resp)
+	if err != nil {
+		log.Printf("[ERROR] error parsing scaling_policy_action from response= %#v", resp)
+		return rst
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"operation": utils.PathSearch("operation", curJson, nil),
+			"size":      utils.PathSearch("size", curJson, nil),
+			"limits":    utils.PathSearch("limits", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenGetBandwidthPolicyResponseBodyScheduledPolicy(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson, err := jmespath.Search("scaling_policy.scheduled_policy", resp)
+	if err != nil {
+		log.Printf("[ERROR] error parsing scheduled_policy from response= %#v", resp)
+		return rst
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"launch_time":      utils.PathSearch("launch_time", curJson, nil),
+			"recurrence_type":  utils.PathSearch("recurrence_type", curJson, nil),
+			"recurrence_value": utils.PathSearch("recurrence_value", curJson, nil),
+			"start_time":       utils.PathSearch("start_time", curJson, nil),
+			"end_time":         utils.PathSearch("end_time", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func resourceASBandWidthPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	updateBandwidthPolicyhasChanges := []string{
+		"scaling_policy_name",
+		"scaling_policy_type",
+		"bandwidth_id",
+		"scaling_resource_type",
+		"alarm_id",
+		"cool_down_time",
+		"description",
+		"scaling_policy_action",
+		"scheduled_policy",
+	}
+
+	if d.HasChanges(updateBandwidthPolicyhasChanges...) {
+		// updateBandwidthPolicy: update the AS bandwidth scaling policy
+		var (
+			updateBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
+			updateBandwidthPolicyProduct = "autoscaling"
+		)
+		updateBandwidthPolicyClient, err := config.NewServiceClient(updateBandwidthPolicyProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating ASBandWidthPolicy Client: %s", err)
+		}
+
+		updateBandwidthPolicyPath := updateBandwidthPolicyClient.Endpoint + updateBandwidthPolicyHttpUrl
+		updateBandwidthPolicyPath = strings.Replace(updateBandwidthPolicyPath, "{project_id}", updateBandwidthPolicyClient.ProjectID, -1)
+		updateBandwidthPolicyPath = strings.Replace(updateBandwidthPolicyPath, "{id}", d.Id(), -1)
+
+		updateBandwidthPolicyOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateBandwidthPolicyOpt.JSONBody = utils.RemoveNil(buildUpdateBandwidthPolicyBodyParams(d, config))
+		_, err = updateBandwidthPolicyClient.Request("PUT", updateBandwidthPolicyPath, &updateBandwidthPolicyOpt)
+		if err != nil {
+			return diag.Errorf("error updating ASBandWidthPolicy: %s", err)
+		}
+	}
+	return resourceASBandWidthPolicyRead(ctx, d, meta)
+}
+
+func buildUpdateBandwidthPolicyBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"scaling_policy_name":   utils.ValueIngoreEmpty(d.Get("scaling_policy_name")),
+		"scaling_policy_type":   utils.ValueIngoreEmpty(d.Get("scaling_policy_type")),
+		"scaling_resource_id":   utils.ValueIngoreEmpty(d.Get("bandwidth_id")),
+		"scaling_resource_type": utils.ValueIngoreEmpty(d.Get("scaling_resource_type")),
+		"alarm_id":              utils.ValueIngoreEmpty(d.Get("alarm_id")),
+		"cool_down_time":        utils.ValueIngoreEmpty(d.Get("cool_down_time")),
+		"description":           utils.ValueIngoreEmpty(d.Get("description")),
+		"scaling_policy_action": buildUpdateBandwidthPolicyScalingPolicyActionChildBody(d),
+		"scheduled_policy":      buildUpdateBandwidthPolicyScheduledPolicyChildBody(d),
+	}
+	return bodyParams
+}
+
+func buildUpdateBandwidthPolicyScalingPolicyActionChildBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("scaling_policy_action").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw := rawParams[0].(map[string]interface{})
+	params := map[string]interface{}{
+		"operation": utils.ValueIngoreEmpty(raw["operation"]),
+		"size":      utils.ValueIngoreEmpty(raw["size"]),
+		"limits":    utils.ValueIngoreEmpty(raw["limits"]),
+	}
+
+	return params
+}
+
+func buildUpdateBandwidthPolicyScheduledPolicyChildBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("scheduled_policy").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw := rawParams[0].(map[string]interface{})
+	params := map[string]interface{}{
+		"launch_time":      utils.ValueIngoreEmpty(raw["launch_time"]),
+		"recurrence_type":  utils.ValueIngoreEmpty(raw["recurrence_type"]),
+		"recurrence_value": utils.ValueIngoreEmpty(raw["recurrence_value"]),
+		"start_time":       utils.ValueIngoreEmpty(raw["start_time"]),
+		"end_time":         utils.ValueIngoreEmpty(raw["end_time"]),
+	}
+
+	return params
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource **huaweicloud_as_bandwidth_policy**


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1960 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASBandWidthPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== RUN   TestAccASBandWidthPolicy_alarm
=== PAUSE TestAccASBandWidthPolicy_alarm
=== CONT  TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_alarm
--- PASS: TestAccASBandWidthPolicy_alarm (23.84s)
--- PASS: TestAccASBandWidthPolicy_basic (43.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        43.586s
```
