### PR TITLE
refactor(utils/func): add new case for removenil function

### DIFF
--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -233,6 +233,17 @@ func RemoveNil(data map[string]interface{}) map[string]interface{} {
 		switch v := v.(type) {
 		case map[string]interface{}:
 			withoutNil[k] = RemoveNil(v)
+		case []map[string]interface{}:
+			rv := make([]map[string]interface{}, 0, len(v))
+			for _, vv := range v {
+				rst := RemoveNil(vv)
+				if len(rst) > 0 {
+					rv = append(rv, rst)
+				}
+			}
+			if len(rv) > 0 {
+				withoutNil[k] = rv
+			}
 		default:
 			withoutNil[k] = v
 		}

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+const (
+	greenCode  = "\033[1;32m"
+	yellowCode = "\033[1;33m"
+	resetCode  = "\033[0m"
+)
+
+func green(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", greenCode, str, resetCode)
+}
+
+func yellow(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", yellowCode, str, resetCode)
+}
+
+func TestAccFunction_RemoveNil(t *testing.T) {
+	var (
+		testInput = map[string]interface{}{
+			"level_one_index_zero": nil,
+			"level_one_index_one": []map[string]interface{}{
+				{
+					"level_two_index_zero": nil,
+				},
+				{
+					"level_two_index_one": "192.168.0.1",
+				},
+			},
+			"level_one_index_two": []map[string]interface{}{
+				{
+					"level_two_index_zero": nil,
+				},
+			},
+			"level_one_index_three": "172.16.0.237",
+		}
+
+		expected = map[string]interface{}{
+			"level_one_index_one": []map[string]interface{}{
+				{
+					"level_two_index_one": "192.168.0.1",
+				},
+			},
+			"level_one_index_three": "172.16.0.237",
+		}
+	)
+
+	if !reflect.DeepEqual(RemoveNil(testInput), expected) {
+		t.Fatalf("The processing result of RemoveNil method is not as expected, want %s, but %s", green(expected), yellow(testInput))
+	}
+	t.Logf("The processing result of RemoveNil method meets expectation: %s", green(expected))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
refactor the `RemoveNil` method and support the list type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run=TestAccObsBucket_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run=TestAccObsBucket_ -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_multiAZ
=== PAUSE TestAccObsBucket_multiAZ
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_basic
=== CONT  TestAccObsBucket_logging
=== CONT  TestAccObsBucket_parallelFS
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_parallelFS (17.42s)
=== CONT  TestAccObsBucket_multiAZ
--- PASS: TestAccObsBucket_logging (24.69s)
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucket_versioning (32.81s)
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_basic (36.60s)
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_multiAZ (20.87s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_withEpsId (17.22s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_website (16.17s)
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucket_cors (15.89s)
--- PASS: TestAccObsBucket_lifecycle (16.10s)
--- PASS: TestAccObsBucket_quota (15.44s)
--- PASS: TestAccObsBucket_encryption (44.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       77.264s
```
