### PR TITLE
chore: reduce the length of the random name for test resource

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -179,11 +179,11 @@ func TestAccPreCheckMrsCustom(t *testing.T) {
 }
 
 func RandomAccResourceName() string {
-	return fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+	return fmt.Sprintf("tf_test_%s", acctest.RandString(5))
 }
 
 func RandomAccResourceNameWithDash() string {
-	return fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	return fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 }
 
 func RandomCidr() string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
current: the length of the random name is 17, the format: **tf_acc_test_xxxxx**,
 it is too long for some resources, so change to **tf_test_xxxxx**


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
