### PR TITLE
refactor: feat(common/func): add new wait method and refactor another

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -149,33 +149,69 @@ func CheckForRetryableError(err error) *resource.RetryError {
 	}
 }
 
-func WaitOrderComplete(ctx context.Context, d *schema.ResourceData, config *config.Config, orderNum string) error {
-	bssV2Client, err := config.BssV2Client(GetRegion(d, config))
-	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud bss V2 client: %s", err)
-	}
+func WaitOrderComplete(ctx context.Context, client *golangsdk.ServiceClient, orderId string,
+	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"3", "6"}, // 3: Processing; 6: Pending payment.
 		Target:       []string{"5"},      // 5: Completed.
-		Refresh:      refreshOrderStatus(bssV2Client, orderNum),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Refresh:      refreshOrderStatusFunc(client, orderId),
+		Timeout:      timeout,
 		Delay:        5 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
-	_, err = stateConf.WaitForStateContext(ctx)
+	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf("Error while waiting for the order (%s) to complete payment: %#v", orderNum, err)
+		return fmt.Errorf("error waiting for the order (%s) to complete payment: %#v", orderId, err)
 	}
 	return nil
 }
 
-func refreshOrderStatus(c *golangsdk.ServiceClient, orderNum string) resource.StateRefreshFunc {
+func refreshOrderStatusFunc(client *golangsdk.ServiceClient, orderId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		r, err := orders.Get(c, orderNum).Extract()
+		r, err := orders.Get(client, orderId).Extract()
 		if err != nil {
 			return nil, "Error", err
 		}
 		return r, strconv.Itoa(r.OrderInfo.Status), nil
+	}
+}
+
+// WaitOrderResourceComplete is the method to wait for the resource to be generated.
+// Notes: Note that this method needs to be used in conjunction with method "WaitOrderComplete", because the ID of some
+// resources may not be generated when the order is not completed.
+func WaitOrderResourceComplete(ctx context.Context, client *golangsdk.ServiceClient, orderId string,
+	timeout time.Duration) (string, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"DONE"},
+		Refresh:      refreshOrderResourceStatusFunc(client, orderId),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	res, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error while waiting for the order (%s) to complete: %#v", orderId, err)
+	}
+
+	r := res.(resources.Resource)
+	return r.ResourceId, nil
+}
+
+func refreshOrderResourceStatusFunc(client *golangsdk.ServiceClient, orderId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		listOpts := resources.ListOpts{
+			OrderId:          orderId,
+			OnlyMainResource: 1,
+		}
+		resp, err := resources.List(client, listOpts)
+		if err != nil || resp == nil {
+			return nil, "ERROR", fmt.Errorf("error waiting for the order (%s) to complete: %#v", orderId, err)
+		}
+		if resp.TotalCount < 1 {
+			return nil, "PENDING", nil
+		}
+		return resp.Resources[0], "DONE", nil
 	}
 }
 

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -1152,7 +1152,11 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 		}
 
 		if strings.EqualFold(d.Get("charging_mode").(string), "prePaid") {
-			err = common.WaitOrderComplete(ctx, d, config, resp.OrderID)
+			bssClient, err := config.BssV2Client(config.GetRegion(d))
+			if err != nil {
+				return diag.Errorf("error creating BSS v2 client: %s", err)
+			}
+			err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return diag.Errorf("The order (%s) is not completed while extending system disk (%s) size: %#v",
 					resp.OrderID, d.Id(), err)

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -370,7 +370,12 @@ func resourceVaultCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 		d.SetId(resp.Orders[0].ResourceId)
-		err = common.WaitOrderComplete(ctx, d, config, resp.Orders[0].ID)
+
+		bssClient, err := config.BssV2Client(config.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+		err = common.WaitOrderComplete(ctx, bssClient, resp.Orders[0].ID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return diag.Errorf("the order is not completed while creating CBR vault (%s): %v", d.Id(), err)
 		}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -275,7 +275,11 @@ func resourceLoadBalancerV3Create(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		// wait for the order to be completed.
-		err = common.WaitOrderComplete(ctx, d, config, resp.OrderID)
+		bssClient, err := config.BssV2Client(config.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+		err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return diag.Errorf("the order is not completed while creating ELB loadbalancer (%s): %#v", resp.LoadBalancerID, err)
 		}
@@ -461,7 +465,11 @@ func resourceLoadBalancerV3Update(ctx context.Context, d *schema.ResourceData, m
 			}
 
 			// wait for the order to be completed.
-			err = common.WaitOrderComplete(ctx, d, config, resp.OrderID)
+			bssClient, err := config.BssV2Client(config.GetRegion(d))
+			if err != nil {
+				return diag.Errorf("error creating BSS v2 client: %s", err)
+			}
+			err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return diag.Errorf("the order is not completed while updating ELB loadbalancer (%s): %#v", resp.LoadBalancerID, err)
 			}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -236,7 +236,11 @@ func resourceEvsVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	// If charging mode is PrePaid, wait for the order to be completed.
 	if job.OrderID != "" {
-		err = common.WaitOrderComplete(ctx, d, config, job.OrderID)
+		bssClient, err := config.BssV2Client(config.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+		err = common.WaitOrderComplete(ctx, bssClient, job.OrderID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return fmtp.DiagErrorf("The order is not completed while creating EVS volume (%s): %#v", d.Id(), err)
 		}
@@ -379,7 +383,11 @@ func resourceEvsVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		if strings.EqualFold(d.Get("charging_mode").(string), "prePaid") {
-			err = common.WaitOrderComplete(ctx, d, config, resp.OrderID)
+			bssClient, err := config.BssV2Client(config.GetRegion(d))
+			if err != nil {
+				return diag.Errorf("error creating BSS v2 client: %s", err)
+			}
+			err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return fmtp.DiagErrorf("The order (%s) is not completed while extending EVS volume (%s) size: %#v",
 					resp.OrderID, d.Id(), err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bss/v2/resources/requests.go
@@ -1,8 +1,6 @@
 package resources
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -29,14 +27,7 @@ type ListOpts struct {
 	ExpireTimeEnd string `json:"expire_time_end,omitempty"`
 }
 
-// Get is a method to retrieves a particular resource based on its unique ID.
-func Get(c *golangsdk.ServiceClient, resourceId string, onlyMainRes bool) (*Resource, error) {
-	opts := ListOpts{
-		ResourceIds: []string{resourceId},
-	}
-	if onlyMainRes {
-		opts.OnlyMainResource = 1
-	}
+func List(c *golangsdk.ServiceClient, opts ListOpts) (*QueryResp, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err
@@ -49,11 +40,7 @@ func Get(c *golangsdk.ServiceClient, resourceId string, onlyMainRes bool) (*Reso
 	if err != nil {
 		return nil, err
 	}
-	if r.TotalCount < 1 {
-		return nil, fmt.Errorf("unabled to find the resource (%s) from the server.", resourceId)
-	}
-	resList := r.Resources
-	return &resList[0], nil
+	return &r, nil
 }
 
 // EnableAutoRenew is a method to enable the auto-renew of the prepaid resource.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new waiting function "WaitOrderResourceComplete" and refactor another waiting funtion "WaitOrderComplete".

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstance_ -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== RUN   TestAccComputeInstance_disks
=== PAUSE TestAccComputeInstance_disks
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== RUN   TestAccComputeInstance_tags
=== PAUSE TestAccComputeInstance_tags
=== RUN   TestAccComputeInstance_powerAction
=== PAUSE TestAccComputeInstance_powerAction
=== CONT  TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_tags
=== CONT  TestAccComputeInstance_prePaid
=== CONT  TestAccComputeInstance_powerAction
--- PASS: TestAccComputeInstance_basic (185.62s)
=== CONT  TestAccComputeInstance_disks
--- PASS: TestAccComputeInstance_prePaid (199.35s)
--- PASS: TestAccComputeInstance_tags (256.28s)
--- PASS: TestAccComputeInstance_disks (218.62s)
--- PASS: TestAccComputeInstance_powerAction (452.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       452.729s
```
```
make testacc TEST='./huaweicloud/services/acceptance/dcs' TESTARGS='-run=TestAccDcsInstances_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs -v -run=TestAccDcsInstances_ -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_withEpsId
--- PASS: TestAccDcsInstances_whitelists (86.93s)
=== CONT  TestAccDcsInstances_single
--- PASS: TestAccDcsInstances_withEpsId (95.50s)
--- PASS: TestAccDcsInstances_tiny (97.37s)
--- PASS: TestAccDcsInstances_basic (131.13s)
--- PASS: TestAccDcsInstances_single (82.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       169.510s
```
```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccVault_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccVault_ -timeout 360m -parallel 4
=== RUN   TestAccVault_BasicServer
=== PAUSE TestAccVault_BasicServer
=== RUN   TestAccVault_ReplicaServer
=== PAUSE TestAccVault_ReplicaServer
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== RUN   TestAccVault_BasicVolume
=== PAUSE TestAccVault_BasicVolume
=== RUN   TestAccVault_BasicTurbo
=== PAUSE TestAccVault_BasicTurbo
=== RUN   TestAccVault_ReplicaTurbo
=== PAUSE TestAccVault_ReplicaTurbo
=== RUN   TestAccVault_AutoBind
=== PAUSE TestAccVault_AutoBind
=== CONT  TestAccVault_BasicServer
=== CONT  TestAccVault_BasicTurbo
=== CONT  TestAccVault_prePaidServer
=== CONT  TestAccVault_BasicVolume
--- PASS: TestAccVault_BasicVolume (254.00s)
=== CONT  TestAccVault_ReplicaServer
--- PASS: TestAccVault_ReplicaServer (23.57s)
=== CONT  TestAccVault_AutoBind
--- PASS: TestAccVault_AutoBind (31.63s)
=== CONT  TestAccVault_ReplicaTurbo
--- PASS: TestAccVault_BasicServer (314.10s)
--- PASS: TestAccVault_ReplicaTurbo (21.97s)
--- PASS: TestAccVault_prePaidServer (388.01s)
--- PASS: TestAccVault_BasicTurbo (740.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr   740.326s
```
```
make testacc TEST='./huaweicloud/services/acceptance/elb' TESTARGS='-run=TestAccElbV3LoadBalancer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run=TestAccElbV3LoadBalancer_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_withEIP
=== CONT  TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEpsId (34.08s)
--- PASS: TestAccElbV3LoadBalancer_withEIP (35.66s)
--- PASS: TestAccElbV3LoadBalancer_basic (60.28s)
--- PASS: TestAccElbV3LoadBalancer_prePaid (135.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       135.851s
```
```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run=TestAccEvsVolume_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run=TestAccEvsVolume_ -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== RUN   TestAccEvsVolume_withEpsId
=== PAUSE TestAccEvsVolume_withEpsId
=== RUN   TestAccEvsVolume_prePaid
=== PAUSE TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolume_withEpsId
=== CONT  TestAccEvsVolume_basic
    resource_huaweicloud_evs_volume_test.go:33: Step 1/2 error: Check failed: Check 6/19 error: huaweicloud_evs_volume.test.0: Attribute 'tags.foo' not found
--- FAIL: TestAccEvsVolume_basic (29.23s)
--- PASS: TestAccEvsVolume_withEpsId (35.83s)
--- PASS: TestAccEvsVolume_prePaid (140.96s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs   141.109s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
