### PR TITLE
fix(lts): check the resource deleted when refreshing

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -11,6 +11,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -30,6 +31,18 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
+
+// ErrorResp is the response when API failed
+type ErrorResp struct {
+	ErrorCode string `json:"error_code"`
+	ErrorMsg  string `json:"error_msg"`
+}
+
+func ParseErrorMsg(body []byte) (ErrorResp, error) {
+	resp := ErrorResp{}
+	err := json.Unmarshal(body, &resp)
+	return resp, err
+}
 
 // GetRegion returns the region that was specified ina the resource. If a
 // region was not set, the provider-level region is checked. The provider-level

--- a/huaweicloud/resource_huaweicloud_lts_group.go
+++ b/huaweicloud/resource_huaweicloud_lts_group.go
@@ -81,7 +81,9 @@ func resourceGroupV2Read(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return fmtp.Errorf("Error HuaweiCloud log group %s: No Found", d.Id())
+	logp.Printf("[WARN] log group %s: resource is gone and will be removed in Terraform state", d.Id())
+	d.SetId("")
+	return nil
 }
 
 func resourceGroupV2Update(d *schema.ResourceData, meta interface{}) error {

--- a/huaweicloud/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/resource_huaweicloud_lts_stream.go
@@ -1,8 +1,10 @@
 package huaweicloud
 
 import (
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/lts/huawei/logstreams"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
@@ -72,15 +74,25 @@ func resourceStreamV2Read(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("Error creating HuaweiCloud LTS client: %s", err)
 	}
 
-	groupId := d.Get("group_id").(string)
-	streams, err := logstreams.List(client, groupId).Extract()
+	streamID := d.Id()
+	groupID := d.Get("group_id").(string)
+	streams, err := logstreams.List(client, groupID).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error getting HuaweiCloud log stream %s: %s", d.Id(), err)
+		if apiError, ok := err.(golangsdk.ErrDefault400); ok {
+			// "LTS.0201" indicates the log group is not exist
+			if resp, pErr := common.ParseErrorMsg(apiError.Body); pErr == nil && resp.ErrorCode == "LTS.0201" {
+				logp.Printf("[WARN] log group stream %s: the log group %s is gone", streamID, groupID)
+				d.SetId("")
+				return nil
+			}
+		}
+
+		return fmtp.Errorf("Error getting HuaweiCloud log stream %s: %s", streamID, err)
 	}
 
 	for _, stream := range streams.LogStreams {
-		if stream.ID == d.Id() {
-			logp.Printf("[DEBUG] Retrieved log stream %s: %#v", d.Id(), stream)
+		if stream.ID == streamID {
+			logp.Printf("[DEBUG] Retrieved log stream %s: %#v", streamID, stream)
 			d.SetId(stream.ID)
 			d.Set("stream_name", stream.Name)
 			d.Set("filter_count", stream.FilterCount)
@@ -88,7 +100,9 @@ func resourceStreamV2Read(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return fmtp.Errorf("Error HuaweiCloud log group stream %s: No Found", d.Id())
+	logp.Printf("[WARN] log group stream %s: resource is gone and will be removed in Terraform state", streamID)
+	d.SetId("")
+	return nil
 }
 
 func resourceStreamV2Delete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

if log groups and log group streams are not destroyed by terraform, an error will accoured when refreshing them.
we should check deleted before refreshing

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLogTankGroupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLogTankGroupV2_basic -timeout 360m -parallel 4
=== RUN   TestAccLogTankGroupV2_basic
=== PAUSE TestAccLogTankGroupV2_basic
=== CONT  TestAccLogTankGroupV2_basic
--- PASS: TestAccLogTankGroupV2_basic (17.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       18.028s
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLogTankStreamV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLogTankStreamV2_basic -timeout 360m -parallel 4
=== RUN   TestAccLogTankStreamV2_basic
=== PAUSE TestAccLogTankStreamV2_basic
=== CONT  TestAccLogTankStreamV2_basic
--- PASS: TestAccLogTankStreamV2_basic (10.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       10.112s
```
