### PR TITLE
feat(dms/kafka): add new resources user and permissions

### DIFF
--- a/docs/resources/dms_kafka_permissions.md
+++ b/docs/resources/dms_kafka_permissions.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_permissions
+
+Use the resource to grant user permissions of a kafka topic within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "kafka_instance_id" {}
+variable "kafka_topic_name" {}
+variable "user_1" {}
+variable "user_2" {}
+
+resource "huaweicloud_dms_kafka_permissions" "test" {
+  instance_id = var.kafka_instance_id
+  topic_name  = var.kafka_topic_name
+  policies {
+    user_name     = var.user_1
+    access_policy = "all"
+  }
+
+  policies {
+    user_name     = var.user_2
+    access_policy = "pub"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS kafka permissions resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DMS kafka instance to which the permissions belongs.
+  Changing this creates a new resource.
+
+* `topic_name` - (Required, String, ForceNew) Specifies the name of the topic to which the permissions belongs.
+  Changing this creates a new resource.
+
+* `policies` - (Required, List) Specifies the permissions policies. The [object](#dms_kafka_policies) structure is
+  documented below.
+
+<a name="dms_kafka_policies"></a>
+The `policies` block supports:
+
+* `user_name` -(Required, String) Specifies the user name.
+
+* `access_policy` -(Required, String) Specifies the permissions type. The value can be:
+  + **all**: publish and subscribe permissions.
+  + **pub**: publish permissions.
+  + **sub**: subscribe permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is formatted `<instance_id>/<topic_name>`.
+
+## Import
+
+DMS kafka permissions can be imported using the kafka instance ID and topic name separated by a slash, e.g.:
+
+```
+terraform import huaweicloud_dms_kafka_permissions.permissions c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/topic_1
+```

--- a/docs/resources/dms_kafka_user.md
+++ b/docs/resources/dms_kafka_user.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_user
+
+Manages a DMS kafka user resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "kafka_instance_id" {}
+
+resource "huaweicloud_dms_kafka_user" "user" {
+  instance_id = var.kafka_instance_id
+  name        = "user_1"
+  password    = "Test@123"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS kafka user resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DMS kafka instance to which the user belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the user. Changing this creates a new resource.
+
+* `password` - (Required, String) Specifies the password of the user. The parameter must be 8 to 32 characters
+  long and contain only letters(case-sensitive), digits, and special characters(`~!@#$%^&*()-_=+|[{}]:'",<.>/?).
+  The value must be different from name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is formatted `<instance_id>/<user_name>`.
+
+## Import
+
+DMS kafka users can be imported using the kafka instance ID and user name separated by a slash, e.g.
+
+```
+terraform import huaweicloud_dms_kafka_user.user c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/user_1
+```

--- a/huaweicloud/config/hc_config.go
+++ b/huaweicloud/config/hc_config.go
@@ -22,6 +22,7 @@ import (
 	ctsv3 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3"
 	iamv3 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3"
 	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	dmsv2 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2"
 	kpsv3 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3"
 	livev1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
 	mpcv1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/mpc/v1"
@@ -265,6 +266,15 @@ func (c *Config) HcCdnV1Client(region string) (*cdnv1.CdnClient, error) {
 		return nil, err
 	}
 	return cdnv1.NewCdnClient(hcClient), nil
+}
+
+// HcDmsV2Client is the DMS service client using huaweicloud-sdk-go-v3 package
+func (c *Config) HcDmsV2Client(region string) (*dmsv2.KafkaClient, error) {
+	hcClient, err := NewHcClient(c, region, "dmsv2", false)
+	if err != nil {
+		return nil, err
+	}
+	return dmsv2.NewKafkaClient(hcClient), nil
 }
 
 // NewHcClient is the common client using huaweicloud-sdk-go-v3 package

--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -234,6 +234,8 @@ func isSecurityFields(field string) bool {
 	// 'nonce' is apply to the random string for authorization methods.
 	// 'email', 'phone' and 'sip_number' can uniquely identify a person.
 	// 'signature' are used for encryption.
-	securityFields := []string{"adminpass", "encrypted_user_data", "nonce", "email", "phone", "sip_number", "signature"}
+	// 'user_passwd' is apply to the dms/kafka user request JSON body
+	securityFields := []string{"adminpass", "encrypted_user_data", "nonce", "email", "phone", "sip_number",
+		"signature", "user_passwd"}
 	return utils.StrSliceContains(securityFields, checkField)
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -662,6 +662,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_permission":   dli.ResourceDliPermission(),
 
 			"huaweicloud_dms_instance":          deprecated.ResourceDmsInstancesV1(),
+			"huaweicloud_dms_kafka_user":        dms.ResourceDmsKafkaUser(),
+			"huaweicloud_dms_kafka_permissions": dms.ResourceDmsKafkaPermissions(),
 			"huaweicloud_dms_kafka_instance":    dms.ResourceDmsKafkaInstance(),
 			"huaweicloud_dms_kafka_topic":       dms.ResourceDmsKafkaTopic(),
 			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_permissions_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_permissions_test.go
@@ -1,0 +1,148 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDmsKafkaPermissionsFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.HcDmsV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
+	}
+
+	// Split instance_id and topic_name from resource id
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<topic_name>")
+	}
+	instanceId := parts[0]
+	topicName := parts[1]
+
+	request := &model.ShowTopicAccessPolicyRequest{
+		InstanceId: instanceId,
+		TopicName:  topicName,
+	}
+
+	response, err := client.ShowTopicAccessPolicy(request)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DMS kafka premissions: %s", err)
+	}
+
+	if response.Policies != nil && len(*response.Policies) != 0 {
+		policies := *response.Policies
+		return policies, nil
+	}
+
+	return nil, fmt.Errorf("can not found DMS kafka user")
+}
+
+func TestAccDmsKafkaPermissions_basic(t *testing.T) {
+	var policies []model.PolicyEntity
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_kafka_permissions.test"
+	password := acceptance.RandomPassword()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&policies,
+		getDmsKafkaPermissionsFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaPermissions_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "policies.0.user_name",
+						"huaweicloud_dms_kafka_user.test1", "name"),
+					resource.TestCheckResourceAttr(resourceName, "policies.0.access_policy", "all"),
+				),
+			},
+			{
+				Config: testAccDmsKafkaPermissions_update(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "policies.0.user_name",
+						"huaweicloud_dms_kafka_user.test1", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "policies.1.user_name",
+						"huaweicloud_dms_kafka_user.test2", "name"),
+					resource.TestCheckResourceAttr(resourceName, "policies.0.access_policy", "pub"),
+					resource.TestCheckResourceAttr(resourceName, "policies.1.access_policy", "sub"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDmsKafkaPermissions_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_user" "test1" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%[2]s-1"
+  password    = "%[3]s"
+}
+
+resource "huaweicloud_dms_kafka_permissions" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  topic_name  = huaweicloud_dms_kafka_topic.topic.name
+
+  policies {
+    user_name     = huaweicloud_dms_kafka_user.test1.name
+    access_policy = "all"
+  }
+}
+`, testAccDmsKafkaTopic_basic(rName), rName, password)
+}
+
+func testAccDmsKafkaPermissions_update(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_user" "test1" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%[2]s-1"
+  password    = "%[3]s"
+}
+
+resource "huaweicloud_dms_kafka_user" "test2" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%[2]s-2"
+  password    = "%[3]s"
+}
+
+resource "huaweicloud_dms_kafka_permissions" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  topic_name  = huaweicloud_dms_kafka_topic.topic.name
+
+  policies {
+    user_name     = huaweicloud_dms_kafka_user.test1.name
+    access_policy = "pub"
+  }
+
+  policies {
+    user_name     = huaweicloud_dms_kafka_user.test2.name
+    access_policy = "sub"
+  }
+}
+`, testAccDmsKafkaTopic_basic(rName), rName, password)
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
@@ -119,7 +119,7 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   partitions  = 10
   aging_time  = 36
 }
-`, testAccKafkaInstance_base(rName), rName)
+`, testAccKafkaInstance_basic(rName), rName)
 }
 
 func testAccDmsKafkaTopic_update_part1(rName string) string {
@@ -132,7 +132,7 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   partitions  = 20
   aging_time  = 72
 }
-`, testAccKafkaInstance_base(rName), rName)
+`, testAccKafkaInstance_basic(rName), rName)
 }
 
 func testAccDmsKafkaTopic_update_part2(rName string) string {
@@ -147,5 +147,5 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   sync_flushing    = true
   sync_replication = true
 }
-`, testAccKafkaInstance_base(rName), rName)
+`, testAccKafkaInstance_basic(rName), rName)
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_user_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_user_test.go
@@ -1,0 +1,103 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDmsKafkaUserFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.HcDmsV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
+	}
+
+	// Split instance_id and user from resource id
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<user>")
+	}
+	instanceId := parts[0]
+	instanceUser := parts[1]
+
+	// List all instance users
+	request := &model.ShowInstanceUsersRequest{
+		InstanceId: instanceId,
+	}
+
+	response, err := client.ShowInstanceUsers(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing DMS kafka users in %s, error: %s", instanceId, err)
+	}
+	if response.Users != nil && len(*response.Users) != 0 {
+		users := *response.Users
+		for _, user := range users {
+			if *user.UserName == instanceUser {
+				return user, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("can not found DMS kafka user")
+}
+
+func TestAccDmsKafkaUser_basic(t *testing.T) {
+	var user model.ShowInstanceUsersEntity
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_kafka_user.test"
+	password := acceptance.RandomPassword()
+	passwordUpdate := password + "update"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&user,
+		getDmsKafkaUserFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaUser_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				Config: testAccDmsKafkaUser_basic(rName, passwordUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccDmsKafkaUser_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_user" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%s"
+  password    = "%s"
+}
+`, testAccKafkaInstance_basic(rName), rName, password)
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_permissions.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_permissions.go
@@ -1,0 +1,207 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDmsKafkaPermissions() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaPermissionsCreateOrUpdate,
+		UpdateContext: resourceDmsKafkaPermissionsCreateOrUpdate,
+		DeleteContext: resourceDmsKafkaPermissionsDelete,
+		ReadContext:   resourceDmsKafkaPermissionsRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"topic_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"access_policy": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"pub", "sub", "all",
+							}, false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildPoliciesOpts(rawPolicies []interface{}) ([]model.AccessPolicyEntity, error) {
+	if len(rawPolicies) < 1 {
+		return nil, nil
+	}
+
+	policies := make([]model.AccessPolicyEntity, len(rawPolicies))
+	for i, v := range rawPolicies {
+		policy := v.(map[string]interface{})
+		var accessPolicy model.AccessPolicyEntityAccessPolicy
+		if err := accessPolicy.UnmarshalJSON([]byte(policy["access_policy"].(string))); err != nil {
+			return nil, fmt.Errorf("error parsing the argument access_policy: %s", err)
+		}
+		policies[i] = model.AccessPolicyEntity{
+			UserName:     utils.String(policy["user_name"].(string)),
+			AccessPolicy: &accessPolicy,
+		}
+	}
+
+	return policies, nil
+}
+
+func resourceDmsKafkaPermissionsCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	topicName := d.Get("topic_name").(string)
+	instanceId := d.Get("instance_id").(string)
+
+	policies, err := buildPoliciesOpts(d.Get("policies").([]interface{}))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createOrUpdateOpts := &model.UpdateTopicAccessPolicyRequest{
+		InstanceId: instanceId,
+		Body: &model.UpdateTopicAccessPolicyReq{
+			Topics: []model.AccessPolicyTopicEntity{
+				{
+					Name:     topicName,
+					Policies: policies,
+				},
+			},
+		},
+	}
+
+	_, err = client.UpdateTopicAccessPolicy(createOrUpdateOpts)
+	if err != nil {
+		return diag.Errorf("error creating DMS kafka permissions: %s", err)
+	}
+
+	id := instanceId + "/" + topicName
+	d.SetId(id)
+	return resourceDmsKafkaPermissionsRead(ctx, d, meta)
+}
+
+func resourceDmsKafkaPermissionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	// Split instance_id and topic_name from resource id
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<topic_name>")
+	}
+	instanceId := parts[0]
+	topicName := parts[1]
+
+	request := &model.ShowTopicAccessPolicyRequest{
+		InstanceId: instanceId,
+		TopicName:  topicName,
+	}
+
+	response, err := client.ShowTopicAccessPolicy(request)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DMS kafka premission")
+	}
+
+	if response.Policies != nil && len(*response.Policies) != 0 {
+		policies := *response.Policies
+		d.Set("instance_id", instanceId)
+		d.Set("topic_name", topicName)
+		d.Set("policies", flattenPolicies(policies))
+		return nil
+	}
+
+	// DB premission deleted
+	log.Printf("[WARN] failed to fetch DMS kafka premission %s: deleted", d.Id())
+	d.SetId("")
+
+	return nil
+}
+
+func resourceDmsKafkaPermissionsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	topicName := d.Get("topic_name").(string)
+	instanceId := d.Get("instance_id").(string)
+
+	deleteOpts := &model.UpdateTopicAccessPolicyRequest{
+		InstanceId: instanceId,
+		Body: &model.UpdateTopicAccessPolicyReq{
+			Topics: []model.AccessPolicyTopicEntity{
+				{
+					Name:     topicName,
+					Policies: []model.AccessPolicyEntity{},
+				},
+			},
+		},
+	}
+
+	_, err = client.UpdateTopicAccessPolicy(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting DMS kafka permissions: %s", err)
+	}
+
+	return nil
+}
+
+func flattenPolicies(policies []model.PolicyEntity) []map[string]interface{} {
+	policiesToSet := make([]map[string]interface{}, len(policies))
+	for i, v := range policies {
+		policiesToSet[i] = map[string]interface{}{
+			"user_name":     v.UserName,
+			"access_policy": v.AccessPolicy.Value(),
+		}
+	}
+
+	return policiesToSet
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_user.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_user.go
@@ -1,0 +1,175 @@
+package dms
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDmsKafkaUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaUserCreate,
+		UpdateContext: resourceDmsKafkaUserUpdate,
+		DeleteContext: resourceDmsKafkaUserDelete,
+		ReadContext:   resourceDmsKafkaUserRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	instanceUser := d.Get("name").(string)
+	instanceId := d.Get("instance_id").(string)
+
+	createOpts := &model.CreateInstanceUserRequest{
+		InstanceId: instanceId,
+		Body: &model.CreateInstanceUserReq{
+			UserName:   utils.String(instanceUser),
+			UserPasswd: utils.String(d.Get("password").(string)),
+		},
+	}
+
+	_, err = client.CreateInstanceUser(createOpts)
+	if err != nil {
+		return diag.Errorf("error creating DMS instance user: %s", err)
+	}
+
+	id := instanceId + "/" + instanceUser
+	d.SetId(id)
+	return resourceDmsKafkaUserRead(ctx, d, meta)
+}
+
+func resourceDmsKafkaUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	// Split instance_id and user from resource id
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<user>")
+	}
+	instanceId := parts[0]
+	instanceUser := parts[1]
+
+	// List all instance users
+	request := &model.ShowInstanceUsersRequest{
+		InstanceId: instanceId,
+	}
+
+	response, err := client.ShowInstanceUsers(request)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error listing DMS instance users")
+	}
+
+	if response.Users != nil && len(*response.Users) != 0 {
+		users := *response.Users
+		for _, user := range users {
+			if *user.UserName == instanceUser {
+				d.Set("instance_id", instanceId)
+				d.Set("name", instanceUser)
+				return nil
+			}
+		}
+	}
+
+	// DB user deleted
+	d.SetId("")
+	log.Printf("[WARN] failed to fetch DMS instance user %s: deleted", instanceUser)
+
+	return nil
+}
+
+func resourceDmsKafkaUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+
+	updateOpts := &model.ResetUserPasswrodRequest{
+		InstanceId: instanceId,
+		UserName:   d.Get("name").(string),
+		Body: &model.ResetUserPasswrodReq{
+			NewPassword: utils.String(d.Get("password").(string)),
+		},
+	}
+
+	_, err = client.ResetUserPasswrod(updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating DMS instance user: %s", err)
+	}
+
+	return resourceDmsKafkaUserRead(ctx, d, meta)
+}
+
+func resourceDmsKafkaUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*config.Config)
+	client, err := c.HcDmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	users := []string{d.Get("name").(string)}
+	action := model.GetBatchDeleteInstanceUsersReqActionEnum().DELETE
+
+	deleteOpts := &model.BatchDeleteInstanceUsersRequest{
+		InstanceId: instanceId,
+		Body: &model.BatchDeleteInstanceUsersReq{
+			Action: &action,
+			Users:  &users,
+		},
+	}
+
+	log.Printf("[DEBUG] Delete DMS instance user options: %#v", deleteOpts)
+	_, err = client.BatchDeleteInstanceUsers(deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting DMS instance user: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/kafka_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/kafka_client.go
@@ -1,0 +1,1209 @@
+package v2
+
+import (
+	http_client "github.com/huaweicloud/huaweicloud-sdk-go-v3/core"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/invoker"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+)
+
+type KafkaClient struct {
+	HcClient *http_client.HcHttpClient
+}
+
+func NewKafkaClient(hcClient *http_client.HcHttpClient) *KafkaClient {
+	return &KafkaClient{HcClient: hcClient}
+}
+
+func KafkaClientBuilder() *http_client.HcHttpClientBuilder {
+	builder := http_client.NewHcHttpClientBuilder()
+	return builder
+}
+
+// BatchCreateOrDeleteKafkaTag 批量添加或删除实例标签
+//
+// 批量添加或删除实例标签。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) BatchCreateOrDeleteKafkaTag(request *model.BatchCreateOrDeleteKafkaTagRequest) (*model.BatchCreateOrDeleteKafkaTagResponse, error) {
+	requestDef := GenReqDefForBatchCreateOrDeleteKafkaTag()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchCreateOrDeleteKafkaTagResponse), nil
+	}
+}
+
+// BatchCreateOrDeleteKafkaTagInvoker 批量添加或删除实例标签
+func (c *KafkaClient) BatchCreateOrDeleteKafkaTagInvoker(request *model.BatchCreateOrDeleteKafkaTagRequest) *BatchCreateOrDeleteKafkaTagInvoker {
+	requestDef := GenReqDefForBatchCreateOrDeleteKafkaTag()
+	return &BatchCreateOrDeleteKafkaTagInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// BatchDeleteInstanceTopic Kafka实例批量删除Topic
+//
+// 该接口用于向Kafka实例批量删除Topic。批量删除多个消费组时，部分删除成功，部分失败，此时接口返回删除成功，并在返回中显示删除失败的消费组信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) BatchDeleteInstanceTopic(request *model.BatchDeleteInstanceTopicRequest) (*model.BatchDeleteInstanceTopicResponse, error) {
+	requestDef := GenReqDefForBatchDeleteInstanceTopic()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchDeleteInstanceTopicResponse), nil
+	}
+}
+
+// BatchDeleteInstanceTopicInvoker Kafka实例批量删除Topic
+func (c *KafkaClient) BatchDeleteInstanceTopicInvoker(request *model.BatchDeleteInstanceTopicRequest) *BatchDeleteInstanceTopicInvoker {
+	requestDef := GenReqDefForBatchDeleteInstanceTopic()
+	return &BatchDeleteInstanceTopicInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// BatchDeleteInstanceUsers 批量删除用户
+//
+// 批量删除Kafka实例的用户。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) BatchDeleteInstanceUsers(request *model.BatchDeleteInstanceUsersRequest) (*model.BatchDeleteInstanceUsersResponse, error) {
+	requestDef := GenReqDefForBatchDeleteInstanceUsers()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchDeleteInstanceUsersResponse), nil
+	}
+}
+
+// BatchDeleteInstanceUsersInvoker 批量删除用户
+func (c *KafkaClient) BatchDeleteInstanceUsersInvoker(request *model.BatchDeleteInstanceUsersRequest) *BatchDeleteInstanceUsersInvoker {
+	requestDef := GenReqDefForBatchDeleteInstanceUsers()
+	return &BatchDeleteInstanceUsersInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// BatchRestartOrDeleteInstances 批量重启或删除实例
+//
+// 批量重启或删除实例。
+//
+// 在实例重启过程中，客户端的生产与消费消息等请求会被拒绝。
+//
+// 实例删除后，实例中原有的数据将被删除，且没有备份，请谨慎操作。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) BatchRestartOrDeleteInstances(request *model.BatchRestartOrDeleteInstancesRequest) (*model.BatchRestartOrDeleteInstancesResponse, error) {
+	requestDef := GenReqDefForBatchRestartOrDeleteInstances()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchRestartOrDeleteInstancesResponse), nil
+	}
+}
+
+// BatchRestartOrDeleteInstancesInvoker 批量重启或删除实例
+func (c *KafkaClient) BatchRestartOrDeleteInstancesInvoker(request *model.BatchRestartOrDeleteInstancesRequest) *BatchRestartOrDeleteInstancesInvoker {
+	requestDef := GenReqDefForBatchRestartOrDeleteInstances()
+	return &BatchRestartOrDeleteInstancesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateConnector 创建实例的转储节点
+//
+// 创建实例的转储节点。
+//
+// **当前通过调用API，只支持按需实例创建转储节点。**
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) CreateConnector(request *model.CreateConnectorRequest) (*model.CreateConnectorResponse, error) {
+	requestDef := GenReqDefForCreateConnector()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateConnectorResponse), nil
+	}
+}
+
+// CreateConnectorInvoker 创建实例的转储节点
+func (c *KafkaClient) CreateConnectorInvoker(request *model.CreateConnectorRequest) *CreateConnectorInvoker {
+	requestDef := GenReqDefForCreateConnector()
+	return &CreateConnectorInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateInstanceTopic Kafka实例创建Topic
+//
+// 该接口用于向Kafka实例创建Topic。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) CreateInstanceTopic(request *model.CreateInstanceTopicRequest) (*model.CreateInstanceTopicResponse, error) {
+	requestDef := GenReqDefForCreateInstanceTopic()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateInstanceTopicResponse), nil
+	}
+}
+
+// CreateInstanceTopicInvoker Kafka实例创建Topic
+func (c *KafkaClient) CreateInstanceTopicInvoker(request *model.CreateInstanceTopicRequest) *CreateInstanceTopicInvoker {
+	requestDef := GenReqDefForCreateInstanceTopic()
+	return &CreateInstanceTopicInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateInstanceUser 创建用户
+//
+// 创建Kafka实例的用户，用户可连接开启SASL的Kafka实例。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) CreateInstanceUser(request *model.CreateInstanceUserRequest) (*model.CreateInstanceUserResponse, error) {
+	requestDef := GenReqDefForCreateInstanceUser()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateInstanceUserResponse), nil
+	}
+}
+
+// CreateInstanceUserInvoker 创建用户
+func (c *KafkaClient) CreateInstanceUserInvoker(request *model.CreateInstanceUserRequest) *CreateInstanceUserInvoker {
+	requestDef := GenReqDefForCreateInstanceUser()
+	return &CreateInstanceUserInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreatePartition 新增Kafka实例指定Topic分区
+//
+// 新增Kafka实例指定Topic分区。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) CreatePartition(request *model.CreatePartitionRequest) (*model.CreatePartitionResponse, error) {
+	requestDef := GenReqDefForCreatePartition()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreatePartitionResponse), nil
+	}
+}
+
+// CreatePartitionInvoker 新增Kafka实例指定Topic分区
+func (c *KafkaClient) CreatePartitionInvoker(request *model.CreatePartitionRequest) *CreatePartitionInvoker {
+	requestDef := GenReqDefForCreatePartition()
+	return &CreatePartitionInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreatePostPaidInstance 创建实例
+//
+// [创建按需计费类型的Kafka实例。](tag:hc,hk,hws,hws_hk,otc,hws_ocb,ctc,sbc,hk_sbc,cmcc)[创建kafka实例。](tag:ocb)
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) CreatePostPaidInstance(request *model.CreatePostPaidInstanceRequest) (*model.CreatePostPaidInstanceResponse, error) {
+	requestDef := GenReqDefForCreatePostPaidInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreatePostPaidInstanceResponse), nil
+	}
+}
+
+// CreatePostPaidInstanceInvoker 创建实例
+func (c *KafkaClient) CreatePostPaidInstanceInvoker(request *model.CreatePostPaidInstanceRequest) *CreatePostPaidInstanceInvoker {
+	requestDef := GenReqDefForCreatePostPaidInstance()
+	return &CreatePostPaidInstanceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateSinkTask 创建转储任务
+//
+// 创建转储任务。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) CreateSinkTask(request *model.CreateSinkTaskRequest) (*model.CreateSinkTaskResponse, error) {
+	requestDef := GenReqDefForCreateSinkTask()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateSinkTaskResponse), nil
+	}
+}
+
+// CreateSinkTaskInvoker 创建转储任务
+func (c *KafkaClient) CreateSinkTaskInvoker(request *model.CreateSinkTaskRequest) *CreateSinkTaskInvoker {
+	requestDef := GenReqDefForCreateSinkTask()
+	return &CreateSinkTaskInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteBackgroundTask 删除后台任务管理中的指定记录
+//
+// 删除后台任务管理中的指定记录。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) DeleteBackgroundTask(request *model.DeleteBackgroundTaskRequest) (*model.DeleteBackgroundTaskResponse, error) {
+	requestDef := GenReqDefForDeleteBackgroundTask()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteBackgroundTaskResponse), nil
+	}
+}
+
+// DeleteBackgroundTaskInvoker 删除后台任务管理中的指定记录
+func (c *KafkaClient) DeleteBackgroundTaskInvoker(request *model.DeleteBackgroundTaskRequest) *DeleteBackgroundTaskInvoker {
+	requestDef := GenReqDefForDeleteBackgroundTask()
+	return &DeleteBackgroundTaskInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteInstance 删除指定的实例
+//
+// 删除指定的实例，释放该实例的所有资源。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) DeleteInstance(request *model.DeleteInstanceRequest) (*model.DeleteInstanceResponse, error) {
+	requestDef := GenReqDefForDeleteInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteInstanceResponse), nil
+	}
+}
+
+// DeleteInstanceInvoker 删除指定的实例
+func (c *KafkaClient) DeleteInstanceInvoker(request *model.DeleteInstanceRequest) *DeleteInstanceInvoker {
+	requestDef := GenReqDefForDeleteInstance()
+	return &DeleteInstanceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteSinkTask 删除单个转储任务
+//
+// 删除单个转储任务。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) DeleteSinkTask(request *model.DeleteSinkTaskRequest) (*model.DeleteSinkTaskResponse, error) {
+	requestDef := GenReqDefForDeleteSinkTask()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteSinkTaskResponse), nil
+	}
+}
+
+// DeleteSinkTaskInvoker 删除单个转储任务
+func (c *KafkaClient) DeleteSinkTaskInvoker(request *model.DeleteSinkTaskRequest) *DeleteSinkTaskInvoker {
+	requestDef := GenReqDefForDeleteSinkTask()
+	return &DeleteSinkTaskInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListAvailableZones 查询可用区信息
+//
+// 在创建实例时，需要配置实例所在的可用区ID，可通过该接口查询可用区的ID。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListAvailableZones(request *model.ListAvailableZonesRequest) (*model.ListAvailableZonesResponse, error) {
+	requestDef := GenReqDefForListAvailableZones()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListAvailableZonesResponse), nil
+	}
+}
+
+// ListAvailableZonesInvoker 查询可用区信息
+func (c *KafkaClient) ListAvailableZonesInvoker(request *model.ListAvailableZonesRequest) *ListAvailableZonesInvoker {
+	requestDef := GenReqDefForListAvailableZones()
+	return &ListAvailableZonesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListBackgroundTasks 查询实例的后台任务列表
+//
+// 查询实例的后台任务列表。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListBackgroundTasks(request *model.ListBackgroundTasksRequest) (*model.ListBackgroundTasksResponse, error) {
+	requestDef := GenReqDefForListBackgroundTasks()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListBackgroundTasksResponse), nil
+	}
+}
+
+// ListBackgroundTasksInvoker 查询实例的后台任务列表
+func (c *KafkaClient) ListBackgroundTasksInvoker(request *model.ListBackgroundTasksRequest) *ListBackgroundTasksInvoker {
+	requestDef := GenReqDefForListBackgroundTasks()
+	return &ListBackgroundTasksInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListEngineProducts 查询产品规格列表
+//
+// 查询产品规格列表。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListEngineProducts(request *model.ListEngineProductsRequest) (*model.ListEngineProductsResponse, error) {
+	requestDef := GenReqDefForListEngineProducts()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListEngineProductsResponse), nil
+	}
+}
+
+// ListEngineProductsInvoker 查询产品规格列表
+func (c *KafkaClient) ListEngineProductsInvoker(request *model.ListEngineProductsRequest) *ListEngineProductsInvoker {
+	requestDef := GenReqDefForListEngineProducts()
+	return &ListEngineProductsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListInstanceTopics Kafka实例查询Topic
+//
+// 该接口用于查询指定Kafka实例的Topic详情。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListInstanceTopics(request *model.ListInstanceTopicsRequest) (*model.ListInstanceTopicsResponse, error) {
+	requestDef := GenReqDefForListInstanceTopics()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListInstanceTopicsResponse), nil
+	}
+}
+
+// ListInstanceTopicsInvoker Kafka实例查询Topic
+func (c *KafkaClient) ListInstanceTopicsInvoker(request *model.ListInstanceTopicsRequest) *ListInstanceTopicsInvoker {
+	requestDef := GenReqDefForListInstanceTopics()
+	return &ListInstanceTopicsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListInstances 查询所有实例列表
+//
+// 查询租户的实例列表，支持按照条件查询。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListInstances(request *model.ListInstancesRequest) (*model.ListInstancesResponse, error) {
+	requestDef := GenReqDefForListInstances()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListInstancesResponse), nil
+	}
+}
+
+// ListInstancesInvoker 查询所有实例列表
+func (c *KafkaClient) ListInstancesInvoker(request *model.ListInstancesRequest) *ListInstancesInvoker {
+	requestDef := GenReqDefForListInstances()
+	return &ListInstancesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListProducts 查询产品规格列表
+//
+// 在创建kafka实例时，需要配置订购的产品ID（即product_id），可通过该接口查询产品规格。
+//
+// 例如，要订购按需计费、基准带宽为100MB的kafka实例，可从接口响应消息中，查找Hourly的消息体，然后找到bandwidth为100MB的记录对应的product_id，该product_id的值即是创建上述kafka实例时需要配置的产品ID。
+//
+// 同时，unavailable_zones字段表示资源不足的可用区列表，如果为空，则表示所有可用区都有资源，如果不为空，则表示字段值的可用区没有资源。所以必须确保您购买的资源所在的可用区有资源，不在该字段列表内。
+//
+// [例如，响应消息中bandwidth字段为1200MB的记录，unavailable_zones字段包含cn-east-2b、cn-east-2a和cn-east-2d，表示在华东-上海2的可用区1、可用区2、可用区3都没有该资源。](tag:hc,hws)
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListProducts(request *model.ListProductsRequest) (*model.ListProductsResponse, error) {
+	requestDef := GenReqDefForListProducts()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListProductsResponse), nil
+	}
+}
+
+// ListProductsInvoker 查询产品规格列表
+func (c *KafkaClient) ListProductsInvoker(request *model.ListProductsRequest) *ListProductsInvoker {
+	requestDef := GenReqDefForListProducts()
+	return &ListProductsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListSinkTasks 查询转储任务列表
+//
+// 查询转储任务列表。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ListSinkTasks(request *model.ListSinkTasksRequest) (*model.ListSinkTasksResponse, error) {
+	requestDef := GenReqDefForListSinkTasks()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListSinkTasksResponse), nil
+	}
+}
+
+// ListSinkTasksInvoker 查询转储任务列表
+func (c *KafkaClient) ListSinkTasksInvoker(request *model.ListSinkTasksRequest) *ListSinkTasksInvoker {
+	requestDef := GenReqDefForListSinkTasks()
+	return &ListSinkTasksInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ResetManagerPassword 重置Manager密码
+//
+// 重置Manager密码。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ResetManagerPassword(request *model.ResetManagerPasswordRequest) (*model.ResetManagerPasswordResponse, error) {
+	requestDef := GenReqDefForResetManagerPassword()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResetManagerPasswordResponse), nil
+	}
+}
+
+// ResetManagerPasswordInvoker 重置Manager密码
+func (c *KafkaClient) ResetManagerPasswordInvoker(request *model.ResetManagerPasswordRequest) *ResetManagerPasswordInvoker {
+	requestDef := GenReqDefForResetManagerPassword()
+	return &ResetManagerPasswordInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ResetMessageOffset 重置消费组消费进度到指定位置
+//
+// Kafka实例不支持在线重置消费进度。在执行重置消费进度之前，必须停止被重置消费组客户端。
+//
+// &gt; 停止待重置消费组客户端，然后等待一段时间（即ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG配置的时间，默认为1000毫秒）后，服务端才认为此消费组客户端已下线。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ResetMessageOffset(request *model.ResetMessageOffsetRequest) (*model.ResetMessageOffsetResponse, error) {
+	requestDef := GenReqDefForResetMessageOffset()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResetMessageOffsetResponse), nil
+	}
+}
+
+// ResetMessageOffsetInvoker 重置消费组消费进度到指定位置
+func (c *KafkaClient) ResetMessageOffsetInvoker(request *model.ResetMessageOffsetRequest) *ResetMessageOffsetInvoker {
+	requestDef := GenReqDefForResetMessageOffset()
+	return &ResetMessageOffsetInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ResetPassword 重置密码
+//
+// 重置密码。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ResetPassword(request *model.ResetPasswordRequest) (*model.ResetPasswordResponse, error) {
+	requestDef := GenReqDefForResetPassword()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResetPasswordResponse), nil
+	}
+}
+
+// ResetPasswordInvoker 重置密码
+func (c *KafkaClient) ResetPasswordInvoker(request *model.ResetPasswordRequest) *ResetPasswordInvoker {
+	requestDef := GenReqDefForResetPassword()
+	return &ResetPasswordInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ResetUserPasswrod 重置用户密码
+//
+// 重置用户密码
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ResetUserPasswrod(request *model.ResetUserPasswrodRequest) (*model.ResetUserPasswrodResponse, error) {
+	requestDef := GenReqDefForResetUserPasswrod()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResetUserPasswrodResponse), nil
+	}
+}
+
+// ResetUserPasswrodInvoker 重置用户密码
+func (c *KafkaClient) ResetUserPasswrodInvoker(request *model.ResetUserPasswrodRequest) *ResetUserPasswrodInvoker {
+	requestDef := GenReqDefForResetUserPasswrod()
+	return &ResetUserPasswrodInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ResizeInstance 实例规格变更
+//
+// 实例规格变更。
+//
+// **当前通过调用API，只支持按需实例进行实例规格变更。**
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ResizeInstance(request *model.ResizeInstanceRequest) (*model.ResizeInstanceResponse, error) {
+	requestDef := GenReqDefForResizeInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResizeInstanceResponse), nil
+	}
+}
+
+// ResizeInstanceInvoker 实例规格变更
+func (c *KafkaClient) ResizeInstanceInvoker(request *model.ResizeInstanceRequest) *ResizeInstanceInvoker {
+	requestDef := GenReqDefForResizeInstance()
+	return &ResizeInstanceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// RestartManager 重启Manager
+//
+// 重启Manager。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) RestartManager(request *model.RestartManagerRequest) (*model.RestartManagerResponse, error) {
+	requestDef := GenReqDefForRestartManager()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.RestartManagerResponse), nil
+	}
+}
+
+// RestartManagerInvoker 重启Manager
+func (c *KafkaClient) RestartManagerInvoker(request *model.RestartManagerRequest) *RestartManagerInvoker {
+	requestDef := GenReqDefForRestartManager()
+	return &RestartManagerInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowBackgroundTask 查询后台任务管理中的指定记录
+//
+// 查询后台任务管理中的指定记录。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowBackgroundTask(request *model.ShowBackgroundTaskRequest) (*model.ShowBackgroundTaskResponse, error) {
+	requestDef := GenReqDefForShowBackgroundTask()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowBackgroundTaskResponse), nil
+	}
+}
+
+// ShowBackgroundTaskInvoker 查询后台任务管理中的指定记录
+func (c *KafkaClient) ShowBackgroundTaskInvoker(request *model.ShowBackgroundTaskRequest) *ShowBackgroundTaskInvoker {
+	requestDef := GenReqDefForShowBackgroundTask()
+	return &ShowBackgroundTaskInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowCesHierarchy 查询实例在CES的监控层级关系
+//
+// 查询实例在CES的监控层级关系。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowCesHierarchy(request *model.ShowCesHierarchyRequest) (*model.ShowCesHierarchyResponse, error) {
+	requestDef := GenReqDefForShowCesHierarchy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowCesHierarchyResponse), nil
+	}
+}
+
+// ShowCesHierarchyInvoker 查询实例在CES的监控层级关系
+func (c *KafkaClient) ShowCesHierarchyInvoker(request *model.ShowCesHierarchyRequest) *ShowCesHierarchyInvoker {
+	requestDef := GenReqDefForShowCesHierarchy()
+	return &ShowCesHierarchyInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowCluster 查询Kafka集群元数据信息
+//
+// 查询Kafka集群元数据信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowCluster(request *model.ShowClusterRequest) (*model.ShowClusterResponse, error) {
+	requestDef := GenReqDefForShowCluster()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowClusterResponse), nil
+	}
+}
+
+// ShowClusterInvoker 查询Kafka集群元数据信息
+func (c *KafkaClient) ShowClusterInvoker(request *model.ShowClusterRequest) *ShowClusterInvoker {
+	requestDef := GenReqDefForShowCluster()
+	return &ShowClusterInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowCoordinators 查询Kafka实例的协调器信息
+//
+// 查询Kafka实例的协调器信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowCoordinators(request *model.ShowCoordinatorsRequest) (*model.ShowCoordinatorsResponse, error) {
+	requestDef := GenReqDefForShowCoordinators()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowCoordinatorsResponse), nil
+	}
+}
+
+// ShowCoordinatorsInvoker 查询Kafka实例的协调器信息
+func (c *KafkaClient) ShowCoordinatorsInvoker(request *model.ShowCoordinatorsRequest) *ShowCoordinatorsInvoker {
+	requestDef := GenReqDefForShowCoordinators()
+	return &ShowCoordinatorsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowGroups 查询消费组信息
+//
+// 查询消费组信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowGroups(request *model.ShowGroupsRequest) (*model.ShowGroupsResponse, error) {
+	requestDef := GenReqDefForShowGroups()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowGroupsResponse), nil
+	}
+}
+
+// ShowGroupsInvoker 查询消费组信息
+func (c *KafkaClient) ShowGroupsInvoker(request *model.ShowGroupsRequest) *ShowGroupsInvoker {
+	requestDef := GenReqDefForShowGroups()
+	return &ShowGroupsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowInstance 查询指定实例
+//
+// 查询指定实例的详细信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowInstance(request *model.ShowInstanceRequest) (*model.ShowInstanceResponse, error) {
+	requestDef := GenReqDefForShowInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowInstanceResponse), nil
+	}
+}
+
+// ShowInstanceInvoker 查询指定实例
+func (c *KafkaClient) ShowInstanceInvoker(request *model.ShowInstanceRequest) *ShowInstanceInvoker {
+	requestDef := GenReqDefForShowInstance()
+	return &ShowInstanceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowInstanceExtendProductInfo 查询实例的扩容规格列表
+//
+// 查询实例的扩容规格列表。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowInstanceExtendProductInfo(request *model.ShowInstanceExtendProductInfoRequest) (*model.ShowInstanceExtendProductInfoResponse, error) {
+	requestDef := GenReqDefForShowInstanceExtendProductInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowInstanceExtendProductInfoResponse), nil
+	}
+}
+
+// ShowInstanceExtendProductInfoInvoker 查询实例的扩容规格列表
+func (c *KafkaClient) ShowInstanceExtendProductInfoInvoker(request *model.ShowInstanceExtendProductInfoRequest) *ShowInstanceExtendProductInfoInvoker {
+	requestDef := GenReqDefForShowInstanceExtendProductInfo()
+	return &ShowInstanceExtendProductInfoInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowInstanceMessages 查询消息
+//
+// 查询消息的偏移量和消息内容。
+// 先根据时间戳查询消息的偏移量，再根据偏移量查询消息内容。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowInstanceMessages(request *model.ShowInstanceMessagesRequest) (*model.ShowInstanceMessagesResponse, error) {
+	requestDef := GenReqDefForShowInstanceMessages()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowInstanceMessagesResponse), nil
+	}
+}
+
+// ShowInstanceMessagesInvoker 查询消息
+func (c *KafkaClient) ShowInstanceMessagesInvoker(request *model.ShowInstanceMessagesRequest) *ShowInstanceMessagesInvoker {
+	requestDef := GenReqDefForShowInstanceMessages()
+	return &ShowInstanceMessagesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowInstanceTopicDetail 查询Kafka实例Topic详细信息
+//
+// 查询Kafka实例Topic详细信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowInstanceTopicDetail(request *model.ShowInstanceTopicDetailRequest) (*model.ShowInstanceTopicDetailResponse, error) {
+	requestDef := GenReqDefForShowInstanceTopicDetail()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowInstanceTopicDetailResponse), nil
+	}
+}
+
+// ShowInstanceTopicDetailInvoker 查询Kafka实例Topic详细信息
+func (c *KafkaClient) ShowInstanceTopicDetailInvoker(request *model.ShowInstanceTopicDetailRequest) *ShowInstanceTopicDetailInvoker {
+	requestDef := GenReqDefForShowInstanceTopicDetail()
+	return &ShowInstanceTopicDetailInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowInstanceUsers 查询用户列表
+//
+// 查询用户列表。
+//
+// Kafka实例开启SASL功能时，才支持多用户管理的功能。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowInstanceUsers(request *model.ShowInstanceUsersRequest) (*model.ShowInstanceUsersResponse, error) {
+	requestDef := GenReqDefForShowInstanceUsers()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowInstanceUsersResponse), nil
+	}
+}
+
+// ShowInstanceUsersInvoker 查询用户列表
+func (c *KafkaClient) ShowInstanceUsersInvoker(request *model.ShowInstanceUsersRequest) *ShowInstanceUsersInvoker {
+	requestDef := GenReqDefForShowInstanceUsers()
+	return &ShowInstanceUsersInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowKafkaProjectTags 查询项目标签
+//
+// 查询项目标签。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowKafkaProjectTags(request *model.ShowKafkaProjectTagsRequest) (*model.ShowKafkaProjectTagsResponse, error) {
+	requestDef := GenReqDefForShowKafkaProjectTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowKafkaProjectTagsResponse), nil
+	}
+}
+
+// ShowKafkaProjectTagsInvoker 查询项目标签
+func (c *KafkaClient) ShowKafkaProjectTagsInvoker(request *model.ShowKafkaProjectTagsRequest) *ShowKafkaProjectTagsInvoker {
+	requestDef := GenReqDefForShowKafkaProjectTags()
+	return &ShowKafkaProjectTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowKafkaTags 查询实例标签
+//
+// 查询实例标签。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowKafkaTags(request *model.ShowKafkaTagsRequest) (*model.ShowKafkaTagsResponse, error) {
+	requestDef := GenReqDefForShowKafkaTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowKafkaTagsResponse), nil
+	}
+}
+
+// ShowKafkaTagsInvoker 查询实例标签
+func (c *KafkaClient) ShowKafkaTagsInvoker(request *model.ShowKafkaTagsRequest) *ShowKafkaTagsInvoker {
+	requestDef := GenReqDefForShowKafkaTags()
+	return &ShowKafkaTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowKafkaTopicPartitionDiskusage 查询topic的磁盘存储情况
+//
+// 查询topic在Broker上磁盘占用情况。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowKafkaTopicPartitionDiskusage(request *model.ShowKafkaTopicPartitionDiskusageRequest) (*model.ShowKafkaTopicPartitionDiskusageResponse, error) {
+	requestDef := GenReqDefForShowKafkaTopicPartitionDiskusage()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowKafkaTopicPartitionDiskusageResponse), nil
+	}
+}
+
+// ShowKafkaTopicPartitionDiskusageInvoker 查询topic的磁盘存储情况
+func (c *KafkaClient) ShowKafkaTopicPartitionDiskusageInvoker(request *model.ShowKafkaTopicPartitionDiskusageRequest) *ShowKafkaTopicPartitionDiskusageInvoker {
+	requestDef := GenReqDefForShowKafkaTopicPartitionDiskusage()
+	return &ShowKafkaTopicPartitionDiskusageInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowMaintainWindows 查询维护时间窗时间段
+//
+// 查询维护时间窗开始时间和结束时间。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowMaintainWindows(request *model.ShowMaintainWindowsRequest) (*model.ShowMaintainWindowsResponse, error) {
+	requestDef := GenReqDefForShowMaintainWindows()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowMaintainWindowsResponse), nil
+	}
+}
+
+// ShowMaintainWindowsInvoker 查询维护时间窗时间段
+func (c *KafkaClient) ShowMaintainWindowsInvoker(request *model.ShowMaintainWindowsRequest) *ShowMaintainWindowsInvoker {
+	requestDef := GenReqDefForShowMaintainWindows()
+	return &ShowMaintainWindowsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowMessages 查询分区指定时间段的消息
+//
+// 查询分区指定时间段的消息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowMessages(request *model.ShowMessagesRequest) (*model.ShowMessagesResponse, error) {
+	requestDef := GenReqDefForShowMessages()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowMessagesResponse), nil
+	}
+}
+
+// ShowMessagesInvoker 查询分区指定时间段的消息
+func (c *KafkaClient) ShowMessagesInvoker(request *model.ShowMessagesRequest) *ShowMessagesInvoker {
+	requestDef := GenReqDefForShowMessages()
+	return &ShowMessagesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowPartitionBeginningMessage 查询分区最早消息的位置
+//
+// 查询分区最早消息的位置。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowPartitionBeginningMessage(request *model.ShowPartitionBeginningMessageRequest) (*model.ShowPartitionBeginningMessageResponse, error) {
+	requestDef := GenReqDefForShowPartitionBeginningMessage()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowPartitionBeginningMessageResponse), nil
+	}
+}
+
+// ShowPartitionBeginningMessageInvoker 查询分区最早消息的位置
+func (c *KafkaClient) ShowPartitionBeginningMessageInvoker(request *model.ShowPartitionBeginningMessageRequest) *ShowPartitionBeginningMessageInvoker {
+	requestDef := GenReqDefForShowPartitionBeginningMessage()
+	return &ShowPartitionBeginningMessageInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowPartitionEndMessage 查询分区最新消息的位置
+//
+// 查询分区最新消息的位置。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowPartitionEndMessage(request *model.ShowPartitionEndMessageRequest) (*model.ShowPartitionEndMessageResponse, error) {
+	requestDef := GenReqDefForShowPartitionEndMessage()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowPartitionEndMessageResponse), nil
+	}
+}
+
+// ShowPartitionEndMessageInvoker 查询分区最新消息的位置
+func (c *KafkaClient) ShowPartitionEndMessageInvoker(request *model.ShowPartitionEndMessageRequest) *ShowPartitionEndMessageInvoker {
+	requestDef := GenReqDefForShowPartitionEndMessage()
+	return &ShowPartitionEndMessageInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowPartitionMessage 查询分区指定偏移量的消息
+//
+// 查询分区指定偏移量的消息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowPartitionMessage(request *model.ShowPartitionMessageRequest) (*model.ShowPartitionMessageResponse, error) {
+	requestDef := GenReqDefForShowPartitionMessage()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowPartitionMessageResponse), nil
+	}
+}
+
+// ShowPartitionMessageInvoker 查询分区指定偏移量的消息
+func (c *KafkaClient) ShowPartitionMessageInvoker(request *model.ShowPartitionMessageRequest) *ShowPartitionMessageInvoker {
+	requestDef := GenReqDefForShowPartitionMessage()
+	return &ShowPartitionMessageInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowSinkTaskDetail 查询单个转储任务
+//
+// 查询单个转储任务。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowSinkTaskDetail(request *model.ShowSinkTaskDetailRequest) (*model.ShowSinkTaskDetailResponse, error) {
+	requestDef := GenReqDefForShowSinkTaskDetail()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowSinkTaskDetailResponse), nil
+	}
+}
+
+// ShowSinkTaskDetailInvoker 查询单个转储任务
+func (c *KafkaClient) ShowSinkTaskDetailInvoker(request *model.ShowSinkTaskDetailRequest) *ShowSinkTaskDetailInvoker {
+	requestDef := GenReqDefForShowSinkTaskDetail()
+	return &ShowSinkTaskDetailInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowTopicAccessPolicy 查询用户权限
+//
+// 查询用户权限。
+//
+// Kafka实例开启SASL功能时，才支持多用户管理的功能。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) ShowTopicAccessPolicy(request *model.ShowTopicAccessPolicyRequest) (*model.ShowTopicAccessPolicyResponse, error) {
+	requestDef := GenReqDefForShowTopicAccessPolicy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowTopicAccessPolicyResponse), nil
+	}
+}
+
+// ShowTopicAccessPolicyInvoker 查询用户权限
+func (c *KafkaClient) ShowTopicAccessPolicyInvoker(request *model.ShowTopicAccessPolicyRequest) *ShowTopicAccessPolicyInvoker {
+	requestDef := GenReqDefForShowTopicAccessPolicy()
+	return &ShowTopicAccessPolicyInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateInstance 修改实例信息
+//
+// 修改实例的名称和描述信息。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateInstance(request *model.UpdateInstanceRequest) (*model.UpdateInstanceResponse, error) {
+	requestDef := GenReqDefForUpdateInstance()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateInstanceResponse), nil
+	}
+}
+
+// UpdateInstanceInvoker 修改实例信息
+func (c *KafkaClient) UpdateInstanceInvoker(request *model.UpdateInstanceRequest) *UpdateInstanceInvoker {
+	requestDef := GenReqDefForUpdateInstance()
+	return &UpdateInstanceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateInstanceAutoCreateTopic 开启或关闭实例自动创建topic功能
+//
+// 开启或关闭实例自动创建topic功能。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateInstanceAutoCreateTopic(request *model.UpdateInstanceAutoCreateTopicRequest) (*model.UpdateInstanceAutoCreateTopicResponse, error) {
+	requestDef := GenReqDefForUpdateInstanceAutoCreateTopic()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateInstanceAutoCreateTopicResponse), nil
+	}
+}
+
+// UpdateInstanceAutoCreateTopicInvoker 开启或关闭实例自动创建topic功能
+func (c *KafkaClient) UpdateInstanceAutoCreateTopicInvoker(request *model.UpdateInstanceAutoCreateTopicRequest) *UpdateInstanceAutoCreateTopicInvoker {
+	requestDef := GenReqDefForUpdateInstanceAutoCreateTopic()
+	return &UpdateInstanceAutoCreateTopicInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateInstanceCrossVpcIp 修改实例跨VPC访问的内网IP
+//
+// 修改实例跨VPC访问的内网IP。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateInstanceCrossVpcIp(request *model.UpdateInstanceCrossVpcIpRequest) (*model.UpdateInstanceCrossVpcIpResponse, error) {
+	requestDef := GenReqDefForUpdateInstanceCrossVpcIp()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateInstanceCrossVpcIpResponse), nil
+	}
+}
+
+// UpdateInstanceCrossVpcIpInvoker 修改实例跨VPC访问的内网IP
+func (c *KafkaClient) UpdateInstanceCrossVpcIpInvoker(request *model.UpdateInstanceCrossVpcIpRequest) *UpdateInstanceCrossVpcIpInvoker {
+	requestDef := GenReqDefForUpdateInstanceCrossVpcIp()
+	return &UpdateInstanceCrossVpcIpInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateInstanceTopic 修改Kafka实例Topic
+//
+// 修改Kafka实例Topic
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateInstanceTopic(request *model.UpdateInstanceTopicRequest) (*model.UpdateInstanceTopicResponse, error) {
+	requestDef := GenReqDefForUpdateInstanceTopic()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateInstanceTopicResponse), nil
+	}
+}
+
+// UpdateInstanceTopicInvoker 修改Kafka实例Topic
+func (c *KafkaClient) UpdateInstanceTopicInvoker(request *model.UpdateInstanceTopicRequest) *UpdateInstanceTopicInvoker {
+	requestDef := GenReqDefForUpdateInstanceTopic()
+	return &UpdateInstanceTopicInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateSinkTaskQuota 修改转储任务的配额
+//
+// 修改转储任务的配额。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateSinkTaskQuota(request *model.UpdateSinkTaskQuotaRequest) (*model.UpdateSinkTaskQuotaResponse, error) {
+	requestDef := GenReqDefForUpdateSinkTaskQuota()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateSinkTaskQuotaResponse), nil
+	}
+}
+
+// UpdateSinkTaskQuotaInvoker 修改转储任务的配额
+func (c *KafkaClient) UpdateSinkTaskQuotaInvoker(request *model.UpdateSinkTaskQuotaRequest) *UpdateSinkTaskQuotaInvoker {
+	requestDef := GenReqDefForUpdateSinkTaskQuota()
+	return &UpdateSinkTaskQuotaInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateTopicAccessPolicy 设置用户权限
+//
+// 设置用户权限。
+//
+// Kafka实例开启SASL功能时，才支持多用户管理的功能。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateTopicAccessPolicy(request *model.UpdateTopicAccessPolicyRequest) (*model.UpdateTopicAccessPolicyResponse, error) {
+	requestDef := GenReqDefForUpdateTopicAccessPolicy()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateTopicAccessPolicyResponse), nil
+	}
+}
+
+// UpdateTopicAccessPolicyInvoker 设置用户权限
+func (c *KafkaClient) UpdateTopicAccessPolicyInvoker(request *model.UpdateTopicAccessPolicyRequest) *UpdateTopicAccessPolicyInvoker {
+	requestDef := GenReqDefForUpdateTopicAccessPolicy()
+	return &UpdateTopicAccessPolicyInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateTopicReplica 修改Kafka实例Topic分区的副本
+//
+// 修改Kafka实例Topic分区的副本。
+//
+// 详细说明请参考华为云API Explorer。
+// Please refer to Huawei cloud API Explorer for details.
+func (c *KafkaClient) UpdateTopicReplica(request *model.UpdateTopicReplicaRequest) (*model.UpdateTopicReplicaResponse, error) {
+	requestDef := GenReqDefForUpdateTopicReplica()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateTopicReplicaResponse), nil
+	}
+}
+
+// UpdateTopicReplicaInvoker 修改Kafka实例Topic分区的副本
+func (c *KafkaClient) UpdateTopicReplicaInvoker(request *model.UpdateTopicReplicaRequest) *UpdateTopicReplicaInvoker {
+	requestDef := GenReqDefForUpdateTopicReplica()
+	return &UpdateTopicReplicaInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/kafka_invoker.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/kafka_invoker.go
@@ -1,0 +1,642 @@
+package v2
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/invoker"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+)
+
+type BatchCreateOrDeleteKafkaTagInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchCreateOrDeleteKafkaTagInvoker) Invoke() (*model.BatchCreateOrDeleteKafkaTagResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchCreateOrDeleteKafkaTagResponse), nil
+	}
+}
+
+type BatchDeleteInstanceTopicInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchDeleteInstanceTopicInvoker) Invoke() (*model.BatchDeleteInstanceTopicResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchDeleteInstanceTopicResponse), nil
+	}
+}
+
+type BatchDeleteInstanceUsersInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchDeleteInstanceUsersInvoker) Invoke() (*model.BatchDeleteInstanceUsersResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchDeleteInstanceUsersResponse), nil
+	}
+}
+
+type BatchRestartOrDeleteInstancesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchRestartOrDeleteInstancesInvoker) Invoke() (*model.BatchRestartOrDeleteInstancesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchRestartOrDeleteInstancesResponse), nil
+	}
+}
+
+type CreateConnectorInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateConnectorInvoker) Invoke() (*model.CreateConnectorResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateConnectorResponse), nil
+	}
+}
+
+type CreateInstanceTopicInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateInstanceTopicInvoker) Invoke() (*model.CreateInstanceTopicResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateInstanceTopicResponse), nil
+	}
+}
+
+type CreateInstanceUserInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateInstanceUserInvoker) Invoke() (*model.CreateInstanceUserResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateInstanceUserResponse), nil
+	}
+}
+
+type CreatePartitionInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreatePartitionInvoker) Invoke() (*model.CreatePartitionResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreatePartitionResponse), nil
+	}
+}
+
+type CreatePostPaidInstanceInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreatePostPaidInstanceInvoker) Invoke() (*model.CreatePostPaidInstanceResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreatePostPaidInstanceResponse), nil
+	}
+}
+
+type CreateSinkTaskInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateSinkTaskInvoker) Invoke() (*model.CreateSinkTaskResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateSinkTaskResponse), nil
+	}
+}
+
+type DeleteBackgroundTaskInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteBackgroundTaskInvoker) Invoke() (*model.DeleteBackgroundTaskResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteBackgroundTaskResponse), nil
+	}
+}
+
+type DeleteInstanceInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteInstanceInvoker) Invoke() (*model.DeleteInstanceResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteInstanceResponse), nil
+	}
+}
+
+type DeleteSinkTaskInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteSinkTaskInvoker) Invoke() (*model.DeleteSinkTaskResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteSinkTaskResponse), nil
+	}
+}
+
+type ListAvailableZonesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListAvailableZonesInvoker) Invoke() (*model.ListAvailableZonesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListAvailableZonesResponse), nil
+	}
+}
+
+type ListBackgroundTasksInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListBackgroundTasksInvoker) Invoke() (*model.ListBackgroundTasksResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListBackgroundTasksResponse), nil
+	}
+}
+
+type ListEngineProductsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListEngineProductsInvoker) Invoke() (*model.ListEngineProductsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListEngineProductsResponse), nil
+	}
+}
+
+type ListInstanceTopicsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListInstanceTopicsInvoker) Invoke() (*model.ListInstanceTopicsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListInstanceTopicsResponse), nil
+	}
+}
+
+type ListInstancesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListInstancesInvoker) Invoke() (*model.ListInstancesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListInstancesResponse), nil
+	}
+}
+
+type ListProductsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListProductsInvoker) Invoke() (*model.ListProductsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListProductsResponse), nil
+	}
+}
+
+type ListSinkTasksInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListSinkTasksInvoker) Invoke() (*model.ListSinkTasksResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListSinkTasksResponse), nil
+	}
+}
+
+type ResetManagerPasswordInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ResetManagerPasswordInvoker) Invoke() (*model.ResetManagerPasswordResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ResetManagerPasswordResponse), nil
+	}
+}
+
+type ResetMessageOffsetInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ResetMessageOffsetInvoker) Invoke() (*model.ResetMessageOffsetResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ResetMessageOffsetResponse), nil
+	}
+}
+
+type ResetPasswordInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ResetPasswordInvoker) Invoke() (*model.ResetPasswordResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ResetPasswordResponse), nil
+	}
+}
+
+type ResetUserPasswrodInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ResetUserPasswrodInvoker) Invoke() (*model.ResetUserPasswrodResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ResetUserPasswrodResponse), nil
+	}
+}
+
+type ResizeInstanceInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ResizeInstanceInvoker) Invoke() (*model.ResizeInstanceResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ResizeInstanceResponse), nil
+	}
+}
+
+type RestartManagerInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *RestartManagerInvoker) Invoke() (*model.RestartManagerResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.RestartManagerResponse), nil
+	}
+}
+
+type ShowBackgroundTaskInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowBackgroundTaskInvoker) Invoke() (*model.ShowBackgroundTaskResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowBackgroundTaskResponse), nil
+	}
+}
+
+type ShowCesHierarchyInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowCesHierarchyInvoker) Invoke() (*model.ShowCesHierarchyResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowCesHierarchyResponse), nil
+	}
+}
+
+type ShowClusterInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowClusterInvoker) Invoke() (*model.ShowClusterResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowClusterResponse), nil
+	}
+}
+
+type ShowCoordinatorsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowCoordinatorsInvoker) Invoke() (*model.ShowCoordinatorsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowCoordinatorsResponse), nil
+	}
+}
+
+type ShowGroupsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowGroupsInvoker) Invoke() (*model.ShowGroupsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowGroupsResponse), nil
+	}
+}
+
+type ShowInstanceInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowInstanceInvoker) Invoke() (*model.ShowInstanceResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowInstanceResponse), nil
+	}
+}
+
+type ShowInstanceExtendProductInfoInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowInstanceExtendProductInfoInvoker) Invoke() (*model.ShowInstanceExtendProductInfoResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowInstanceExtendProductInfoResponse), nil
+	}
+}
+
+type ShowInstanceMessagesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowInstanceMessagesInvoker) Invoke() (*model.ShowInstanceMessagesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowInstanceMessagesResponse), nil
+	}
+}
+
+type ShowInstanceTopicDetailInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowInstanceTopicDetailInvoker) Invoke() (*model.ShowInstanceTopicDetailResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowInstanceTopicDetailResponse), nil
+	}
+}
+
+type ShowInstanceUsersInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowInstanceUsersInvoker) Invoke() (*model.ShowInstanceUsersResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowInstanceUsersResponse), nil
+	}
+}
+
+type ShowKafkaProjectTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowKafkaProjectTagsInvoker) Invoke() (*model.ShowKafkaProjectTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowKafkaProjectTagsResponse), nil
+	}
+}
+
+type ShowKafkaTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowKafkaTagsInvoker) Invoke() (*model.ShowKafkaTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowKafkaTagsResponse), nil
+	}
+}
+
+type ShowKafkaTopicPartitionDiskusageInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowKafkaTopicPartitionDiskusageInvoker) Invoke() (*model.ShowKafkaTopicPartitionDiskusageResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowKafkaTopicPartitionDiskusageResponse), nil
+	}
+}
+
+type ShowMaintainWindowsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowMaintainWindowsInvoker) Invoke() (*model.ShowMaintainWindowsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowMaintainWindowsResponse), nil
+	}
+}
+
+type ShowMessagesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowMessagesInvoker) Invoke() (*model.ShowMessagesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowMessagesResponse), nil
+	}
+}
+
+type ShowPartitionBeginningMessageInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowPartitionBeginningMessageInvoker) Invoke() (*model.ShowPartitionBeginningMessageResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowPartitionBeginningMessageResponse), nil
+	}
+}
+
+type ShowPartitionEndMessageInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowPartitionEndMessageInvoker) Invoke() (*model.ShowPartitionEndMessageResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowPartitionEndMessageResponse), nil
+	}
+}
+
+type ShowPartitionMessageInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowPartitionMessageInvoker) Invoke() (*model.ShowPartitionMessageResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowPartitionMessageResponse), nil
+	}
+}
+
+type ShowSinkTaskDetailInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowSinkTaskDetailInvoker) Invoke() (*model.ShowSinkTaskDetailResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowSinkTaskDetailResponse), nil
+	}
+}
+
+type ShowTopicAccessPolicyInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowTopicAccessPolicyInvoker) Invoke() (*model.ShowTopicAccessPolicyResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowTopicAccessPolicyResponse), nil
+	}
+}
+
+type UpdateInstanceInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateInstanceInvoker) Invoke() (*model.UpdateInstanceResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateInstanceResponse), nil
+	}
+}
+
+type UpdateInstanceAutoCreateTopicInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateInstanceAutoCreateTopicInvoker) Invoke() (*model.UpdateInstanceAutoCreateTopicResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateInstanceAutoCreateTopicResponse), nil
+	}
+}
+
+type UpdateInstanceCrossVpcIpInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateInstanceCrossVpcIpInvoker) Invoke() (*model.UpdateInstanceCrossVpcIpResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateInstanceCrossVpcIpResponse), nil
+	}
+}
+
+type UpdateInstanceTopicInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateInstanceTopicInvoker) Invoke() (*model.UpdateInstanceTopicResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateInstanceTopicResponse), nil
+	}
+}
+
+type UpdateSinkTaskQuotaInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateSinkTaskQuotaInvoker) Invoke() (*model.UpdateSinkTaskQuotaResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateSinkTaskQuotaResponse), nil
+	}
+}
+
+type UpdateTopicAccessPolicyInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateTopicAccessPolicyInvoker) Invoke() (*model.UpdateTopicAccessPolicyResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateTopicAccessPolicyResponse), nil
+	}
+}
+
+type UpdateTopicReplicaInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateTopicReplicaInvoker) Invoke() (*model.UpdateTopicReplicaResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateTopicReplicaResponse), nil
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/kafka_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/kafka_meta.go
@@ -1,0 +1,1127 @@
+package v2
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/def"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+	"net/http"
+)
+
+func GenReqDefForBatchCreateOrDeleteKafkaTag() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/kafka/{instance_id}/tags/action").
+		WithResponse(new(model.BatchCreateOrDeleteKafkaTagResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForBatchDeleteInstanceTopic() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/topics/delete").
+		WithResponse(new(model.BatchDeleteInstanceTopicResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForBatchDeleteInstanceUsers() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/instances/{instance_id}/users").
+		WithResponse(new(model.BatchDeleteInstanceUsersResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForBatchRestartOrDeleteInstances() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/action").
+		WithResponse(new(model.BatchRestartOrDeleteInstancesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateConnector() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/connector").
+		WithResponse(new(model.CreateConnectorResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateInstanceTopic() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/topics").
+		WithResponse(new(model.CreateInstanceTopicResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateInstanceUser() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/users").
+		WithResponse(new(model.CreateInstanceUserResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreatePartition() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}/partitions-reassignment").
+		WithResponse(new(model.CreatePartitionResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreatePostPaidInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances").
+		WithResponse(new(model.CreatePostPaidInstanceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateSinkTask() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/connectors/{connector_id}/sink-tasks").
+		WithResponse(new(model.CreateSinkTaskResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ConnectorId").
+		WithJsonTag("connector_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteBackgroundTask() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v2/{project_id}/instances/{instance_id}/tasks/{task_id}").
+		WithResponse(new(model.DeleteBackgroundTaskResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TaskId").
+		WithJsonTag("task_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v2/{project_id}/instances/{instance_id}").
+		WithResponse(new(model.DeleteInstanceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteSinkTask() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v2/{project_id}/connectors/{connector_id}/sink-tasks/{task_id}").
+		WithResponse(new(model.DeleteSinkTaskResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ConnectorId").
+		WithJsonTag("connector_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TaskId").
+		WithJsonTag("task_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListAvailableZones() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/available-zones").
+		WithResponse(new(model.ListAvailableZonesResponse)).
+		WithContentType("application/json")
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListBackgroundTasks() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/tasks").
+		WithResponse(new(model.ListBackgroundTasksResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Start").
+		WithJsonTag("start").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BeginTime").
+		WithJsonTag("begin_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListEngineProducts() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{engine}/products").
+		WithResponse(new(model.ListEngineProductsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Engine").
+		WithJsonTag("engine").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ProductId").
+		WithJsonTag("product_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListInstanceTopics() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/topics").
+		WithResponse(new(model.ListInstanceTopicsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListInstances() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances").
+		WithResponse(new(model.ListInstancesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Engine").
+		WithJsonTag("engine").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Name").
+		WithJsonTag("name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Status").
+		WithJsonTag("status").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("IncludeFailure").
+		WithJsonTag("include_failure").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ExactMatchName").
+		WithJsonTag("exact_match_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListProducts() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/products").
+		WithResponse(new(model.ListProductsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Engine").
+		WithJsonTag("engine").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListSinkTasks() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/connectors/{connector_id}/sink-tasks").
+		WithResponse(new(model.ListSinkTasksResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ConnectorId").
+		WithJsonTag("connector_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResetManagerPassword() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/instances/{instance_id}/kafka-manager-password").
+		WithResponse(new(model.ResetManagerPasswordResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResetMessageOffset() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/groups/{group}/reset-message-offset").
+		WithResponse(new(model.ResetMessageOffsetResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Group").
+		WithJsonTag("group").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResetPassword() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/password").
+		WithResponse(new(model.ResetPasswordResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResetUserPasswrod() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/instances/{instance_id}/users/{user_name}").
+		WithResponse(new(model.ResetUserPasswrodResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("UserName").
+		WithJsonTag("user_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResizeInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/extend").
+		WithResponse(new(model.ResizeInstanceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForRestartManager() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/instances/{instance_id}/restart-kafka-manager").
+		WithResponse(new(model.RestartManagerResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowBackgroundTask() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/tasks/{task_id}").
+		WithResponse(new(model.ShowBackgroundTaskResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TaskId").
+		WithJsonTag("task_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowCesHierarchy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/ces-hierarchy").
+		WithResponse(new(model.ShowCesHierarchyResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowCluster() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/cluster").
+		WithResponse(new(model.ShowClusterResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowCoordinators() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/coordinators").
+		WithResponse(new(model.ShowCoordinatorsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowGroups() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/groups/{group}").
+		WithResponse(new(model.ShowGroupsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Group").
+		WithJsonTag("group").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}").
+		WithResponse(new(model.ShowInstanceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowInstanceExtendProductInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/extend").
+		WithResponse(new(model.ShowInstanceExtendProductInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Type").
+		WithJsonTag("type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Engine").
+		WithJsonTag("engine").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowInstanceMessages() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/messages").
+		WithResponse(new(model.ShowInstanceMessagesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Asc").
+		WithJsonTag("asc").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Download").
+		WithJsonTag("download").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("MessageOffset").
+		WithJsonTag("message_offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Partition").
+		WithJsonTag("partition").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowInstanceTopicDetail() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}").
+		WithResponse(new(model.ShowInstanceTopicDetailResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowInstanceUsers() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/users").
+		WithResponse(new(model.ShowInstanceUsersResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowKafkaProjectTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/kafka/tags").
+		WithResponse(new(model.ShowKafkaProjectTagsResponse)).
+		WithContentType("application/json")
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowKafkaTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/kafka/{instance_id}/tags").
+		WithResponse(new(model.ShowKafkaTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowKafkaTopicPartitionDiskusage() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/topics/diskusage").
+		WithResponse(new(model.ShowKafkaTopicPartitionDiskusageResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("MinSize").
+		WithJsonTag("minSize").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Top").
+		WithJsonTag("top").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Percentage").
+		WithJsonTag("percentage").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowMaintainWindows() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/instances/maintain-windows").
+		WithResponse(new(model.ShowMaintainWindowsResponse)).
+		WithContentType("application/json")
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowMessages() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}/messages").
+		WithResponse(new(model.ShowMessagesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Partition").
+		WithJsonTag("partition").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowPartitionBeginningMessage() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}/partitions/{partition}/beginning-message").
+		WithResponse(new(model.ShowPartitionBeginningMessageResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Partition").
+		WithJsonTag("partition").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowPartitionEndMessage() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}/partitions/{partition}/end-message").
+		WithResponse(new(model.ShowPartitionEndMessageResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Partition").
+		WithJsonTag("partition").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowPartitionMessage() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}/partitions/{partition}/message").
+		WithResponse(new(model.ShowPartitionMessageResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Partition").
+		WithJsonTag("partition").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("MessageOffset").
+		WithJsonTag("message_offset").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowSinkTaskDetail() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v2/{project_id}/connectors/{connector_id}/sink-tasks/{task_id}").
+		WithResponse(new(model.ShowSinkTaskDetailResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ConnectorId").
+		WithJsonTag("connector_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TaskId").
+		WithJsonTag("task_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TopicInfo").
+		WithJsonTag("topic-info").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowTopicAccessPolicy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1/{project_id}/instances/{instance_id}/topics/{topic_name}/accesspolicy").
+		WithResponse(new(model.ShowTopicAccessPolicyResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TopicName").
+		WithJsonTag("topic_name").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateInstance() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/instances/{instance_id}").
+		WithResponse(new(model.UpdateInstanceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateInstanceAutoCreateTopic() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/autotopic").
+		WithResponse(new(model.UpdateInstanceAutoCreateTopicResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateInstanceCrossVpcIp() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/crossvpc/modify").
+		WithResponse(new(model.UpdateInstanceCrossVpcIpResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateInstanceTopic() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/instances/{instance_id}/topics").
+		WithResponse(new(model.UpdateInstanceTopicResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateSinkTaskQuota() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v2/{project_id}/connectors/{connector_id}/sink-tasks").
+		WithResponse(new(model.UpdateSinkTaskQuotaResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ConnectorId").
+		WithJsonTag("connector_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateTopicAccessPolicy() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1/{project_id}/instances/{instance_id}/topics/accesspolicy").
+		WithResponse(new(model.UpdateTopicAccessPolicyResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateTopicReplica() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v2/{project_id}/instances/{instance_id}/management/topics/{topic}/replicas-reassignment").
+		WithResponse(new(model.UpdateTopicReplicaResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Topic").
+		WithJsonTag("topic").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_access_policy_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_access_policy_entity.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 权限实体。
+type AccessPolicyEntity struct {
+
+	// 用户名称。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 权限类型。 - all：拥有发布、订阅权限; - pub：拥有发布权限; - sub：拥有订阅权限。
+	AccessPolicy *AccessPolicyEntityAccessPolicy `json:"access_policy,omitempty"`
+}
+
+func (o AccessPolicyEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AccessPolicyEntity struct{}"
+	}
+
+	return strings.Join([]string{"AccessPolicyEntity", string(data)}, " ")
+}
+
+type AccessPolicyEntityAccessPolicy struct {
+	value string
+}
+
+type AccessPolicyEntityAccessPolicyEnum struct {
+	ALL AccessPolicyEntityAccessPolicy
+	PUB AccessPolicyEntityAccessPolicy
+	SUB AccessPolicyEntityAccessPolicy
+}
+
+func GetAccessPolicyEntityAccessPolicyEnum() AccessPolicyEntityAccessPolicyEnum {
+	return AccessPolicyEntityAccessPolicyEnum{
+		ALL: AccessPolicyEntityAccessPolicy{
+			value: "all",
+		},
+		PUB: AccessPolicyEntityAccessPolicy{
+			value: "pub",
+		},
+		SUB: AccessPolicyEntityAccessPolicy{
+			value: "sub",
+		},
+	}
+}
+
+func (c AccessPolicyEntityAccessPolicy) Value() string {
+	return c.value
+}
+
+func (c AccessPolicyEntityAccessPolicy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *AccessPolicyEntityAccessPolicy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_access_policy_topic_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_access_policy_topic_entity.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 权限实体。
+type AccessPolicyTopicEntity struct {
+
+	// topic名称。
+	Name string `json:"name"`
+
+	// 权限列表。
+	Policies []AccessPolicyEntity `json:"policies"`
+}
+
+func (o AccessPolicyTopicEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AccessPolicyTopicEntity struct{}"
+	}
+
+	return strings.Join([]string{"AccessPolicyTopicEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_create_or_delete_kafka_tag_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_create_or_delete_kafka_tag_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type BatchCreateOrDeleteKafkaTagRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *BatchCreateOrDeleteTagReq `json:"body,omitempty"`
+}
+
+func (o BatchCreateOrDeleteKafkaTagRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateOrDeleteKafkaTagRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateOrDeleteKafkaTagRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_create_or_delete_kafka_tag_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_create_or_delete_kafka_tag_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type BatchCreateOrDeleteKafkaTagResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o BatchCreateOrDeleteKafkaTagResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateOrDeleteKafkaTagResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateOrDeleteKafkaTagResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_create_or_delete_tag_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_create_or_delete_tag_req.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type BatchCreateOrDeleteTagReq struct {
+
+	// 操作标识（仅支持小写）: - create（创建） - delete（删除）
+	Action *BatchCreateOrDeleteTagReqAction `json:"action,omitempty"`
+
+	// 标签列表。
+	Tags *[]TagEntity `json:"tags,omitempty"`
+}
+
+func (o BatchCreateOrDeleteTagReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateOrDeleteTagReq struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateOrDeleteTagReq", string(data)}, " ")
+}
+
+type BatchCreateOrDeleteTagReqAction struct {
+	value string
+}
+
+type BatchCreateOrDeleteTagReqActionEnum struct {
+	CREATE BatchCreateOrDeleteTagReqAction
+	DELETE BatchCreateOrDeleteTagReqAction
+}
+
+func GetBatchCreateOrDeleteTagReqActionEnum() BatchCreateOrDeleteTagReqActionEnum {
+	return BatchCreateOrDeleteTagReqActionEnum{
+		CREATE: BatchCreateOrDeleteTagReqAction{
+			value: "create",
+		},
+		DELETE: BatchCreateOrDeleteTagReqAction{
+			value: "delete",
+		},
+	}
+}
+
+func (c BatchCreateOrDeleteTagReqAction) Value() string {
+	return c.value
+}
+
+func (c BatchCreateOrDeleteTagReqAction) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BatchCreateOrDeleteTagReqAction) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchDeleteInstanceTopicReq struct {
+
+	// 待删除的topic列表。
+	Topics *[]string `json:"topics,omitempty"`
+}
+
+func (o BatchDeleteInstanceTopicReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceTopicReq struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceTopicReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type BatchDeleteInstanceTopicRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *BatchDeleteInstanceTopicReq `json:"body,omitempty"`
+}
+
+func (o BatchDeleteInstanceTopicRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceTopicRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceTopicRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_resp_topics.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_resp_topics.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchDeleteInstanceTopicRespTopics struct {
+
+	// Topic名称。
+	Id *string `json:"id,omitempty"`
+
+	// 是否删除成功。
+	Success *bool `json:"success,omitempty"`
+}
+
+func (o BatchDeleteInstanceTopicRespTopics) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceTopicRespTopics struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceTopicRespTopics", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_topic_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type BatchDeleteInstanceTopicResponse struct {
+
+	// Topic列表。
+	Topics         *[]BatchDeleteInstanceTopicRespTopics `json:"topics,omitempty"`
+	HttpStatusCode int                                   `json:"-"`
+}
+
+func (o BatchDeleteInstanceTopicResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceTopicResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceTopicResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_users_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_users_req.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type BatchDeleteInstanceUsersReq struct {
+
+	// 删除类型。当前只支持delete。
+	Action *BatchDeleteInstanceUsersReqAction `json:"action,omitempty"`
+
+	// 用户列表。
+	Users *[]string `json:"users,omitempty"`
+}
+
+func (o BatchDeleteInstanceUsersReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceUsersReq struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceUsersReq", string(data)}, " ")
+}
+
+type BatchDeleteInstanceUsersReqAction struct {
+	value string
+}
+
+type BatchDeleteInstanceUsersReqActionEnum struct {
+	DELETE BatchDeleteInstanceUsersReqAction
+}
+
+func GetBatchDeleteInstanceUsersReqActionEnum() BatchDeleteInstanceUsersReqActionEnum {
+	return BatchDeleteInstanceUsersReqActionEnum{
+		DELETE: BatchDeleteInstanceUsersReqAction{
+			value: "delete",
+		},
+	}
+}
+
+func (c BatchDeleteInstanceUsersReqAction) Value() string {
+	return c.value
+}
+
+func (c BatchDeleteInstanceUsersReqAction) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BatchDeleteInstanceUsersReqAction) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_users_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_users_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type BatchDeleteInstanceUsersRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *BatchDeleteInstanceUsersReq `json:"body,omitempty"`
+}
+
+func (o BatchDeleteInstanceUsersRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceUsersRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceUsersRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_users_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_delete_instance_users_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type BatchDeleteInstanceUsersResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o BatchDeleteInstanceUsersResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteInstanceUsersResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteInstanceUsersResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instance_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instance_req.go
@@ -1,0 +1,119 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type BatchRestartOrDeleteInstanceReq struct {
+
+	// 实例的ID列表。
+	Instances *[]string `json:"instances,omitempty"`
+
+	// 对实例的操作：restart、delete
+	Action BatchRestartOrDeleteInstanceReqAction `json:"action"`
+
+	// 参数值为kafka，表示删除租户所有创建失败的Kafka实例。
+	AllFailure *BatchRestartOrDeleteInstanceReqAllFailure `json:"all_failure,omitempty"`
+}
+
+func (o BatchRestartOrDeleteInstanceReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchRestartOrDeleteInstanceReq struct{}"
+	}
+
+	return strings.Join([]string{"BatchRestartOrDeleteInstanceReq", string(data)}, " ")
+}
+
+type BatchRestartOrDeleteInstanceReqAction struct {
+	value string
+}
+
+type BatchRestartOrDeleteInstanceReqActionEnum struct {
+	RESTART BatchRestartOrDeleteInstanceReqAction
+	DELETE  BatchRestartOrDeleteInstanceReqAction
+}
+
+func GetBatchRestartOrDeleteInstanceReqActionEnum() BatchRestartOrDeleteInstanceReqActionEnum {
+	return BatchRestartOrDeleteInstanceReqActionEnum{
+		RESTART: BatchRestartOrDeleteInstanceReqAction{
+			value: "restart",
+		},
+		DELETE: BatchRestartOrDeleteInstanceReqAction{
+			value: "delete",
+		},
+	}
+}
+
+func (c BatchRestartOrDeleteInstanceReqAction) Value() string {
+	return c.value
+}
+
+func (c BatchRestartOrDeleteInstanceReqAction) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BatchRestartOrDeleteInstanceReqAction) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type BatchRestartOrDeleteInstanceReqAllFailure struct {
+	value string
+}
+
+type BatchRestartOrDeleteInstanceReqAllFailureEnum struct {
+	TRUE  BatchRestartOrDeleteInstanceReqAllFailure
+	FALSE BatchRestartOrDeleteInstanceReqAllFailure
+	KAFKA BatchRestartOrDeleteInstanceReqAllFailure
+}
+
+func GetBatchRestartOrDeleteInstanceReqAllFailureEnum() BatchRestartOrDeleteInstanceReqAllFailureEnum {
+	return BatchRestartOrDeleteInstanceReqAllFailureEnum{
+		TRUE: BatchRestartOrDeleteInstanceReqAllFailure{
+			value: "true",
+		},
+		FALSE: BatchRestartOrDeleteInstanceReqAllFailure{
+			value: "false",
+		},
+		KAFKA: BatchRestartOrDeleteInstanceReqAllFailure{
+			value: "kafka",
+		},
+	}
+}
+
+func (c BatchRestartOrDeleteInstanceReqAllFailure) Value() string {
+	return c.value
+}
+
+func (c BatchRestartOrDeleteInstanceReqAllFailure) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BatchRestartOrDeleteInstanceReqAllFailure) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instance_resp_results.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instance_resp_results.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchRestartOrDeleteInstanceRespResults struct {
+
+	// 操作结果。   - success: 操作成功   - failed: 操作失败
+	Result *string `json:"result,omitempty"`
+
+	// 实例ID。
+	Instance *string `json:"instance,omitempty"`
+}
+
+func (o BatchRestartOrDeleteInstanceRespResults) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchRestartOrDeleteInstanceRespResults struct{}"
+	}
+
+	return strings.Join([]string{"BatchRestartOrDeleteInstanceRespResults", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instances_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instances_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type BatchRestartOrDeleteInstancesRequest struct {
+	Body *BatchRestartOrDeleteInstanceReq `json:"body,omitempty"`
+}
+
+func (o BatchRestartOrDeleteInstancesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchRestartOrDeleteInstancesRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchRestartOrDeleteInstancesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instances_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_batch_restart_or_delete_instances_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type BatchRestartOrDeleteInstancesResponse struct {
+
+	// 修改实例的结果。
+	Results        *[]BatchRestartOrDeleteInstanceRespResults `json:"results,omitempty"`
+	HttpStatusCode int                                        `json:"-"`
+}
+
+func (o BatchRestartOrDeleteInstancesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchRestartOrDeleteInstancesResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchRestartOrDeleteInstancesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_connector_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_connector_req.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type CreateConnectorReq struct {
+
+	// 部署connector的规格，基准带宽，表示单位时间内传送的最大数据量，单位Byte/秒。  取值范围：   - 100MB   - 300MB   - 600MB   - 1200MB  可以不填，则默认跟当前实例的规格是一致。  第一阶段实现先不填，保持和当前实例规格一致，后面再扩展可以选择不同的规格。  新规格产品暂不支持转储。
+	Specification *CreateConnectorReqSpecification `json:"specification,omitempty"`
+
+	// 转储节点数量。不能小于2个。 默认是2个。
+	NodeCnt *string `json:"node_cnt,omitempty"`
+
+	// 转储节点规格编码。
+	SpecCode string `json:"spec_code"`
+}
+
+func (o CreateConnectorReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateConnectorReq struct{}"
+	}
+
+	return strings.Join([]string{"CreateConnectorReq", string(data)}, " ")
+}
+
+type CreateConnectorReqSpecification struct {
+	value string
+}
+
+type CreateConnectorReqSpecificationEnum struct {
+	E_100_MB  CreateConnectorReqSpecification
+	E_300_MB  CreateConnectorReqSpecification
+	E_600_MB  CreateConnectorReqSpecification
+	E_1200_MB CreateConnectorReqSpecification
+}
+
+func GetCreateConnectorReqSpecificationEnum() CreateConnectorReqSpecificationEnum {
+	return CreateConnectorReqSpecificationEnum{
+		E_100_MB: CreateConnectorReqSpecification{
+			value: "100MB",
+		},
+		E_300_MB: CreateConnectorReqSpecification{
+			value: "300MB",
+		},
+		E_600_MB: CreateConnectorReqSpecification{
+			value: "600MB",
+		},
+		E_1200_MB: CreateConnectorReqSpecification{
+			value: "1200MB",
+		},
+	}
+}
+
+func (c CreateConnectorReqSpecification) Value() string {
+	return c.value
+}
+
+func (c CreateConnectorReqSpecification) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreateConnectorReqSpecification) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_connector_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_connector_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateConnectorRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *CreateConnectorReq `json:"body,omitempty"`
+}
+
+func (o CreateConnectorRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateConnectorRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateConnectorRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_connector_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_connector_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateConnectorResponse struct {
+
+	// 任务ID。
+	JobId *string `json:"job_id,omitempty"`
+
+	// 实例转储ID。
+	ConnectorId    *string `json:"connector_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateConnectorResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateConnectorResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateConnectorResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_topic_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_topic_req.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type CreateInstanceTopicReq struct {
+
+	// topic名称，长度为4-64，以字母开头且只支持大小写字母、中横线、下划线以及数字。
+	Id string `json:"id"`
+
+	// 副本数，配置数据的可靠性。 取值范围：1-3。
+	Replication *int32 `json:"replication,omitempty"`
+
+	// 是否使用同步落盘。默认值为false。同步落盘会导致性能降低。
+	SyncMessageFlush *bool `json:"sync_message_flush,omitempty"`
+
+	// topic分区数，设置消费的并发数。 取值范围：[1-100](tag:hc,hk,hws,hws_hk,otc,hws_ocb,ctc,sbc,hk_sbc)[1-20](tag:cmcc)。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 是否开启同步复制，开启后，客户端生产消息时相应的也要设置acks=-1，否则不生效，默认关闭。
+	SyncReplication *bool `json:"sync_replication,omitempty"`
+
+	// 消息老化时间。默认值为72。 取值范围[1~168](tag:hc,hk,hws,hws_hk,hws_ocb,ctc,sbc,hk_sbc)[1-720](tag:ocb,otc)，单位小时。
+	RetentionTime *int32 `json:"retention_time,omitempty"`
+}
+
+func (o CreateInstanceTopicReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateInstanceTopicReq struct{}"
+	}
+
+	return strings.Join([]string{"CreateInstanceTopicReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_topic_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_topic_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateInstanceTopicRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *CreateInstanceTopicReq `json:"body,omitempty"`
+}
+
+func (o CreateInstanceTopicRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateInstanceTopicRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateInstanceTopicRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_topic_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_topic_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateInstanceTopicResponse struct {
+
+	// topic名称。
+	Name           *string `json:"name,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateInstanceTopicResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateInstanceTopicResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateInstanceTopicResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_user_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_user_req.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type CreateInstanceUserReq struct {
+
+	// 用户名称。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 用户密码。  密码不能和用户名相同。 复杂度要求： - 输入长度为8到32位的字符串。 - 必须包含如下四种字符中的两种组合：   - 小写字母   - 大写字母   - 数字   - 特殊字符包括（`~!@#$%^&*()-_=+\\|[{}]:'\",<.>/?）
+	UserPasswd *string `json:"user_passwd,omitempty"`
+}
+
+func (o CreateInstanceUserReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateInstanceUserReq struct{}"
+	}
+
+	return strings.Join([]string{"CreateInstanceUserReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_user_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_user_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateInstanceUserRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *CreateInstanceUserReq `json:"body,omitempty"`
+}
+
+func (o CreateInstanceUserRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateInstanceUserRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateInstanceUserRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_user_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_instance_user_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateInstanceUserResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o CreateInstanceUserResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateInstanceUserResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateInstanceUserResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_partition_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_partition_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type CreatePartitionReq struct {
+
+	// 期望调整分区后的数量，必须大于当前分区数量，小于等于[100](tag:hc,hk,hws,hws_hk,otc,hws_ocb,ctc,sbc,hk_sbc)[20](tag:cmcc)。
+	Partition *int32 `json:"partition,omitempty"`
+}
+
+func (o CreatePartitionReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePartitionReq struct{}"
+	}
+
+	return strings.Join([]string{"CreatePartitionReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_partition_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_partition_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreatePartitionRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。
+	Topic string `json:"topic"`
+
+	Body *CreatePartitionReq `json:"body,omitempty"`
+}
+
+func (o CreatePartitionRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePartitionRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreatePartitionRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_partition_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_partition_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreatePartitionResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o CreatePartitionResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePartitionResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreatePartitionResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_post_paid_instance_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_post_paid_instance_req.go
@@ -1,0 +1,415 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 创建实例请求体。
+type CreatePostPaidInstanceReq struct {
+
+	// 实例名称。  由英文字符开头，只能由英文字母、数字、中划线、下划线组成，长度为4~64的字符。
+	Name string `json:"name"`
+
+	// 实例的描述信息。  长度不超过1024的字符串。  > \\与\"在json报文中属于特殊字符，如果参数值中需要显示\\或者\"字符，请在字符前增加转义字符\\，比如\\\\或者\\\"。
+	Description *string `json:"description,omitempty"`
+
+	// 消息引擎。取值填写为：kafka。
+	Engine CreatePostPaidInstanceReqEngine `json:"engine"`
+
+	// 消息引擎的版本。取值填写为：1.1.0和2.3.0。
+	EngineVersion CreatePostPaidInstanceReqEngineVersion `json:"engine_version"`
+
+	// [新规格实例：Kafka实例业务TPS规格，取值范围：   - c6.2u4g.cluster   - c6.4u8g.cluster   - c6.8u16g.cluster   - c6.12u24g.cluster   - c6.16u32g.cluster  老规格实例：](tag:hc,hk) Kafka实例的基准带宽，表示单位时间内传送的最大数据量，单位MB。取值范围：   - 100MB   - 300MB   - 600MB   - 1200MB
+	Specification *CreatePostPaidInstanceReqSpecification `json:"specification,omitempty"`
+
+	// 代理个数。 [老规格实例此参数无需设置。 新规格实例取值范围：3 ~ 30。](tag:hc,hk)  [此参数无需设置](tag:hws,hws_hk,otc,ocb,hws_ocb,ctc,sbc,hk_sbc,cmcc)
+	BrokerNum *int32 `json:"broker_num,omitempty"`
+
+	// 消息存储空间，单位GB。   - Kafka实例规格为100MB时，存储空间取值范围600GB ~ 90000GB。   - Kafka实例规格为300MB时，存储空间取值范围1200GB ~ 90000GB。   - Kafka实例规格为600MB时，存储空间取值范围2400GB ~ 90000GB。   - Kafka实例规格为1200MB，存储空间取值范围4800GB ~ 90000GB   [- Kafka实例规格为c6.2u4g.cluster时，存储空间取值范围600GB ~ 300000GB。   - Kafka实例规格为c6.4u8g.cluster时，存储空间取值范围1200GB ~ 600000GB。   - Kafka实例规格为c6.8u16g.cluster时，存储空间取值范围2400GB ~ 900000GB。   - Kafka实例规格为c6.12u24g.cluster时，存储空间取值范围3600GB ~ 900000GB。   - Kafka实例规格为c6.16u32g.cluster时，存储空间取值范围4800GB ~ 900000GB。](tag:hc,hk)
+	StorageSpace int32 `json:"storage_space"`
+
+	// Kafka实例的最大分区数量。   - 参数specification为100MB时，取值300   - 参数specification为300MB时，取值900   - 参数specification为600MB时，取值1800   - 参数specification为1200MB时，取值1800    [新规格实例此参数无需设置，每种规格对应的分区数上限参考：https://support.huaweicloud.com/productdesc-kafka/Kafka-specification.html](tag:hc,hk)   [新规格实例此参数无需设置，每种规格对应的分区数上限参考：https://support.huaweicloud.com/intl/zh-cn/productdesc-kafka/Kafka-specification.html](tag:hws,hws_hk)
+	PartitionNum *CreatePostPaidInstanceReqPartitionNum `json:"partition_num,omitempty"`
+
+	// 当ssl_enable为true时，该参数必选，ssl_enable为false时，该参数无效。  认证用户名，只能由英文字母、数字、中划线组成，长度为4~64的字符。
+	AccessUser *string `json:"access_user,omitempty"`
+
+	// 当ssl_enable为true时，该参数必选，ssl_enable为false时，该参数无效。  实例的认证密码。  复杂度要求： - 输入长度为8到32位的字符串。 - 必须包含如下四种字符中的两种组合：   - 小写字母   - 大写字母   - 数字   - 特殊字符包括（`~!@#$%^&*()-_=+\\|[{}]:'\",<.>/?）
+	Password *string `json:"password,omitempty"`
+
+	// 虚拟私有云ID。  获取方法如下：登录虚拟私有云服务的控制台界面，在虚拟私有云的详情页面查找VPC ID。
+	VpcId string `json:"vpc_id"`
+
+	// 指定实例所属的安全组。  获取方法如下：登录虚拟私有云服务的控制台界面，在安全组的详情页面查找安全组ID。
+	SecurityGroupId string `json:"security_group_id"`
+
+	// 子网信息。  获取方法如下：登录虚拟私有云服务的控制台界面，单击VPC下的子网，进入子网详情页面，查找网络ID。
+	SubnetId string `json:"subnet_id"`
+
+	// 创建节点到指定且有资源的可用区ID。该参数不能为空数组或者数组的值为空。 创建Kafka实例，支持节点部署在1个或3个及3个以上的可用区。在为节点指定可用区时，用逗号分隔开。
+	AvailableZones []string `json:"available_zones"`
+
+	// 产品ID。 产品ID可以从**查询产品规格列表**接口查询到，不同局点的产品ID的格式可能不同。 一种是包含字母的产品ID，例如：c6.2u4g.cluster；另一种是全数字格式的产品ID，例如：00300-30308-0--0。
+	ProductId string `json:"product_id"`
+
+	// 表示登录Kafka Manager的用户名。只能由英文字母、数字、中划线组成，长度为4~64的字符。
+	KafkaManagerUser string `json:"kafka_manager_user"`
+
+	// 表示登录Kafka Manager的密码。  复杂度要求：   - 输入长度为8到32位的字符串。   - 必须包含如下四种字符中的两种组合：       - 小写字母       - 大写字母       - 数字       - 特殊字符包括（`~!@#$%^&*()-_=+\\|[{}]:'\",<.>/?）
+	KafkaManagerPassword string `json:"kafka_manager_password"`
+
+	// 维护时间窗开始时间，格式为HH:mm。 - 维护时间窗开始和结束时间必须为指定的时间段。 - 开始时间必须为22:00、02:00、06:00、10:00、14:00和18:00。 - 该参数不能单独为空，若该值为空，则结束时间也为空。系统分配一个默认开始时间02:00。
+	MaintainBegin *string `json:"maintain_begin,omitempty"`
+
+	// 维护时间窗结束时间，格式为HH:mm。 - 维护时间窗开始和结束时间必须为指定的时间段。 - 结束时间在开始时间基础上加四个小时，即当开始时间为22:00时，结束时间为02:00。 - 该参数不能单独为空，若该值为空，则开始时间也为空，系统分配一个默认结束时间06:00。
+	MaintainEnd *string `json:"maintain_end,omitempty"`
+
+	// 是否开启公网访问功能。默认不开启公网。 - true：开启 - false：不开启
+	EnablePublicip *bool `json:"enable_publicip,omitempty"`
+
+	// 表示公网带宽，单位是Mbit/s。  [取值范围： - Kafka实例规格为100MB时，公网带宽取值范围3到900，且必须为实例节点个数的倍数。 - Kafka实例规格为300MB时，公网带宽取值范围3到900，且必须为实例节点个数的倍数。 - Kafka实例规格为600MB时，公网带宽取值范围4到1200，且必须为实例节点个数的倍数。 - Kafka实例规格为1200MB时，公网带宽取值范围8到2400，且必须为实例节点个数的倍数。](tag:hws,hws_hk,otc,ocb,hws_ocb,ctc,sbc,hk_sbc,cmcc) [老规格实例取值范围： - Kafka实例规格为100MB时，公网带宽取值范围3到900，且必须为实例节点个数的倍数。 - Kafka实例规格为300MB时，公网带宽取值范围3到900，且必须为实例节点个数的倍数。 - Kafka实例规格为600MB时，公网带宽取值范围4到1200，且必须为实例节点个数的倍数。 - Kafka实例规格为1200MB时，公网带宽取值范围8到2400，且必须为实例节点个数的倍数。  新规格实例取值范围： - Kafka实例规格为c6.2u4g.cluster时，公网带宽取值范围3到250，且必须为实例节点个数的倍数。 - Kafka实例规格为c6.4u8g.cluster时，公网带宽取值范围3到500，且必须为实例节点个数的倍数。 - Kafka实例规格为c6.8u16g.cluster时，公网带宽取值范围4到1000，且必须为实例节点个数的倍数。 - Kafka实例规格为c6.12u24g.cluster时，公网带宽取值范围8到1500，且必须为实例节点个数的倍数。 - Kafka实例规格为c6.16u32g.cluster时，公网带宽取值范围8到2000，且必须为实例节点个数的倍数。](tag:hc,hk)
+	PublicBandwidth *int32 `json:"public_bandwidth,omitempty"`
+
+	// 实例绑定的弹性IP地址的ID。  以英文逗号隔开多个弹性IP地址的ID。  如果开启了公网访问功能（即enable_publicip为true），该字段为必选。
+	PublicipId *string `json:"publicip_id,omitempty"`
+
+	// 是否打开SSL加密访问。  实例创建后将不支持动态开启和关闭。  - true：打开SSL加密访问。 - false：不打开SSL加密访问。
+	SslEnable *bool `json:"ssl_enable,omitempty"`
+
+	// 磁盘的容量到达容量阈值后，对于消息的处理策略。  取值如下： - produce_reject：表示拒绝消息写入。 - time_base：表示自动删除最老消息。
+	RetentionPolicy *CreatePostPaidInstanceReqRetentionPolicy `json:"retention_policy,omitempty"`
+
+	// 是否开启消息转储功能。  默认不开启消息转储。
+	ConnectorEnable *bool `json:"connector_enable,omitempty"`
+
+	// 是否打开kafka自动创建topic功能。 - true：开启 - false：关闭  当您选择开启，表示生产或消费一个未创建的Topic时，会自动创建一个包含3个分区和3个副本的Topic。  默认是false关闭。
+	EnableAutoTopic *bool `json:"enable_auto_topic,omitempty"`
+
+	// 存储IO规格。 [新老规格的实例的存储IO规格不相同，创建实例请选择对应的存储IO规格。 新规格实例取值范围：   - dms.physical.storage.high.v2：使用高IO的磁盘类型。   - dms.physical.storage.ultra.v2：使用超高IO的磁盘类型。  老规格实例取值范围：](tag:hc,hk)   - 参数specification为100MB时，取值dms.physical.storage.high或者dms.physical.storage.ultra   - 参数specification为300MB时，取值dms.physical.storage.high或者dms.physical.storage.ultra   - 参数specification为600MB时，取值dms.physical.storage.ultra   - 参数specification为1200MB时，取值dms.physical.storage.ultra存储IO规格。如何选择磁盘类型请参考磁盘类型及性能介绍。
+	StorageSpecCode CreatePostPaidInstanceReqStorageSpecCode `json:"storage_spec_code"`
+
+	// 企业项目ID。若为企业项目帐号，该参数必填。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 标签列表。
+	Tags *[]TagEntity `json:"tags,omitempty"`
+}
+
+func (o CreatePostPaidInstanceReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePostPaidInstanceReq struct{}"
+	}
+
+	return strings.Join([]string{"CreatePostPaidInstanceReq", string(data)}, " ")
+}
+
+type CreatePostPaidInstanceReqEngine struct {
+	value string
+}
+
+type CreatePostPaidInstanceReqEngineEnum struct {
+	KAFKA CreatePostPaidInstanceReqEngine
+}
+
+func GetCreatePostPaidInstanceReqEngineEnum() CreatePostPaidInstanceReqEngineEnum {
+	return CreatePostPaidInstanceReqEngineEnum{
+		KAFKA: CreatePostPaidInstanceReqEngine{
+			value: "kafka",
+		},
+	}
+}
+
+func (c CreatePostPaidInstanceReqEngine) Value() string {
+	return c.value
+}
+
+func (c CreatePostPaidInstanceReqEngine) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreatePostPaidInstanceReqEngine) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type CreatePostPaidInstanceReqEngineVersion struct {
+	value string
+}
+
+type CreatePostPaidInstanceReqEngineVersionEnum struct {
+	E_1_1_0 CreatePostPaidInstanceReqEngineVersion
+	E_2_3_0 CreatePostPaidInstanceReqEngineVersion
+}
+
+func GetCreatePostPaidInstanceReqEngineVersionEnum() CreatePostPaidInstanceReqEngineVersionEnum {
+	return CreatePostPaidInstanceReqEngineVersionEnum{
+		E_1_1_0: CreatePostPaidInstanceReqEngineVersion{
+			value: "1.1.0",
+		},
+		E_2_3_0: CreatePostPaidInstanceReqEngineVersion{
+			value: "2.3.0",
+		},
+	}
+}
+
+func (c CreatePostPaidInstanceReqEngineVersion) Value() string {
+	return c.value
+}
+
+func (c CreatePostPaidInstanceReqEngineVersion) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreatePostPaidInstanceReqEngineVersion) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type CreatePostPaidInstanceReqSpecification struct {
+	value string
+}
+
+type CreatePostPaidInstanceReqSpecificationEnum struct {
+	E_100_MB          CreatePostPaidInstanceReqSpecification
+	E_300_MB          CreatePostPaidInstanceReqSpecification
+	E_600_MB          CreatePostPaidInstanceReqSpecification
+	E_1200_MB         CreatePostPaidInstanceReqSpecification
+	C6_2U4G_CLUSTER   CreatePostPaidInstanceReqSpecification
+	C6_4U8G_CLUSTER   CreatePostPaidInstanceReqSpecification
+	C6_8U16G_CLUSTER  CreatePostPaidInstanceReqSpecification
+	C6_12U24G_CLUSTER CreatePostPaidInstanceReqSpecification
+	C6_16U32G_CLUSTER CreatePostPaidInstanceReqSpecification
+}
+
+func GetCreatePostPaidInstanceReqSpecificationEnum() CreatePostPaidInstanceReqSpecificationEnum {
+	return CreatePostPaidInstanceReqSpecificationEnum{
+		E_100_MB: CreatePostPaidInstanceReqSpecification{
+			value: "100MB",
+		},
+		E_300_MB: CreatePostPaidInstanceReqSpecification{
+			value: "300MB",
+		},
+		E_600_MB: CreatePostPaidInstanceReqSpecification{
+			value: "600MB",
+		},
+		E_1200_MB: CreatePostPaidInstanceReqSpecification{
+			value: "1200MB",
+		},
+		C6_2U4G_CLUSTER: CreatePostPaidInstanceReqSpecification{
+			value: "c6.2u4g.cluster",
+		},
+		C6_4U8G_CLUSTER: CreatePostPaidInstanceReqSpecification{
+			value: "c6.4u8g.cluster",
+		},
+		C6_8U16G_CLUSTER: CreatePostPaidInstanceReqSpecification{
+			value: "c6.8u16g.cluster",
+		},
+		C6_12U24G_CLUSTER: CreatePostPaidInstanceReqSpecification{
+			value: "c6.12u24g.cluster",
+		},
+		C6_16U32G_CLUSTER: CreatePostPaidInstanceReqSpecification{
+			value: "c6.16u32g.cluster",
+		},
+	}
+}
+
+func (c CreatePostPaidInstanceReqSpecification) Value() string {
+	return c.value
+}
+
+func (c CreatePostPaidInstanceReqSpecification) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreatePostPaidInstanceReqSpecification) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type CreatePostPaidInstanceReqPartitionNum struct {
+	value int32
+}
+
+type CreatePostPaidInstanceReqPartitionNumEnum struct {
+	E_250  CreatePostPaidInstanceReqPartitionNum
+	E_300  CreatePostPaidInstanceReqPartitionNum
+	E_500  CreatePostPaidInstanceReqPartitionNum
+	E_900  CreatePostPaidInstanceReqPartitionNum
+	E_1000 CreatePostPaidInstanceReqPartitionNum
+	E_1500 CreatePostPaidInstanceReqPartitionNum
+	E_1800 CreatePostPaidInstanceReqPartitionNum
+	E_2000 CreatePostPaidInstanceReqPartitionNum
+}
+
+func GetCreatePostPaidInstanceReqPartitionNumEnum() CreatePostPaidInstanceReqPartitionNumEnum {
+	return CreatePostPaidInstanceReqPartitionNumEnum{
+		E_250: CreatePostPaidInstanceReqPartitionNum{
+			value: 250,
+		}, E_300: CreatePostPaidInstanceReqPartitionNum{
+			value: 300,
+		}, E_500: CreatePostPaidInstanceReqPartitionNum{
+			value: 500,
+		}, E_900: CreatePostPaidInstanceReqPartitionNum{
+			value: 900,
+		}, E_1000: CreatePostPaidInstanceReqPartitionNum{
+			value: 1000,
+		}, E_1500: CreatePostPaidInstanceReqPartitionNum{
+			value: 1500,
+		}, E_1800: CreatePostPaidInstanceReqPartitionNum{
+			value: 1800,
+		}, E_2000: CreatePostPaidInstanceReqPartitionNum{
+			value: 2000,
+		},
+	}
+}
+
+func (c CreatePostPaidInstanceReqPartitionNum) Value() int32 {
+	return c.value
+}
+
+func (c CreatePostPaidInstanceReqPartitionNum) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreatePostPaidInstanceReqPartitionNum) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("int32")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(int32)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to int32 error")
+	}
+}
+
+type CreatePostPaidInstanceReqRetentionPolicy struct {
+	value string
+}
+
+type CreatePostPaidInstanceReqRetentionPolicyEnum struct {
+	TIME_BASE      CreatePostPaidInstanceReqRetentionPolicy
+	PRODUCE_REJECT CreatePostPaidInstanceReqRetentionPolicy
+}
+
+func GetCreatePostPaidInstanceReqRetentionPolicyEnum() CreatePostPaidInstanceReqRetentionPolicyEnum {
+	return CreatePostPaidInstanceReqRetentionPolicyEnum{
+		TIME_BASE: CreatePostPaidInstanceReqRetentionPolicy{
+			value: "time_base",
+		},
+		PRODUCE_REJECT: CreatePostPaidInstanceReqRetentionPolicy{
+			value: "produce_reject",
+		},
+	}
+}
+
+func (c CreatePostPaidInstanceReqRetentionPolicy) Value() string {
+	return c.value
+}
+
+func (c CreatePostPaidInstanceReqRetentionPolicy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreatePostPaidInstanceReqRetentionPolicy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type CreatePostPaidInstanceReqStorageSpecCode struct {
+	value string
+}
+
+type CreatePostPaidInstanceReqStorageSpecCodeEnum struct {
+	DMS_PHYSICAL_STORAGE_HIGH_V2  CreatePostPaidInstanceReqStorageSpecCode
+	DMS_PHYSICAL_STORAGE_ULTRA_V2 CreatePostPaidInstanceReqStorageSpecCode
+	DMS_PHYSICAL_STORAGE_NORMAL   CreatePostPaidInstanceReqStorageSpecCode
+	DMS_PHYSICAL_STORAGE_HIGH     CreatePostPaidInstanceReqStorageSpecCode
+	DMS_PHYSICAL_STORAGE_ULTRA    CreatePostPaidInstanceReqStorageSpecCode
+}
+
+func GetCreatePostPaidInstanceReqStorageSpecCodeEnum() CreatePostPaidInstanceReqStorageSpecCodeEnum {
+	return CreatePostPaidInstanceReqStorageSpecCodeEnum{
+		DMS_PHYSICAL_STORAGE_HIGH_V2: CreatePostPaidInstanceReqStorageSpecCode{
+			value: "dms.physical.storage.high.v2",
+		},
+		DMS_PHYSICAL_STORAGE_ULTRA_V2: CreatePostPaidInstanceReqStorageSpecCode{
+			value: "dms.physical.storage.ultra.v2",
+		},
+		DMS_PHYSICAL_STORAGE_NORMAL: CreatePostPaidInstanceReqStorageSpecCode{
+			value: "dms.physical.storage.normal",
+		},
+		DMS_PHYSICAL_STORAGE_HIGH: CreatePostPaidInstanceReqStorageSpecCode{
+			value: "dms.physical.storage.high",
+		},
+		DMS_PHYSICAL_STORAGE_ULTRA: CreatePostPaidInstanceReqStorageSpecCode{
+			value: "dms.physical.storage.ultra",
+		},
+	}
+}
+
+func (c CreatePostPaidInstanceReqStorageSpecCode) Value() string {
+	return c.value
+}
+
+func (c CreatePostPaidInstanceReqStorageSpecCode) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreatePostPaidInstanceReqStorageSpecCode) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_post_paid_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_post_paid_instance_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreatePostPaidInstanceRequest struct {
+	Body *CreatePostPaidInstanceReq `json:"body,omitempty"`
+}
+
+func (o CreatePostPaidInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePostPaidInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreatePostPaidInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_post_paid_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_post_paid_instance_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreatePostPaidInstanceResponse struct {
+
+	// 实例ID
+	InstanceId     *string `json:"instance_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreatePostPaidInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePostPaidInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreatePostPaidInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_sink_task_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_sink_task_req.go
@@ -1,0 +1,109 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type CreateSinkTaskReq struct {
+
+	// 源数据类型，目前只支持BLOB。
+	SourceType CreateSinkTaskReqSourceType `json:"source_type"`
+
+	// 转储任务名称。
+	TaskName string `json:"task_name"`
+
+	// 转存的目标类型，当前只支持OBS。
+	DestinationType CreateSinkTaskReqDestinationType `json:"destination_type"`
+
+	ObsDestinationDescriptor *ObsDestinationDescriptor `json:"obs_destination_descriptor"`
+}
+
+func (o CreateSinkTaskReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateSinkTaskReq struct{}"
+	}
+
+	return strings.Join([]string{"CreateSinkTaskReq", string(data)}, " ")
+}
+
+type CreateSinkTaskReqSourceType struct {
+	value string
+}
+
+type CreateSinkTaskReqSourceTypeEnum struct {
+	BLOB CreateSinkTaskReqSourceType
+}
+
+func GetCreateSinkTaskReqSourceTypeEnum() CreateSinkTaskReqSourceTypeEnum {
+	return CreateSinkTaskReqSourceTypeEnum{
+		BLOB: CreateSinkTaskReqSourceType{
+			value: "BLOB",
+		},
+	}
+}
+
+func (c CreateSinkTaskReqSourceType) Value() string {
+	return c.value
+}
+
+func (c CreateSinkTaskReqSourceType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreateSinkTaskReqSourceType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type CreateSinkTaskReqDestinationType struct {
+	value string
+}
+
+type CreateSinkTaskReqDestinationTypeEnum struct {
+	OBS CreateSinkTaskReqDestinationType
+}
+
+func GetCreateSinkTaskReqDestinationTypeEnum() CreateSinkTaskReqDestinationTypeEnum {
+	return CreateSinkTaskReqDestinationTypeEnum{
+		OBS: CreateSinkTaskReqDestinationType{
+			value: "OBS",
+		},
+	}
+}
+
+func (c CreateSinkTaskReqDestinationType) Value() string {
+	return c.value
+}
+
+func (c CreateSinkTaskReqDestinationType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *CreateSinkTaskReqDestinationType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_sink_task_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_sink_task_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type CreateSinkTaskRequest struct {
+
+	// 实例转储ID。 请参考[实例生命周期][查询实例]接口返回的数据。
+	ConnectorId string `json:"connector_id"`
+
+	Body *CreateSinkTaskReq `json:"body,omitempty"`
+}
+
+func (o CreateSinkTaskRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateSinkTaskRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateSinkTaskRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_sink_task_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_create_sink_task_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type CreateSinkTaskResponse struct {
+
+	// 任务ID。
+	TaskId         *string `json:"task_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateSinkTaskResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateSinkTaskResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateSinkTaskResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_background_task_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_background_task_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeleteBackgroundTaskRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 任务ID。
+	TaskId string `json:"task_id"`
+}
+
+func (o DeleteBackgroundTaskRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteBackgroundTaskRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteBackgroundTaskRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_background_task_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_background_task_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeleteBackgroundTaskResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DeleteBackgroundTaskResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteBackgroundTaskResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteBackgroundTaskResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_instance_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeleteInstanceRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o DeleteInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_instance_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeleteInstanceResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DeleteInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_sink_task_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_sink_task_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type DeleteSinkTaskRequest struct {
+
+	// 实例转储ID。 请参考[实例生命周期][查询实例]接口返回的数据。
+	ConnectorId string `json:"connector_id"`
+
+	// 转储任务ID。
+	TaskId string `json:"task_id"`
+}
+
+func (o DeleteSinkTaskRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteSinkTaskRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteSinkTaskRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_sink_task_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_delete_sink_task_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type DeleteSinkTaskResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DeleteSinkTaskResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteSinkTaskResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteSinkTaskResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_diskusage_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_diskusage_entity.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type DiskusageEntity struct {
+
+	// Broker名称。
+	BrokerName *string `json:"broker_name,omitempty"`
+
+	// 磁盘容量。
+	DataDiskSize *string `json:"data_disk_size,omitempty"`
+
+	// 已使用的磁盘容量。
+	DataDiskUse *string `json:"data_disk_use,omitempty"`
+
+	// 剩余可用的磁盘容量。
+	DataDiskFree *string `json:"data_disk_free,omitempty"`
+
+	// 消息标签。
+	DataDiskUsePercentage *string `json:"data_disk_use_percentage,omitempty"`
+
+	// 消息标签。
+	Status *string `json:"status,omitempty"`
+
+	// topic磁盘容量使用列表。
+	TopicList *[]DiskusageTopicEntity `json:"topic_list,omitempty"`
+}
+
+func (o DiskusageEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DiskusageEntity struct{}"
+	}
+
+	return strings.Join([]string{"DiskusageEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_diskusage_topic_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_diskusage_topic_entity.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type DiskusageTopicEntity struct {
+
+	// 磁盘使用量。
+	Size *string `json:"size,omitempty"`
+
+	// topic名称。
+	TopicName *string `json:"topic_name,omitempty"`
+
+	// 分区。
+	TopicPartition *string `json:"topic_partition,omitempty"`
+
+	// 磁盘使用量的占比。
+	Percentage *float64 `json:"percentage,omitempty"`
+}
+
+func (o DiskusageTopicEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DiskusageTopicEntity struct{}"
+	}
+
+	return strings.Join([]string{"DiskusageTopicEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_available_zones_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_available_zones_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListAvailableZonesRequest struct {
+}
+
+func (o ListAvailableZonesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListAvailableZonesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListAvailableZonesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_available_zones_resp_available_zones.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_available_zones_resp_available_zones.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListAvailableZonesRespAvailableZones struct {
+
+	// 是否售罄。
+	SoldOut *bool `json:"soldOut,omitempty"`
+
+	// 可用区ID。
+	Id *string `json:"id,omitempty"`
+
+	// 可用区编码。
+	Code *string `json:"code,omitempty"`
+
+	// 可用区名称。
+	Name *string `json:"name,omitempty"`
+
+	// 可用区端口号。
+	Port *string `json:"port,omitempty"`
+
+	// 分区上是否还有可用资源。
+	ResourceAvailability *string `json:"resource_availability,omitempty"`
+
+	// 是否为默认可用区。
+	DefaultAz *bool `json:"default_az,omitempty"`
+
+	// 剩余时间。
+	RemainTime *int64 `json:"remain_time,omitempty"`
+
+	// 是否支持IPv6。
+	Ipv6Enable *bool `json:"ipv6_enable,omitempty"`
+}
+
+func (o ListAvailableZonesRespAvailableZones) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListAvailableZonesRespAvailableZones struct{}"
+	}
+
+	return strings.Join([]string{"ListAvailableZonesRespAvailableZones", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_available_zones_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_available_zones_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListAvailableZonesResponse struct {
+
+	// 区域ID。
+	RegionId *string `json:"region_id,omitempty"`
+
+	// 可用区数组。
+	AvailableZones *[]ListAvailableZonesRespAvailableZones `json:"available_zones,omitempty"`
+	HttpStatusCode int                                     `json:"-"`
+}
+
+func (o ListAvailableZonesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListAvailableZonesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListAvailableZonesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_background_tasks_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_background_tasks_request.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListBackgroundTasksRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 开启查询的任务编号。
+	Start *int32 `json:"start,omitempty"`
+
+	// 查询的任务个数。
+	Limit *int32 `json:"limit,omitempty"`
+
+	// 查询任务的最小时间，格式为YYYYMMDDHHmmss。
+	BeginTime *string `json:"begin_time,omitempty"`
+
+	// 查询任务的最大时间，格式为YYYYMMDDHHmmss。
+	EndTime *string `json:"end_time,omitempty"`
+}
+
+func (o ListBackgroundTasksRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListBackgroundTasksRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListBackgroundTasksRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_background_tasks_resp_tasks.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_background_tasks_resp_tasks.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListBackgroundTasksRespTasks struct {
+
+	// 任务ID。
+	Id *string `json:"id,omitempty"`
+
+	// 任务名称。
+	Name *string `json:"name,omitempty"`
+
+	// 用户名。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 用户ID。
+	UserId *string `json:"user_id,omitempty"`
+
+	// 任务参数。
+	Params *string `json:"params,omitempty"`
+
+	// 任务状态。
+	Status *string `json:"status,omitempty"`
+
+	// 启动时间。
+	CreatedAt *string `json:"created_at,omitempty"`
+
+	// 结束时间。
+	UpdatedAt *string `json:"updated_at,omitempty"`
+}
+
+func (o ListBackgroundTasksRespTasks) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListBackgroundTasksRespTasks struct{}"
+	}
+
+	return strings.Join([]string{"ListBackgroundTasksRespTasks", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_background_tasks_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_background_tasks_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListBackgroundTasksResponse struct {
+
+	// 任务数量。
+	TaskCount *string `json:"task_count,omitempty"`
+
+	// 任务列表。
+	Tasks          *[]ListBackgroundTasksRespTasks `json:"tasks,omitempty"`
+	HttpStatusCode int                             `json:"-"`
+}
+
+func (o ListBackgroundTasksResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListBackgroundTasksResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListBackgroundTasksResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_ios_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_ios_entity.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 支持的磁盘IO类型信息。
+type ListEngineIosEntity struct {
+
+	// 磁盘IO编码。
+	IoSpec *string `json:"io_spec,omitempty"`
+
+	// 磁盘类型。
+	Type *string `json:"type,omitempty"`
+
+	// 可用区。
+	AvailableZones *[]string `json:"available_zones,omitempty"`
+
+	// 不可用区。
+	UnavailableZones *[]string `json:"unavailable_zones,omitempty"`
+}
+
+func (o ListEngineIosEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEngineIosEntity struct{}"
+	}
+
+	return strings.Join([]string{"ListEngineIosEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_products_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_products_entity.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 产品规格的详细信息。
+type ListEngineProductsEntity struct {
+
+	// 产品类型。当前产品类型有单机和集群。
+	Type *string `json:"type,omitempty"`
+
+	// 产品ID。
+	ProductId *string `json:"product_id,omitempty"`
+
+	// 底层资源类型。
+	EcsFlavorId *string `json:"ecs_flavor_id,omitempty"`
+
+	// 账单计费类型。
+	BillingCode *string `json:"billing_code,omitempty"`
+
+	// CPU架构。
+	ArchTypes *[]string `json:"arch_types,omitempty"`
+
+	// 计费模式。   - monthly：包年/包月类型。   - hourly：按需类型。
+	ChargingMode *[]string `json:"charging_mode,omitempty"`
+
+	// 支持的磁盘IO类型列表。
+	Ios *[]ListEngineIosEntity `json:"ios,omitempty"`
+
+	// 当前规格实例支持的功能特性列表。
+	SupportFeatures *[]ListEngineSupportFeaturesEntity `json:"support_features,omitempty"`
+
+	Properties *ListEnginePropertiesEntity `json:"properties,omitempty"`
+}
+
+func (o ListEngineProductsEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEngineProductsEntity struct{}"
+	}
+
+	return strings.Join([]string{"ListEngineProductsEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_products_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_products_request.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Request Object
+type ListEngineProductsRequest struct {
+
+	// 消息引擎的类型。
+	Engine ListEngineProductsRequestEngine `json:"engine"`
+
+	// 产品ID。
+	ProductId *string `json:"product_id,omitempty"`
+}
+
+func (o ListEngineProductsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEngineProductsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListEngineProductsRequest", string(data)}, " ")
+}
+
+type ListEngineProductsRequestEngine struct {
+	value string
+}
+
+type ListEngineProductsRequestEngineEnum struct {
+	KAFKA ListEngineProductsRequestEngine
+}
+
+func GetListEngineProductsRequestEngineEnum() ListEngineProductsRequestEngineEnum {
+	return ListEngineProductsRequestEngineEnum{
+		KAFKA: ListEngineProductsRequestEngine{
+			value: "kafka",
+		},
+	}
+}
+
+func (c ListEngineProductsRequestEngine) Value() string {
+	return c.value
+}
+
+func (c ListEngineProductsRequestEngine) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ListEngineProductsRequestEngine) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_products_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_products_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListEngineProductsResponse struct {
+
+	// 分布式消息服务的产品类型。
+	Engine *string `json:"engine,omitempty"`
+
+	// 支持的产品版本类型。
+	Versions *[]string `json:"versions,omitempty"`
+
+	// 产品规格的详细信息。
+	Products       *[]ListEngineProductsEntity `json:"products,omitempty"`
+	HttpStatusCode int                         `json:"-"`
+}
+
+func (o ListEngineProductsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEngineProductsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListEngineProductsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_properties_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_properties_entity.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 当前规格实例的属性。
+type ListEnginePropertiesEntity struct {
+
+	// 每个Broker的最大分区数。
+	MaxPartitionPerBroker *string `json:"max_partition_per_broker,omitempty"`
+
+	// Broker的最大个数。
+	MaxBroker *string `json:"max_broker,omitempty"`
+
+	// 每个节点的最大存储。单位为GB。
+	MaxStoragePerNode *string `json:"max_storage_per_node,omitempty"`
+
+	// 每个Broker的最大消费者数。
+	MaxConsumerPerBroker *string `json:"max_consumer_per_broker,omitempty"`
+
+	// Broker的最小个数。
+	MinBroker *string `json:"min_broker,omitempty"`
+
+	// 每个Broker的最大带宽。
+	MaxBandwidthPerBroker *string `json:"max_bandwidth_per_broker,omitempty"`
+
+	// 每个节点的最小存储。单位为GB。
+	MinStoragePerNode *string `json:"min_storage_per_node,omitempty"`
+
+	// 每个Broker的最大TPS。
+	MaxTpsPerBroker *string `json:"max_tps_per_broker,omitempty"`
+
+	// product_id的别名。
+	ProductAlias *string `json:"product_alias,omitempty"`
+}
+
+func (o ListEnginePropertiesEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEnginePropertiesEntity struct{}"
+	}
+
+	return strings.Join([]string{"ListEnginePropertiesEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_support_features_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_support_features_entity.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 实例支持的功能特性。
+type ListEngineSupportFeaturesEntity struct {
+
+	// 功能名称。
+	Name *string `json:"name,omitempty"`
+
+	Properties *ListEngineSupportFeaturesPropertiesEntity `json:"properties,omitempty"`
+}
+
+func (o ListEngineSupportFeaturesEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEngineSupportFeaturesEntity struct{}"
+	}
+
+	return strings.Join([]string{"ListEngineSupportFeaturesEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_support_features_properties_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_engine_support_features_properties_entity.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 实例支持的功能属性描述。
+type ListEngineSupportFeaturesPropertiesEntity struct {
+
+	// 转储功能的最大任务数。
+	MaxTask *string `json:"max_task,omitempty"`
+
+	// 转储功能的最小任务数。
+	MinTask *string `json:"min_task,omitempty"`
+
+	// 转储功能的最大节点数。
+	MaxNode *string `json:"max_node,omitempty"`
+
+	// 转储功能的最小节点数。
+	MinNode *string `json:"min_node,omitempty"`
+}
+
+func (o ListEngineSupportFeaturesPropertiesEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListEngineSupportFeaturesPropertiesEntity struct{}"
+	}
+
+	return strings.Join([]string{"ListEngineSupportFeaturesPropertiesEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instance_topics_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instance_topics_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListInstanceTopicsRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ListInstanceTopicsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListInstanceTopicsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListInstanceTopicsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instance_topics_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instance_topics_response.go
@@ -1,0 +1,36 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListInstanceTopicsResponse struct {
+
+	// topic总数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 分页查询的大小。
+	Size *int32 `json:"size,omitempty"`
+
+	// 剩余分区数。
+	RemainPartitions *int32 `json:"remain_partitions,omitempty"`
+
+	// 分区总数。
+	MaxPartitions *int32 `json:"max_partitions,omitempty"`
+
+	// topic列表。
+	Topics         *[]TopicEntity `json:"topics,omitempty"`
+	HttpStatusCode int            `json:"-"`
+}
+
+func (o ListInstanceTopicsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListInstanceTopicsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListInstanceTopicsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instances_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instances_request.go
@@ -1,0 +1,190 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Request Object
+type ListInstancesRequest struct {
+
+	// 消息引擎：kafka。
+	Engine *string `json:"engine,omitempty"`
+
+	// 实例名称。
+	Name *string `json:"name,omitempty"`
+
+	// 实例ID。
+	InstanceId *string `json:"instance_id,omitempty"`
+
+	// 实例状态。
+	Status *ListInstancesRequestStatus `json:"status,omitempty"`
+
+	// 是否返回创建失败的实例数。  当参数值为“true”时，返回创建失败的实例数。参数值为“false”或者其他值，不返回创建失败的实例数。
+	IncludeFailure *ListInstancesRequestIncludeFailure `json:"include_failure,omitempty"`
+
+	// 是否按照实例名称进行精确匹配查询。  默认为“false”，表示模糊匹配实例名称查询。若参数值为“true”表示按照实例名称进行精确匹配查询。
+	ExactMatchName *ListInstancesRequestExactMatchName `json:"exact_match_name,omitempty"`
+
+	// 企业项目ID。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ListInstancesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListInstancesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListInstancesRequest", string(data)}, " ")
+}
+
+type ListInstancesRequestStatus struct {
+	value string
+}
+
+type ListInstancesRequestStatusEnum struct {
+	CREATING        ListInstancesRequestStatus
+	RUNNING         ListInstancesRequestStatus
+	FAULTY          ListInstancesRequestStatus
+	RESTARTING      ListInstancesRequestStatus
+	RESIZING        ListInstancesRequestStatus
+	RESIZING_FAILED ListInstancesRequestStatus
+	FROZEN          ListInstancesRequestStatus
+}
+
+func GetListInstancesRequestStatusEnum() ListInstancesRequestStatusEnum {
+	return ListInstancesRequestStatusEnum{
+		CREATING: ListInstancesRequestStatus{
+			value: "CREATING",
+		},
+		RUNNING: ListInstancesRequestStatus{
+			value: "RUNNING",
+		},
+		FAULTY: ListInstancesRequestStatus{
+			value: "FAULTY",
+		},
+		RESTARTING: ListInstancesRequestStatus{
+			value: "RESTARTING",
+		},
+		RESIZING: ListInstancesRequestStatus{
+			value: "RESIZING",
+		},
+		RESIZING_FAILED: ListInstancesRequestStatus{
+			value: "RESIZING FAILED",
+		},
+		FROZEN: ListInstancesRequestStatus{
+			value: "FROZEN",
+		},
+	}
+}
+
+func (c ListInstancesRequestStatus) Value() string {
+	return c.value
+}
+
+func (c ListInstancesRequestStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ListInstancesRequestStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ListInstancesRequestIncludeFailure struct {
+	value string
+}
+
+type ListInstancesRequestIncludeFailureEnum struct {
+	TRUE  ListInstancesRequestIncludeFailure
+	FALSE ListInstancesRequestIncludeFailure
+}
+
+func GetListInstancesRequestIncludeFailureEnum() ListInstancesRequestIncludeFailureEnum {
+	return ListInstancesRequestIncludeFailureEnum{
+		TRUE: ListInstancesRequestIncludeFailure{
+			value: "true",
+		},
+		FALSE: ListInstancesRequestIncludeFailure{
+			value: "false",
+		},
+	}
+}
+
+func (c ListInstancesRequestIncludeFailure) Value() string {
+	return c.value
+}
+
+func (c ListInstancesRequestIncludeFailure) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ListInstancesRequestIncludeFailure) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ListInstancesRequestExactMatchName struct {
+	value string
+}
+
+type ListInstancesRequestExactMatchNameEnum struct {
+	TRUE  ListInstancesRequestExactMatchName
+	FALSE ListInstancesRequestExactMatchName
+}
+
+func GetListInstancesRequestExactMatchNameEnum() ListInstancesRequestExactMatchNameEnum {
+	return ListInstancesRequestExactMatchNameEnum{
+		TRUE: ListInstancesRequestExactMatchName{
+			value: "true",
+		},
+		FALSE: ListInstancesRequestExactMatchName{
+			value: "false",
+		},
+	}
+}
+
+func (c ListInstancesRequestExactMatchName) Value() string {
+	return c.value
+}
+
+func (c ListInstancesRequestExactMatchName) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ListInstancesRequestExactMatchName) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instances_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_instances_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListInstancesResponse struct {
+
+	// 实例列表
+	Instances *[]ShowInstanceResp `json:"instances,omitempty"`
+
+	// 实例数量。
+	InstanceNum    *int32 `json:"instance_num,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListInstancesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListInstancesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListInstancesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListProductsRequest struct {
+
+	// 消息引擎的类型。当前只支持kafka类型。
+	Engine string `json:"engine"`
+}
+
+func (o ListProductsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProductsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListProductsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_detail.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListProductsRespDetail struct {
+
+	// 单位时间内的消息量最大值。
+	Tps *string `json:"tps,omitempty"`
+
+	// 消息存储空间。
+	Storage *string `json:"storage,omitempty"`
+
+	// Kafka实例的分区数量。
+	PartitionNum *string `json:"partition_num,omitempty"`
+
+	// 产品ID。
+	ProductId *string `json:"product_id,omitempty"`
+
+	// 规格ID。
+	SpecCode *string `json:"spec_code,omitempty"`
+
+	// IO信息。
+	Io *[]ListProductsRespIo `json:"io,omitempty"`
+
+	// Kafka实例的基准带宽。
+	Bandwidth *string `json:"bandwidth,omitempty"`
+
+	// 资源售罄的可用区列表。
+	UnavailableZones *[]string `json:"unavailable_zones,omitempty"`
+
+	// 有可用资源的可用区列表。
+	AvailableZones *[]string `json:"available_zones,omitempty"`
+
+	// 该产品规格对应的虚拟机规格。
+	EcsFlavorId *string `json:"ecs_flavor_id,omitempty"`
+
+	// 实例规格架构类型。当前仅支持X86。
+	ArchType *string `json:"arch_type,omitempty"`
+}
+
+func (o ListProductsRespDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProductsRespDetail struct{}"
+	}
+
+	return strings.Join([]string{"ListProductsRespDetail", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_hourly.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_hourly.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListProductsRespHourly struct {
+
+	// 消息引擎的名称，该字段显示为kafka。
+	Name *string `json:"name,omitempty"`
+
+	// 消息引擎的版本，当前仅支持1.1.0和2.3.0。
+	Version *string `json:"version,omitempty"`
+
+	// 产品规格列表。
+	Values *[]ListProductsRespValues `json:"values,omitempty"`
+}
+
+func (o ListProductsRespHourly) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProductsRespHourly struct{}"
+	}
+
+	return strings.Join([]string{"ListProductsRespHourly", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_io.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_io.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListProductsRespIo struct {
+
+	// IO类型。
+	IoType *string `json:"io_type,omitempty"`
+
+	// IO规格。
+	StorageSpecCode *string `json:"storage_spec_code,omitempty"`
+
+	// IO未售罄的可用区列表。
+	AvailableZones *[]string `json:"available_zones,omitempty"`
+
+	// IO已售罄的不可用区列表。
+	UnavailableZones *[]string `json:"unavailable_zones,omitempty"`
+
+	// 磁盘类型。
+	VolumeType *string `json:"volume_type,omitempty"`
+}
+
+func (o ListProductsRespIo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProductsRespIo struct{}"
+	}
+
+	return strings.Join([]string{"ListProductsRespIo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_values.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_resp_values.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListProductsRespValues struct {
+
+	// 规格详情。
+	Detail *[]ListProductsRespDetail `json:"detail,omitempty"`
+
+	// 实例类型。
+	Name *string `json:"name,omitempty"`
+
+	// 资源售罄的可用区列表。
+	UnavailableZones *[]string `json:"unavailable_zones,omitempty"`
+
+	// 有可用资源的可用区列表。
+	AvailableZones *[]string `json:"available_zones,omitempty"`
+}
+
+func (o ListProductsRespValues) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProductsRespValues struct{}"
+	}
+
+	return strings.Join([]string{"ListProductsRespValues", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_products_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListProductsResponse struct {
+
+	// 表示按需付费的产品列表。
+	Hourly *[]ListProductsRespHourly `json:"Hourly,omitempty"`
+
+	// 表示包年包月的产品列表。当前暂不支持通过API创建包年包月的Kafka实例。
+	Monthly        *[]ListProductsRespHourly `json:"Monthly,omitempty"`
+	HttpStatusCode int                       `json:"-"`
+}
+
+func (o ListProductsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListProductsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListProductsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_sink_tasks_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_sink_tasks_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ListSinkTasksRequest struct {
+
+	// 实例转储ID。 请参考[实例生命周期][查询实例]接口返回的数据。
+	ConnectorId string `json:"connector_id"`
+}
+
+func (o ListSinkTasksRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListSinkTasksRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListSinkTasksRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_sink_tasks_resp_tasks.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_sink_tasks_resp_tasks.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListSinkTasksRespTasks struct {
+
+	// 任务ID。
+	TaskId *string `json:"task_id,omitempty"`
+
+	// 转储任务名称。
+	TaskName *string `json:"task_name,omitempty"`
+
+	// 转储任务类型。
+	DestinationType *string `json:"destination_type,omitempty"`
+
+	// 转储任务创建时间戳。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 转储任务状态。
+	Status *string `json:"status,omitempty"`
+
+	// 返回任务转存的topics列表或者正则表达式。
+	Topics *string `json:"topics,omitempty"`
+}
+
+func (o ListSinkTasksRespTasks) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListSinkTasksRespTasks struct{}"
+	}
+
+	return strings.Join([]string{"ListSinkTasksRespTasks", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_sink_tasks_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_list_sink_tasks_response.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ListSinkTasksResponse struct {
+
+	// 转储任务列表。
+	Tasks *[]ListSinkTasksRespTasks `json:"tasks,omitempty"`
+
+	// 转储任务总数。
+	TotalNumber *int32 `json:"total_number,omitempty"`
+
+	// 总的支持任务个数。
+	MaxTasks *int32 `json:"max_tasks,omitempty"`
+
+	// 任务总数的配额。
+	QuotaTasks     *int32 `json:"quota_tasks,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListSinkTasksResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListSinkTasksResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListSinkTasksResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_maintain_windows_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_maintain_windows_entity.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MaintainWindowsEntity struct {
+
+	// 是否为默认时间段。
+	Default *bool `json:"default,omitempty"`
+
+	// 维护时间窗结束时间。
+	End *string `json:"end,omitempty"`
+
+	// 维护时间窗开始时间。
+	Begin *string `json:"begin,omitempty"`
+
+	// 序号。
+	Seq *int32 `json:"seq,omitempty"`
+}
+
+func (o MaintainWindowsEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MaintainWindowsEntity struct{}"
+	}
+
+	return strings.Join([]string{"MaintainWindowsEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_messages_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_messages_entity.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type MessagesEntity struct {
+
+	// topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 消息所在的分区。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 消息key。
+	Key *string `json:"key,omitempty"`
+
+	// 消息内容。
+	Value *string `json:"value,omitempty"`
+
+	// 消息大小。
+	Size *int32 `json:"size,omitempty"`
+
+	// topic名称。
+	Timestamp *int64 `json:"timestamp,omitempty"`
+
+	// 大数据标识。
+	HugeMessage *bool `json:"huge_message,omitempty"`
+
+	// 消息偏移量。
+	MessageOffset *int32 `json:"message_offset,omitempty"`
+
+	// 消息ID。
+	MessageId *string `json:"message_id,omitempty"`
+
+	// 应用ID。
+	AppId *string `json:"app_id,omitempty"`
+
+	// 消息标签。
+	Tag *string `json:"tag,omitempty"`
+}
+
+func (o MessagesEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "MessagesEntity struct{}"
+	}
+
+	return strings.Join([]string{"MessagesEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_obs_destination_descriptor.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_obs_destination_descriptor.go
@@ -1,0 +1,136 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// 转存目标的描述。
+type ObsDestinationDescriptor struct {
+
+	// 转存的topic列表名称，支持多个topic同时放置，以逗号“,”分隔。同时支持正则表达式。 例如topic1,topic2。
+	Topics string `json:"topics"`
+
+	// 转存topic的正则表达式，与topics必须二选一，不能同时都设置或者“.*”。
+	TopicsRegex *string `json:"topics_regex,omitempty"`
+
+	// 转储启动偏移量：   - latest: 从Topic最后端开始消费。   - earliest: 从Topic最前端消息开始消费。  默认是latest。
+	ConsumerStrategy ObsDestinationDescriptorConsumerStrategy `json:"consumer_strategy"`
+
+	// 转储文件格式。当前只支持text。
+	DestinationFileType ObsDestinationDescriptorDestinationFileType `json:"destination_file_type"`
+
+	// 访问密钥AK。
+	AccessKey string `json:"access_key"`
+
+	// 访问密钥SK。
+	SecretKey string `json:"secret_key"`
+
+	// 存储该通道数据的OBS桶名称。
+	ObsBucketName string `json:"obs_bucket_name"`
+
+	// 存储在obs的路径，默认可以不填。 取值范围：英文字母、数字、下划线、中划线和斜杠，最大长度为64个字符。 默认配置为空。
+	ObsPath *string `json:"obs_path,omitempty"`
+
+	// 将转储文件的生成时间使用“yyyy/MM/dd/HH/mm”格式生成分区字符串，用来定义写到OBS的Object文件所在的目录层次结构。   - N/A：置空，不使用日期时间目录。   - yyyy：年   - yyyy/MM：年/月   - yyyy/MM/dd：年/月/日   - yyyy/MM/dd/HH：年/月/日/时   - yyyy/MM/dd/HH/mm：年/月/日/时/分，例如：2017/11/10/14/49，目录结构就是“2017 > 11 > 10 > 14 > 49”，“2017”表示最外层文件夹。  默认值：空 > 数据转储成功后，存储的目录结构为“obs_bucket_path/file_prefix/partition_format”。默认时间是GMT+8 时间
+	PartitionFormat *string `json:"partition_format,omitempty"`
+
+	// 转储文件的记录分隔符，用于分隔写入转储文件的用户数据。 取值范围：   - 逗号“,”   - 分号“;”   - 竖线“|”   - 换行符“\\n”   - NULL  默认值：换行符“\\n”。
+	RecordDelimiter *string `json:"record_delimiter,omitempty"`
+
+	// 根据用户配置的时间，周期性的将数据导入OBS，若某个时间段内无数据，则此时间段不会生成打包文件。 取值范围：30～900 单位：秒。 > 使用OBS通道转储流式数据时该参数为必选配置。
+	DeliverTimeInterval int32 `json:"deliver_time_interval"`
+}
+
+func (o ObsDestinationDescriptor) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ObsDestinationDescriptor struct{}"
+	}
+
+	return strings.Join([]string{"ObsDestinationDescriptor", string(data)}, " ")
+}
+
+type ObsDestinationDescriptorConsumerStrategy struct {
+	value string
+}
+
+type ObsDestinationDescriptorConsumerStrategyEnum struct {
+	LATEST   ObsDestinationDescriptorConsumerStrategy
+	EARLIEST ObsDestinationDescriptorConsumerStrategy
+}
+
+func GetObsDestinationDescriptorConsumerStrategyEnum() ObsDestinationDescriptorConsumerStrategyEnum {
+	return ObsDestinationDescriptorConsumerStrategyEnum{
+		LATEST: ObsDestinationDescriptorConsumerStrategy{
+			value: "latest",
+		},
+		EARLIEST: ObsDestinationDescriptorConsumerStrategy{
+			value: "earliest",
+		},
+	}
+}
+
+func (c ObsDestinationDescriptorConsumerStrategy) Value() string {
+	return c.value
+}
+
+func (c ObsDestinationDescriptorConsumerStrategy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ObsDestinationDescriptorConsumerStrategy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ObsDestinationDescriptorDestinationFileType struct {
+	value string
+}
+
+type ObsDestinationDescriptorDestinationFileTypeEnum struct {
+	TEXT ObsDestinationDescriptorDestinationFileType
+}
+
+func GetObsDestinationDescriptorDestinationFileTypeEnum() ObsDestinationDescriptorDestinationFileTypeEnum {
+	return ObsDestinationDescriptorDestinationFileTypeEnum{
+		TEXT: ObsDestinationDescriptorDestinationFileType{
+			value: "TEXT",
+		},
+	}
+}
+
+func (c ObsDestinationDescriptorDestinationFileType) Value() string {
+	return c.value
+}
+
+func (c ObsDestinationDescriptorDestinationFileType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ObsDestinationDescriptorDestinationFileType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_policy_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_policy_entity.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type PolicyEntity struct {
+
+	// 是否为创建topic时所选择的用户。
+	Owner *bool `json:"owner,omitempty"`
+
+	// 用户名。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 权限类型。 - all：拥有发布、订阅权限; - pub：拥有发布权限; - sub：拥有订阅权限。
+	AccessPolicy *PolicyEntityAccessPolicy `json:"access_policy,omitempty"`
+}
+
+func (o PolicyEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "PolicyEntity struct{}"
+	}
+
+	return strings.Join([]string{"PolicyEntity", string(data)}, " ")
+}
+
+type PolicyEntityAccessPolicy struct {
+	value string
+}
+
+type PolicyEntityAccessPolicyEnum struct {
+	ALL PolicyEntityAccessPolicy
+	PUB PolicyEntityAccessPolicy
+	SUB PolicyEntityAccessPolicy
+}
+
+func GetPolicyEntityAccessPolicyEnum() PolicyEntityAccessPolicyEnum {
+	return PolicyEntityAccessPolicyEnum{
+		ALL: PolicyEntityAccessPolicy{
+			value: "all",
+		},
+		PUB: PolicyEntityAccessPolicy{
+			value: "pub",
+		},
+		SUB: PolicyEntityAccessPolicy{
+			value: "sub",
+		},
+	}
+}
+
+func (c PolicyEntityAccessPolicy) Value() string {
+	return c.value
+}
+
+func (c PolicyEntityAccessPolicy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *PolicyEntityAccessPolicy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_manager_password_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_manager_password_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResetManagerPasswordReq struct {
+
+	// 8-32个字符。 至少包含以下字符中的3种：   - 大写字母   - 小写字母   - 数字   - 特殊字符`~!@#$%^&*()-_=+\\\\|[{}];:\\'\\\",<.>/?  和空格，并且不能以-开头。
+	NewPassword *string `json:"new_password,omitempty"`
+}
+
+func (o ResetManagerPasswordReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetManagerPasswordReq struct{}"
+	}
+
+	return strings.Join([]string{"ResetManagerPasswordReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_manager_password_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_manager_password_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ResetManagerPasswordRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *ResetManagerPasswordReq `json:"body,omitempty"`
+}
+
+func (o ResetManagerPasswordRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetManagerPasswordRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResetManagerPasswordRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_manager_password_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_manager_password_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ResetManagerPasswordResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o ResetManagerPasswordResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetManagerPasswordResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResetManagerPasswordResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_message_offset_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_message_offset_req.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResetMessageOffsetReq struct {
+
+	// topic名称。
+	Topic string `json:"topic"`
+
+	// 分区编号，默认值为-1，若传入值为-1，则重置所有分区。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 重置消费进度到指定偏移量。 - 如果传入offset小于当前最小的offset，则重置到最小的offset。 - 如果大于最大的offset，则重置到最大的offset。  **message_offset、timestamp二者必选其一。**
+	MessageOffset *int32 `json:"message_offset,omitempty"`
+
+	// 重置消费进度到指定时间，格式为unix时间戳，单位为毫秒。 - 如果传入timestamp早于当前最早的timestamp，则重置到最早的timestamp。 - 如果晚于最晚的timestamp，则重置到最晚的timestamp。  **message_offset、timestamp二者必选其一。**
+	Timestamp *int32 `json:"timestamp,omitempty"`
+}
+
+func (o ResetMessageOffsetReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetMessageOffsetReq struct{}"
+	}
+
+	return strings.Join([]string{"ResetMessageOffsetReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_message_offset_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_message_offset_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ResetMessageOffsetRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 消费组名称。
+	Group string `json:"group"`
+
+	Body *ResetMessageOffsetReq `json:"body,omitempty"`
+}
+
+func (o ResetMessageOffsetRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetMessageOffsetRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResetMessageOffsetRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_message_offset_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_message_offset_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ResetMessageOffsetResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o ResetMessageOffsetResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetMessageOffsetResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResetMessageOffsetResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_password_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_password_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResetPasswordReq struct {
+
+	// 8-32个字符。 至少包含以下字符中的3种：   - 大写字母   - 小写字母   - 数字   - 特殊字符`~!@#$%^&*()-_=+\\\\|[{}];:\\'\\\",<.>/?  和空格，并且不能以-开头。
+	NewPassword *string `json:"new_password,omitempty"`
+}
+
+func (o ResetPasswordReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetPasswordReq struct{}"
+	}
+
+	return strings.Join([]string{"ResetPasswordReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_password_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_password_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ResetPasswordRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *ResetPasswordReq `json:"body,omitempty"`
+}
+
+func (o ResetPasswordRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetPasswordRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResetPasswordRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_password_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_password_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ResetPasswordResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o ResetPasswordResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetPasswordResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResetPasswordResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_replica_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_replica_req.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 期望调整的分区副本分配情况。
+type ResetReplicaReq struct {
+
+	// 期望调整的分区副本分配情况。
+	Partitions *[]ResetReplicaReqPartitions `json:"partitions,omitempty"`
+}
+
+func (o ResetReplicaReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetReplicaReq struct{}"
+	}
+
+	return strings.Join([]string{"ResetReplicaReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_replica_req_partitions.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_replica_req_partitions.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResetReplicaReqPartitions struct {
+
+	// 分区ID。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 副本期望所在的broker ID。其中Array首位为leader副本，所有分区需要有同样数量的副本，副本数不能大于总broker的数量。
+	Replicas *[]int32 `json:"replicas,omitempty"`
+}
+
+func (o ResetReplicaReqPartitions) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetReplicaReqPartitions struct{}"
+	}
+
+	return strings.Join([]string{"ResetReplicaReqPartitions", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_user_passwrod_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_user_passwrod_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResetUserPasswrodReq struct {
+
+	// 用户新密码。
+	NewPassword *string `json:"new_password,omitempty"`
+}
+
+func (o ResetUserPasswrodReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetUserPasswrodReq struct{}"
+	}
+
+	return strings.Join([]string{"ResetUserPasswrodReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_user_passwrod_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_user_passwrod_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ResetUserPasswrodRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 用户名称。
+	UserName string `json:"user_name"`
+
+	Body *ResetUserPasswrodReq `json:"body,omitempty"`
+}
+
+func (o ResetUserPasswrodRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetUserPasswrodRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResetUserPasswrodRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_user_passwrod_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_reset_user_passwrod_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ResetUserPasswrodResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o ResetUserPasswrodResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetUserPasswrodResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResetUserPasswrodResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_resize_instance_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_resize_instance_req.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResizeInstanceReq struct {
+
+	// 规格变更后的规格ID。 若只扩展磁盘大小，则规格ID保持和原实例不变。
+	NewSpecCode *string `json:"new_spec_code,omitempty"`
+
+	// 规格变更后的消息存储空间，单位：GB。 若扩展实例基准带宽，则new_storage_space不能低于基准带宽规定的最小磁盘大小。
+	NewStorageSpace *int32 `json:"new_storage_space,omitempty"`
+}
+
+func (o ResizeInstanceReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResizeInstanceReq struct{}"
+	}
+
+	return strings.Join([]string{"ResizeInstanceReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_resize_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_resize_instance_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ResizeInstanceRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *ResizeInstanceReq `json:"body,omitempty"`
+}
+
+func (o ResizeInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResizeInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResizeInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_resize_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_resize_instance_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ResizeInstanceResponse struct {
+
+	// 规格变更任务ID。
+	JobId          *string `json:"job_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ResizeInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResizeInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResizeInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_restart_manager_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_restart_manager_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type RestartManagerRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o RestartManagerRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RestartManagerRequest struct{}"
+	}
+
+	return strings.Join([]string{"RestartManagerRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_restart_manager_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_restart_manager_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type RestartManagerResponse struct {
+
+	// 执行结果。
+	Result *string `json:"result,omitempty"`
+
+	// 实例ID。
+	InstanceId     *string `json:"instance_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o RestartManagerResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RestartManagerResponse struct{}"
+	}
+
+	return strings.Join([]string{"RestartManagerResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_background_task_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_background_task_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowBackgroundTaskRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 任务ID。
+	TaskId string `json:"task_id"`
+}
+
+func (o ShowBackgroundTaskRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowBackgroundTaskRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowBackgroundTaskRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_background_task_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_background_task_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowBackgroundTaskResponse struct {
+
+	// 任务数量。
+	TaskCount *string `json:"task_count,omitempty"`
+
+	// 任务列表。
+	Tasks          *[]ListBackgroundTasksRespTasks `json:"tasks,omitempty"`
+	HttpStatusCode int                             `json:"-"`
+}
+
+func (o ShowBackgroundTaskResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowBackgroundTaskResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowBackgroundTaskResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ces_hierarchy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ces_hierarchy_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowCesHierarchyRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowCesHierarchyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCesHierarchyRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowCesHierarchyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ces_hierarchy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ces_hierarchy_response.go
@@ -1,0 +1,36 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowCesHierarchyResponse struct {
+
+	// 监控维度。
+	Dimensions *[]ShowCeshierarchyRespDimensions `json:"dimensions,omitempty"`
+
+	// 实例信息。
+	InstanceIds *[]ShowCeshierarchyRespInstanceIds `json:"instance_ids,omitempty"`
+
+	// 节点信息。
+	Nodes *[]ShowCeshierarchyRespNodes `json:"nodes,omitempty"`
+
+	// 队列信息。
+	Queues *[]ShowCeshierarchyRespQueues `json:"queues,omitempty"`
+
+	// 消费组信息。
+	Groups         *[]ShowCeshierarchyRespGroups `json:"groups,omitempty"`
+	HttpStatusCode int                           `json:"-"`
+}
+
+func (o ShowCesHierarchyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCesHierarchyResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowCesHierarchyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_children.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_children.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 子维度信息。
+type ShowCeshierarchyRespChildren struct {
+
+	// 子维度名称。
+	Name *string `json:"name,omitempty"`
+
+	// 监控指标名称列表。
+	Metrics *[]string `json:"metrics,omitempty"`
+
+	// 监控查询使用的key。
+	KeyName *[]string `json:"key_name,omitempty"`
+
+	// 监控维度路由。
+	DimRouter *[]string `json:"dim_router,omitempty"`
+}
+
+func (o ShowCeshierarchyRespChildren) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespChildren struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespChildren", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_dimensions.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_dimensions.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespDimensions struct {
+
+	// 监控维度名称。
+	Name *string `json:"name,omitempty"`
+
+	// 监控指标名称。
+	Metrics *[]string `json:"metrics,omitempty"`
+
+	// 监控查询使用的key。
+	KeyName *[]string `json:"key_name,omitempty"`
+
+	// 监控维度路由。
+	DimRouter *[]string `json:"dim_router,omitempty"`
+
+	// 子维度列表。
+	Children *[]ShowCeshierarchyRespChildren `json:"children,omitempty"`
+}
+
+func (o ShowCeshierarchyRespDimensions) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespDimensions struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespDimensions", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_groups.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_groups.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespGroups struct {
+
+	// 消费组名称。
+	Name *string `json:"name,omitempty"`
+
+	// topic信息。
+	Queues *[]ShowCeshierarchyRespQueues1 `json:"queues,omitempty"`
+}
+
+func (o ShowCeshierarchyRespGroups) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespGroups struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespGroups", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_instance_ids.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_instance_ids.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespInstanceIds struct {
+
+	// 实例ID。
+	Name *string `json:"name,omitempty"`
+}
+
+func (o ShowCeshierarchyRespInstanceIds) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespInstanceIds struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespInstanceIds", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_nodes.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_nodes.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespNodes struct {
+
+	// 节点名称。
+	Name *string `json:"name,omitempty"`
+}
+
+func (o ShowCeshierarchyRespNodes) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespNodes struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespNodes", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_partitions.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_partitions.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespPartitions struct {
+
+	// 分区名称。
+	Name *string `json:"name,omitempty"`
+}
+
+func (o ShowCeshierarchyRespPartitions) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespPartitions struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespPartitions", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_queues.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_queues.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespQueues struct {
+
+	// topic名称。
+	Name *string `json:"name,omitempty"`
+
+	// 分区列表。
+	Partitions *[]ShowCeshierarchyRespPartitions `json:"partitions,omitempty"`
+}
+
+func (o ShowCeshierarchyRespQueues) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespQueues struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespQueues", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_queues_1.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_ceshierarchy_resp_queues_1.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowCeshierarchyRespQueues1 struct {
+
+	// topic名称。
+	Name *string `json:"name,omitempty"`
+
+	// 分区信息。
+	Partitions *[]ShowCeshierarchyRespPartitions `json:"partitions,omitempty"`
+}
+
+func (o ShowCeshierarchyRespQueues1) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCeshierarchyRespQueues1 struct{}"
+	}
+
+	return strings.Join([]string{"ShowCeshierarchyRespQueues1", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowClusterRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowClusterRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClusterRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowClusterRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_resp_cluster.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_resp_cluster.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 集群基本信息。
+type ShowClusterRespCluster struct {
+
+	// 控制器ID。
+	Controller *string `json:"controller,omitempty"`
+
+	// 节点列表。
+	Brokers *[]ShowClusterRespClusterBrokers `json:"brokers,omitempty"`
+
+	// 主题数量。
+	TopicsCount *int32 `json:"topics_count,omitempty"`
+
+	// 分区数量。
+	PartitionsCount *int32 `json:"partitions_count,omitempty"`
+
+	// 在线分区数量。
+	OnlinePartitionsCount *int32 `json:"online_partitions_count,omitempty"`
+
+	// 副本数量。
+	ReplicasCount *int32 `json:"replicas_count,omitempty"`
+
+	// ISR（In-Sync Replicas） 副本总数。
+	IsrReplicasCount *int32 `json:"isr_replicas_count,omitempty"`
+
+	// 消费组数量。
+	ConsumersCount *int32 `json:"consumers_count,omitempty"`
+}
+
+func (o ShowClusterRespCluster) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClusterRespCluster struct{}"
+	}
+
+	return strings.Join([]string{"ShowClusterRespCluster", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_resp_cluster_brokers.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_resp_cluster_brokers.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 节点。
+type ShowClusterRespClusterBrokers struct {
+
+	// 节点IP。
+	Host *string `json:"host,omitempty"`
+
+	// 端口号。
+	Port *int32 `json:"port,omitempty"`
+
+	// 节点ID。
+	BrokerId *string `json:"broker_id,omitempty"`
+
+	// 是否为contoller节点。
+	IsController *bool `json:"is_controller,omitempty"`
+
+	// 服务端版本。
+	Version *string `json:"version,omitempty"`
+
+	// broker注册时间，为unix时间戳格式。
+	RegisterTime *int64 `json:"register_time,omitempty"`
+
+	// Kafka实例节点的连通性是否正常。
+	IsHealth *bool `json:"is_health,omitempty"`
+}
+
+func (o ShowClusterRespClusterBrokers) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClusterRespClusterBrokers struct{}"
+	}
+
+	return strings.Join([]string{"ShowClusterRespClusterBrokers", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_cluster_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowClusterResponse struct {
+	Cluster        *ShowClusterRespCluster `json:"cluster,omitempty"`
+	HttpStatusCode int                     `json:"-"`
+}
+
+func (o ShowClusterResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClusterResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowClusterResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_coordinators_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_coordinators_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowCoordinatorsRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowCoordinatorsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCoordinatorsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowCoordinatorsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_coordinators_resp_coordinators.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_coordinators_resp_coordinators.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 协调器信息。
+type ShowCoordinatorsRespCoordinators struct {
+
+	// 消费组ID。
+	GroupId *string `json:"group_id,omitempty"`
+
+	// 对应协调器的broker id。
+	Id *int32 `json:"id,omitempty"`
+
+	// 对应协调器的地址。
+	Host *string `json:"host,omitempty"`
+
+	// 端口号。
+	Port *int32 `json:"port,omitempty"`
+}
+
+func (o ShowCoordinatorsRespCoordinators) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCoordinatorsRespCoordinators struct{}"
+	}
+
+	return strings.Join([]string{"ShowCoordinatorsRespCoordinators", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_coordinators_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_coordinators_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowCoordinatorsResponse struct {
+
+	// 所有消费组对应的协调器列表。
+	Coordinators   *[]ShowCoordinatorsRespCoordinators `json:"coordinators,omitempty"`
+	HttpStatusCode int                                 `json:"-"`
+}
+
+func (o ShowCoordinatorsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCoordinatorsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowCoordinatorsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowGroupsRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 消费组名称。
+	Group string `json:"group"`
+}
+
+func (o ShowGroupsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGroupsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowGroupsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 消费组信息。
+type ShowGroupsRespGroup struct {
+
+	// 消费组名称。
+	GroupId *string `json:"group_id,omitempty"`
+
+	// 消费组状态。包含以下状态： - Dead：消费组内没有任何成员，且没有任何元数据。 - Empty：消费组内没有任何成员，存在元数据。 - PreparingRebalance：准备开启rebalance。 - CompletingRebalance：所有成员加入group。 - Stable：消费组内成员可正常消费。
+	State *string `json:"state,omitempty"`
+
+	// 协调器编号。
+	CoordinatorId *int32 `json:"coordinator_id,omitempty"`
+
+	// 消费者列表。
+	Members *[]ShowGroupsRespGroupMembers `json:"members,omitempty"`
+
+	// 消费进度。
+	GroupMessageOffsets *[]ShowGroupsRespGroupGroupMessageOffsets `json:"group_message_offsets,omitempty"`
+
+	// 分区分配策略。
+	AssignmentStrategy *string `json:"assignment_strategy,omitempty"`
+}
+
+func (o ShowGroupsRespGroup) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGroupsRespGroup struct{}"
+	}
+
+	return strings.Join([]string{"ShowGroupsRespGroup", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group_assignment.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group_assignment.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowGroupsRespGroupAssignment struct {
+
+	// topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区列表。
+	Partitions *[]int32 `json:"partitions,omitempty"`
+}
+
+func (o ShowGroupsRespGroupAssignment) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGroupsRespGroupAssignment struct{}"
+	}
+
+	return strings.Join([]string{"ShowGroupsRespGroupAssignment", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group_group_message_offsets.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group_group_message_offsets.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowGroupsRespGroupGroupMessageOffsets struct {
+
+	// 分区编号。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 剩余可消费消息数，即消息堆积数。
+	Lag *int32 `json:"lag,omitempty"`
+
+	// topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 当前消费进度。
+	MessageCurrentOffset *int32 `json:"message_current_offset,omitempty"`
+
+	// 最大消息位置（LEO）。
+	MessageLogEndOffset *int32 `json:"message_log_end_offset,omitempty"`
+}
+
+func (o ShowGroupsRespGroupGroupMessageOffsets) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGroupsRespGroupGroupMessageOffsets struct{}"
+	}
+
+	return strings.Join([]string{"ShowGroupsRespGroupGroupMessageOffsets", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group_members.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_resp_group_members.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowGroupsRespGroupMembers struct {
+
+	// 消费组consumer地址。
+	Host *string `json:"host,omitempty"`
+
+	// consumer分配到的分区信息。
+	Assignment *[]ShowGroupsRespGroupAssignment `json:"assignment,omitempty"`
+
+	// 消费组consumer的ID。
+	MemberId *string `json:"member_id,omitempty"`
+
+	// 客户端ID。
+	ClientId *string `json:"client_id,omitempty"`
+}
+
+func (o ShowGroupsRespGroupMembers) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGroupsRespGroupMembers struct{}"
+	}
+
+	return strings.Join([]string{"ShowGroupsRespGroupMembers", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_groups_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowGroupsResponse struct {
+	Group          *ShowGroupsRespGroup `json:"group,omitempty"`
+	HttpStatusCode int                  `json:"-"`
+}
+
+func (o ShowGroupsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowGroupsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowGroupsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_extend_product_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_extend_product_info_request.go
@@ -1,0 +1,120 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Request Object
+type ShowInstanceExtendProductInfoRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 产品的类型。 - advanced: 专享版 - platinum: 铂金版 - dec: 专属云版 - exp: 体验版
+	Type ShowInstanceExtendProductInfoRequestType `json:"type"`
+
+	// 消息引擎的类型。当前支持的类型为kafka。
+	Engine ShowInstanceExtendProductInfoRequestEngine `json:"engine"`
+}
+
+func (o ShowInstanceExtendProductInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceExtendProductInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceExtendProductInfoRequest", string(data)}, " ")
+}
+
+type ShowInstanceExtendProductInfoRequestType struct {
+	value string
+}
+
+type ShowInstanceExtendProductInfoRequestTypeEnum struct {
+	ADVANCED ShowInstanceExtendProductInfoRequestType
+	PLATINUM ShowInstanceExtendProductInfoRequestType
+	DEC      ShowInstanceExtendProductInfoRequestType
+	EXP      ShowInstanceExtendProductInfoRequestType
+}
+
+func GetShowInstanceExtendProductInfoRequestTypeEnum() ShowInstanceExtendProductInfoRequestTypeEnum {
+	return ShowInstanceExtendProductInfoRequestTypeEnum{
+		ADVANCED: ShowInstanceExtendProductInfoRequestType{
+			value: "advanced",
+		},
+		PLATINUM: ShowInstanceExtendProductInfoRequestType{
+			value: "platinum",
+		},
+		DEC: ShowInstanceExtendProductInfoRequestType{
+			value: "dec",
+		},
+		EXP: ShowInstanceExtendProductInfoRequestType{
+			value: "exp",
+		},
+	}
+}
+
+func (c ShowInstanceExtendProductInfoRequestType) Value() string {
+	return c.value
+}
+
+func (c ShowInstanceExtendProductInfoRequestType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowInstanceExtendProductInfoRequestType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ShowInstanceExtendProductInfoRequestEngine struct {
+	value string
+}
+
+type ShowInstanceExtendProductInfoRequestEngineEnum struct {
+	KAFKA ShowInstanceExtendProductInfoRequestEngine
+}
+
+func GetShowInstanceExtendProductInfoRequestEngineEnum() ShowInstanceExtendProductInfoRequestEngineEnum {
+	return ShowInstanceExtendProductInfoRequestEngineEnum{
+		KAFKA: ShowInstanceExtendProductInfoRequestEngine{
+			value: "kafka",
+		},
+	}
+}
+
+func (c ShowInstanceExtendProductInfoRequestEngine) Value() string {
+	return c.value
+}
+
+func (c ShowInstanceExtendProductInfoRequestEngine) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowInstanceExtendProductInfoRequestEngine) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_extend_product_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_extend_product_info_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowInstanceExtendProductInfoResponse struct {
+
+	// 表示按需付费的产品列表。
+	Hourly *[]ListProductsRespHourly `json:"hourly,omitempty"`
+
+	// 表示包年包月的产品列表。当前暂不支持通过API创建包年包月的Kafka实例。
+	Monthly        *[]ListProductsRespHourly `json:"monthly,omitempty"`
+	HttpStatusCode int                       `json:"-"`
+}
+
+func (o ShowInstanceExtendProductInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceExtendProductInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceExtendProductInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_messages_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_messages_request.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowInstanceMessagesRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。  Topic名称必现以字母开头且只支持大小写字母、中横线、下划线以及数字。
+	Topic string `json:"topic"`
+
+	// 是否按照时间排序。
+	Asc *bool `json:"asc,omitempty"`
+
+	// 开始时间。  Unix毫秒时间戳。  查询消息偏移量时，为必选参数。
+	StartTime *string `json:"start_time,omitempty"`
+
+	// 结束时间。  Unix毫秒时间戳。  查询消息偏移量时，为必选参数。
+	EndTime *string `json:"end_time,omitempty"`
+
+	// 分页大小。取值范围为0~50。
+	Limit *string `json:"limit,omitempty"`
+
+	// 偏移量，表示从此偏移量开始查询， offset大于等于0。
+	Offset *string `json:"offset,omitempty"`
+
+	// 是否下载。
+	Download *bool `json:"download,omitempty"`
+
+	// 消息偏移量。  **查询消息内容时，为必选参数。**  若start_time、end_time参数不为空，该参数无效。
+	MessageOffset *string `json:"message_offset,omitempty"`
+
+	// 分区。  **查询消息内容时，为必选参数。**  若start_time、end_time参数不为空，该参数无效。
+	Partition *string `json:"partition,omitempty"`
+}
+
+func (o ShowInstanceMessagesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceMessagesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceMessagesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_messages_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_messages_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowInstanceMessagesResponse struct {
+
+	// 消息列表。
+	Messages *[]MessagesEntity `json:"messages,omitempty"`
+
+	// 消息总条数。
+	Total *int64 `json:"total,omitempty"`
+
+	// 消息条数。
+	Size           *int64 `json:"size,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowInstanceMessagesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceMessagesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceMessagesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowInstanceRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_resp.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_resp.go
@@ -1,0 +1,322 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type ShowInstanceResp struct {
+
+	// 实例名称。
+	Name *string `json:"name,omitempty"`
+
+	// 引擎。
+	Engine *string `json:"engine,omitempty"`
+
+	// 版本。
+	EngineVersion *string `json:"engine_version,omitempty"`
+
+	// 实例描述。
+	Description *string `json:"description,omitempty"`
+
+	// 实例规格。
+	Specification *string `json:"specification,omitempty"`
+
+	// 消息存储空间，单位：GB。
+	StorageSpace *int32 `json:"storage_space,omitempty"`
+
+	// Kafka实例的分区数量。
+	PartitionNum *string `json:"partition_num,omitempty"`
+
+	// 已使用的消息存储空间，单位：GB。
+	UsedStorageSpace *int32 `json:"used_storage_space,omitempty"`
+
+	// 实例连接IP地址。
+	ConnectAddress *string `json:"connect_address,omitempty"`
+
+	// 实例连接端口。
+	Port *int32 `json:"port,omitempty"`
+
+	// 实例的状态。 [详细状态说明见[实例状态说明](https://support.huaweicloud.com/api-kafka/kafka-api-180514012.html)。](tag:hws)[详细状态说明见[实例状态说明](https://support.huaweicloud.com/intl/zh-cn/api-kafka/kafka-api-180514012.html)。](tag:hws_hk)
+	Status *string `json:"status,omitempty"`
+
+	// 实例ID。
+	InstanceId *string `json:"instance_id,omitempty"`
+
+	// 资源规格标识。   - dms.instance.kafka.cluster.c3.mini：Kafka实例的基准带宽为100MByte/秒。   - dms.instance.kafka.cluster.c3.small.2：Kafka实例的基准带宽为300MByte/秒。   - dms.instance.kafka.cluster.c3.middle.2：Kafka实例的基准带宽为600MByte/秒。   - dms.instance.kafka.cluster.c3.high.2：Kafka实例的基准带宽为1200MByte/秒。
+	ResourceSpecCode *string `json:"resource_spec_code,omitempty"`
+
+	// 付费模式，1表示按需计费，0表示包年/包月计费。
+	ChargingMode *int32 `json:"charging_mode,omitempty"`
+
+	// VPC ID。
+	VpcId *string `json:"vpc_id,omitempty"`
+
+	// VPC的名称。
+	VpcName *string `json:"vpc_name,omitempty"`
+
+	// 完成创建时间。  格式为时间戳，指从格林威治时间 1970年01月01日00时00分00秒起至指定时间的偏差总毫秒数。
+	CreatedAt *string `json:"created_at,omitempty"`
+
+	// 用户ID。
+	UserId *string `json:"user_id,omitempty"`
+
+	// 用户名。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 实例访问用户名。
+	AccessUser *string `json:"access_user,omitempty"`
+
+	// 订单ID，只有在包周期计费时才会有order_id值，其他计费方式order_id值为空。
+	OrderId *string `json:"order_id,omitempty"`
+
+	// 维护时间窗开始时间，格式为HH:mm:ss。
+	MaintainBegin *string `json:"maintain_begin,omitempty"`
+
+	// 维护时间窗结束时间，格式为HH:mm:ss。
+	MaintainEnd *string `json:"maintain_end,omitempty"`
+
+	// 实例是否开启公网访问功能。 - true：开启 - false：未开启
+	EnablePublicip *bool `json:"enable_publicip,omitempty"`
+
+	// Kafka实例的Kafka Manager连接地址。
+	ManagementConnectAddress *string `json:"management_connect_address,omitempty"`
+
+	// 是否开启安全认证。 - true：开启 - false：未开启
+	SslEnable *bool `json:"ssl_enable,omitempty"`
+
+	// 是否开启双向认证。
+	SslTwoWayEnable *bool `json:"ssl_two_way_enable,omitempty"`
+
+	// 是否能够证书替换。
+	CertReplaced *bool `json:"cert_replaced,omitempty"`
+
+	// 企业项目ID。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 实例扩容时用于区分老实例与新实例。 - true：新创建的实例，允许磁盘动态扩容不需要重启。 - false：老实例
+	IsLogicalVolume *bool `json:"is_logical_volume,omitempty"`
+
+	// 实例扩容磁盘次数，如果超过20次则无法扩容磁盘。
+	ExtendTimes *int32 `json:"extend_times,omitempty"`
+
+	// 是否打开kafka自动创建topic功能。   - true：开启   - false：关闭
+	EnableAutoTopic *bool `json:"enable_auto_topic,omitempty"`
+
+	// 实例类型：集群，cluster。
+	Type *ShowInstanceRespType `json:"type,omitempty"`
+
+	// 产品标识。
+	ProductId *string `json:"product_id,omitempty"`
+
+	// 安全组ID。
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+
+	// 租户安全组名称。
+	SecurityGroupName *string `json:"security_group_name,omitempty"`
+
+	// 子网ID。
+	SubnetId *string `json:"subnet_id,omitempty"`
+
+	// 实例节点所在的可用区，返回“可用区ID”。
+	AvailableZones *[]string `json:"available_zones,omitempty"`
+
+	// 总共消息存储空间，单位：GB。
+	TotalStorageSpace *int32 `json:"total_storage_space,omitempty"`
+
+	// 实例公网连接IP地址。当实例开启了公网访问，实例才包含该参数。
+	PublicConnectAddress *string `json:"public_connect_address,omitempty"`
+
+	// 存储资源ID。
+	StorageResourceId *string `json:"storage_resource_id,omitempty"`
+
+	// IO规格。
+	StorageSpecCode *string `json:"storage_spec_code,omitempty"`
+
+	// 服务类型。
+	ServiceType *string `json:"service_type,omitempty"`
+
+	// 存储类型。
+	StorageType *string `json:"storage_type,omitempty"`
+
+	// 消息老化策略。
+	RetentionPolicy *ShowInstanceRespRetentionPolicy `json:"retention_policy,omitempty"`
+
+	// Kafka公网开启状态。
+	KafkaPublicStatus *string `json:"kafka_public_status,omitempty"`
+
+	// kafka公网访问带宽。
+	PublicBandwidth *int32 `json:"public_bandwidth,omitempty"`
+
+	// 登录Kafka Manager的用户名。
+	KafkaManagerUser *string `json:"kafka_manager_user,omitempty"`
+
+	// 是否开启消息收集功能。
+	EnableLogCollection *bool `json:"enable_log_collection,omitempty"`
+
+	// 跨VPC访问信息。
+	CrossVpcInfo *string `json:"cross_vpc_info,omitempty"`
+
+	// 是否开启ipv6。
+	Ipv6Enable *bool `json:"ipv6_enable,omitempty"`
+
+	// IPv6的连接地址。
+	Ipv6ConnectAddresses *[]string `json:"ipv6_connect_addresses,omitempty"`
+
+	// 是否开启转储。新规格产品暂不支持开启转储。
+	ConnectorEnable *bool `json:"connector_enable,omitempty"`
+
+	// 转储任务ID。
+	ConnectorId *string `json:"connector_id,omitempty"`
+
+	// 是否开启Kafka rest功能。
+	RestEnable *bool `json:"rest_enable,omitempty"`
+
+	// Kafka rest连接地址。
+	RestConnectAddress *string `json:"rest_connect_address,omitempty"`
+
+	// kafka公网访问带宽。待删除版本。
+	PublicBoundwidth *int32 `json:"public_boundwidth,omitempty"`
+
+	// 是否开启消息查询功能。
+	MessageQueryInstEnable *bool `json:"message_query_inst_enable,omitempty"`
+
+	// 是否开启VPC明文访问。
+	VpcClientPlain *bool `json:"vpc_client_plain,omitempty"`
+
+	// Kafka实例支持的特性功能。
+	SupportFeatures *string `json:"support_features,omitempty"`
+
+	// 是否开启消息轨迹功能。
+	TraceEnable *bool `json:"trace_enable,omitempty"`
+
+	// 是否开启代理。
+	AgentEnable *bool `json:"agent_enable,omitempty"`
+
+	// 租户侧连接地址。
+	PodConnectAddress *string `json:"pod_connect_address,omitempty"`
+
+	// 是否开启磁盘加密。
+	DiskEncrypted *bool `json:"disk_encrypted,omitempty"`
+
+	// Kafka实例私有连接地址。
+	KafkaPrivateConnectAddress *string `json:"kafka_private_connect_address,omitempty"`
+
+	// 云监控版本。
+	CesVersion *string `json:"ces_version,omitempty"`
+
+	// 区分实例什么时候开启的公网访问：true,actived,closed,false。
+	PublicAccessEnabled *string `json:"public_access_enabled,omitempty"`
+
+	// 节点数。
+	NodeNum *int32 `json:"node_num,omitempty"`
+
+	// 是否启用新规格计费。
+	NewSpecBillingEnable *bool `json:"new_spec_billing_enable,omitempty"`
+
+	// 节点数量。
+	BrokerNum *int32 `json:"broker_num,omitempty"`
+
+	// 标签列表。
+	Tags *[]TagEntity `json:"tags,omitempty"`
+
+	// 是否为容灾实例。
+	DrEnable *bool `json:"dr_enable,omitempty"`
+}
+
+func (o ShowInstanceResp) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceResp struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceResp", string(data)}, " ")
+}
+
+type ShowInstanceRespType struct {
+	value string
+}
+
+type ShowInstanceRespTypeEnum struct {
+	SINGLE  ShowInstanceRespType
+	CLUSTER ShowInstanceRespType
+}
+
+func GetShowInstanceRespTypeEnum() ShowInstanceRespTypeEnum {
+	return ShowInstanceRespTypeEnum{
+		SINGLE: ShowInstanceRespType{
+			value: "single",
+		},
+		CLUSTER: ShowInstanceRespType{
+			value: "cluster",
+		},
+	}
+}
+
+func (c ShowInstanceRespType) Value() string {
+	return c.value
+}
+
+func (c ShowInstanceRespType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowInstanceRespType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ShowInstanceRespRetentionPolicy struct {
+	value string
+}
+
+type ShowInstanceRespRetentionPolicyEnum struct {
+	TIME_BASE      ShowInstanceRespRetentionPolicy
+	PRODUCE_REJECT ShowInstanceRespRetentionPolicy
+}
+
+func GetShowInstanceRespRetentionPolicyEnum() ShowInstanceRespRetentionPolicyEnum {
+	return ShowInstanceRespRetentionPolicyEnum{
+		TIME_BASE: ShowInstanceRespRetentionPolicy{
+			value: "time_base",
+		},
+		PRODUCE_REJECT: ShowInstanceRespRetentionPolicy{
+			value: "produce_reject",
+		},
+	}
+}
+
+func (c ShowInstanceRespRetentionPolicy) Value() string {
+	return c.value
+}
+
+func (c ShowInstanceRespRetentionPolicy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowInstanceRespRetentionPolicy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_response.go
@@ -1,0 +1,324 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Response Object
+type ShowInstanceResponse struct {
+
+	// 实例名称。
+	Name *string `json:"name,omitempty"`
+
+	// 引擎。
+	Engine *string `json:"engine,omitempty"`
+
+	// 版本。
+	EngineVersion *string `json:"engine_version,omitempty"`
+
+	// 实例描述。
+	Description *string `json:"description,omitempty"`
+
+	// 实例规格。
+	Specification *string `json:"specification,omitempty"`
+
+	// 消息存储空间，单位：GB。
+	StorageSpace *int32 `json:"storage_space,omitempty"`
+
+	// Kafka实例的分区数量。
+	PartitionNum *string `json:"partition_num,omitempty"`
+
+	// 已使用的消息存储空间，单位：GB。
+	UsedStorageSpace *int32 `json:"used_storage_space,omitempty"`
+
+	// 实例连接IP地址。
+	ConnectAddress *string `json:"connect_address,omitempty"`
+
+	// 实例连接端口。
+	Port *int32 `json:"port,omitempty"`
+
+	// 实例的状态。 [详细状态说明见[实例状态说明](https://support.huaweicloud.com/api-kafka/kafka-api-180514012.html)。](tag:hws)[详细状态说明见[实例状态说明](https://support.huaweicloud.com/intl/zh-cn/api-kafka/kafka-api-180514012.html)。](tag:hws_hk)
+	Status *string `json:"status,omitempty"`
+
+	// 实例ID。
+	InstanceId *string `json:"instance_id,omitempty"`
+
+	// 资源规格标识。   - dms.instance.kafka.cluster.c3.mini：Kafka实例的基准带宽为100MByte/秒。   - dms.instance.kafka.cluster.c3.small.2：Kafka实例的基准带宽为300MByte/秒。   - dms.instance.kafka.cluster.c3.middle.2：Kafka实例的基准带宽为600MByte/秒。   - dms.instance.kafka.cluster.c3.high.2：Kafka实例的基准带宽为1200MByte/秒。
+	ResourceSpecCode *string `json:"resource_spec_code,omitempty"`
+
+	// 付费模式，1表示按需计费，0表示包年/包月计费。
+	ChargingMode *int32 `json:"charging_mode,omitempty"`
+
+	// VPC ID。
+	VpcId *string `json:"vpc_id,omitempty"`
+
+	// VPC的名称。
+	VpcName *string `json:"vpc_name,omitempty"`
+
+	// 完成创建时间。  格式为时间戳，指从格林威治时间 1970年01月01日00时00分00秒起至指定时间的偏差总毫秒数。
+	CreatedAt *string `json:"created_at,omitempty"`
+
+	// 用户ID。
+	UserId *string `json:"user_id,omitempty"`
+
+	// 用户名。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 实例访问用户名。
+	AccessUser *string `json:"access_user,omitempty"`
+
+	// 订单ID，只有在包周期计费时才会有order_id值，其他计费方式order_id值为空。
+	OrderId *string `json:"order_id,omitempty"`
+
+	// 维护时间窗开始时间，格式为HH:mm:ss。
+	MaintainBegin *string `json:"maintain_begin,omitempty"`
+
+	// 维护时间窗结束时间，格式为HH:mm:ss。
+	MaintainEnd *string `json:"maintain_end,omitempty"`
+
+	// 实例是否开启公网访问功能。 - true：开启 - false：未开启
+	EnablePublicip *bool `json:"enable_publicip,omitempty"`
+
+	// Kafka实例的Kafka Manager连接地址。
+	ManagementConnectAddress *string `json:"management_connect_address,omitempty"`
+
+	// 是否开启安全认证。 - true：开启 - false：未开启
+	SslEnable *bool `json:"ssl_enable,omitempty"`
+
+	// 是否开启双向认证。
+	SslTwoWayEnable *bool `json:"ssl_two_way_enable,omitempty"`
+
+	// 是否能够证书替换。
+	CertReplaced *bool `json:"cert_replaced,omitempty"`
+
+	// 企业项目ID。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 实例扩容时用于区分老实例与新实例。 - true：新创建的实例，允许磁盘动态扩容不需要重启。 - false：老实例
+	IsLogicalVolume *bool `json:"is_logical_volume,omitempty"`
+
+	// 实例扩容磁盘次数，如果超过20次则无法扩容磁盘。
+	ExtendTimes *int32 `json:"extend_times,omitempty"`
+
+	// 是否打开kafka自动创建topic功能。   - true：开启   - false：关闭
+	EnableAutoTopic *bool `json:"enable_auto_topic,omitempty"`
+
+	// 实例类型：集群，cluster。
+	Type *ShowInstanceResponseType `json:"type,omitempty"`
+
+	// 产品标识。
+	ProductId *string `json:"product_id,omitempty"`
+
+	// 安全组ID。
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+
+	// 租户安全组名称。
+	SecurityGroupName *string `json:"security_group_name,omitempty"`
+
+	// 子网ID。
+	SubnetId *string `json:"subnet_id,omitempty"`
+
+	// 实例节点所在的可用区，返回“可用区ID”。
+	AvailableZones *[]string `json:"available_zones,omitempty"`
+
+	// 总共消息存储空间，单位：GB。
+	TotalStorageSpace *int32 `json:"total_storage_space,omitempty"`
+
+	// 实例公网连接IP地址。当实例开启了公网访问，实例才包含该参数。
+	PublicConnectAddress *string `json:"public_connect_address,omitempty"`
+
+	// 存储资源ID。
+	StorageResourceId *string `json:"storage_resource_id,omitempty"`
+
+	// IO规格。
+	StorageSpecCode *string `json:"storage_spec_code,omitempty"`
+
+	// 服务类型。
+	ServiceType *string `json:"service_type,omitempty"`
+
+	// 存储类型。
+	StorageType *string `json:"storage_type,omitempty"`
+
+	// 消息老化策略。
+	RetentionPolicy *ShowInstanceResponseRetentionPolicy `json:"retention_policy,omitempty"`
+
+	// Kafka公网开启状态。
+	KafkaPublicStatus *string `json:"kafka_public_status,omitempty"`
+
+	// kafka公网访问带宽。
+	PublicBandwidth *int32 `json:"public_bandwidth,omitempty"`
+
+	// 登录Kafka Manager的用户名。
+	KafkaManagerUser *string `json:"kafka_manager_user,omitempty"`
+
+	// 是否开启消息收集功能。
+	EnableLogCollection *bool `json:"enable_log_collection,omitempty"`
+
+	// 跨VPC访问信息。
+	CrossVpcInfo *string `json:"cross_vpc_info,omitempty"`
+
+	// 是否开启ipv6。
+	Ipv6Enable *bool `json:"ipv6_enable,omitempty"`
+
+	// IPv6的连接地址。
+	Ipv6ConnectAddresses *[]string `json:"ipv6_connect_addresses,omitempty"`
+
+	// 是否开启转储。新规格产品暂不支持开启转储。
+	ConnectorEnable *bool `json:"connector_enable,omitempty"`
+
+	// 转储任务ID。
+	ConnectorId *string `json:"connector_id,omitempty"`
+
+	// 是否开启Kafka rest功能。
+	RestEnable *bool `json:"rest_enable,omitempty"`
+
+	// Kafka rest连接地址。
+	RestConnectAddress *string `json:"rest_connect_address,omitempty"`
+
+	// kafka公网访问带宽。待删除版本。
+	PublicBoundwidth *int32 `json:"public_boundwidth,omitempty"`
+
+	// 是否开启消息查询功能。
+	MessageQueryInstEnable *bool `json:"message_query_inst_enable,omitempty"`
+
+	// 是否开启VPC明文访问。
+	VpcClientPlain *bool `json:"vpc_client_plain,omitempty"`
+
+	// Kafka实例支持的特性功能。
+	SupportFeatures *string `json:"support_features,omitempty"`
+
+	// 是否开启消息轨迹功能。
+	TraceEnable *bool `json:"trace_enable,omitempty"`
+
+	// 是否开启代理。
+	AgentEnable *bool `json:"agent_enable,omitempty"`
+
+	// 租户侧连接地址。
+	PodConnectAddress *string `json:"pod_connect_address,omitempty"`
+
+	// 是否开启磁盘加密。
+	DiskEncrypted *bool `json:"disk_encrypted,omitempty"`
+
+	// Kafka实例私有连接地址。
+	KafkaPrivateConnectAddress *string `json:"kafka_private_connect_address,omitempty"`
+
+	// 云监控版本。
+	CesVersion *string `json:"ces_version,omitempty"`
+
+	// 区分实例什么时候开启的公网访问：true,actived,closed,false。
+	PublicAccessEnabled *string `json:"public_access_enabled,omitempty"`
+
+	// 节点数。
+	NodeNum *int32 `json:"node_num,omitempty"`
+
+	// 是否启用新规格计费。
+	NewSpecBillingEnable *bool `json:"new_spec_billing_enable,omitempty"`
+
+	// 节点数量。
+	BrokerNum *int32 `json:"broker_num,omitempty"`
+
+	// 标签列表。
+	Tags *[]TagEntity `json:"tags,omitempty"`
+
+	// 是否为容灾实例。
+	DrEnable       *bool `json:"dr_enable,omitempty"`
+	HttpStatusCode int   `json:"-"`
+}
+
+func (o ShowInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceResponse", string(data)}, " ")
+}
+
+type ShowInstanceResponseType struct {
+	value string
+}
+
+type ShowInstanceResponseTypeEnum struct {
+	SINGLE  ShowInstanceResponseType
+	CLUSTER ShowInstanceResponseType
+}
+
+func GetShowInstanceResponseTypeEnum() ShowInstanceResponseTypeEnum {
+	return ShowInstanceResponseTypeEnum{
+		SINGLE: ShowInstanceResponseType{
+			value: "single",
+		},
+		CLUSTER: ShowInstanceResponseType{
+			value: "cluster",
+		},
+	}
+}
+
+func (c ShowInstanceResponseType) Value() string {
+	return c.value
+}
+
+func (c ShowInstanceResponseType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowInstanceResponseType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ShowInstanceResponseRetentionPolicy struct {
+	value string
+}
+
+type ShowInstanceResponseRetentionPolicyEnum struct {
+	TIME_BASE      ShowInstanceResponseRetentionPolicy
+	PRODUCE_REJECT ShowInstanceResponseRetentionPolicy
+}
+
+func GetShowInstanceResponseRetentionPolicyEnum() ShowInstanceResponseRetentionPolicyEnum {
+	return ShowInstanceResponseRetentionPolicyEnum{
+		TIME_BASE: ShowInstanceResponseRetentionPolicy{
+			value: "time_base",
+		},
+		PRODUCE_REJECT: ShowInstanceResponseRetentionPolicy{
+			value: "produce_reject",
+		},
+	}
+}
+
+func (c ShowInstanceResponseRetentionPolicy) Value() string {
+	return c.value
+}
+
+func (c ShowInstanceResponseRetentionPolicy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowInstanceResponseRetentionPolicy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowInstanceTopicDetailRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。
+	Topic string `json:"topic"`
+}
+
+func (o ShowInstanceTopicDetailRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceTopicDetailRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceTopicDetailRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_resp_partitions.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_resp_partitions.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowInstanceTopicDetailRespPartitions struct {
+
+	// 分区ID。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// leader副本所在节点的id。
+	Leader *int32 `json:"leader,omitempty"`
+
+	// 分区leader副本的LEO（Log End Offset）。
+	Leo *int32 `json:"leo,omitempty"`
+
+	// 分区高水位（HW，High Watermark）。
+	Hw *int32 `json:"hw,omitempty"`
+
+	// 分区leader副本的LSO（Log Start Offset）。
+	Lso *int32 `json:"lso,omitempty"`
+
+	// 分区上次写入消息的时间。  格式为Unix时间戳。  单位：毫秒。
+	LastUpdateTimestamp *int64 `json:"last_update_timestamp,omitempty"`
+
+	// 副本列表。
+	Replicas *[]ShowInstanceTopicDetailRespReplicas `json:"replicas,omitempty"`
+}
+
+func (o ShowInstanceTopicDetailRespPartitions) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceTopicDetailRespPartitions struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceTopicDetailRespPartitions", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_resp_replicas.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_resp_replicas.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowInstanceTopicDetailRespReplicas struct {
+
+	// 副本所在的节点ID。
+	Broker *int32 `json:"broker,omitempty"`
+
+	// 该副本是否为leader。
+	Leader *bool `json:"leader,omitempty"`
+
+	// 该副本是否在ISR副本中。
+	InSync *bool `json:"in_sync,omitempty"`
+
+	// 该副本当前日志大小。单位：Byte。
+	Size *int32 `json:"size,omitempty"`
+
+	// 该副本当前落后hw的消息数。
+	Lag *int32 `json:"lag,omitempty"`
+}
+
+func (o ShowInstanceTopicDetailRespReplicas) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceTopicDetailRespReplicas struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceTopicDetailRespReplicas", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_topic_detail_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowInstanceTopicDetailResponse struct {
+
+	// topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区列表。
+	Partitions *[]ShowInstanceTopicDetailRespPartitions `json:"partitions,omitempty"`
+
+	// 订阅该topic的消费组名称列表。
+	GroupSubscribed *[]string `json:"group_subscribed,omitempty"`
+	HttpStatusCode  int       `json:"-"`
+}
+
+func (o ShowInstanceTopicDetailResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceTopicDetailResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceTopicDetailResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_users_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_users_entity.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowInstanceUsersEntity struct {
+
+	// 用户名称。
+	UserName *string `json:"user_name,omitempty"`
+
+	// 用户角色。
+	Role *string `json:"role,omitempty"`
+
+	// 是否为默认应用。
+	DefaultApp *bool `json:"default_app,omitempty"`
+
+	// 创建时间。
+	CreatedTime *int64 `json:"created_time,omitempty"`
+}
+
+func (o ShowInstanceUsersEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceUsersEntity struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceUsersEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_users_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_users_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowInstanceUsersRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowInstanceUsersRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceUsersRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceUsersRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_users_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_instance_users_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowInstanceUsersResponse struct {
+
+	// 用户列表。
+	Users          *[]ShowInstanceUsersEntity `json:"users,omitempty"`
+	HttpStatusCode int                        `json:"-"`
+}
+
+func (o ShowInstanceUsersResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowInstanceUsersResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowInstanceUsersResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_project_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_project_tags_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowKafkaProjectTagsRequest struct {
+}
+
+func (o ShowKafkaProjectTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowKafkaProjectTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowKafkaProjectTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_project_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_project_tags_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowKafkaProjectTagsResponse struct {
+
+	// 标签列表
+	Tags           *[]TagMultyValueEntity `json:"tags,omitempty"`
+	HttpStatusCode int                    `json:"-"`
+}
+
+func (o ShowKafkaProjectTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowKafkaProjectTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowKafkaProjectTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_tags_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowKafkaTagsRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o ShowKafkaTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowKafkaTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowKafkaTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_tags_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowKafkaTagsResponse struct {
+
+	// 标签列表
+	Tags           *[]TagEntity `json:"tags,omitempty"`
+	HttpStatusCode int          `json:"-"`
+}
+
+func (o ShowKafkaTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowKafkaTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowKafkaTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_topic_partition_diskusage_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_topic_partition_diskusage_request.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowKafkaTopicPartitionDiskusageRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// 占用磁盘大小，默认值1G (1K ,1M , 1G)。
+	MinSize *string `json:"minSize,omitempty"`
+
+	// 占用磁盘大小，查询top N。
+	Top *string `json:"top,omitempty"`
+
+	// 占用磁盘大小，查询大于占比的分区。
+	Percentage *string `json:"percentage,omitempty"`
+}
+
+func (o ShowKafkaTopicPartitionDiskusageRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowKafkaTopicPartitionDiskusageRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowKafkaTopicPartitionDiskusageRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_topic_partition_diskusage_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_kafka_topic_partition_diskusage_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowKafkaTopicPartitionDiskusageResponse struct {
+
+	// Broker列表。
+	BrokerList     *[]DiskusageEntity `json:"broker_list,omitempty"`
+	HttpStatusCode int                `json:"-"`
+}
+
+func (o ShowKafkaTopicPartitionDiskusageResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowKafkaTopicPartitionDiskusageResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowKafkaTopicPartitionDiskusageResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_maintain_windows_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_maintain_windows_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowMaintainWindowsRequest struct {
+}
+
+func (o ShowMaintainWindowsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowMaintainWindowsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowMaintainWindowsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_maintain_windows_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_maintain_windows_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowMaintainWindowsResponse struct {
+
+	// 支持的维护时间窗列表。
+	MaintainWindows *[]MaintainWindowsEntity `json:"maintain_windows,omitempty"`
+	HttpStatusCode  int                      `json:"-"`
+}
+
+func (o ShowMaintainWindowsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowMaintainWindowsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowMaintainWindowsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_messages_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_messages_request.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowMessagesRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。  Topic名称必现以字母开头且只支持大小写字母、中横线、下划线以及数字。
+	Topic string `json:"topic"`
+
+	// 查询起始时间，为unix时间戳格式，默认值为0。
+	StartTime *string `json:"start_time,omitempty"`
+
+	// 查询结束时间，为unix时间戳格式，默认值为系统当前时间。
+	EndTime *string `json:"end_time,omitempty"`
+
+	// 单页返回消息数，默认值为10。
+	Limit *int32 `json:"limit,omitempty"`
+
+	// 偏移量，表示从此偏移量开始查询， offset大于等于0。
+	Offset *int32 `json:"offset,omitempty"`
+
+	// 分区编号，默认值为-1，若传入值为-1，则查询所有分区。
+	Partition *string `json:"partition,omitempty"`
+}
+
+func (o ShowMessagesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowMessagesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowMessagesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_messages_resp_messages.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_messages_resp_messages.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowMessagesRespMessages struct {
+
+	// topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区编号。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 消息编号。
+	MessageOffset *int32 `json:"message_offset,omitempty"`
+
+	// 消息大小，单位字节。
+	Size *int32 `json:"size,omitempty"`
+
+	// 生产消息的时间。 格式为Unix时间戳。单位为毫秒。
+	Timestamp *int64 `json:"timestamp,omitempty"`
+}
+
+func (o ShowMessagesRespMessages) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowMessagesRespMessages struct{}"
+	}
+
+	return strings.Join([]string{"ShowMessagesRespMessages", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_messages_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_messages_response.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowMessagesResponse struct {
+
+	// 消息列表。
+	Messages *[]ShowMessagesRespMessages `json:"messages,omitempty"`
+
+	// 消息总数。
+	MessagesCount *int32 `json:"messages_count,omitempty"`
+
+	// 总页数。
+	OffsetsCount *int32 `json:"offsets_count,omitempty"`
+
+	// 当前页数。
+	Offset         *int32 `json:"offset,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowMessagesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowMessagesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowMessagesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_beginning_message_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_beginning_message_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowPartitionBeginningMessageRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。  Topic名称必现以字母开头且只支持大小写字母、中横线、下划线以及数字。
+	Topic string `json:"topic"`
+
+	// 分区编号。
+	Partition int32 `json:"partition"`
+}
+
+func (o ShowPartitionBeginningMessageRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionBeginningMessageRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionBeginningMessageRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_beginning_message_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_beginning_message_response.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowPartitionBeginningMessageResponse struct {
+
+	// Topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区编号。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 最新消息位置。
+	Offset *int32 `json:"offset,omitempty"`
+
+	// 生产消息的时间。 格式为Unix时间戳。单位为毫秒。
+	Timestamp      *int64 `json:"timestamp,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowPartitionBeginningMessageResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionBeginningMessageResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionBeginningMessageResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_end_message_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_end_message_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowPartitionEndMessageRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。  Topic名称必现以字母开头且只支持大小写字母、中横线、下划线以及数字。
+	Topic string `json:"topic"`
+
+	// 分区编号。
+	Partition int32 `json:"partition"`
+}
+
+func (o ShowPartitionEndMessageRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionEndMessageRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionEndMessageRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_end_message_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_end_message_response.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowPartitionEndMessageResponse struct {
+
+	// Topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区编号。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 最新消息位置。
+	Offset *int32 `json:"offset,omitempty"`
+
+	// 生产消息的时间。 格式为Unix时间戳。单位为毫秒。
+	Timestamp      *int64 `json:"timestamp,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ShowPartitionEndMessageResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionEndMessageResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionEndMessageResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_message_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_message_entity.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 消息体。
+type ShowPartitionMessageEntity struct {
+
+	// 消息的key。
+	Key *string `json:"key,omitempty"`
+
+	// 消息内容。
+	Value *string `json:"value,omitempty"`
+
+	// Topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区编号。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 消息位置。
+	MessageOffset *int64 `json:"message_offset,omitempty"`
+
+	// 消息大小，单位字节。
+	Size *int32 `json:"size,omitempty"`
+
+	// 生产消息的时间。 格式为Unix时间戳。单位为毫秒。
+	Timestamp *int64 `json:"timestamp,omitempty"`
+}
+
+func (o ShowPartitionMessageEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionMessageEntity struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionMessageEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_message_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_message_request.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowPartitionMessageRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。  Topic名称必现以字母开头且只支持大小写字母、中横线、下划线以及数字。
+	Topic string `json:"topic"`
+
+	// 分区编号。
+	Partition int32 `json:"partition"`
+
+	// 消息位置。
+	MessageOffset string `json:"message_offset"`
+}
+
+func (o ShowPartitionMessageRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionMessageRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionMessageRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_message_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_partition_message_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowPartitionMessageResponse struct {
+
+	// 消息列表。
+	Message        *[]ShowPartitionMessageEntity `json:"message,omitempty"`
+	HttpStatusCode int                           `json:"-"`
+}
+
+func (o ShowPartitionMessageResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowPartitionMessageResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowPartitionMessageResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_request.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Request Object
+type ShowSinkTaskDetailRequest struct {
+
+	// 实例转储ID。 请参考[实例生命周期][查询实例]接口返回的数据。
+	ConnectorId string `json:"connector_id"`
+
+	// 转储任务ID。
+	TaskId string `json:"task_id"`
+
+	// 是否包含topic信息。默认是false。
+	TopicInfo *ShowSinkTaskDetailRequestTopicInfo `json:"topic-info,omitempty"`
+}
+
+func (o ShowSinkTaskDetailRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowSinkTaskDetailRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowSinkTaskDetailRequest", string(data)}, " ")
+}
+
+type ShowSinkTaskDetailRequestTopicInfo struct {
+	value string
+}
+
+type ShowSinkTaskDetailRequestTopicInfoEnum struct {
+	TRUE  ShowSinkTaskDetailRequestTopicInfo
+	FALSE ShowSinkTaskDetailRequestTopicInfo
+}
+
+func GetShowSinkTaskDetailRequestTopicInfoEnum() ShowSinkTaskDetailRequestTopicInfoEnum {
+	return ShowSinkTaskDetailRequestTopicInfoEnum{
+		TRUE: ShowSinkTaskDetailRequestTopicInfo{
+			value: "true",
+		},
+		FALSE: ShowSinkTaskDetailRequestTopicInfo{
+			value: "false",
+		},
+	}
+}
+
+func (c ShowSinkTaskDetailRequestTopicInfo) Value() string {
+	return c.value
+}
+
+func (c ShowSinkTaskDetailRequestTopicInfo) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowSinkTaskDetailRequestTopicInfo) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_resp_obs_destination_descriptor.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_resp_obs_destination_descriptor.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 转存目标的描述。
+type ShowSinkTaskDetailRespObsDestinationDescriptor struct {
+
+	// 消费启动策略：  - latest：从Topic最后端开始消费。  - earliest: 从Topic最前端消息开始消费。  默认是latest。
+	ConsumerStrategy *string `json:"consumer_strategy,omitempty"`
+
+	// 转储文件格式。目前只支持text格式。
+	DestinationFileType *string `json:"destination_file_type,omitempty"`
+
+	// 存储该通道数据的OBS桶名称。
+	ObsBucketName *string `json:"obs_bucket_name,omitempty"`
+
+	// 存储在obs的路径。
+	ObsPath *string `json:"obs_path,omitempty"`
+
+	// 将转储文件的生成时间使用“yyyy/MM/dd/HH/mm”格式生成分区字符串，用来定义写到OBS的Object文件所在的目录层次结构。   - N/A：置空，不使用日期时间目录。   - yyyy：年   - yyyy/MM：年/月   - yyyy/MM/dd：年/月/日   - yyyy/MM/dd/HH：年/月/日/时   - yyyy/MM/dd/HH/mm：年/月/日/时/分，例如：2017/11/10/14/49，目录结构就是“2017 > 11 > 10 > 14 > 49”，“2017”表示最外层文件夹。  默认值：空 > 数据转储成功后，存储的目录结构为“obs_bucket_path/file_prefix/partition_format”。默认时间是GMT+8 时间
+	PartitionFormat *string `json:"partition_format,omitempty"`
+
+	// 转储文件的记录分隔符，用于分隔写入转储文件的用户数据。 取值范围：   - 逗号“,”   - 分号“;”   - 竖线“|”   - 换行符“\\n”   - NULL  默认值：换行符“\\n”。
+	RecordDelimiter *string `json:"record_delimiter,omitempty"`
+
+	// 根据用户配置的时间，周期性的将数据导入OBS，若某个时间段内无数据，则此时间段不会生成打包文件。 取值范围：30～900 缺省值：300 单位：秒。 > 使用OBS通道转储流式数据时该参数为必选配置。
+	DeliverTimeInterval *int32 `json:"deliver_time_interval,omitempty"`
+
+	// 每个传输文件多大后就开始上传，单位为byte。 默认值5242880。
+	ObsPartSize *int64 `json:"obs_part_size,omitempty"`
+}
+
+func (o ShowSinkTaskDetailRespObsDestinationDescriptor) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowSinkTaskDetailRespObsDestinationDescriptor struct{}"
+	}
+
+	return strings.Join([]string{"ShowSinkTaskDetailRespObsDestinationDescriptor", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_resp_partitions.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_resp_partitions.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowSinkTaskDetailRespPartitions struct {
+
+	// 分区ID。
+	PartitionId *string `json:"partition_id,omitempty"`
+
+	// 运行状态。
+	Status *string `json:"status,omitempty"`
+
+	// 已转储的消息偏移量。
+	LastTransferOffset *string `json:"last_transfer_offset,omitempty"`
+
+	// 消息偏移量。
+	LogEndOffset *string `json:"log_end_offset,omitempty"`
+
+	// 积压的消息数。
+	Lag *string `json:"lag,omitempty"`
+}
+
+func (o ShowSinkTaskDetailRespPartitions) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowSinkTaskDetailRespPartitions struct{}"
+	}
+
+	return strings.Join([]string{"ShowSinkTaskDetailRespPartitions", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_resp_topics_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_resp_topics_info.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ShowSinkTaskDetailRespTopicsInfo struct {
+
+	// topic名称。
+	Topic *string `json:"topic,omitempty"`
+
+	// 分区列表。
+	Partitions *[]ShowSinkTaskDetailRespPartitions `json:"partitions,omitempty"`
+}
+
+func (o ShowSinkTaskDetailRespTopicsInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowSinkTaskDetailRespTopicsInfo struct{}"
+	}
+
+	return strings.Join([]string{"ShowSinkTaskDetailRespTopicsInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_sink_task_detail_response.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowSinkTaskDetailResponse struct {
+
+	// 转储任务名称。
+	TaskName *string `json:"task_name,omitempty"`
+
+	// 转储任务类型。
+	DestinationType *string `json:"destination_type,omitempty"`
+
+	// 转储任务创建时间戳。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 转储任务状态。
+	Status *string `json:"status,omitempty"`
+
+	// 返回任务转存的topics列表或者正则表达式。
+	Topics *string `json:"topics,omitempty"`
+
+	ObsDestinationDescriptor *ShowSinkTaskDetailRespObsDestinationDescriptor `json:"obs_destination_descriptor,omitempty"`
+
+	// topic信息。
+	TopicsInfo     *[]ShowSinkTaskDetailRespTopicsInfo `json:"topics_info,omitempty"`
+	HttpStatusCode int                                 `json:"-"`
+}
+
+func (o ShowSinkTaskDetailResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowSinkTaskDetailResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowSinkTaskDetailResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_topic_access_policy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_topic_access_policy_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type ShowTopicAccessPolicyRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。
+	TopicName string `json:"topic_name"`
+}
+
+func (o ShowTopicAccessPolicyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTopicAccessPolicyRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowTopicAccessPolicyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_topic_access_policy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_show_topic_access_policy_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type ShowTopicAccessPolicyResponse struct {
+
+	// topic名称。
+	Name *string `json:"name,omitempty"`
+
+	// topic类型。
+	TopicType *int32 `json:"topic_type,omitempty"`
+
+	// 权限列表。
+	Policies       *[]PolicyEntity `json:"policies,omitempty"`
+	HttpStatusCode int             `json:"-"`
+}
+
+func (o ShowTopicAccessPolicyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTopicAccessPolicyResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowTopicAccessPolicyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_tag_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_tag_entity.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type TagEntity struct {
+
+	// 键。最大长度36个unicode字符。  key不能为空，不能为空字符串。  不能包含下列字符：非打印字符ASCII(0-31)，“=”,“*”,“<”,“>”,“\\”,“,”,“|”,“/”。
+	Key *string `json:"key,omitempty"`
+
+	// 值。每个值最大长度43个unicode字符。  value不能为空，可以空字符串。  不能包含下列字符：非打印字符ASCII(0-31), “=”,“*”,“<”,“>”,“\\”,“,”,“|”,“/”。
+	Value *string `json:"value,omitempty"`
+}
+
+func (o TagEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TagEntity struct{}"
+	}
+
+	return strings.Join([]string{"TagEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_tag_multy_value_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_tag_multy_value_entity.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type TagMultyValueEntity struct {
+
+	// 键。最大长度36个unicode字符。  key不能为空，不能为空字符串。  不能包含下列字符：非打印字符ASCII(0-31)，“=”,“*”,“<”,“>”,“\\”,“,”,“|”,“/”。
+	Key *string `json:"key,omitempty"`
+
+	// 值。每个值最大长度43个unicode字符。  value不能为空，可以空字符串。  不能包含下列字符：非打印字符ASCII(0-31), “=”,“*”,“<”,“>”,“\\”,“,”,“|”,“/”。
+	Values *[]string `json:"values,omitempty"`
+}
+
+func (o TagMultyValueEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TagMultyValueEntity struct{}"
+	}
+
+	return strings.Join([]string{"TagMultyValueEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_topic_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_topic_entity.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type TopicEntity struct {
+
+	// 是否为默认策略。
+	PoliciesOnly *bool `json:"policiesOnly,omitempty"`
+
+	// topic名称。
+	Name *string `json:"name,omitempty"`
+
+	// 副本数，配置数据的可靠性。
+	Replication *int32 `json:"replication,omitempty"`
+
+	// topic分区数，设置消费的并发数。
+	Partition *int32 `json:"partition,omitempty"`
+
+	// 消息老化时间。
+	RetentionTime *int32 `json:"retention_time,omitempty"`
+
+	// 是否开启同步复制，开启后，客户端生产消息时相应的也要设置acks=-1，否则不生效，默认关闭。
+	SyncReplication *bool `json:"sync_replication,omitempty"`
+
+	// 是否使用同步落盘。默认值为false。同步落盘会导致性能降低。
+	SyncMessageFlush *bool `json:"sync_message_flush,omitempty"`
+
+	// 扩展配置。
+	ExternalConfigs *interface{} `json:"external_configs,omitempty"`
+
+	// topic类型。
+	TopicType *int32 `json:"topic_type,omitempty"`
+}
+
+func (o TopicEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TopicEntity struct{}"
+	}
+
+	return strings.Join([]string{"TopicEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_auto_create_topic_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_auto_create_topic_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type UpdateInstanceAutoCreateTopicReq struct {
+
+	// 是否开启自动创建topic功能。
+	EnableAutoTopic bool `json:"enable_auto_topic"`
+}
+
+func (o UpdateInstanceAutoCreateTopicReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceAutoCreateTopicReq struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceAutoCreateTopicReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_auto_create_topic_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_auto_create_topic_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateInstanceAutoCreateTopicRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *UpdateInstanceAutoCreateTopicReq `json:"body,omitempty"`
+}
+
+func (o UpdateInstanceAutoCreateTopicRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceAutoCreateTopicRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceAutoCreateTopicRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_auto_create_topic_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_auto_create_topic_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateInstanceAutoCreateTopicResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdateInstanceAutoCreateTopicResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceAutoCreateTopicResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceAutoCreateTopicResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type UpdateInstanceCrossVpcIpReq struct {
+
+	// 用户自定义的advertised_ip_contents键值对。  键是listeners IP。  值是advertised.listeners IP，或者域名。  > IP修改未修改项也需填上。
+	AdvertisedIpContents map[string]string `json:"advertised_ip_contents"`
+}
+
+func (o UpdateInstanceCrossVpcIpReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceCrossVpcIpReq struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceCrossVpcIpReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateInstanceCrossVpcIpRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *UpdateInstanceCrossVpcIpReq `json:"body,omitempty"`
+}
+
+func (o UpdateInstanceCrossVpcIpRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceCrossVpcIpRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceCrossVpcIpRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_resp_results.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_resp_results.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 修改broker跨VPC访问的结果。
+type UpdateInstanceCrossVpcIpRespResults struct {
+
+	// advertised.listeners IP/域名。
+	AdvertisedIp *string `json:"advertised_ip,omitempty"`
+
+	// 修改broker跨VPC访问的状态。
+	Success *bool `json:"success,omitempty"`
+
+	// listeners IP。
+	Ip *string `json:"ip,omitempty"`
+}
+
+func (o UpdateInstanceCrossVpcIpRespResults) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceCrossVpcIpRespResults struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceCrossVpcIpRespResults", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_cross_vpc_ip_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateInstanceCrossVpcIpResponse struct {
+
+	// 修改跨VPC访问结果。
+	Success *bool `json:"success,omitempty"`
+
+	// 修改broker跨VPC访问的结果列表。
+	Results        *[]UpdateInstanceCrossVpcIpRespResults `json:"results,omitempty"`
+	HttpStatusCode int                                    `json:"-"`
+}
+
+func (o UpdateInstanceCrossVpcIpResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceCrossVpcIpResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceCrossVpcIpResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_req.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type UpdateInstanceReq struct {
+
+	// 实例名称。  由英文字符开头，只能由英文字母、数字、中划线、下划线组成，长度为4~64的字符。
+	Name *string `json:"name,omitempty"`
+
+	// 实例的描述信息。  长度不超过1024的字符串。  > \\与\"在json报文中属于特殊字符，如果参数值中需要显示\\或者\"字符，请在字符前增加转义字符\\，比如\\\\或者\\\"。
+	Description *string `json:"description,omitempty"`
+
+	// 维护时间窗开始时间，格式为HH:mm:ss。   - 维护时间窗开始和结束时间必须为指定的时间段。   - 开始时间必须为22:00:00、02:00:00、06:00:00、10:00:00、14:00:00和18:00:00。   - 该参数不能单独为空，若该值为空，则结束时间也为空。系统分配一个默认开始时间02:00:00。
+	MaintainBegin *string `json:"maintain_begin,omitempty"`
+
+	// 维护时间窗结束时间，格式为HH:mm:ss。   - 维护时间窗开始和结束时间必须为指定的时间段。   - 结束时间在开始时间基础上加四个小时，即当开始时间为22:00:00时，结束时间为02:00:00。   - 该参数不能单独为空，若该值为空，则开始时间也为空。系统分配一个默认结束时间06:00:00。
+	MaintainEnd *string `json:"maintain_end,omitempty"`
+
+	// 安全组ID。
+	SecurityGroupId *string `json:"security_group_id,omitempty"`
+
+	// 容量阈值策略。 支持两种策略模式： - produce_reject: 生产受限 - time_base: 自动删除
+	RetentionPolicy *UpdateInstanceReqRetentionPolicy `json:"retention_policy,omitempty"`
+
+	// 企业项目。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o UpdateInstanceReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceReq struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceReq", string(data)}, " ")
+}
+
+type UpdateInstanceReqRetentionPolicy struct {
+	value string
+}
+
+type UpdateInstanceReqRetentionPolicyEnum struct {
+	PRODUCE_REJECT UpdateInstanceReqRetentionPolicy
+	TIME_BASE      UpdateInstanceReqRetentionPolicy
+}
+
+func GetUpdateInstanceReqRetentionPolicyEnum() UpdateInstanceReqRetentionPolicyEnum {
+	return UpdateInstanceReqRetentionPolicyEnum{
+		PRODUCE_REJECT: UpdateInstanceReqRetentionPolicy{
+			value: "produce_reject",
+		},
+		TIME_BASE: UpdateInstanceReqRetentionPolicy{
+			value: "time_base",
+		},
+	}
+}
+
+func (c UpdateInstanceReqRetentionPolicy) Value() string {
+	return c.value
+}
+
+func (c UpdateInstanceReqRetentionPolicy) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *UpdateInstanceReqRetentionPolicy) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter != nil {
+		val, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+		if err == nil {
+			c.value = val.(string)
+			return nil
+		}
+		return err
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateInstanceRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *UpdateInstanceReq `json:"body,omitempty"`
+}
+
+func (o UpdateInstanceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateInstanceResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdateInstanceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_req.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 修改的topic列表。
+type UpdateInstanceTopicReq struct {
+
+	// 修改的topic列表。
+	Topics *[]UpdateInstanceTopicReqTopics `json:"topics,omitempty"`
+}
+
+func (o UpdateInstanceTopicReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceTopicReq struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceTopicReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_req_topics.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_req_topics.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// 修改的topic。
+type UpdateInstanceTopicReqTopics struct {
+
+	// topic名称，不支持修改。
+	Id string `json:"id"`
+
+	// 老化时间，单位小时。
+	RetentionTime *int32 `json:"retention_time,omitempty"`
+
+	// 是否同步复制。
+	SyncReplication *bool `json:"sync_replication,omitempty"`
+
+	// 是否同步落盘。
+	SyncMessageFlush *bool `json:"sync_message_flush,omitempty"`
+
+	// 分区数。
+	NewPartitionNumbers *int32 `json:"new_partition_numbers,omitempty"`
+}
+
+func (o UpdateInstanceTopicReqTopics) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceTopicReqTopics struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceTopicReqTopics", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateInstanceTopicRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *UpdateInstanceTopicReq `json:"body,omitempty"`
+}
+
+func (o UpdateInstanceTopicRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceTopicRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceTopicRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_instance_topic_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateInstanceTopicResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdateInstanceTopicResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateInstanceTopicResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateInstanceTopicResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_sink_task_quota_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_sink_task_quota_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type UpdateSinkTaskQuotaReq struct {
+
+	// 转储任务的总个数。
+	SinkMaxTasks int32 `json:"sink_max_tasks"`
+}
+
+func (o UpdateSinkTaskQuotaReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateSinkTaskQuotaReq struct{}"
+	}
+
+	return strings.Join([]string{"UpdateSinkTaskQuotaReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_sink_task_quota_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_sink_task_quota_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateSinkTaskQuotaRequest struct {
+
+	// 实例转储ID。 请参考[实例生命周期][查询实例]接口返回的数据。
+	ConnectorId string `json:"connector_id"`
+
+	Body *UpdateSinkTaskQuotaReq `json:"body,omitempty"`
+}
+
+func (o UpdateSinkTaskQuotaRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateSinkTaskQuotaRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateSinkTaskQuotaRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_sink_task_quota_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_sink_task_quota_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateSinkTaskQuotaResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdateSinkTaskQuotaResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateSinkTaskQuotaResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateSinkTaskQuotaResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_access_policy_req.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_access_policy_req.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type UpdateTopicAccessPolicyReq struct {
+
+	// topic列表。
+	Topics []AccessPolicyTopicEntity `json:"topics"`
+}
+
+func (o UpdateTopicAccessPolicyReq) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateTopicAccessPolicyReq struct{}"
+	}
+
+	return strings.Join([]string{"UpdateTopicAccessPolicyReq", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_access_policy_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_access_policy_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateTopicAccessPolicyRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	Body *UpdateTopicAccessPolicyReq `json:"body,omitempty"`
+}
+
+func (o UpdateTopicAccessPolicyRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateTopicAccessPolicyRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateTopicAccessPolicyRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_access_policy_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_access_policy_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateTopicAccessPolicyResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdateTopicAccessPolicyResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateTopicAccessPolicyResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateTopicAccessPolicyResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_replica_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_replica_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Request Object
+type UpdateTopicReplicaRequest struct {
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+
+	// Topic名称。
+	Topic string `json:"topic"`
+
+	Body *ResetReplicaReq `json:"body,omitempty"`
+}
+
+func (o UpdateTopicReplicaRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateTopicReplicaRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateTopicReplicaRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_replica_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model/model_update_topic_replica_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Response Object
+type UpdateTopicReplicaResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o UpdateTopicReplicaResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateTopicReplicaResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateTopicReplicaResponse", string(data)}, " ")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -448,6 +448,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new resources user and permissions

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resources user and permissions
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsKafkaUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaUser_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaUser_basic
=== PAUSE TestAccDmsKafkaUser_basic
=== CONT  TestAccDmsKafkaUser_basic
--- PASS: TestAccDmsKafkaUser_basic (630.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       630.896s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsKafkaPermissions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaPermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaPermissions_basic
=== PAUSE TestAccDmsKafkaPermissions_basic
=== CONT  TestAccDmsKafkaPermissions_basic
--- PASS: TestAccDmsKafkaPermissions_basic (728.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       728.857s
```
