### PR TITLE
fix(gaussdb/refresh): update the logic of 404 check

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_cassandra_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_cassandra_instance_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/geminidb/v3/instances"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -51,6 +52,9 @@ func testAccCheckGeminiDBInstanceDestroy(s *terraform.State) error {
 
 		found, err := instances.GetInstanceByID(client, rs.Primary.ID)
 		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
 			return err
 		}
 		if found.Id != "" {
@@ -80,6 +84,9 @@ func testAccCheckGeminiDBInstanceExists(n string, instance *instances.GeminiDBIn
 
 		found, err := instances.GetInstanceByID(client, rs.Primary.ID)
 		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return fmt.Errorf("Instance <%s> not found.", rs.Primary.ID)
+			}
 			return err
 		}
 		if found.Id == "" {

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_redis_instance_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/geminidb/v3/instances"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -67,6 +68,9 @@ func testAccCheckGaussRedisInstanceDestroy(s *terraform.State) error {
 
 		found, err := instances.GetInstanceByID(client, rs.Primary.ID)
 		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
 			return err
 		}
 		if found.Id != "" {
@@ -96,6 +100,9 @@ func testAccCheckGaussRedisInstanceExists(n string, instance *instances.GeminiDB
 
 		found, err := instances.GetInstanceByID(client, rs.Primary.ID)
 		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return fmt.Errorf("Instance <%s> not found.", rs.Primary.ID)
+			}
 			return err
 		}
 		if found.Id == "" {

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -326,10 +326,10 @@ func GeminiDBInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceI
 		instance, err := instances.GetInstanceByID(client, instanceID)
 
 		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return instance, "deleted", nil
+			}
 			return nil, "", err
-		}
-		if instance.Id == "" {
-			return instance, "deleted", nil
 		}
 
 		return instance, instance.Status, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the logic of 404 not found check.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBDehResourceDataSource_basic
=== PAUSE TestAccGeminiDBDehResourceDataSource_basic
=== RUN   TestAccCassandraFlavorsDataSource_basic
=== PAUSE TestAccCassandraFlavorsDataSource_basic
=== RUN   TestAccGeminiDBInstanceDataSource_basic
=== PAUSE TestAccGeminiDBInstanceDataSource_basic
=== RUN   TestAccGeminiDBInstancesDataSource_basic
=== PAUSE TestAccGeminiDBInstancesDataSource_basic
=== RUN   TestAccGaussdbMysqlConfigurationDataSource_basic
=== PAUSE TestAccGaussdbMysqlConfigurationDataSource_basic
=== RUN   TestAccGaussDBMysqlDehResourceDataSource_basic
=== PAUSE TestAccGaussDBMysqlDehResourceDataSource_basic
=== RUN   TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== PAUSE TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== RUN   TestAccGaussdbMysqlInstanceDataSource_basic
=== PAUSE TestAccGaussdbMysqlInstanceDataSource_basic
=== RUN   TestAccGaussdbMysqlInstancesDataSource_basic
=== PAUSE TestAccGaussdbMysqlInstancesDataSource_basic
=== RUN   TestAccGaussDBNoSQLFlavors_basic
=== PAUSE TestAccGaussDBNoSQLFlavors_basic
=== RUN   TestAccGaussDBNoSQLFlavors_mongodb
=== PAUSE TestAccGaussDBNoSQLFlavors_mongodb
=== RUN   TestAccGaussDBNoSQLFlavors_influxdb
=== PAUSE TestAccGaussDBNoSQLFlavors_influxdb
=== RUN   TestAccGaussDBNoSQLFlavors_redis
=== PAUSE TestAccGaussDBNoSQLFlavors_redis
=== RUN   TestAccGaussDBNoSQLFlavors_vcpus
=== PAUSE TestAccGaussDBNoSQLFlavors_vcpus
=== RUN   TestAccGaussDBNoSQLFlavors_memory
=== PAUSE TestAccGaussDBNoSQLFlavors_memory
=== RUN   TestAccGaussDBNoSQLFlavors_az
=== PAUSE TestAccGaussDBNoSQLFlavors_az
=== RUN   TestAccOpenGaussInstanceDataSource_basic
=== PAUSE TestAccOpenGaussInstanceDataSource_basic
=== RUN   TestAccOpenGaussInstancesDataSource_basic
=== PAUSE TestAccOpenGaussInstancesDataSource_basic
=== RUN   TestAccGaussRedisInstanceDataSource_basic
=== PAUSE TestAccGaussRedisInstanceDataSource_basic
=== RUN   TestAccGeminiDBInstance_basic
=== PAUSE TestAccGeminiDBInstance_basic
=== RUN   TestAccGaussInfluxInstance_basic
=== PAUSE TestAccGaussInfluxInstance_basic
=== RUN   TestAccGaussMongoInstance_basic
=== PAUSE TestAccGaussMongoInstance_basic
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBProxy_basic
=== PAUSE TestAccGaussDBProxy_basic
=== RUN   TestAccOpenGaussInstance_basic
=== PAUSE TestAccOpenGaussInstance_basic
=== RUN   TestAccOpenGaussInstance_haModeCentralized
=== PAUSE TestAccOpenGaussInstance_haModeCentralized
=== RUN   TestAccGaussRedisInstance_basic
=== PAUSE TestAccGaussRedisInstance_basic
=== CONT  TestAccGeminiDBDehResourceDataSource_basic
=== CONT  TestAccGaussDBNoSQLFlavors_memory
=== CONT  TestAccGaussdbMysqlInstanceDataSource_basic
=== CONT  TestAccGaussdbMysqlConfigurationDataSource_basic
--- PASS: TestAccGeminiDBDehResourceDataSource_basic (13.41s)
=== CONT  TestAccGaussRedisInstance_basic
--- PASS: TestAccGaussdbMysqlConfigurationDataSource_basic (16.24s)
=== CONT  TestAccOpenGaussInstance_haModeCentralized
--- PASS: TestAccGaussDBNoSQLFlavors_memory (19.17s)
=== CONT  TestAccOpenGaussInstance_basic
--- PASS: TestAccGaussdbMysqlInstanceDataSource_basic (1309.79s)
=== CONT  TestAccGaussDBProxy_basic
--- PASS: TestAccOpenGaussInstance_haModeCentralized (1904.92s)
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBProxy_basic
    resource_huaweicloud_gaussdb_mysql_proxy_test.go:35: Step 1/2 error: Check failed: Check 2/3 error: huaweicloud_gaussdb_mysql_proxy.test: Attribute 'flavor' expected "gaussdb.proxy.xlarge.arm.2", got ""
--- FAIL: TestAccGaussDBProxy_basic (1622.01s)
=== CONT  TestAccGaussMongoInstance_basic
--- PASS: TestAccGaussDBInstance_basic (1261.12s)
=== CONT  TestAccGaussInfluxInstance_basic
--- PASS: TestAccGaussRedisInstance_basic (3259.31s)
=== CONT  TestAccGeminiDBInstance_basic
--- PASS: TestAccGaussMongoInstance_basic (1282.29s)
=== CONT  TestAccGaussRedisInstanceDataSource_basic
--- PASS: TestAccGeminiDBInstance_basic (1086.89s)
=== CONT  TestAccOpenGaussInstancesDataSource_basic
--- PASS: TestAccGaussInfluxInstance_basic (1546.29s)
=== CONT  TestAccOpenGaussInstanceDataSource_basic
--- PASS: TestAccGaussRedisInstanceDataSource_basic (1133.48s)
=== CONT  TestAccGaussDBNoSQLFlavors_az
--- PASS: TestAccGaussDBNoSQLFlavors_az (12.34s)
=== CONT  TestAccGeminiDBInstanceDataSource_basic
--- PASS: TestAccOpenGaussInstancesDataSource_basic (1628.53s)
=== CONT  TestAccGeminiDBInstancesDataSource_basic
--- PASS: TestAccOpenGaussInstanceDataSource_basic (1693.55s)
=== CONT  TestAccGaussDBNoSQLFlavors_influxdb
--- PASS: TestAccGaussDBNoSQLFlavors_influxdb (10.31s)
=== CONT  TestAccGaussDBNoSQLFlavors_vcpus
--- PASS: TestAccGeminiDBInstanceDataSource_basic (1079.95s)
=== CONT  TestAccGaussDBNoSQLFlavors_redis
--- PASS: TestAccGaussDBNoSQLFlavors_vcpus (11.37s)
=== CONT  TestAccGaussDBNoSQLFlavors_basic
--- PASS: TestAccGaussDBNoSQLFlavors_redis (10.53s)
=== CONT  TestAccGaussDBNoSQLFlavors_mongodb
--- PASS: TestAccGaussDBNoSQLFlavors_mongodb (11.91s)
=== CONT  TestAccCassandraFlavorsDataSource_basic
--- PASS: TestAccGaussDBNoSQLFlavors_basic (21.32s)
=== CONT  TestAccGaussdbMysqlInstancesDataSource_basic
--- PASS: TestAccCassandraFlavorsDataSource_basic (10.05s)
=== CONT  TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
--- PASS: TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic (11.54s)
=== CONT  TestAccGaussDBMysqlDehResourceDataSource_basic
--- PASS: TestAccGaussDBMysqlDehResourceDataSource_basic (9.42s)
--- PASS: TestAccGeminiDBInstancesDataSource_basic (1065.84s)
--- PASS: TestAccGaussdbMysqlInstancesDataSource_basic (1428.72s)
--- PASS: TestAccOpenGaussInstance_basic (9865.02s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   9884.265s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
