### PR TITLE
fix(gaussdb/opengauss): extend the check cycle of backup status

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -152,7 +152,7 @@ resource "huaweicloud_vpc_subnet" "test" {
   gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
 
   timeouts {
-    delete = "20m"
+    delete = "40m"
   }
 }
 
@@ -160,7 +160,7 @@ resource "huaweicloud_networking_secgroup" "test" {
   name = "%[1]s"
 
   timeouts {
-    delete = "20m"
+    delete = "40m"
   }
 }
 

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -452,12 +452,13 @@ func resourceOpenGaussInstanceCreate(ctx context.Context, d *schema.ResourceData
 
 	// waiting for the instance to become ready
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"BUILD", "BACKING UP"},
-		Target:       []string{"ACTIVE"},
-		Refresh:      OpenGaussInstanceStateRefreshFunc(client, d.Id()),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        20 * time.Second,
-		PollInterval: 20 * time.Second,
+		Pending:                   []string{"BUILD", "BACKING UP"},
+		Target:                    []string{"ACTIVE"},
+		Refresh:                   OpenGaussInstanceStateRefreshFunc(client, d.Id()),
+		Timeout:                   d.Timeout(schema.TimeoutCreate),
+		Delay:                     20 * time.Second,
+		PollInterval:              20 * time.Second,
+		ContinuousTargetOccurence: 2,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For large-scale instances (OpenGauss), it takes a long time to enter the BACKING_UP status.
For OpenGauss instances with many (CN/DN) nodes, there is a certain delay in their release, so the release of subnets and security groups takes a certain amount of time.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. extend the check cycle of backup status.
2. extend the timeouts for resource deletion.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
PENDING
```
