### PR TITLE
fix(evs): add continuous check to work around inconsistent APIs

### DIFF
--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -248,12 +248,13 @@ func resourceEvsVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	logp.Printf("[DEBUG] Waiting for the EVS volume to become available, the volume ID is %s.", d.Id())
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"creating"},
-		Target:     []string{"available"},
-		Refresh:    CloudVolumeRefreshFunc(evsV2Client, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      3 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Pending:                   []string{"creating"},
+		Target:                    []string{"available"},
+		Refresh:                   CloudVolumeRefreshFunc(evsV2Client, d.Id()),
+		Timeout:                   d.Timeout(schema.TimeoutCreate),
+		Delay:                     3 * time.Second,
+		MinTimeout:                5 * time.Second,
+		ContinuousTargetOccurence: 2,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

the basic acceptance testing runs failed:
```
run acceptance basic tests: TestAccEvsVolume_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_basic
    resource_huaweicloud_evs_volume_test.go:33: Step 1/2 error: Check failed: Check 6/19 error: huaweicloud_evs_volume.test.0: Attribute 'tags.foo' not found
--- FAIL: TestAccEvsVolume_basic (48.92s)
FAIL
FAIL	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs	48.948s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```

the root case is the `tags` field is **absent** in the first response
```
"volume": {
    .....
    "status": "available",
    "tags": {},
    .....
}
```

so the work around is getting the state again with **ContinuousTargetOccurence**.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_basic
--- PASS: TestAccEvsVolume_basic (88.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       88.816s
```
