### PR TITLE
fix(tags): ignore system tag key CCE-Cluster-ID

### DIFF
--- a/huaweicloud/utils/tags.go
+++ b/huaweicloud/utils/tags.go
@@ -63,6 +63,7 @@ func TagsToMap(tags []tags.ResourceTag) map[string]string {
 	}
 
 	// ignore system tags to keep the tags consistent with what the user set
+	delete(result, "CCE-Cluster-ID")
 	delete(result, "CCE-Dynamic-Provisioning-Node")
 
 	return result


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

the acceptance testing is failed:
```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
    resource_huaweicloud_cce_node_v3_test.go:27: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:


        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # huaweicloud_cce_node.test will be updated in-place
          ~ resource "huaweicloud_cce_node" "test" {
                availability_zone = "cn-north-4a"
                cluster_id        = "97b7a4b3-46ff-11ed-a1a4-0255ac10026d"
                flavor_id         = "s6.large.2"
                id                = "7cbeb064-4700-11ed-a25b-0255ac100244"
                key_pair          = "tf-acc-test-7mtmq"
                name              = "tf-acc-test-7mtmq"
                os                = "EulerOS 2.9"
                private_ip        = "192.168.0.42"
                region            = "cn-north-4"
                runtime           = "docker"
                server_id         = "b2adc6ec-7eb0-4e8b-a5f7-03f4fa6c14f8"
                status            = "Active"
                subnet_id         = "fefe17c6-e874-457e-9743-d6925e6988a7"
              ~ tags              = {
                  - "CCE-Cluster-ID" = "97b7a4b3-46ff-11ed-a1a4-0255ac10026d" -> null
                    "foo"            = "bar"
                    "key"            = "value"
                }

                data_volumes {
                    extend_params  = {}
                    hw_passthrough = false
                    size           = 100
                    volumetype     = "SSD"
                }

                root_volume {
                    extend_params  = {}
                    hw_passthrough = false
                    size           = 40
                    volumetype     = "SSD"
                }
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccCCENodeV3_basic (843.15s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       843.219s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

the reason is `CCE-Cluster-ID` will be added by system, and we can not specify it manaually.

```
Error: Error creating HuaweiCloud Node: Bad request with: [POST https://cce.cn-north-4.myhuaweicloud.com/api/v3/projects/xxxx/clusters/xxxx/nodes],
error message: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","code":400,"errorCode":"CCE.01400001",
"errorMessage":"Invalid request.","error_code":"CCE_CM.0004","error_msg":"Request is invalid","message":"Tag's key or value is illegal","reason":"BadRequest"}

  on main.tf line 54, in resource "huaweicloud_cce_node" "node_1":
  54: resource "huaweicloud_cce_node" "node_1" {
```

this PR is similar to #1463 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (904.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       904.185s
```
