### PR TITLE
refactor(ims): move ims's codes to services

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -730,7 +730,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_vpc":                 ResourceIecVpc(),
 			"huaweicloud_iec_vpc_subnet":          resourceIecSubnet(),
 
-			"huaweicloud_images_image": ResourceImsImage(),
+			"huaweicloud_images_image": ims.ResourceImsImage(),
 
 			"huaweicloud_iotda_space":               iotda.ResourceSpace(),
 			"huaweicloud_iotda_product":             iotda.ResourceProduct(),

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package ims
 
 import (
 	"fmt"
@@ -8,6 +8,8 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -22,9 +24,9 @@ func TestAccImsImage_basic(t *testing.T) {
 	resourceName := "huaweicloud_images_image.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckImsImageDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckImsImageDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccImsImage_basic(rName),
@@ -63,16 +65,16 @@ func TestAccImsImage_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_images_image.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckImsImageDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckImsImageDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccImsImage_withEpsId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImsImageExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -80,8 +82,8 @@ func TestAccImsImage_withEpsId(t *testing.T) {
 }
 
 func testAccCheckImsImageDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	imageClient, err := config.ImageV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud Image: %s", err)
 	}
@@ -91,7 +93,7 @@ func testAccCheckImsImageDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := getCloudimage(imageClient, rs.Primary.ID)
+		_, err := ims.GetCloudimage(imageClient, rs.Primary.ID)
 		if err == nil {
 			return fmtp.Errorf("Image still exists")
 		}
@@ -111,13 +113,13 @@ func testAccCheckImsImageExists(n string, image *cloudimages.Image) resource.Tes
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		imageClient, err := config.ImageV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		imageClient, err := config.ImageV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud Image: %s", err)
 		}
 
-		found, err := getCloudimage(imageClient, rs.Primary.ID)
+		found, err := ims.GetCloudimage(imageClient, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -258,5 +260,5 @@ resource "huaweicloud_images_image" "test" {
     key = "value"
   }
 }
-`, rName, rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, rName, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package ims
 
 import (
 	"strings"
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
@@ -42,7 +43,7 @@ func ResourceImsImage() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"tags": tagsSchema(),
+			"tags": common.TagsSchema(),
 
 			"max_ram": {
 				Type:     schema.TypeInt,
@@ -150,7 +151,7 @@ func resourceContainerImageTags(d *schema.ResourceData) []cloudimages.ImageTag {
 
 func resourceImsImageCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	imsClient, err := config.ImageV2Client(GetRegion(d, config))
+	imsClient, err := config.ImageV2Client(common.GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud image client: %s", err)
 	}
@@ -165,7 +166,7 @@ func resourceImsImageCreate(d *schema.ResourceData, meta interface{}) error {
 			MinRam:              d.Get("min_ram").(int),
 			InstanceId:          val.(string),
 			ImageTags:           imageTags,
-			EnterpriseProjectID: GetEnterpriseProjectID(d, config),
+			EnterpriseProjectID: common.GetEnterpriseProjectID(d, config),
 		}
 		logp.Printf("[DEBUG] Create Options: %#v", createOpts)
 		v, err = cloudimages.CreateImageByServer(imsClient, createOpts).ExtractJobResponse()
@@ -182,7 +183,7 @@ func resourceImsImageCreate(d *schema.ResourceData, meta interface{}) error {
 			CmkId:               d.Get("cmk_id").(string),
 			Type:                d.Get("type").(string),
 			ImageTags:           imageTags,
-			EnterpriseProjectID: GetEnterpriseProjectID(d, config),
+			EnterpriseProjectID: common.GetEnterpriseProjectID(d, config),
 		}
 		logp.Printf("[DEBUG] Create Options: %#v", createOpts)
 		v, err = cloudimages.CreateImageByOBS(imsClient, createOpts).ExtractJobResponse()
@@ -214,7 +215,7 @@ func resourceImsImageCreate(d *schema.ResourceData, meta interface{}) error {
 	return fmtp.Errorf("Unexpected conversion error in resourceImsImageCreate.")
 }
 
-func getCloudimage(client *golangsdk.ServiceClient, id string) (*cloudimages.Image, error) {
+func GetCloudimage(client *golangsdk.ServiceClient, id string) (*cloudimages.Image, error) {
 	listOpts := &cloudimages.ListOpts{
 		ID:    id,
 		Limit: 1,
@@ -252,12 +253,12 @@ func getInstanceID(data string) string {
 
 func resourceImsImageRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	imsClient, err := config.ImageV2Client(GetRegion(d, config))
+	imsClient, err := config.ImageV2Client(common.GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud image client: %s", err)
 	}
 
-	img, err := getCloudimage(imsClient, d.Id())
+	img, err := GetCloudimage(imsClient, d.Id())
 	if err != nil {
 		return fmtp.Errorf("Image %s not found: %s", d.Id(), err)
 	}
@@ -298,7 +299,7 @@ func resourceImsImageRead(d *schema.ResourceData, meta interface{}) error {
 
 func setTagForImage(d *schema.ResourceData, meta interface{}, imageID string, tagmap map[string]interface{}) error {
 	config := meta.(*config.Config)
-	client, err := config.ImageV2Client(GetRegion(d, config))
+	client, err := config.ImageV2Client(common.GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud image client: %s", err)
 	}
@@ -323,7 +324,7 @@ func setTagForImage(d *schema.ResourceData, meta interface{}, imageID string, ta
 
 func resourceImsImageUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	imsClient, err := config.ImageV2Client(GetRegion(d, config))
+	imsClient, err := config.ImageV2Client(common.GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud image client: %s", err)
 	}
@@ -353,7 +354,7 @@ func resourceImsImageUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		if hasFilledOpt(d, "tags") {
+		if common.HasFilledOpt(d, "tags") {
 			tagmap := d.Get("tags").(map[string]interface{})
 			if len(tagmap) > 0 {
 				logp.Printf("[DEBUG] Setting tags: %v", tagmap)
@@ -370,7 +371,7 @@ func resourceImsImageUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceImsImageDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*config.Config)
-	imageClient, err := config.ImageV2Client(GetRegion(d, config))
+	imageClient, err := config.ImageV2Client(common.GetRegion(d, config))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud image client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Move image's source codes to services/ims.
Move image's test codes to services/acceptance/ims.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ims' TESTARGS='-run TestAccImsImage_basic' 2>&1 | tee /usr1/tf.log
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImage_basic -timeout 360m -parallel 4
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== CONT  TestAccImsImage_basic
--- PASS: TestAccImsImage_basic (370.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       370.838s
```
