### PR TITLE
feat(config/logger): support masking map field

### DIFF
--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -211,7 +211,11 @@ func maskSecurityFields(data map[string]interface{}) {
 				data[k] = "** large string **"
 			}
 		case map[string]interface{}:
-			maskSecurityFields(val)
+			if isSecurityFields(k) {
+				data[k] = map[string]string{"***": "***"}
+			} else {
+				maskSecurityFields(val)
+			}
 		}
 	}
 }
@@ -232,7 +236,8 @@ func isSecurityFields(field string) bool {
 	// 'email', 'phone' and 'sip_number' can uniquely identify a person.
 	// 'signature' are used for encryption.
 	// 'user_passwd' is apply to the dms/kafka user request JSON body
+	// 'auth' is apply to kms keypairs associate or disassociate request JSON body
 	securityFields := []string{"adminpass", "encrypted_user_data", "nonce", "email", "phone", "sip_number",
-		"signature", "user_passwd"}
+		"signature", "user_passwd", "auth"}
 	return utils.StrSliceContains(securityFields, checkField)
 }

--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -201,7 +201,7 @@ func FormatHeaders(headers http.Header, seperator string) string {
 	return strings.Join(redactedHeaders, seperator)
 }
 
-func maskSecurityFields(data map[string]interface{}) bool {
+func maskSecurityFields(data map[string]interface{}) {
 	for k, val := range data {
 		switch val := val.(type) {
 		case string:
@@ -211,12 +211,9 @@ func maskSecurityFields(data map[string]interface{}) bool {
 				data[k] = "** large string **"
 			}
 		case map[string]interface{}:
-			if masked := maskSecurityFields(val); masked {
-				return true
-			}
+			maskSecurityFields(val)
 		}
 	}
-	return false
 }
 
 func isSecurityFields(field string) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

sometime we want to mask an object when logging.
```
API Request Body: {
  "keypair_name": "KeyPair-001",
  "server": {
    "auth": {
      "key": "admin@1234",
      "type": "password"
    },
    "id": "b70cddf5-e798-4645-a685-ea9b8b5ebb33"
  }
}
```
the **auth** field is security and should be masked.
After applying the PR, the content of the request body is as follows:
```
API Request Body: {
  "keypair_name": "KeyPair-001",
  "server": {
    "auth": {
      "***": "***"
    },
    "id": "895bc22e-8bd3-46ac-88d7-6d1744dd801a"
  }
}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

