### PR TITLE
fix(dli): enhance the acceptance test of DLI

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
@@ -32,7 +32,7 @@ func getDliAuthResourceFunc(config *config.Config, state *terraform.ResourceStat
 
 // test database permissions
 func TestAccResourceDliAuth_basic(t *testing.T) {
-	var obj auth.GrantDataPermissionOpts
+	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
 	name := acceptance.RandomAccResourceName()
 
@@ -93,7 +93,7 @@ resource "huaweicloud_dli_permission" "test" {
 }
 
 func TestAccResourceDliAuth_flink(t *testing.T) {
-	var obj auth.GrantDataPermissionOpts
+	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
 	name := acceptance.RandomAccResourceName()
 
@@ -154,7 +154,7 @@ resource "huaweicloud_dli_permission" "test" {
 }
 
 func TestAccResourceDliAuth_table(t *testing.T) {
-	var obj auth.GrantDataPermissionOpts
+	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
 	name := acceptance.RandomAccResourceName()
 
@@ -217,7 +217,7 @@ resource "huaweicloud_dli_permission" "test" {
 }
 
 func TestAccResourceDliAuth_package(t *testing.T) {
-	var obj auth.GrantDataPermissionOpts
+	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
 	name := acceptance.RandomAccResourceName()
 	packageGroupName := acceptance.RandomAccResourceNameWithDash()
@@ -283,7 +283,7 @@ resource "huaweicloud_dli_permission" "test" {
 }
 
 func TestAccResourceDliAuth_queue(t *testing.T) {
-	var obj auth.GrantDataPermissionOpts
+	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
 	name := acceptance.RandomAccResourceName()
 

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
@@ -123,7 +123,7 @@ func TestAccResourceDliSqlJob_async(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"rows", "schema", "conf"},
+				ImportStateVerifyIgnore: []string{"rows", "schema", "conf", "duration", "status"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccResourceDli'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccResourceDli -timeout 360m -parallel 4
=== RUN   TestAccResourceDliFlinkJarJob_basic
=== PAUSE TestAccResourceDliFlinkJarJob_basic
=== RUN   TestAccResourceDliFlinkJarJob_all
=== PAUSE TestAccResourceDliFlinkJarJob_all
=== RUN   TestAccResourceDliFlinkJob_basic
=== PAUSE TestAccResourceDliFlinkJob_basic
=== RUN   TestAccResourceDliAuth_basic
=== PAUSE TestAccResourceDliAuth_basic
=== RUN   TestAccResourceDliAuth_flink
=== PAUSE TestAccResourceDliAuth_flink
=== RUN   TestAccResourceDliAuth_table
=== PAUSE TestAccResourceDliAuth_table
=== RUN   TestAccResourceDliAuth_package
=== PAUSE TestAccResourceDliAuth_package
=== RUN   TestAccResourceDliAuth_queue
=== PAUSE TestAccResourceDliAuth_queue
=== RUN   TestAccResourceDliSqlJob_basic
=== PAUSE TestAccResourceDliSqlJob_basic
=== RUN   TestAccResourceDliSqlJob_query
=== PAUSE TestAccResourceDliSqlJob_query
=== RUN   TestAccResourceDliSqlJob_async
=== PAUSE TestAccResourceDliSqlJob_async
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== RUN   TestAccResourceDliTable_OBS
=== PAUSE TestAccResourceDliTable_OBS
=== CONT  TestAccResourceDliFlinkJarJob_basic
=== CONT  TestAccResourceDliAuth_queue
=== CONT  TestAccResourceDliAuth_flink
=== CONT  TestAccResourceDliFlinkJarJob_basic
    acceptance.go:298: HW_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.
--- SKIP: TestAccResourceDliFlinkJarJob_basic (0.00s)
=== CONT  TestAccResourceDliAuth_basic
=== CONT  TestAccResourceDliAuth_package
--- PASS: TestAccResourceDliAuth_basic (24.61s)
=== CONT  TestAccResourceDliFlinkJob_basic
--- PASS: TestAccResourceDliAuth_package (29.67s)
=== CONT  TestAccResourceDliFlinkJarJob_all
    acceptance.go:298: HW_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.
--- SKIP: TestAccResourceDliFlinkJarJob_all (0.00s)
=== CONT  TestAccResourceDliSqlJob_async
--- PASS: TestAccResourceDliAuth_flink (72.66s)
=== CONT  TestAccResourceDliTable_OBS
--- PASS: TestAccResourceDliSqlJob_async (57.46s)
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccResourceDliTable_OBS (18.97s)
=== CONT  TestAccResourceDliSqlJob_query
--- PASS: TestAccResourceDliTable_basic (16.47s)
=== CONT  TestAccResourceDliAuth_table
--- PASS: TestAccResourceDliFlinkJob_basic (82.81s)
=== CONT  TestAccResourceDliSqlJob_basic
--- PASS: TestAccResourceDliAuth_table (28.02s)
--- PASS: TestAccResourceDliSqlJob_query (56.45s)
--- PASS: TestAccResourceDliSqlJob_basic (57.79s)
--- PASS: TestAccResourceDliAuth_queue (263.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       263.827s
```
