### PR TITLE
feat(ecs): support updting keypair without rebuilding

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -224,8 +224,10 @@ The following arguments are supported:
 
 * `admin_pass` - (Optional, String) Specifies the administrative password to assign to the instance.
 
-* `key_pair` - (Optional, String, ForceNew) Specifies the name of a key pair to put on the instance. The key pair must
-  already be created and associated with the tenant's account. Changing this creates a new instance.
+* `key_pair` - (Optional, String) Specifies the SSH keypair name used for logging in to the instance.
+
+* `private_key` - (Optional, String) Specifies the the private key of the keypair in use. This parameter is mandatory
+  when replacing or unbinding a keypair and the instance is in **Running** state.
 
 * `system_disk_type` - (Optional, String, ForceNew) Specifies the system disk type of the instance. Defaults to `GPSSD`.
   Changing this creates a new instance.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20221012025003-ca06d8f91378
+	github.com/chnsz/golangsdk v0.0.0-20221014072812-3b89f7691e5b
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20221012025003-ca06d8f91378 h1:SoDcMCytOsID5seooZIH0rSvUrK8LNTuvTdlT5dEZT4=
-github.com/chnsz/golangsdk v0.0.0-20221012025003-ca06d8f91378/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221014072812-3b89f7691e5b h1:jRkdj7TDeSx7ppB1DAMK4VQbI1UWS9n9p4jPeCV8Jfg=
+github.com/chnsz/golangsdk v0.0.0-20221014072812-3b89f7691e5b/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/compute_instance_keypair.go
+++ b/huaweicloud/compute_instance_keypair.go
@@ -1,0 +1,143 @@
+package huaweicloud
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/kms/v3/keypairs"
+)
+
+func updateEcsInstanceKeyPair(ctx context.Context, d *schema.ResourceData, conf *config.Config) error {
+	var taskID string
+	serverID := d.Id()
+	region := GetRegion(d, conf)
+	kmsClient, err := conf.KmsV3Client(region)
+
+	if err != nil {
+		return fmt.Errorf("error creating KMS v3 client: %s", err)
+	}
+
+	authOpts, err := buildKeypairAuthOpts(d)
+	if err != nil {
+		return err
+	}
+
+	old, new := d.GetChange("key_pair")
+	oldKey := old.(string)
+	newKey := new.(string)
+
+	if newKey == "" {
+		log.Printf("[DEBUG] disassociate the keypair %s of instance %s", oldKey, serverID)
+		unbindOpts := keypairs.DisassociateOpts{
+			ServerID: serverID,
+			Auth:     authOpts,
+		}
+
+		if taskID, err = keypairs.Disassociate(kmsClient, unbindOpts); err != nil {
+			return fmt.Errorf("error disassociate the keypair %s of instance %s: %s", oldKey, serverID, err)
+		}
+	} else {
+		log.Printf("[DEBUG] associate the keypair %s with instance %s", newKey, serverID)
+		bindOpts := keypairs.AssociateOpts{
+			Name: newKey,
+			Server: keypairs.EcsServerOpts{
+				ID:   serverID,
+				Auth: authOpts,
+			},
+		}
+
+		if taskID, err = keypairs.Associate(kmsClient, bindOpts); err != nil {
+			return fmt.Errorf("error associate the keypair %s with instance %s: %s", newKey, serverID, err)
+		}
+	}
+
+	if taskID != "" {
+		return waitForKeyPairTaskState(ctx, kmsClient, taskID, d.Timeout(schema.TimeoutUpdate))
+	}
+
+	return nil
+}
+
+func buildKeypairAuthOpts(d *schema.ResourceData) (*keypairs.AuthOpts, error) {
+	if isEcsInstanceShutDown(d) {
+		log.Printf("[DEBUG] authentication is not required because the ECS instance %s was shutdown", d.Id())
+		return nil, nil
+	}
+
+	old, _ := d.GetChange("key_pair")
+	oldKey := old.(string)
+
+	// bind a new keypair
+	if oldKey == "" {
+		passwd := d.Get("admin_pass").(string)
+		if passwd == "" {
+			return nil, fmt.Errorf("the root password is required when binding a new keypair")
+		}
+
+		log.Printf("[DEBUG] the authentication type is password")
+		passwdAuth := keypairs.AuthOpts{
+			Type: "password",
+			Key:  passwd,
+		}
+		return &passwdAuth, nil
+	}
+
+	// replace or unbind an existing keypair
+	privateKey := d.Get("private_key").(string)
+	if privateKey == "" {
+		return nil, fmt.Errorf("the private key of existing keypair must be specified when replacing or unbinding")
+	}
+
+	log.Printf("[DEBUG] the authentication type is keypair")
+	keypairAuth := keypairs.AuthOpts{
+		Type: "keypair",
+		Key:  privateKey,
+	}
+	return &keypairAuth, nil
+}
+
+func isEcsInstanceShutDown(d *schema.ResourceData) bool {
+	status := d.Get("status").(string)
+	return status == "SHUTOFF"
+}
+
+func waitForKeyPairTaskState(ctx context.Context, client *golangsdk.ServiceClient, taskID string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING", "READY"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      keyPairTaskStateRefreshFunc(client, taskID),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for keypair task %s to become SUCCESS: %s", taskID, err)
+	}
+	return nil
+}
+
+func keyPairTaskStateRefreshFunc(c *golangsdk.ServiceClient, taskID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		taskInfo, err := keypairs.GetTask(c, taskID).Extract()
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		// the format of Status is xxx_mmm, e.g. SUCCESS_BIND, FAILED_UNBIND
+		status := strings.Split(taskInfo.Status, "_")[0]
+		if status == "FAILED" {
+			return taskInfo, status, fmt.Errorf("%s", taskInfo.Status)
+		}
+		return taskInfo, status, nil
+	}
+}

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -675,6 +675,10 @@ func (c *Config) KmsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("kmsv1", region)
 }
 
+func (c *Config) KmsV3Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("kmsv3", region)
+}
+
 // WafV1Client is not avaliable in HuaweiCloud, will be imported by other clouds
 func (c *Config) WafV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("waf", region)

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -29,7 +29,7 @@ var multiCatalogKeys = map[string][]string{
 	"vpc":          {"networkv2", "vpcv3", "fwv2"},
 	"elb":          {"elbv2", "elbv3"},
 	"dns":          {"dns_region"},
-	"kms":          {"kmsv1"},
+	"kms":          {"kmsv1", "kmsv3"},
 	"mrs":          {"mrsv2"},
 	"rds":          {"rdsv1"},
 	"waf":          {"waf-dedicated"},
@@ -404,6 +404,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"kmsv1": {
 		Name:    "kms",
 		Version: "v1",
+		Product: "DEW",
+	},
+	"kmsv3": {
+		Name:    "kms",
+		Version: "v3",
 		Product: "DEW",
 	},
 	"waf": {

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -340,6 +340,18 @@ func TestAccServiceEndpoints_Security(t *testing.T) {
 	}
 	t.Logf("KMS(v1) endpoint:\t %s", actualURL)
 
+	// test the endpoint of KMS service v3
+	serviceClient, err = config.KmsV3Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud KMS(v3) client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://kms.%s.%s/v3/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("KMS(v3) endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("KMS(v3) endpoint:\t %s", actualURL)
+
 	// test the endpoint of SCM service
 	serviceClient, err = config.ScmV3Client(HW_REGION_NAME)
 	if err != nil {

--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -113,7 +113,12 @@ func ResourceComputeInstanceV2() *schema.Resource {
 			"key_pair": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+			},
+			"private_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				RequiredWith: []string{"key_pair"},
 			},
 			"security_groups": {
 				Type:          schema.TypeSet,
@@ -1176,6 +1181,13 @@ func resourceComputeInstanceV2Update(ctx context.Context, d *schema.ResourceData
 		if err != nil {
 			return diag.Errorf(
 				"error waiting for huaweicloud_compute_instance system disk %s to become ready: %s", systemDiskID, err)
+		}
+	}
+
+	// update the key_pair before power action
+	if d.HasChange("key_pair") {
+		if err := updateEcsInstanceKeyPair(ctx, d, config); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v3/keypairs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v3/keypairs/requests.go
@@ -1,0 +1,83 @@
+package keypairs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// AssociateOpts is the request body of binding an SSH keypair
+type AssociateOpts struct {
+	// the SSH keypair name
+	Name string `json:"keypair_name" required:"true"`
+	// Information about the VM to which the key pair is to be bound
+	Server EcsServerOpts `json:"server" required:"true"`
+}
+
+// DisassociateOpts is the request body of unbinding an SSH keypair
+type DisassociateOpts struct {
+	// the ID of the VM to which the SSH key pair is to be unbound
+	ServerID string `json:"id" required:"true"`
+	// server authentication object, this parameter is required when the server is poweron
+	Auth *AuthOpts `json:"auth,omitempty"`
+}
+
+// EcsServerOpts is object about the VM to which the key pair is to be bound
+type EcsServerOpts struct {
+	// the ID of the VM to which the SSH key pair is to be bound
+	ID string `json:"id" required:"true"`
+	// server authentication object, this parameter is required when the server is poweron
+	Auth *AuthOpts `json:"auth,omitempty"`
+	// whether to disable SSH login on the VM
+	DisablePassword *bool `json:"disable_password,omitempty"`
+}
+
+// AuthOpts is the object about server authentication
+type AuthOpts struct {
+	// the Authentication type, the value can be password or keypair
+	Type string `json:"type,omitempty"`
+	// If type is set to password, this parameter indicates the password.
+	// If type is set to keypair, this parameter indicates the private key.
+	Key string `json:"key,omitempty"`
+}
+
+// Associate is used to bind an SSH key pair to a specified VM
+func Associate(c *golangsdk.ServiceClient, opts AssociateOpts) (string, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	var r golangsdk.Result
+	_, err = c.Post(associateURL(c), b, &r.Body, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var resp TaskResp
+	r.ExtractInto(&resp)
+	return resp.ID, nil
+}
+
+// Disassociate is used to unbind an SSH key pair to a specified VM
+func Disassociate(c *golangsdk.ServiceClient, opts DisassociateOpts) (string, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "server")
+	if err != nil {
+		return "", err
+	}
+
+	var r golangsdk.Result
+	_, err = c.Post(disassociateURL(c), b, &r.Body, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var resp TaskResp
+	r.ExtractInto(&resp)
+	return resp.ID, nil
+}
+
+// GetTask retrieves the keypair task with the provided ID. To extract the task object
+// from the response, call the Extract method on the GetResult.
+func GetTask(client *golangsdk.ServiceClient, taskID string) (r GetResult) {
+	_, r.Err = client.Get(getTaskURL(client, taskID), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v3/keypairs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v3/keypairs/results.go
@@ -1,0 +1,33 @@
+package keypairs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// TaskResp is the response body of Associate or Disassociate
+type TaskResp struct {
+	// the task ID
+	ID string `json:"task_id"`
+}
+
+// Task contains all the information about a keypair task
+type Task struct {
+	// the task ID
+	ID string `json:"task_id"`
+	// the ECS instance ID
+	ServerID string `json:"server_id"`
+	// the keypair processing state
+	Status string `json:"task_status"`
+}
+
+// GetResult contains the response body and error from a GetTask request.
+type GetResult struct {
+	golangsdk.Result
+}
+
+// Extract the Task from result
+func (r GetResult) Extract() (Task, error) {
+	var s Task
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v3/keypairs/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v3/keypairs/urls.go
@@ -1,0 +1,21 @@
+package keypairs
+
+import "github.com/chnsz/golangsdk"
+
+const (
+	resourcePath = "keypairs"
+)
+
+// associateURL /v3/{project_id}/keypairs/associate
+func associateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(resourcePath, "associate")
+}
+
+// disassociateURL /v3/{project_id}/keypairs/disassociate
+func disassociateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(resourcePath, "disassociate")
+}
+
+func getTaskURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("tasks", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20221012025003-ca06d8f91378
+# github.com/chnsz/golangsdk v0.0.0-20221014072812-3b89f7691e5b
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -196,6 +196,7 @@ github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages
 github.com/chnsz/golangsdk/openstack/ims/v2/tags
 github.com/chnsz/golangsdk/openstack/kms/v1/keys
 github.com/chnsz/golangsdk/openstack/kms/v1/rotation
+github.com/chnsz/golangsdk/openstack/kms/v3/keypairs
 github.com/chnsz/golangsdk/openstack/lts/huawei/loggroups
 github.com/chnsz/golangsdk/openstack/lts/huawei/logstreams
 github.com/chnsz/golangsdk/openstack/maas/v1/task


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

calling APIs in [kms/v3/keypairs](https://github.com/chnsz/golangsdk/tree/master/openstack/kms/v3/keypairs) can update keypair without rebuilding the instance.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (189.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       189.192s

$ make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccServiceEndpoints_Security'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccServiceEndpoints_Security -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_Security
    endpoints_test.go:317: anti-ddos endpoint:   https://antiddos.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/
    endpoints_test.go:329: KMS(v1.0) endpoint:   https://kms.cn-north-4.myhuaweicloud.com/v1.0/
    endpoints_test.go:341: KMS(v1) endpoint:     https://kms.cn-north-4.myhuaweicloud.com/v1/xxxx/
    endpoints_test.go:353: KMS(v3) endpoint:     https://kms.cn-north-4.myhuaweicloud.com/v3/xxxx/
    endpoints_test.go:365: SCM endpoint:         https://scm.cn-north-4.myhuaweicloud.com/v3/
    endpoints_test.go:377: WAF endpoint:         https://waf.cn-north-4.myhuaweicloud.com/v1/xxxx/waf/
    endpoints_test.go:389: WAF dedicated endpoint:       https://waf.cn-north-4.myhuaweicloud.com/v1/xxxx/premium-waf/
--- PASS: TestAccServiceEndpoints_Security (0.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.699s
```
