### PR TITLE
fix(gaussdb/proxy): unset all parameters because no response

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy_test.go
@@ -49,6 +49,11 @@ func TestAccGaussDBProxy_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"instance_id",
+					"flavor",
+					"node_num",
+				},
 			},
 		},
 	})

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -89,24 +88,7 @@ func resourceGaussDBProxyCreate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourceGaussDBProxyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.GaussdbV3Client(config.GetRegion(d))
-	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud GaussDB client: %s ", err)
-	}
-
-	proxy, err := instances.GetProxy(client, d.Id()).Extract()
-	if err != nil {
-		return fmtp.DiagErrorf("Error fetchting gaussdb_mysql_proxy: %s", err)
-	}
-	mErr := multierror.Append(nil,
-		d.Set("instance_id", d.Id()),
-		d.Set("flavor", proxy.Flavor),
-		d.Set("node_num", proxy.NodeNum),
-		d.Set("address", proxy.Address),
-		d.Set("port", proxy.Port),
-	)
-	return diag.FromErr(mErr.ErrorOrNil())
+	return nil
 }
 
 func resourceGaussDBProxyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
unset all parameters of mysql proxy resource because there is no response in the query API.

```
API Response Body: {
  "master_node": {
    "available_zones": [
      {
        "code": "cn-north-4a",
        "description": "cn-north-4a"
      }
    ],
    "id": "ac4d5354f5174158b5579a92164b84a0no07",
    "instance_id": "c3ebf34a219940c988c4b2692f4ddc62in07",
    "name": "tf-acc-test-m4rwx_node01",
    "status": "ACTIVE",
    "weight": null
  },
  "proxy": {
    "address": null,
    "delay_threshold_in_seconds": null,
    "eip": null,
    "elb_vip": null,
    "flavor_ref": null,
    "mode": null,
    "name": "",
    "node_num": null,
    "nodes": [],
    "pool_id": null,
    "pool_status": null,
    "port": null,
    "ram": null,
    "status": "closed",
    "transaction_split": null,
    "vcpus": null
  },
  "readonly_nodes": [
    {
      "available_zones": [
        {
          "code": "cn-north-4a",
          "description": "cn-north-4a"
        }
      ],
      "id": "9fd05749910546e4b433d799a4819e81no07",
      "instance_id": "c3ebf34a219940c988c4b2692f4ddc62in07",
      "name": "tf-acc-test-m4rwx_node02",
      "status": "ACTIVE",
      "weight": null
    }
  ]
}
```
It‘s a temporary solution. In the future, we will replace it with a [new API](https://support.huaweicloud.com/api-gaussdb/ShowGaussMySqlProxyList.html).
We are waiting for the API creation response to return the unique ID of MySQL proxy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. unset all parameters because no response.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb' TESTARGS='-run=TestAccGaussDBProxy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run=TestAccGaussDBProxy_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBProxy_basic
=== PAUSE TestAccGaussDBProxy_basic
=== CONT  TestAccGaussDBProxy_basic
--- PASS: TestAccGaussDBProxy_basic (1497.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1497.151s
```
