### PR TITLE
fix(dms/rabbitmq): fix crash when creating Rabbitmq instance

### DIFF
--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_instances_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_instances_test.go
@@ -17,7 +17,7 @@ func TestAccKafkaInstancesDataSource_basic(t *testing.T) {
 	dc3 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_3")
 	dc4 := acceptance.InitDataSourceCheck("data.huaweicloud_dms_kafka_instances.query_4")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -47,6 +47,7 @@ func TestAccKafkaInstancesDataSource_basic(t *testing.T) {
 
 func testAccKafkaInstancesDataSource_basic() string {
 	rName := acceptance.RandomAccResourceNameWithDash()
+	fuzzyName := rName[0 : len(rName)-1]
 
 	return fmt.Sprintf(`
 %s
@@ -56,11 +57,15 @@ data "huaweicloud_dms_kafka_instances" "query_0" {
     huaweicloud_dms_kafka_instance.test,
   ]
 
-  name        = "tf-acc-test"
+  name        = "%s"
   fuzzy_match = true
 }
 
 data "huaweicloud_dms_kafka_instances" "query_1" {
+  depends_on = [
+    huaweicloud_dms_kafka_instance.test,
+  ]
+  
   name = huaweicloud_dms_kafka_instance.test.name
 }
 
@@ -69,6 +74,10 @@ data "huaweicloud_dms_kafka_instances" "query_2" {
 }
 
 data "huaweicloud_dms_kafka_instances" "query_3" {
+  depends_on = [
+    huaweicloud_dms_kafka_instance.test,
+  ]
+  
   enterprise_project_id = huaweicloud_dms_kafka_instance.test.enterprise_project_id
 }
 
@@ -79,5 +88,5 @@ data "huaweicloud_dms_kafka_instances" "query_4" {
 
   status = "RUNNING"
 }
-`, testAccKafkaInstance_basic(rName))
+`, testAccKafkaInstance_basic(rName), fuzzyName)
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -33,7 +33,8 @@ func TestAccKafkaInstance_basic(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	// DMS instances use the tenant-level shared lock, the instances cannot be created or modified in parallel.
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -84,7 +85,7 @@ func TestAccKafkaInstance_withEpsId(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -114,7 +115,7 @@ func TestAccKafkaInstance_compatible(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -144,7 +145,7 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix crash when creating Rabbitmq instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2445

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsRabbitmq'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRabbitmq -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
--- PASS: TestAccDmsRabbitmqInstances_basic (1017.36s)
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (683.31s)
=== RUN   TestAccDmsRabbitmqInstances_compatible
--- PASS: TestAccDmsRabbitmqInstances_compatible (693.20s)
=== RUN   TestAccDmsRabbitmqInstances_single
--- PASS: TestAccDmsRabbitmqInstances_single (657.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3051.784s
```
