### PR TITLE
fix(workflows): set up go 1.18+ before running acceptance test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ">=1.18"
+    - run: go version
 
     - name: Build
       run: make build FLAGS='-mod=readonly'

--- a/.github/workflows/cron-ci.yml
+++ b/.github/workflows/cron-ci.yml
@@ -73,6 +73,10 @@ jobs:
           ref: master
           fetch-depth: 100
 
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.18"
+
       # run acceptance test
       - name: Run acceptance basic test
         # run the step only when HW_ACCESS_KEY is setted

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -165,6 +165,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.18"
+
       # run acceptance test
       - name: Run acceptance basic test
         # run the step only when HW_ACCESS_KEY is setted


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

the Continuous Integration action runned **failed**
https://github.com/huaweicloud/terraform-provider-huaweicloud/actions/runs/3307410651

go 1.18+ should be setup before running acceptance test

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
