### PR TITLE
refactor(cce): move cce resources to services path

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -363,12 +363,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_flavors": bms.DataSourceBmsFlavors(),
 			"huaweicloud_cbr_vaults":  cbr.DataSourceCbrVaultsV3(),
 
-			"huaweicloud_cce_addon_template": DataSourceCCEAddonTemplateV3(),
-			"huaweicloud_cce_cluster":        DataSourceCCEClusterV3(),
+			"huaweicloud_cce_addon_template": cce.DataSourceCCEAddonTemplateV3(),
+			"huaweicloud_cce_cluster":        cce.DataSourceCCEClusterV3(),
 			"huaweicloud_cce_clusters":       cce.DataSourceCCEClusters(),
-			"huaweicloud_cce_node":           DataSourceCCENodeV3(),
+			"huaweicloud_cce_node":           cce.DataSourceCCENodeV3(),
 			"huaweicloud_cce_nodes":          cce.DataSourceCCENodes(),
-			"huaweicloud_cce_node_pool":      DataSourceCCENodePoolV3(),
+			"huaweicloud_cce_node_pool":      cce.DataSourceCCENodePoolV3(),
 			"huaweicloud_cci_namespaces":     cci.DataSourceCciNamespaces(),
 
 			"huaweicloud_cdm_flavors": DataSourceCdmFlavorV1(),
@@ -516,8 +516,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnet_v1":             vpc.DataSourceVpcSubnetV1(),
 			"huaweicloud_vpc_subnet_ids_v1":         vpc.DataSourceVpcSubnetIdsV1(),
 
-			"huaweicloud_cce_cluster_v3": DataSourceCCEClusterV3(),
-			"huaweicloud_cce_node_v3":    DataSourceCCENodeV3(),
+			"huaweicloud_cce_cluster_v3": cce.DataSourceCCEClusterV3(),
+			"huaweicloud_cce_node_v3":    cce.DataSourceCCENodeV3(),
 
 			"huaweicloud_csbs_backup_v1":        dataSourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy_v1": dataSourceCSBSBackupPolicyV1(),
@@ -593,11 +593,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cc_connection":       cc.ResourceCloudConnection(),
 			"huaweicloud_cc_network_instance": cc.ResourceNetworkInstance(),
 
-			"huaweicloud_cce_cluster":     ResourceCCEClusterV3(),
-			"huaweicloud_cce_node":        ResourceCCENodeV3(),
-			"huaweicloud_cce_node_attach": ResourceCCENodeAttachV3(),
-			"huaweicloud_cce_addon":       ResourceCCEAddonV3(),
-			"huaweicloud_cce_node_pool":   ResourceCCENodePool(),
+			"huaweicloud_cce_cluster":     cce.ResourceCCEClusterV3(),
+			"huaweicloud_cce_node":        cce.ResourceCCENodeV3(),
+			"huaweicloud_cce_node_attach": cce.ResourceCCENodeAttachV3(),
+			"huaweicloud_cce_addon":       cce.ResourceCCEAddonV3(),
+			"huaweicloud_cce_node_pool":   cce.ResourceCCENodePool(),
 			"huaweicloud_cce_namespace":   cce.ResourceCCENamespaceV1(),
 			"huaweicloud_cce_pvc":         cce.ResourceCcePersistentVolumeClaimsV1(),
 
@@ -941,8 +941,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_v1":                             vpc.ResourceVirtualPrivateCloudV1(),
 			"huaweicloud_vpc_subnet_v1":                      vpc.ResourceVpcSubnetV1(),
 
-			"huaweicloud_cce_cluster_v3": ResourceCCEClusterV3(),
-			"huaweicloud_cce_node_v3":    ResourceCCENodeV3(),
+			"huaweicloud_cce_cluster_v3": cce.ResourceCCEClusterV3(),
+			"huaweicloud_cce_node_v3":    cce.ResourceCCENodeV3(),
 
 			"huaweicloud_as_configuration_v1": as.ResourceASConfiguration(),
 			"huaweicloud_as_group_v1":         as.ResourceASGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -82,6 +82,8 @@ var (
 	HW_AAD_IP_ADDRESS  = os.Getenv("HW_AAD_IP_ADDRESS")
 
 	HW_FGS_TRIGGER_LTS_AGENCY = os.Getenv("HW_FGS_TRIGGER_LTS_AGENCY")
+
+	HW_KMS_ENVIRONMENT = os.Getenv("HW_KMS_ENVIRONMENT")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -384,5 +386,19 @@ func TestAccPreCheckAadForwardRule(t *testing.T) {
 func TestAccPreCheckScmCertificateName(t *testing.T) {
 	if HW_CERTIFICATE_NAME == "" {
 		t.Skip("HW_CERTIFICATE_NAME must be set for SCM acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKms(t *testing.T) {
+	if HW_KMS_ENVIRONMENT == "" {
+		t.Skip("This environment does not support KMS tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckProjectID(t *testing.T) {
+	if HW_PROJECT_ID == "" {
+		t.Skip("HW_PROJECT_ID must be set for acceptance tests")
 	}
 }

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_addon_template_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_addon_template_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
@@ -6,14 +6,15 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEAddonTemplateV3DataSource_basic(rName),

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_cluster_v3_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -16,8 +17,8 @@ func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3DataSource_basic(rName),

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_clusters_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_clusters_test.go
@@ -19,7 +19,7 @@ func TestAccCCEClustersDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCEClusterV3DataSource_basic(rName),
+				Config: testAccCCEClustersDataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "clusters.0.name", rName),
@@ -31,7 +31,7 @@ func TestAccCCEClustersDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCCEClusterV3DataSource_basic(rName string) string {
+func testAccCCEClustersDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_v3_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -16,8 +17,8 @@ func TestAccCCENodePoolV3DataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_cce_node_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePoolV3DataSource_basic(rName),

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_v3_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -16,8 +17,8 @@ func TestAccCCENodeV3DataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_cce_node.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3DataSource_basic(rName),

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_v3_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -22,9 +23,9 @@ func TestAccCCEAddonV3_basic(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEAddonV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEAddonV3_basic(rName),
@@ -52,11 +53,11 @@ func TestAccCCEAddonV3_values(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckProjectID(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEAddonV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEAddonV3_values(rName),
@@ -70,8 +71,8 @@ func TestAccCCEAddonV3_values(t *testing.T) {
 }
 
 func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceAddonV3Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceAddonV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCE Addon client: %s", err)
 	}
@@ -115,8 +116,8 @@ func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon)
 			return fmtp.Errorf("Cluster id is not set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceAddonV3Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceAddonV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud CCE Addon client: %s", err)
 		}
@@ -243,5 +244,5 @@ resource "huaweicloud_cce_addon" "test" {
   
   depends_on = [huaweicloud_cce_node_pool.test]
 }
-`, testAccCCENodePool_Base(rName), rName, HW_PROJECT_ID)
+`, testAccCCENodePool_Base(rName), rName, acceptance.HW_PROJECT_ID)
 }

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_v3_test.go
@@ -162,7 +162,7 @@ func testAccCCEAddonV3_Base(rName string) string {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%s"
-  flavor_id         = "s6.large.2"
+  flavor_id         = "c7.large.4"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_compute_keypair.test.name
 
@@ -184,7 +184,7 @@ func testAccCCEAddonV3_basic(rName string) string {
 
 resource "huaweicloud_cce_addon" "test" {
   cluster_id    = huaweicloud_cce_cluster.test.id
-  version       = "1.1.10"
+  version       = "1.2.1"
   template_name = "metrics-server"
   depends_on    = [huaweicloud_cce_node.test]
 }
@@ -199,7 +199,7 @@ resource "huaweicloud_cce_node_pool" "test" {
   cluster_id         = huaweicloud_cce_cluster.test.id
   name               = "%s"
   os                 = "EulerOS 2.5"
-  flavor_id          = "s6.large.2"
+  flavor_id          = "c7.large.4"
   initial_node_count = 4
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   key_pair           = huaweicloud_compute_keypair.test.name

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_v3_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -21,9 +22,9 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_basic(rName),
@@ -60,9 +61,9 @@ func TestAccCCEClusterV3_prePaid(t *testing.T) {
 	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_prePaid(rName),
@@ -85,9 +86,9 @@ func TestAccCCEClusterV3_withEip(t *testing.T) {
 	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_withEip(rName),
@@ -122,15 +123,15 @@ func TestAccCCEClusterV3_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_withEpsId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -144,9 +145,9 @@ func TestAccCCEClusterV3_turbo(t *testing.T) {
 	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_turbo(rName),
@@ -166,9 +167,9 @@ func TestAccCCEClusterV3_HibernateAndAwake(t *testing.T) {
 	resourceName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCEClusterV3_basic(rName),
@@ -199,8 +200,8 @@ func TestAccCCEClusterV3_HibernateAndAwake(t *testing.T) {
 }
 
 func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
@@ -230,8 +231,8 @@ func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resour
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 		}
@@ -419,7 +420,7 @@ resource "huaweicloud_cce_cluster" "test" {
   enterprise_project_id  = "%s"
 }
 
-`, testAccCCEClusterV3_Base(rName), rName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccCCEClusterV3_Base(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccCCEClusterV3_turbo(rName string) string {

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_attach_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_attach_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccCCENodeAttachV3_basic(t *testing.T) {
@@ -19,9 +20,9 @@ func TestAccCCENodeAttachV3_basic(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeAttachV3_basic(rName),

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -24,9 +25,9 @@ func TestAccCCENodePool_basic(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePool_basic(rName),
@@ -80,9 +81,9 @@ func TestAccCCENodePool_tagsLabelsTaints(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePool_tagsLabelsTaints(rName),
@@ -129,11 +130,11 @@ func TestAccCCENodePool_data_volume_encryption(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckKms(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKms(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodePoolDestroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodePool_data_volume_encryption(rName),
@@ -148,8 +149,8 @@ func TestAccCCENodePool_data_volume_encryption(t *testing.T) {
 }
 
 func testAccCheckCCENodePoolDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
@@ -214,8 +215,8 @@ func testAccCheckCCENodePoolExists(n string, cluster string, nodePool *nodepools
 			return fmtp.Errorf("Cluster id is not set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 		}

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_v3_test.go
@@ -1,10 +1,11 @@
-package huaweicloud
+package cce
 
 import (
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -25,9 +26,9 @@ func TestAccCCENodeV3_basic(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_basic(rName),
@@ -64,9 +65,9 @@ func TestAccCCENodeV3_auto_assign_eip(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_auto_assign_eip(rName),
@@ -90,9 +91,9 @@ func TestAccCCENodeV3_existing_eip(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_existing_eip(rName),
@@ -116,9 +117,9 @@ func TestAccCCENodeV3_volume_extendParams(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_volume_extendParams(rName),
@@ -143,11 +144,11 @@ func TestAccCCENodeV3_data_volume_encryption(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckKms(t)
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKms(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_data_volume_encryption(rName),
@@ -170,9 +171,9 @@ func TestAccCCENodeV3_prePaid(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_prePaid(rName),
@@ -197,9 +198,9 @@ func TestAccCCENodeV3_password(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_password(rName),
@@ -221,9 +222,9 @@ func TestAccCCENodeV3_storage(t *testing.T) {
 	clusterName := "huaweicloud_cce_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3_storage(rName),
@@ -237,8 +238,8 @@ func TestAccCCENodeV3_storage(t *testing.T) {
 }
 
 func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceV3Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
@@ -281,8 +282,8 @@ func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) re
 			return fmtp.Errorf("Cluster id is not set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceV3Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud CCE client: %s", err)
 		}

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_addon_template.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_addon_template.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
@@ -89,7 +89,7 @@ func DataSourceCCEAddonTemplateV3() *schema.Resource {
 
 func dataSourceCCEAddonTemplateV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	region := GetRegion(d, config)
+	region := config.GetRegion(d)
 	client, err := config.CceAddonV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client : %s", err)

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
@@ -183,7 +183,7 @@ func DataSourceCCEClusterV3() *schema.Resource {
 
 func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	cceClient, err := config.CceV3Client(GetRegion(d, config))
+	cceClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Unable to create HuaweiCloud CCE client : %s", err)
 	}
@@ -218,7 +218,7 @@ func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta 
 
 	d.SetId(Cluster.Metadata.Id)
 	mErr := multierror.Append(nil,
-		d.Set("region", GetRegion(d, config)),
+		d.Set("region", config.GetRegion(d)),
 		d.Set("name", Cluster.Metadata.Name),
 		d.Set("status", Cluster.Status.Phase),
 		d.Set("flavor_id", Cluster.Spec.Flavor),

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pool_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pool_v3.go
@@ -1,9 +1,10 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
 	"strings"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
@@ -126,7 +127,7 @@ func DataSourceCCENodePoolV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tagsSchema(),
+			"tags": common.TagsSchema(),
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -157,7 +158,7 @@ func DataSourceCCENodePoolV3() *schema.Resource {
 
 func dataSourceCceNodePoolsV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	cceClient, err := config.CceV3Client(GetRegion(d, config))
+	cceClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("unable to create HuaweiCloud CCE client : %s", err)
 	}
@@ -188,7 +189,7 @@ func dataSourceCceNodePoolsV3Read(_ context.Context, d *schema.ResourceData, met
 
 	d.SetId(NodePool.Metadata.Id)
 	mErr := multierror.Append(nil,
-		d.Set("region", GetRegion(d, config)),
+		d.Set("region", config.GetRegion(d)),
 		d.Set("node_pool_id", NodePool.Metadata.Id),
 		d.Set("name", NodePool.Metadata.Name),
 		d.Set("type", NodePool.Spec.Type),

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_node_v3.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
@@ -135,7 +135,7 @@ func DataSourceCCENodeV3() *schema.Resource {
 
 func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	cceClient, err := config.CceV3Client(GetRegion(d, config))
+	cceClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Unable to create HuaweiCloud CCE client : %s", err)
 	}
@@ -193,7 +193,7 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 		d.Set("public_ip", Node.Status.PublicIP),
 		d.Set("private_ip", Node.Status.PrivateIP),
 		d.Set("status", Node.Status.Phase),
-		d.Set("region", GetRegion(d, config)),
+		d.Set("region", config.GetRegion(d)),
 	)
 
 	var volumes []map[string]interface{}
@@ -216,7 +216,7 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 	mErr = multierror.Append(mErr, d.Set("root_volume", rootVolume))
 
 	// fetch tags from ECS instance
-	computeClient, err := config.ComputeV1Client(GetRegion(d, config))
+	computeClient, err := config.ComputeV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
 	}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_addon_v3.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_addon_v3.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
@@ -180,7 +180,7 @@ func getValuesValues(d *schema.ResourceData) (basic, custom, flavor map[string]i
 
 func resourceCCEAddonV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	cceClient, err := config.CceAddonV3Client(GetRegion(d, config))
+	cceClient, err := config.CceAddonV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Unable to create HuaweiCloud CCE client : %s", err)
 	}
@@ -239,7 +239,7 @@ func resourceCCEAddonV3Create(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceCCEAddonV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	cceClient, err := config.CceAddonV3Client(GetRegion(d, config))
+	cceClient, err := config.CceAddonV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
@@ -268,7 +268,7 @@ func resourceCCEAddonV3Read(_ context.Context, d *schema.ResourceData, meta inte
 
 func resourceCCEAddonV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	cceClient, err := config.CceAddonV3Client(GetRegion(d, config))
+	cceClient, err := config.CceAddonV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCEAddon Client: %s", err)
 	}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -137,7 +138,7 @@ func ResourceCCENodeAttachV3() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			//(node/ecs_tags)
-			"tags": tagsSchema(),
+			"tags": common.TagsSchema(),
 
 			"flavor_id": {
 				Type:     schema.TypeString,
@@ -236,7 +237,7 @@ func ResourceCCENodeAttachV3() *schema.Resource {
 }
 
 func resourceCCENodeAttachV3ServerConfig(d *schema.ResourceData) *nodes.ServerConfig {
-	if hasFilledOpt(d, "tags") || hasFilledOpt(d, "image_id") {
+	if common.HasFilledOpt(d, "tags") || common.HasFilledOpt(d, "image_id") {
 		serverConfig := nodes.ServerConfig{
 			UserTags: resourceCCENodeTags(d),
 		}
@@ -273,8 +274,8 @@ func resourceCCENodeAttachV3RuntimeConfig(d *schema.ResourceData) *nodes.Runtime
 }
 
 func resourceCCENodeAttachV3K8sOptions(d *schema.ResourceData) *nodes.K8sOptions {
-	if hasFilledOpt(d, "labels") || hasFilledOpt(d, "taints") || hasFilledOpt(d, "max_pods") ||
-		hasFilledOpt(d, "nic_multi_queue") || hasFilledOpt(d, "nic_threshold") {
+	if common.HasFilledOpt(d, "labels") || common.HasFilledOpt(d, "taints") || common.HasFilledOpt(d, "max_pods") ||
+		common.HasFilledOpt(d, "nic_multi_queue") || common.HasFilledOpt(d, "nic_threshold") {
 		k8sOptions := nodes.K8sOptions{
 			Labels:        resourceCCENodeK8sTags(d),
 			Taints:        resourceCCETaint(d),
@@ -289,7 +290,7 @@ func resourceCCENodeAttachV3K8sOptions(d *schema.ResourceData) *nodes.K8sOptions
 }
 
 func resourceCCENodeAttachV3Lifecycle(d *schema.ResourceData) *nodes.Lifecycle {
-	if hasFilledOpt(d, "preinstall") || hasFilledOpt(d, "postinstall") {
+	if common.HasFilledOpt(d, "preinstall") || common.HasFilledOpt(d, "postinstall") {
 		lifecycle := nodes.Lifecycle{
 			Preinstall:  d.Get("preinstall").(string),
 			PostInstall: d.Get("postinstall").(string),
@@ -301,7 +302,7 @@ func resourceCCENodeAttachV3Lifecycle(d *schema.ResourceData) *nodes.Lifecycle {
 
 func resourceCCENodeAttachV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodeClient, err := config.CceV3Client(GetRegion(d, config))
+	nodeClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE Node client: %s", err)
 	}
@@ -343,7 +344,7 @@ func resourceCCENodeAttachV3Create(ctx context.Context, d *schema.ResourceData, 
 	logp.Printf("[DEBUG] Add node Options: %#v", addOpts)
 	// Add loginSpec here so it wouldn't go in the above log entry
 	var loginSpec nodes.LoginSpec
-	if hasFilledOpt(d, "key_pair") {
+	if common.HasFilledOpt(d, "key_pair") {
 		loginSpec = nodes.LoginSpec{
 			SshKey: d.Get("key_pair").(string),
 		}
@@ -392,7 +393,7 @@ func resourceCCENodeAttachV3Create(ctx context.Context, d *schema.ResourceData, 
 func resourceCCENodeAttachV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	if d.HasChanges("os", "key_pair", "password") {
-		nodeClient, err := config.CceV3Client(GetRegion(d, config))
+		nodeClient, err := config.CceV3Client(config.GetRegion(d))
 		if err != nil {
 			return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
 		}
@@ -420,7 +421,7 @@ func resourceCCENodeAttachV3Update(ctx context.Context, d *schema.ResourceData, 
 		logp.Printf("[DEBUG] Reset node Options: %#v", resetOpts)
 		// Add loginSpec here so it wouldn't go in the above log entry
 		var loginSpec nodes.LoginSpec
-		if hasFilledOpt(d, "key_pair") {
+		if common.HasFilledOpt(d, "key_pair") {
 			loginSpec = nodes.LoginSpec{
 				SshKey: d.Get("key_pair").(string),
 			}
@@ -472,7 +473,7 @@ func resourceCCENodeAttachV3Update(ctx context.Context, d *schema.ResourceData, 
 
 func resourceCCENodeAttachV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodeClient, err := config.CceV3Client(GetRegion(d, config))
+	nodeClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
@@ -482,7 +483,7 @@ func resourceCCENodeAttachV3Delete(ctx context.Context, d *schema.ResourceData, 
 	var removeOpts nodes.RemoveOpts
 	var loginSpec nodes.LoginSpec
 
-	if hasFilledOpt(d, "key_pair") {
+	if common.HasFilledOpt(d, "key_pair") {
 		loginSpec = nodes.LoginSpec{
 			SshKey: d.Get("key_pair").(string),
 		}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package cce
 
 import (
 	"context"
@@ -194,7 +194,7 @@ func ResourceCCENodePool() *schema.Resource {
 						},
 					}},
 			},
-			"tags": tagsSchema(),
+			"tags": common.TagsSchema(),
 			"billing_mode": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -277,7 +277,7 @@ func resourceCCENodePoolTags(d *schema.ResourceData) []tags.ResourceTag {
 
 func resourceCCENodePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodePoolClient, err := config.CceV3Client(GetRegion(d, config))
+	nodePoolClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE Node Pool client: %s", err)
 	}
@@ -343,11 +343,11 @@ func resourceCCENodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
 	// Add loginSpec here so it wouldn't go in the above log entry
 	var loginSpec nodes.LoginSpec
-	if hasFilledOpt(d, "key_pair") {
+	if common.HasFilledOpt(d, "key_pair") {
 		loginSpec = nodes.LoginSpec{
 			SshKey: d.Get("key_pair").(string),
 		}
-	} else if hasFilledOpt(d, "password") {
+	} else if common.HasFilledOpt(d, "password") {
 		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
 		if err != nil {
 			return diag.FromErr(err)
@@ -391,7 +391,7 @@ func resourceCCENodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceCCENodePoolRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodePoolClient, err := config.CceV3Client(GetRegion(d, config))
+	nodePoolClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE Node Pool client: %s", err)
 	}
@@ -498,16 +498,16 @@ func resourceCCENodePoolRead(_ context.Context, d *schema.ResourceData, meta int
 
 func resourceCCENodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodePoolClient, err := config.CceV3Client(GetRegion(d, config))
+	nodePoolClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
 	}
 
 	initialNodeCount := d.Get("initial_node_count").(int)
 	var loginSpec nodes.LoginSpec
-	if hasFilledOpt(d, "key_pair") {
+	if common.HasFilledOpt(d, "key_pair") {
 		loginSpec = nodes.LoginSpec{SshKey: d.Get("key_pair").(string)}
-	} else if hasFilledOpt(d, "password") {
+	} else if common.HasFilledOpt(d, "password") {
 		password, err := utils.TryPasswordEncrypt(d.Get("password").(string))
 		if err != nil {
 			return diag.FromErr(err)
@@ -574,7 +574,7 @@ func resourceCCENodePoolUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceCCENodePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodePoolClient, err := config.CceV3Client(GetRegion(d, config))
+	nodePoolClient, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. move cce resources to services path
2. cce node pool, convert values of extend_param to string before setting to avoid error
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEAddonTemplateV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEAddonTemplateV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEAddonTemplateV3DataSource_basic
=== PAUSE TestAccCCEAddonTemplateV3DataSource_basic
=== CONT  TestAccCCEAddonTemplateV3DataSource_basic
--- PASS: TestAccCCEAddonTemplateV3DataSource_basic (519.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       519.341s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEClusterV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEClusterV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== CONT  TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (536.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       536.210s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEClustersDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEClustersDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClustersDataSource_basic
=== PAUSE TestAccCCEClustersDataSource_basic
=== CONT  TestAccCCEClustersDataSource_basic
--- PASS: TestAccCCEClustersDataSource_basic (854.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       854.992s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePoolV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePoolV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (849.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       849.370s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodeV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodeV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3DataSource_basic
=== PAUSE TestAccCCENodeV3DataSource_basic
=== CONT  TestAccCCENodeV3DataSource_basic
--- PASS: TestAccCCENodeV3DataSource_basic (911.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       911.763s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodesDataSource_basic
=== PAUSE TestAccCCENodesDataSource_basic
=== CONT  TestAccCCENodesDataSource_basic
--- PASS: TestAccCCENodesDataSource_basic (872.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       873.025s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEClusterV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (543.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       543.615s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENamespaceV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENamespaceV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENamespaceV1_basic
=== PAUSE TestAccCCENamespaceV1_basic
=== CONT  TestAccCCENamespaceV1_basic
--- PASS: TestAccCCENamespaceV1_basic (857.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       857.742s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodeAttachV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodeAttachV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeAttachV3_basic
=== PAUSE TestAccCCENodeAttachV3_basic
=== CONT  TestAccCCENodeAttachV3_basic
--- PASS: TestAccCCENodeAttachV3_basic (1226.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1226.762s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1395.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1395.943s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (896.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       896.339s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCcePersistentVolumeClaimsV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCcePersistentVolumeClaimsV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCcePersistentVolumeClaimsV1_basic
=== PAUSE TestAccCcePersistentVolumeClaimsV1_basic
=== CONT  TestAccCcePersistentVolumeClaimsV1_basic
--- PASS: TestAccCcePersistentVolumeClaimsV1_basic (873.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       873.864s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEAddonV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEAddonV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEAddonV3_basic
=== PAUSE TestAccCCEAddonV3_basic
=== CONT  TestAccCCEAddonV3_basic
--- PASS: TestAccCCEAddonV3_basic (917.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       917.366s
```
