### PR TITLE
feat(servicestage/component): add new repository parameters

### DIFF
--- a/docs/resources/servicestage_component.md
+++ b/docs/resources/servicestage_component.md
@@ -15,7 +15,9 @@ variable "application_id"
 variable "component_name"
 variable "token_auth_name"
 variable "repo_url"
-variable "domain_name"
+variable "repo_ref"
+variable "repo_namespace"
+variable "organization_name"
 variable "cluster_id"
 
 resource "huaweicloud_servicestage_component" "test" {
@@ -26,13 +28,15 @@ resource "huaweicloud_servicestage_component" "test" {
   framework      = "Web"
 
   source {
-    type          = "GitHub"
-    authorization = var.token_auth_name
-    url           = var.repo_url
+    type           = "GitHub"
+    authorization  = var.token_auth_name
+    url            = var.repo_url
+    repo_ref       = var.repo_ref
+    repo_namespace = var.repo_namespace
   }
 
   builder {
-    organization = var.domain_name
+    organization = var.organization_name
     cluster_id   = var.cluster_id
 
     node_label = {
@@ -108,13 +112,19 @@ The `source` block supports:
 * `authorization` - (Optional, String) Specifies the authorization name.
   This parameter and `storage_type` are alternative.
 
+* `repo_ref` - (Optional, String) Specifies the name of the branch of the code repository.
+  The default value is `master`.
+
+* `repo_namespace` - (Optional, String) Specifies the namespace name.
+
 * `storage_type` - (Optional, String) Specifies the storage type, such as **obs**, **swr**.
+  This parameter is conflict with `repo_ref` and `repo_namespace`.
 
 <a name="servicestage_component_builder"></a>
 The `builder` block supports:
 
 * `organization` - (Required, String) Specifies the organization name.
-  The organization is usually **domain name**.
+  The organization is usually **domain name**. You can find out in the organization management of SWR.
 
 * `cluster_id` - (Required, String) Specifies the cluster ID.
 

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_component_test.go
@@ -294,6 +294,7 @@ resource "huaweicloud_servicestage_component" "test" {
     type          = "GitHub"
     authorization = huaweicloud_servicestage_repo_token_authorization.test.name
     url           = "%[3]s"
+    repo_ref      = "master"
   }
 
   builder {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new repository parameters as follows:
- **repo_ref**
- **repo_namespace**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support "repo_ref" and "repo_namespace" parameters.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccComponent_web'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccComponent_web -timeout 360m -parallel 4
=== RUN   TestAccComponent_web
=== PAUSE TestAccComponent_web
=== CONT  TestAccComponent_web
--- PASS: TestAccComponent_web (873.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      873.082s
```
