### PR TITLE
fix(css/cluster): add the charging_mode parameter

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -145,6 +145,10 @@ The following arguments are supported:
   This parameter is valid only when security_mode is set to true.
   The [kibana_public_access](#Css_kibana_public_access) structure is documented below.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.
+  Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
+  Changing this parameter will create a new resource.
+
 * `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the instance.
   Valid values are *month* and *year*.
   Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
@@ -182,10 +182,10 @@ resource "huaweicloud_css_cluster" "test" {
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
 
-
-  period_unit = "month"
-  period      = %d
-  auto_renew  = "true"
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = %d
+  auto_renew    = "true"
 
   ess_node_config {
     flavor          = "ess.spec-4u8g"

--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
@@ -290,9 +290,10 @@ func ResourceCssCluster() *schema.Resource {
 				Computed: true,
 			},
 
-			"period_unit": common.SchemaPeriodUnit(nil),
-			"period":      common.SchemaPeriod(nil),
-			"auto_renew":  common.SchemaAutoRenew(nil),
+			"charging_mode": common.SchemaChargingMode(nil),
+			"period_unit":   common.SchemaPeriodUnit(nil),
+			"period":        common.SchemaPeriod(nil),
+			"auto_renew":    common.SchemaAutoRenew(nil),
 
 			"expect_node_num": {
 				Type:       schema.TypeInt,
@@ -649,7 +650,7 @@ func buildClusterCreateParameters(d *schema.ResourceData, config *config.Config)
 		}
 	}
 
-	if payModel, ok := d.GetOk("period_unit"); ok {
+	if payModel, ok := d.GetOk("period_unit"); ok || d.Get("charging_mode").(string) == "prePaid" {
 		createOpts.PayInfo = &cssv2model.PayInfoBody{
 			Period:    int32(d.Get("period").(int)),
 			IsAutoPay: utils.Int32(1),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add the charging_mode parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add the charging_mode parameter for CSS cluster resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssCluster_security'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccCssCluster_security -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_security
=== PAUSE TestAccCssCluster_security
=== CONT  TestAccCssCluster_security
--- PASS: TestAccCssCluster_security (1332.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1332.599s
```
