### PR TITLE
fix(servicestage/instance): fix the wrong param reference and document format

### DIFF
--- a/docs/resources/servicestage_component_instance.md
+++ b/docs/resources/servicestage_component_instance.md
@@ -449,7 +449,7 @@ The `command_param` block supports:
 <a name="servicestage_http_param"></a>
 The `http_param` block supports:
 
-* `protocol` - (Required, String) Specifies the protocol. The valid values are `HTTP` and `HTTPS`.
+* `scheme` - (Required, String) Specifies the protocol scheme. The valid values are `HTTP` and `HTTPS`.
 
 * `port` - (Required, Int) Specifies the port number.
 

--- a/docs/resources/servicestage_component_instance.md
+++ b/docs/resources/servicestage_component_instance.md
@@ -373,7 +373,7 @@ The `entrypoint` block supports:
 <a name="servicestage_lifecycle_process"></a>
 The `post_start` and `pre_stop` block supports:
 
-* `type` - (Required, List) Specifies the process type. The valid values are `command` and `http`.
+* `type` - (Required, List) Specifies the process type. The valid values are **command** and **http**.
 
 * `parameters` - (Required, List) Specifies the start post-processing or stop pre-processing parameters.
   The [object](#servicestage_process_param) structure is documented below.
@@ -449,7 +449,7 @@ The `command_param` block supports:
 <a name="servicestage_http_param"></a>
 The `http_param` block supports:
 
-* `scheme` - (Required, String) Specifies the protocol scheme. The valid values are `HTTP` and `HTTPS`.
+* `scheme` - (Required, String) Specifies the protocol scheme. The valid values are **HTTP** and **HTTPS**.
 
 * `port` - (Required, Int) Specifies the port number.
 
@@ -467,7 +467,7 @@ The `external_access` block supports:
 
 * `protocol` - (Optional, String) Specifies the protocol. The valid values are **HTTP** and **HTTPS**.
 
-* `address` - (Optional, String) Specifies the access address. For example: **www.example.com**.
+* `address` - (Optional, String) Specifies the access address. For example: www.example.com.
 
 * `port` - (Optional, Int) Specifies the listening port of the application component process.
 

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_component_instance.go
@@ -122,7 +122,7 @@ func probeDetailSchemaResource() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"protocol": {
+						"scheme": {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
@@ -939,7 +939,7 @@ func buildConfigurationStructure(configs []interface{}) (instances.Configuration
 		Strategy:              buildStrategyStructure(config["strategy"].([]interface{})),
 		Lifecycle:             buildLifecycleStructure(config["lifecycle"].([]interface{})),
 		LogCollectionPolicies: buildLogCollectionPoliciesStructure(config["log_collection_policy"].(*schema.Set)),
-		Scheduler:             buildSchedulerStructure(config["lifecycle"].([]interface{})),
+		Scheduler:             buildSchedulerStructure(config["scheduler"].([]interface{})),
 		Probe:                 probe,
 	}, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The name of scheme parameter for the probe structure is not **protocol**.
The structure reference of scheduler parameter is wrong, not lifecycle structure.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update parameter name in the schema.
2. update parameter reference in the configuration building method.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
PENDING
```
