### PR TITLE
feat(er/az): add new data-source support

### DIFF
--- a/docs/data-sources/er_availability_zones.md
+++ b/docs/data-sources/er_availability_zones.md
@@ -1,0 +1,28 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_availability_zones
+
+Use this data source to query the list of Availability Zones in which the Enterprise Router instance can be created.
+
+## Example Usage
+
+```HCL
+resource "huaweicloud_er_availability_zones" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `names` - The name list of the availability zones.

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -286,6 +286,12 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		WithOutProjectID: true,
 		Product:          "DNS",
 	},
+	"er": {
+		Name:    "er",
+		Version: "v3",
+		Product: "ER",
+	},
+
 	"workspace": {
 		Name:    "workspace",
 		Version: "v2",

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -44,6 +44,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/evs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/gaussdb"
@@ -396,8 +397,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
 
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
-			"huaweicloud_evs_volumes":        evs.DataSourceEvsVolumesV2(),
-			"huaweicloud_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
+
+			"huaweicloud_er_availability_zones": er.DataSourceAvailabilityZones(),
+
+			"huaweicloud_evs_volumes":      evs.DataSourceEvsVolumesV2(),
+			"huaweicloud_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
 
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": gaussdb.DataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_flavors":            gaussdb.DataSourceCassandraFlavors(),

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_availability_zones_test.go
@@ -1,0 +1,35 @@
+package er
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceInstance_basic(t *testing.T) {
+	rName := "data.huaweicloud_er_availability_zones.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceInstance_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "names.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceInstance_basic() string {
+	return `
+data "huaweicloud_er_availability_zones" "test" {}
+`
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product ER
+// ---------------------------------------------------------------
+
+package er
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAvailabilityZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"names": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `The name list of the availability zones.`,
+			},
+		},
+	}
+}
+
+func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getAvailabilityZones: Query the availability zone list of Enterprise router
+	var (
+		getAvailabilityZonesHttpUrl = "v3/{project_id}/enterprise-router/availability-zones"
+		getAvailabilityZonesProduct = "er"
+	)
+	getAvailabilityZonesClient, err := config.NewServiceClient(getAvailabilityZonesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Instance Client: %s", err)
+	}
+
+	getAvailabilityZonesPath := getAvailabilityZonesClient.Endpoint + getAvailabilityZonesHttpUrl
+	getAvailabilityZonesPath = strings.Replace(getAvailabilityZonesPath, "{project_id}", getAvailabilityZonesClient.ProjectID, -1)
+	getAvailabilityZonesPath = strings.Replace(getAvailabilityZonesPath, "{id}", d.Id(), -1)
+
+	getAvailabilityZonesOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getAvailabilityZonesResp, err := getAvailabilityZonesClient.Request("GET", getAvailabilityZonesPath, &getAvailabilityZonesOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Instance")
+	}
+
+	getAvailabilityZonesRespBody, err := utils.FlattenResponse(getAvailabilityZonesResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+	log.Printf("[Lance] The data-source ID is: %s", uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("names", parseAvailabilityZones(utils.PathSearch("availability_zones", getAvailabilityZonesRespBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func parseAvailabilityZones(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curArray := resp.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		if state := utils.PathSearch("state", v, nil); state == "available" {
+			rst = append(rst, utils.PathSearch("code", v, nil))
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data-source to query the name (code) list of availability zones in which the Enterprise Router instance can be created.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data-source support
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccDatasourceInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccDatasourceInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceInstance_basic
=== PAUSE TestAccDatasourceInstance_basic
=== CONT  TestAccDatasourceInstance_basic
--- PASS: TestAccDatasourceInstance_basic (14.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        14.418s
```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
