### PR TITLE
feat(resource/obs_bucket): add new parameter storage info

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -85,7 +85,7 @@ resource "huaweicloud_obs_bucket" "b" {
 
   cors_rule {
     allowed_origins = ["https://obs-website-test.hashicorp.com"]
-    allowed_methods = ["PUT","POST"]
+    allowed_methods = ["PUT", "POST"]
     allowed_headers = ["*"]
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
@@ -145,13 +145,13 @@ The following arguments are supported:
 
 * `bucket` - (Required, String, ForceNew) Specifies the name of the bucket. Changing this parameter will create a new
   resource. A bucket must be named according to the globally applied DNS naming regulations as follows:
-  + The name must be globally unique in OBS.
-  + The name must contain 3 to 63 characters. Only lowercase letters, digits, hyphens (-), and periods (.) are
+    + The name must be globally unique in OBS.
+    + The name must contain 3 to 63 characters. Only lowercase letters, digits, hyphens (-), and periods (.) are
       allowed.
-  + The name cannot start or end with a period (.) or hyphen (-), and cannot contain two consecutive periods (.) or
+    + The name cannot start or end with a period (.) or hyphen (-), and cannot contain two consecutive periods (.) or
       contain a period (.) and a hyphen (-) adjacent to each other.
-  + The name cannot be an IP address.
-  + If the name contains any periods (.), a security certificate verification message may appear when you access the
+    + The name cannot be an IP address.
+    + If the name contains any periods (.), a security certificate verification message may appear when you access the
       bucket or its objects by entering a domain name.
 
 * `storage_class` - (Optional, String) Specifies the storage class of the bucket. OBS provides three storage classes:
@@ -175,9 +175,11 @@ The following arguments are supported:
 * `logging` - (Optional, Map) A settings of bucket logging (documented below).
 
 <!-- markdownlint-disable MD033 -->
+
 * `quota` - (Optional, Int) Specifies bucket storage quota. Must be a positive integer in the unit of byte. The maximum
   storage quota is 2<sup>63</sup> – 1 bytes. The default bucket storage quota is 0, indicating that the bucket storage
   quota is not limited.
+
 <!-- markdownlint-enable MD033 -->
 
 * `website` - (Optional, List) A website object (documented below).
@@ -236,7 +238,7 @@ The `website` object supports the following:
   when redirects are applied. Each rule contains a `Condition` and a `Redirect` as shown in the following table:
 
   Parameter | Key
-    --- | ---
+      --- | ---
   Condition | KeyPrefixEquals, HttpErrorCodeReturnedEquals
   Redirect | Protocol, HostName, ReplaceKeyPrefixWith, ReplaceKeyWith, HttpRedirectCode
 
@@ -310,6 +312,14 @@ In addition to all arguments above, the following attributes are exported:
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.obs.region.myhuaweicloud.com`.
 * `bucket_version` - The OBS version of the bucket.
 * `region` - The region where this bucket resides in.
+* `storage_info` - The OBS storage info of the bucket.
+  The [object](#bucket_storage_info_attr) structure is documented below.
+
+<a name="bucket_storage_info_attr"></a>
+The `storage_info` block supports:
+
+* `size` - The stored size of the bucket.
+* `object_number` - The number of objects stored in the bucket.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -39,6 +39,8 @@ func TestAccObsBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket_version", "3.0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "storage_info.0.size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "storage_info.0.object_number", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new parameters for obs bucket, it is used for query bucket storage info 
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
add new parameter storage info
```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_basic'                                                                                                         
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_basic -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_basic 
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (18.32s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       18.374s 

```
