### PR TITLE
refactor:fix(dds/instance): refactor prepaid creation and acc test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20221031064422-61a49f259426
+	github.com/chnsz/golangsdk v0.0.0-20221102031448-f36857a123e1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20221031064422-61a49f259426 h1:ilzBGTcCty2t2glnmMUI+vRrAyNMVBazDgLAGp/qIqQ=
-github.com/chnsz/golangsdk v0.0.0-20221031064422-61a49f259426/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221102031448-f36857a123e1 h1:bCax/xN4FoQ5D5i37kwEpn/kW274N9jNZUvXr3GEgR0=
+github.com/chnsz/golangsdk v0.0.0-20221102031448-f36857a123e1/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -170,43 +170,19 @@ func TestAccDDSV3Instance_prePaid(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "ssl", "true"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "08:00-09:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "8"),
 				),
 			},
 			{
-				Config: testAccDDSInstanceV3Config_prePaidUpdateBackupStrategy(rName),
+				Config: testAccDDSInstanceV3Config_prePaidUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "00:00-01:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "7"),
-				),
-			},
-			{
-				Config: testAccDDSInstanceV3Config_prePaidUpdateFlavorNum(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckDDSV3InstanceFlavor(&instance, "shard", "num", 3),
-				),
-			},
-			{
-				Config: testAccDDSInstanceV3Config_prePaidUpdateFlavorSize(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckDDSV3InstanceFlavor(&instance, "shard", "size", "30"),
-				),
-			},
-			{
-				Config: testAccDDSInstanceV3Config_prePaidUpdateFlavorSpecCode(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckDDSV3InstanceFlavor(&instance, "mongos", "spec_code", "dds.mongodb.c6.large.4.mongos"),
 				),
 			},
@@ -612,11 +588,11 @@ resource "huaweicloud_dds_instance" "instance" {
   security_group_id = huaweicloud_networking_secgroup.secgroup_acc.id
   password          = "Terraform@123"
   mode              = "Sharding"
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-  auto_renew        = false
-  auto_pay          = true
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = true
 
   datastore {
     type           = "DDS-Community"
@@ -646,17 +622,12 @@ resource "huaweicloud_dds_instance" "instance" {
 
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days  = "8"
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
+    keep_days  = 8
   }
 }`, testAccDDSInstanceV3Config_Base(rName), rName)
 }
 
-func testAccDDSInstanceV3Config_prePaidUpdateBackupStrategy(rName string) string {
+func testAccDDSInstanceV3Config_prePaidUpdate(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -668,179 +639,11 @@ resource "huaweicloud_dds_instance" "instance" {
   security_group_id = huaweicloud_networking_secgroup.secgroup_acc.id
   password          = "Terraform@123"
   mode              = "Sharding"
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-  auto_renew        = false
-  auto_pay          = true
 
-  datastore {
-    type           = "DDS-Community"
-    version        = "3.4"
-    storage_engine = "wiredTiger"
-  }
-
-  flavor {
-    type      = "mongos"
-    num       = 2
-    spec_code = "dds.mongodb.c6.large.2.mongos"
-  }
-  flavor {
-    type      = "shard"
-    num       = 2
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.c6.large.2.shard"
-  }
-  flavor {
-    type      = "config"
-    num       = 1
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.c6.large.2.config"
-  }
-
-  backup_strategy {
-    start_time = "00:00-01:00"
-    keep_days  = "7"
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
-  }
-}`, testAccDDSInstanceV3Config_Base(rName), rName)
-}
-
-func testAccDDSInstanceV3Config_prePaidUpdateFlavorNum(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dds_instance" "instance" {
-  name              = "%s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = data.huaweicloud_vpc.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.secgroup_acc.id
-  password          = "Terraform@123"
-  mode              = "Sharding"
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-  auto_renew        = false
-  auto_pay          = true
-
-  datastore {
-    type           = "DDS-Community"
-    version        = "3.4"
-    storage_engine = "wiredTiger"
-  }
-
-  flavor {
-    type      = "mongos"
-    num       = 2
-    spec_code = "dds.mongodb.c6.large.2.mongos"
-  }
-  flavor {
-    type      = "shard"
-    num       = 3
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.c6.large.2.shard"
-  }
-  flavor {
-    type      = "config"
-    num       = 1
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.c6.large.2.config"
-  }
-
-  backup_strategy {
-    start_time = "08:00-09:00"
-    keep_days  = "8"
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
-  }
-}`, testAccDDSInstanceV3Config_Base(rName), rName)
-}
-
-func testAccDDSInstanceV3Config_prePaidUpdateFlavorSize(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dds_instance" "instance" {
-  name              = "%s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = data.huaweicloud_vpc.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.secgroup_acc.id
-  password          = "Terraform@123"
-  mode              = "Sharding"
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-  auto_renew        = false
-  auto_pay          = true
-
-  datastore {
-    type           = "DDS-Community"
-    version        = "3.4"
-    storage_engine = "wiredTiger"
-  }
-
-  flavor {
-    type      = "mongos"
-    num       = 2
-    spec_code = "dds.mongodb.c6.large.2.mongos"
-  }
-  flavor {
-    type      = "shard"
-    num       = 3
-    storage   = "ULTRAHIGH"
-    size      = 30
-    spec_code = "dds.mongodb.c6.large.2.shard"
-  }
-  flavor {
-    type      = "config"
-    num       = 1
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.c6.large.2.config"
-  }
-
-  backup_strategy {
-    start_time = "08:00-09:00"
-    keep_days  = "8"
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
-  }
-}`, testAccDDSInstanceV3Config_Base(rName), rName)
-}
-
-func testAccDDSInstanceV3Config_prePaidUpdateFlavorSpecCode(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dds_instance" "instance" {
-  name              = "%s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = data.huaweicloud_vpc.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.secgroup_acc.id
-  password          = "Terraform@123"
-  mode              = "Sharding"
-  charging_mode     = "prePaid"
-  period_unit       = "month"
-  period            = 1
-  auto_renew        = false
-  auto_pay          = true
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "true"
 
   datastore {
     type           = "DDS-Community"
@@ -869,13 +672,8 @@ resource "huaweicloud_dds_instance" "instance" {
   }
 
   backup_strategy {
-    start_time = "08:00-09:00"
-    keep_days  = "8"
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
+    start_time = "00:00-01:00"
+    keep_days  = 7
   }
 }`, testAccDDSInstanceV3Config_Base(rName), rName)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/results.go
@@ -14,6 +14,7 @@ type CreateResult struct {
 }
 
 type Instance struct {
+	OrderId             string            `json:"order_id"`
 	Id                  string            `json:"id"`
 	Name                string            `json:"name"`
 	DataStore           DataStore         `json:"datastore"`
@@ -52,6 +53,17 @@ func (r CreateResult) Extract() (*Instance, error) {
 
 type UpdateInstanceResult struct {
 	commonResult
+}
+
+type UpdateResp struct {
+	JobId   string `json:"job_id"`
+	OrderId string `json:"order_id"`
+}
+
+func (r UpdateInstanceResult) Extract() (*UpdateResp, error) {
+	var resp UpdateResp
+	err := r.ExtractInto(&resp)
+	return &resp, err
 }
 
 type DeleteInstanceResult struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20221031064422-61a49f259426
+# github.com/chnsz/golangsdk v0.0.0-20221102031448-f36857a123e1
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. The check logic on the CBC side in the creation and update method is missing, and it will make the deletion method fail.
```
make testacc TEST='./huaweicloud/services/acceptance/dds' TESTARGS='-run=TestAccDDSV3Instance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run=TestAccDDSV3Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== CONT  TestAccDDSV3Instance_prePaid
    resource_huaweicloud_dds_instance_v3_test.go:163: Step 3/5 error: Error running apply: exit status 1
        
        Error: Error updating instance from result: Internal Server Error: [POST https://dds.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/instances/c713d44f188246b3bc75e9269feaba90in02/enlarge], error message: {"error_code":"DBS.280005","error_msg":"Server error. Try again later."} 
        
          with huaweicloud_dds_instance.instance,
          on terraform_plugin_test.tf line 17, in resource "huaweicloud_dds_instance" "instance":
          17: resource "huaweicloud_dds_instance" "instance" {
        
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error unsubscribing DDS instance : Bad request with: [POST https://bss.myhuaweicloud.com/v2/orders/subscriptions/resources/unsubscribe], error message: {"error_code":"CBC.30010035","error_msg":"resource deleted..cse://CSBOrderInterfaceAdapterService/rest/csborderadapterservice/v1/open-api/customers/0970d7b7d400f2470fbec00316a03560/orders/resources/unsubscribe[error_code]:CBC.30010035"}
        
--- FAIL: TestAccDDSV3Instance_prePaid (625.87s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       625.951s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
2. The flavor and volume cannot be updated at the same time.
```
make testacc TEST='./huaweicloud/services/acceptance/dds' TESTARGS='-run=TestAccDDSV3Instance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run=TestAccDDSV3Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== CONT  TestAccDDSV3Instance_prePaid
    resource_huaweicloud_dds_instance_v3_test.go:163: Step 2/2 error: Error running apply: exit status 1
        
        Error: Error updating instance from result: Bad request with: [POST https://dds.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/instances/94b4e2cef98f4e2981000140a2318481in02/enlarge-volume], error message: {"error_code":"DBS.239037","error_msg":"mergeRatingWithNoFee failed to charge"} 
        
          with huaweicloud_dds_instance.instance,
          on terraform_plugin_test.tf line 17, in resource "huaweicloud_dds_instance" "instance":
          17: resource "huaweicloud_dds_instance" "instance" {
        
--- FAIL: TestAccDDSV3Instance_prePaid (2509.58s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2509.660s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
- refactor prepaid creation logic
- fix the update logic that resource cannot update flavor and volume size at the same time
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dds' TESTARGS='-run=TestAccDDSV3Instance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run=TestAccDDSV3Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== CONT  TestAccDDSV3Instance_prePaid
--- PASS: TestAccDDSV3Instance_prePaid (2771.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2772.035s
```
