### PR TITLE
feat(RDS): add a datasource to get storageTypes

### DIFF
--- a/docs/data-sources/rds_storage_types.md
+++ b/docs/data-sources/rds_storage_types.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_storage_types
+
+Use this data source to get the list of RDS storage types.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_rds_storage_types" "test" {
+  db_type    = "MySQL"
+  db_version = "8.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `db_type` - (Required, String) DB engine. The valid values are **MySQL**, **PostgreSQL**, **SQLServer**.
+
+* `db_version` - (Optional, String) DB version number.
+
+* `instance_mode` - (Optional, String) HA mode. The valid values are **single**, **ha**, **replica**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `storage_types` - Storage type list. For details, see Data structure of the storage_type field.
+  The [storage_type](#Storagetype_storageType) structure is documented below.
+
+<a name="Storagetype_storageType"></a>
+The `storage_type` block supports:
+
+* `name` - Storage type.  
+  The options are as follows:
+    - **ULTRAHIGH**: SSD storage.
+    - **LOCALSSD**: Local SSD storage.
+    - **CLOUDSSD**: Cloud SSD storage.
+        This storage type is supported only with general-purpose and dedicated DB instances.
+    - **ESSD**: extreme SSD storage.
+        This storage type is supported only with dedicated DB instances.
+
+* `az_status` - The status details of the AZs to which the specification belongs.
+  Key indicates the AZ ID, and value indicates the specification status in the AZ.
+  The options of value are as follows:
+    - **normal**: The specifications in the AZ are available.
+    - **unsupported**: The specifications are not supported by the AZ.
+    - **sellout**: The specifications in the AZ are sold out.
+
+* `support_compute_group_type` - Performance specifications.
+  The options are as follows:
+    - **normal**: General-enhanced.
+    - **normal2**: General-enhanced II.
+    - **armFlavors**: Kunpeng general-enhanced.
+    - **dedicicatenormal**: Exclusive x86.
+    - **armlocalssd**: Standard Kunpeng.
+    - **normallocalssd**: Standard x86.
+    - **general**: General-purpose.
+    - **dedicated**: Dedicated, which is only supported for cloud SSDs.
+    - **rapid**: Dedicated, which is only supported for extreme SSDs.
+    - **bigmen**: Large-memory.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -466,6 +466,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_engine_versions": rds.DataSourceRdsEngineVersionsV3(),
 			"huaweicloud_rds_instances":       rds.DataSourceRdsInstances(),
 			"huaweicloud_rds_backups":         rds.DataSourceBackup(),
+			"huaweicloud_rds_storage_types":   rds.DataSourceStoragetype(),
 
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_storage_types_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_storage_types_test.go
@@ -1,0 +1,38 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceStoragetype_basic(t *testing.T) {
+	rName := "data.huaweicloud_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceStoragetype_basic() string {
+	return `
+data "huaweicloud_rds_storage_types" "test" {
+  db_type    = "MySQL"
+  db_version = "8.0"
+}`
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_storage_types.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_storage_types.go
@@ -1,0 +1,176 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product RDS
+// ---------------------------------------------------------------
+
+package rds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceStoragetype() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceStoragetypeRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"db_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `DB engine. The valid values are **MySQL**, **PostgreSQL**, **SQLServer**.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"MySQL", "PostgreSQL", "SQLServer",
+				}, false),
+			},
+			"db_version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `DB version number.`,
+			},
+			"instance_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `HA mode. The valid values are **single**, **ha**, **replica**.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"single", "ha", "replica",
+				}, false),
+			},
+			"storage_types": {
+				Type:        schema.TypeList,
+				Elem:        StoragetypeStorageTypeSchema(),
+				Computed:    true,
+				Description: `Storage_type list. For details, see Data structure of the storageType field.`,
+			},
+		},
+	}
+}
+
+func StoragetypeStorageTypeSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Storage type.`,
+			},
+			"az_status": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `The status details of the AZs to which the specification belongs.`,
+			},
+			"support_compute_group_type": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `Performance specifications.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceStoragetypeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// listStorageTypes: Query the List of RDS storage-types.
+	var (
+		listStorageTypesHttpUrl = "v3/{project_id}/storage-type/{db_type}"
+		listStorageTypesProduct = "rds"
+	)
+	listStorageTypesClient, err := config.NewServiceClient(listStorageTypesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Storagetype Client: %s", err)
+	}
+
+	listStorageTypesPath := listStorageTypesClient.Endpoint + listStorageTypesHttpUrl
+	listStorageTypesPath = strings.ReplaceAll(listStorageTypesPath, "{project_id}", listStorageTypesClient.ProjectID)
+	listStorageTypesPath = strings.ReplaceAll(listStorageTypesPath, "{db_type}",
+		fmt.Sprintf("%v", d.Get("db_type")))
+
+	listStorageTypesqueryParams := buildListStorageTypesQueryParams(d)
+	listStorageTypesPath += listStorageTypesqueryParams
+
+	listStorageTypesOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	listStorageTypesResp, err := listStorageTypesClient.Request("GET", listStorageTypesPath, &listStorageTypesOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Storagetype")
+	}
+
+	listStorageTypesRespBody, err := utils.FlattenResponse(listStorageTypesResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("storage_types", flattenListStorageTypesstorageType(listStorageTypesRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListStorageTypesstorageType(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("storage_type", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"name":                       utils.PathSearch("name", v, nil),
+			"az_status":                  utils.PathSearch("az_status", v, nil),
+			"support_compute_group_type": utils.PathSearch("support_compute_group_type", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildListStorageTypesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("db_version"); ok {
+		res = fmt.Sprintf("%s&version_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("instance_mode"); ok {
+		res = fmt.Sprintf("%s&ha_mode=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run=TestAccDatasourceStorage'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run=TestAccDatasourceStorage -timeout 360m -parallel 4
=== RUN   TestAccDatasourceStoragetype_basic
=== PAUSE TestAccDatasourceStoragetype_basic
=== CONT  TestAccDatasourceStoragetype_basic
--- PASS: TestAccDatasourceStoragetype_basic (8.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       8.983s
```
