### PR TITLE
feat(eip): The auto_renew parameter supports update

### DIFF
--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -83,8 +83,8 @@ The following arguments are supported:
 
   This parameter is mandatory if `charging_mode` is set to **prePaid**. Changing this will create a new resource.
 
-* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.  
-  Valid values are **true** and **false**. Defaults to **false**. Changing this will create a new resource.
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.  
+  Valid values are **true** and **false**. Defaults to **false**.
 
 <a name="vpc_eip_publicip"></a>
 The `publicip` block supports:

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -175,7 +175,7 @@ func TestAccVpcEip_prePaid(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcEip_prePaid(randName, 5),
+				Config: testAccVpcEip_prePaid(randName, 5, false),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
@@ -184,13 +184,14 @@ func TestAccVpcEip_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", randName),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
 					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "5"),
 					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "address"),
 				),
 			},
 			{
-				Config: testAccVpcEip_prePaid(updateName, 5),
+				Config: testAccVpcEip_prePaid(updateName, 5, true),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
@@ -199,13 +200,14 @@ func TestAccVpcEip_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
 					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "5"),
 					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "address"),
 				),
 			},
 			{
-				Config: testAccVpcEip_prePaid(updateName, 6),
+				Config: testAccVpcEip_prePaid(updateName, 6, true),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
@@ -214,6 +216,7 @@ func TestAccVpcEip_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
 					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "6"),
 					resource.TestCheckResourceAttrSet(resourceName, "bandwidth.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "address"),
@@ -352,7 +355,7 @@ resource "huaweicloud_vpc_eip" "test" {
 `, rName)
 }
 
-func testAccVpcEip_prePaid(rName string, size int) string {
+func testAccVpcEip_prePaid(rName string, size int, isAutoRenew bool) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc_eip" "test" {
   name = "%[1]s"
@@ -370,8 +373,9 @@ resource "huaweicloud_vpc_eip" "test" {
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = 1
+  auto_renew    = "%[3]v"
 }
-`, rName, size)
+`, rName, size, isAutoRenew)
 }
 
 func testAccVpcEip_deprecated(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The codes of EIP resource is old school and the auto_renew parameter cannot update.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
The update logic of name parameter for prepaid mode has been changed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove region limit for EIP creation.
2. refactor resource codes.
3. the auto_renew parameter cannot update.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== RUN   TestAccVpcEipsDataSource_byTag
=== PAUSE TestAccVpcEipsDataSource_byTag
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== RUN   TestAccEIPAssociate_port
=== PAUSE TestAccEIPAssociate_port
=== RUN   TestAccEIPAssociate_compatible
=== PAUSE TestAccEIPAssociate_compatible
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== RUN   TestAccVpcBandWidth_WithEpsId
=== PAUSE TestAccVpcBandWidth_WithEpsId
=== RUN   TestAccVpcEip_basic
=== PAUSE TestAccVpcEip_basic
=== RUN   TestAccVpcEip_share
=== PAUSE TestAccVpcEip_share
=== RUN   TestAccVpcEip_WithEpsId
=== PAUSE TestAccVpcEip_WithEpsId
=== RUN   TestAccVpcEip_prePaid
=== PAUSE TestAccVpcEip_prePaid
=== RUN   TestAccVpcEip_deprecated
=== PAUSE TestAccVpcEip_deprecated
=== CONT  TestAccBandWidthDataSource_basic
=== CONT  TestAccVpcBandWidth_basic
=== CONT  TestAccVpcEip_deprecated
=== CONT  TestAccVpcEip_share
--- PASS: TestAccVpcBandWidth_basic (42.01s)
=== CONT  TestAccVpcEip_basic
--- PASS: TestAccBandWidthDataSource_basic (47.39s)
=== CONT  TestAccVpcEip_prePaid
--- PASS: TestAccVpcEip_share (47.56s)
=== CONT  TestAccVpcBandWidth_WithEpsId
--- PASS: TestAccVpcBandWidth_WithEpsId (49.78s)
=== CONT  TestAccEIPAssociate_basic
--- PASS: TestAccVpcEip_deprecated (126.28s)
=== CONT  TestAccEIPAssociate_compatible
--- PASS: TestAccVpcEip_basic (85.78s)
=== CONT  TestAccEIPAssociate_port
--- PASS: TestAccEIPAssociate_port (101.07s)
=== CONT  TestAccVpcEip_WithEpsId
--- PASS: TestAccEIPAssociate_compatible (104.30s)
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEip_WithEpsId (36.02s)
=== CONT  TestAccVpcEipsDataSource_byTag
--- PASS: TestAccVpcEipsDataSource_basic (40.00s)
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEipsDataSource_byTag (39.18s)
--- PASS: TestAccVpcEipDataSource_basic (36.78s)
--- PASS: TestAccVpcEip_prePaid (262.80s)
--- PASS: TestAccEIPAssociate_basic (286.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip384.444s
```
