### PR TITLE
refactor(eip): adjust resource codes of the EIP and update related test

### DIFF
--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -8,37 +8,43 @@ Manages an EIP resource within HuaweiCloud.
 
 ## Example Usage
 
-### EIP with Dedicated Bandwidth
+### Create an EIP with Dedicated Bandwidth
 
 ```hcl
-resource "huaweicloud_vpc_eip" "eip_1" {
+var "bandwidth_name" {}
+
+resource "huaweicloud_vpc_eip" "dedicated" {
   publicip {
     type = "5_bgp"
   }
+
   bandwidth {
     share_type  = "PER"
-    name        = "test"
+    name        = var.bandwidth_name
     size        = 10
     charge_mode = "traffic"
   }
 }
 ```
 
-### EIP with Shared Bandwidth
+### Create an EIP with Shared Bandwidth
 
 ```hcl
-resource "huaweicloud_vpc_bandwidth" "bandwidth_1" {
-  name = "bandwidth_1"
+var "bandwidth_name" {}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = var.bandwidth_name
   size = 5
 }
 
-resource "huaweicloud_vpc_eip" "eip_1" {
+resource "huaweicloud_vpc_eip" "shared" {
   publicip {
     type = "5_bgp"
   }
+
   bandwidth {
     share_type = "WHOLE"
-    id         = huaweicloud_vpc_bandwidth.bandwidth_1.id
+    id         = huaweicloud_vpc_bandwidth.test.id
   }
 }
 ```
@@ -47,64 +53,71 @@ resource "huaweicloud_vpc_eip" "eip_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the EIP resource. If omitted, the provider-level
-  region will be used. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the EIP resource.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
 
-* `publicip` - (Required, List) The elastic IP address object.
+* `publicip` - (Required, List) Specifies the EIP configuration.  
+  The [object](#vpc_eip_publicip) structure is documented below.
 
-* `bandwidth` - (Required, List) The bandwidth object.
+* `bandwidth` - (Required, List) Specifies the bandwidth configuration.  
+  The [object](#vpc_eip_bandwidth) structure is documented below.
 
-* `name` - (Optional, String) Specifies the name of the elastic IP. The value can contain 1 to 64 characters,
-  including letters, digits, underscores (_), hyphens (-), and periods (.).
+* `name` - (Optional, String) Specifies the name of the EIP.  
+  The name can contain `1` to `64` characters, including letters, digits, underscores (_), hyphens (-), and periods (.).
 
-* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the elastic IP.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the EIP belongs.  
+  Changing this will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the elastic IP. Changing this
-  creates a new eip.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the EIP.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the elastic IP. Valid values are
-  *prePaid* and *postPaid*, defaults to *postPaid*. Changing this creates a new eip.
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the EIP.  
+  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**. Changing this will create a new resource.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the elastic IP. Valid values are
-  *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new
-  eip.
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the EIP.  
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this will create a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the elastic IP. If `period_unit` is set to
-  *month*, the value ranges from 1 to 9. If `period_unit` is set to *year*, the value ranges from 1 to 3. This parameter
-  is mandatory if `charging_mode` is set to *prePaid*. Changing this creates a new resource.
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the EIP.
+  + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
+  + If `period_unit` is set to **year**, the value ranges from `1` to `3`.
 
-* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
-  Valid values are *true* and *false*. Defaults to *false*.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**. Changing this will create a new resource.
 
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.  
+  Valid values are **true** and **false**. Defaults to **false**. Changing this will create a new resource.
+
+<a name="vpc_eip_publicip"></a>
 The `publicip` block supports:
 
-* `type` - (Optional, String, ForceNew) Specifies the EIP type. Possible values are *5_bgp* (dynamic BGP)
-  and *5_sbgp* (static BGP), the default value is *5_bgp*. Changing this creates a new resource.
+* `type` - (Optional, String, ForceNew) Specifies the EIP type. Possible values are **5_bgp** (dynamic BGP)
+  and **5_sbgp** (static BGP), the default value is **5_bgp**. Changing this will create a new resource.
 
-* `ip_address` - (Optional, String, ForceNew) Specifies the EIP to be assigned. The value must be a valid **IPv4**
-  address in the available IP address range. The system automatically assigns an EIP if you do not specify it.
-  Changing this creates a new resource.
+* `ip_address` - (Optional, String, ForceNew) Specifies the EIP address to be assigned.  
+  The value must be a valid **IPv4** address in the available IP address range.
+  The system automatically assigns an EIP if you do not specify it. Changing this will create a new resource.
 
-* `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) or 6.
+* `ip_version` - (Optional, Int) Specifies the IP version, either `4` (default) or `6`.
 
+<a name="vpc_eip_bandwidth"></a>
 The `bandwidth` block supports:
 
-* `share_type` - (Required, String, ForceNew) Whether the bandwidth is dedicated or shared. Changing this creates a new
-  resource. Possible values are as follows:
+* `share_type` - (Required, String, ForceNew) Specifies whether the bandwidth is dedicated or shared.  
+  Changing this will create a new resource. Possible values are as follows:
   + **PER**: Dedicated bandwidth
   + **WHOLE**: Shared bandwidth
 
-* `name` - (Optional, String) The bandwidth name, which is a string of 1 to 64 characters that contain letters, digits,
-  underscores (_), and hyphens (-). This parameter is mandatory when `share_type` is set to **PER**.
+* `name` - (Optional, String) Specifies the bandwidth name.  
+  The name can contain `1` to `64` characters, including letters, digits, underscores (_), hyphens (-), and periods (.).
+  This parameter is mandatory when `share_type` is set to **PER**.
 
-* `size` - (Optional, Int) The bandwidth size. The value ranges from 1 to 300 Mbit/s. This parameter is mandatory
-  when `share_type` is set to **PER**.
+* `size` - (Optional, Int) The bandwidth size.  
+  The value ranges from `1` to `300` Mbit/s. This parameter is mandatory when `share_type` is set to **PER**.
 
-* `id` - (Optional, String, ForceNew) The shared bandwidth id. This parameter is mandatory when
-  `share_type` is set to **WHOLE**. Changing this creates a new resource.
+* `id` - (Optional, String, ForceNew) The shared bandwidth ID.  
+  This parameter is mandatory when `share_type` is set to **WHOLE**. Changing this will create a new resource.
 
 * `charge_mode` - (Optional, String, ForceNew) Specifies whether the bandwidth is billed by traffic or by bandwidth
-  size. The value can be *traffic* or *bandwidth*. Changing this creates a new resource.
+  size. The value can be **traffic** or **bandwidth**. Changing this will create a new resource.
 
 ## Attributes Reference
 
@@ -121,13 +134,14 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
 
 ## Import
 
 EIPs can be imported using the `id`, e.g.
 
 ```
-$ terraform import huaweicloud_vpc_eip.eip_1 2c7f39f3-702b-48d1-940c-b50384177ee1
+$ terraform import huaweicloud_vpc_eip.test 2c7f39f3-702b-48d1-940c-b50384177ee1
 ```

--- a/huaweicloud/data_source_huaweicloud_iec_eips.go
+++ b/huaweicloud/data_source_huaweicloud_iec_eips.go
@@ -114,7 +114,7 @@ func dataSourceIECNetworkEipsRead(d *schema.ResourceData, meta interface{}) erro
 			"public_ip":            item.PublicIpAddress,
 			"private_ip":           item.PrivateIpAddress,
 			"port_id":              item.PortID,
-			"status":               eip.NormalizeEIPStatus(item.Status),
+			"status":               eip.NormalizeEipStatus(item.Status),
 			"ip_version":           item.IPVersion,
 			"bandwidth_id":         item.BandwidthID,
 			"bandwidth_name":       item.BandwidthName,

--- a/huaweicloud/resource_huaweicloud_iec_eip.go
+++ b/huaweicloud/resource_huaweicloud_iec_eip.go
@@ -183,7 +183,7 @@ func resourceIecEipV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bandwidth_size", n.BandwidthSize)
 	d.Set("bandwidth_share_type", n.BandwidthShareType)
 	d.Set("site_info", n.SiteInfo)
-	d.Set("status", eip.NormalizeEIPStatus(n.Status))
+	d.Set("status", eip.NormalizeEipStatus(n.Status))
 
 	return nil
 }

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
@@ -23,10 +23,15 @@ func TestAccVpcEipsDataSource_basic(t *testing.T) {
 				Config: testAccDataSourceVpcEips_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.name", randName),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
-					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.ip_version", "4"),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_share_type", "PER"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.key", "value"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
 						"huaweicloud_vpc_eip.test", "id"),
 				),
@@ -59,10 +64,15 @@ func TestAccVpcEipsDataSource_byTag(t *testing.T) {
 				Config: testAccDataSourceVpcEips_byTag(randName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.name", randName),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.status", "UNBOUND"),
-					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.type", "5_bgp"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.ip_version", "4"),
 					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.bandwidth_share_type", "PER"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "eips.0.tags.key", "value"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "eips.0.id",
 						"huaweicloud_vpc_eip.test", "id"),
 				),
@@ -77,9 +87,10 @@ func testAccDataSourceVpcEips_byTag(rName string) string {
 
 data "huaweicloud_vpc_eips" "test" {
   public_ips = [huaweicloud_vpc_eip.test.address]
+
   tags = {
     foo = "bar"
   }
 }
-`, testAccVpcEip_tags(rName))
+`, testAccVpcEip_basic(rName))
 }

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip.go
@@ -117,7 +117,7 @@ func dataSourceVpcEipRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	mErr := multierror.Append(nil,
 		d.Set("region", config.GetRegion(d)),
-		d.Set("status", NormalizeEIPStatus(Eip.Status)),
+		d.Set("status", NormalizeEipStatus(Eip.Status)),
 		d.Set("public_ip", Eip.PublicAddress),
 		d.Set("ipv6_address", Eip.PublicIpv6Address),
 		d.Set("ip_version", Eip.IpVersion),

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
@@ -187,7 +187,7 @@ func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta inter
 		eip := map[string]interface{}{
 			"id":                    item.ID,
 			"name":                  item.Alias,
-			"status":                NormalizeEIPStatus(item.Status),
+			"status":                NormalizeEipStatus(item.Status),
 			"type":                  item.Type,
 			"private_ip":            item.PrivateAddress,
 			"public_ip":             item.PublicAddress,

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -1,9 +1,15 @@
 package eip
 
 import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -19,36 +25,60 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
+type BgpType string         // The BGP type of the public IP.
+type IpVersion int          // The Version of the EIP protocol.
+type BandwidthType string   // The bandwidth type bound by EIP.
+type ChargeMode string      // The charging mode of the bandwidth.
+type EipStatus string       // The current status of the EIP.
+type NormalizeStatus string // The Normalized status value.
+
+const (
+	BgpTypeDynamic BgpType = "5_bgp"  // Dynamic BGP
+	BgpTypeStatic  BgpType = "5_sbgp" // Static BGP
+
+	IpVersionV4 IpVersion = 4 // IPv4
+	IpVersionV6 IpVersion = 6 // IPv6
+
+	BandwidthTypeDedicated BandwidthType = "PER"   // Dedicated bandwidth
+	BandwidthTypeShared    BandwidthType = "WHOLE" // Shared bandwidth
+
+	ChargeModeTraffic   ChargeMode = "traffic"   // Billing based on traffic
+	ChargeModeBandwidth ChargeMode = "bandwidth" // Billing based on bandwidth
+
+	EipStatusDown   EipStatus = "DOWN"
+	EipStatusActive EipStatus = "ACTIVE"
+
+	NormalizeStatusBound   NormalizeStatus = "BOUND"
+	NormalizeStatusUnbound NormalizeStatus = "UNBOUND"
+)
+
+// In order to be compatible with other providers, keep the exposed function name (ResourceVpcEIPV1) unchanged.
 func ResourceVpcEIPV1() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVpcEIPV1Create,
-		Read:   resourceVpcEIPV1Read,
-		Update: resourceVpcEIPV1Update,
-		Delete: resourceVpcEIPV1Delete,
+		CreateContext: resourceVpcEipCreate,
+		ReadContext:   resourceVpcEipRead,
+		UpdateContext: resourceVpcEipUpdate,
+		DeleteContext: resourceVpcEipDelete,
+
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which to create the EIP resource.`,
 			},
 			"publicip": {
 				Type:     schema.TypeList,
@@ -59,20 +89,29 @@ func ResourceVpcEIPV1() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "5_bgp",
+							Default:  string(BgpTypeDynamic),
 							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(BgpTypeDynamic), string(BgpTypeStatic),
+							}, false),
+							Description: `The EIP type.`,
 						},
 						"ip_address": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Computed: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							Computed:     true,
+							ValidateFunc: validation.IsIPv4Address,
+							Description:  `The EIP address to be assigned.`,
 						},
 						"ip_version": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.IntInSlice([]int{4, 6}),
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.IntInSlice([]int{
+								int(IpVersionV4), int(IpVersionV6),
+							}),
+							Description: `The IP version.`,
 						},
 						"port_id": {
 							Type:        schema.TypeString,
@@ -82,6 +121,7 @@ func ResourceVpcEIPV1() *schema.Resource {
 						},
 					},
 				},
+				Description: `The EIP configuration.`,
 			},
 			"bandwidth": {
 				Type:     schema.TypeList,
@@ -93,40 +133,77 @@ func ResourceVpcEIPV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(BandwidthTypeDedicated), string(BandwidthTypeShared),
+							}, false),
+							Description: `Whether the bandwidth is dedicated or shared.`,
 						},
 						"id": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
 							Computed:     true,
-							ExactlyOneOf: []string{"bandwidth.0.id", "bandwidth.0.name"},
+							ExactlyOneOf: []string{"bandwidth.0.name"},
+							Description:  `The shared bandwidth ID.`,
 						},
 						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa5\\w-.]*$"),
+									"The name can only contain letters, digits, underscores (_), hyphens (-), and periods (.)."),
+								validation.StringLenBetween(1, 64),
+							),
+							Description: `The bandwidth name.`,
 						},
 						"size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `The bandwidth size.`,
 						},
 						"charge_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
 							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(ChargeModeTraffic), string(ChargeModeBandwidth),
+							}, false),
+							Description: `Whether the bandwidth is billed by traffic or by bandwidth size.`,
 						},
 					},
 				},
+				Description: `The bandwidth configuration.`,
 			},
-			"tags": common.TagsSchema(),
-			"enterprise_project_id": {
+			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa5\\w-.]*$"),
+						"The name can only contain letters, digits, underscores (_), hyphens (-), and periods (.)."),
+					validation.StringLenBetween(1, 64),
+				),
+				Description: `The name of the EIP.`,
 			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The enterprise project ID to which the EIP belongs.`,
+			},
+			"tags": common.TagsSchema(),
+
+			// Charge info: charging_mode, period_unit, period, auto_renew, auto_pay
+			"charging_mode": common.SchemaChargingMode(nil),
+			"period_unit":   common.SchemaPeriodUnit([]string{"publicip.0.ip_address"}),
+			"period":        common.SchemaPeriod([]string{"publicip.0.ip_address"}),
+			"auto_renew":    common.SchemaAutoRenew([]string{"publicip.0.ip_address"}),
+			"auto_pay":      common.SchemaAutoPay([]string{"publicip.0.ip_address"}),
+
+			// Attributes
 			"address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -147,138 +224,139 @@ func ResourceVpcEIPV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
-			"charging_mode": common.SchemaChargingMode(nil),
-			"period_unit":   common.SchemaPeriodUnit([]string{"publicip.0.ip_address"}),
-			"period":        common.SchemaPeriod([]string{"publicip.0.ip_address"}),
-			"auto_renew":    common.SchemaAutoRenew([]string{"publicip.0.ip_address"}),
-			"auto_pay":      common.SchemaAutoPay([]string{"publicip.0.ip_address"}),
 		},
 	}
 }
 
 func validatePrePaidBandWidth(bandwidth eips.BandwidthOpts) error {
-	if bandwidth.Id != "" || bandwidth.Name == "" || bandwidth.ShareType == "WHOLE" {
-		return fmtp.Errorf("shared bandwidth is not supported in prePaid charging mode")
+	if bandwidth.Id != "" || bandwidth.Name == "" || bandwidth.ShareType == string(BandwidthTypeShared) {
+		return fmt.Errorf("shared bandwidth is not supported in prePaid charging mode")
 	}
-	if bandwidth.ChargeMode == "traffic" {
-		return fmtp.Errorf("EIP can only be billed by bandwidth in prePaid charging mode")
-	}
-
-	return nil
-}
-
-func validatePrePaidSupportedRegion(region string) error {
-	var valid bool
-	// reference to: https://support.huaweicloud.com/api-eip/eip_api_0006.html#section4
-	var supportedRegion = []string{
-		"cn-north-4", "cn-east-3", "cn-south-1", "cn-southwest-2",
-		"ap-southeast-2", "ap-southeast-3",
-	}
-
-	for _, r := range supportedRegion {
-		if r == region {
-			valid = true
-			break
-		}
-	}
-	if !valid {
-		return fmtp.Errorf("prepaid charging mode of eip is not supported in %s region", region)
+	if bandwidth.ChargeMode == string(ChargeModeTraffic) {
+		return fmt.Errorf("the EIP can only be billed by bandwidth in prePaid charging mode")
 	}
 
 	return nil
 }
 
-func resourceVpcEIPV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-
-	networkingClient, err := config.NetworkingV1Client(region)
-	if err != nil {
-		return fmtp.Errorf("Error creating networking v1 client: %s", err)
-	}
-	// networkingV2Client is used to create EIP in prePaid charging mode and tags
-	networkingV2Client, err := config.NetworkingV2Client(region)
-	if err != nil {
-		return fmtp.Errorf("Error creating networking v2 client: %s", err)
+func buildVpcEipCreateOpts(config *config.Config, d *schema.ResourceData, isPrePaid bool) (eips.ApplyOpts, error) {
+	bandwidth := resourceBandWidth(d)
+	result := eips.ApplyOpts{
+		IP:                  resourcePublicIP(d),
+		Bandwidth:           bandwidth,
+		EnterpriseProjectID: config.GetEnterpriseProjectID(d),
 	}
 
-	createOpts := eips.ApplyOpts{
-		IP:        resourcePublicIP(d),
-		Bandwidth: resourceBandWidth(d),
-	}
-
-	epsID := config.GetEnterpriseProjectID(d)
-	if epsID != "" {
-		createOpts.EnterpriseProjectID = epsID
-	}
-
-	var prePaid bool
-	if d.Get("charging_mode").(string) == "prePaid" {
+	if isPrePaid {
 		if err := common.ValidatePrePaidChargeInfo(d); err != nil {
-			return err
+			return result, err
 		}
-		if err := validatePrePaidBandWidth(createOpts.Bandwidth); err != nil {
-			return err
-		}
-		if err := validatePrePaidSupportedRegion(region); err != nil {
-			return err
+		if err := validatePrePaidBandWidth(bandwidth); err != nil {
+			return result, err
 		}
 
-		prePaid = true
-		chargeInfo := &sdk_structs.ChargeInfo{
+		result.ExtendParam = &sdk_structs.ChargeInfo{
 			ChargeMode:  d.Get("charging_mode").(string),
 			PeriodType:  d.Get("period_unit").(string),
 			PeriodNum:   d.Get("period").(int),
 			IsAutoRenew: d.Get("auto_renew").(string),
 			IsAutoPay:   common.GetAutoPay(d),
 		}
-		createOpts.ExtendParam = chargeInfo
 	}
+	return result, nil
+}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
-	var eIP eips.PublicIp
-	if prePaid {
-		eIP, err = eips.Apply(networkingV2Client, createOpts).Extract()
-	} else {
-		eIP, err = eips.Apply(networkingClient, createOpts).Extract()
-	}
-
-	if err != nil {
-		return fmtp.Errorf("Error allocating EIP: %s", err)
-	}
-
-	if eIP.ID == "" {
-		return fmtp.Errorf("can not get the resource ID")
-	}
-	d.SetId(eIP.ID)
-
-	// wait for order success
-	if eIP.OrderID != "" {
-		bssClient, err := config.BssV2Client(config.GetRegion(d))
-		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud bss V2 client: %s", err)
-		}
-		if err := orders.WaitForOrderSuccess(bssClient, int(d.Timeout(schema.TimeoutCreate)/time.Second), eIP.OrderID); err != nil {
-			return err
-		}
-	}
-
-	logp.Printf("[DEBUG] Waiting for EIP %s to become available.", eIP.ID)
+func createPrePaidEip(ctx context.Context, config *config.Config, client *golangsdk.ServiceClient,
+	d *schema.ResourceData) error {
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForEIPActive(networkingClient, eIP.ID, timeout)
+	createOpts, err := buildVpcEipCreateOpts(config, d, true)
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for EIP (%s) to become ready: %s",
-			eIP.ID, err)
+		return err
+	}
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+
+	resp, err := eips.Apply(client, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error allocating prePaid EIP: %s", err)
+	}
+
+	// Waiting for EIP creation completed.
+	bssClient, err := config.BssV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating BSS v2 client: %s", err)
+	}
+	if err := common.WaitOrderComplete(ctx, bssClient, resp.OrderID, timeout); err != nil {
+		return err
+	}
+	resourceId, err := common.WaitOrderResourceComplete(ctx, bssClient, resp.OrderID, timeout)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resourceId)
+	return nil
+}
+
+func createPostPaidEip(ctx context.Context, config *config.Config, client *golangsdk.ServiceClient,
+	d *schema.ResourceData) error {
+	createOpts, err := buildVpcEipCreateOpts(config, d, false)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+
+	resp, err := eips.Apply(client, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error allocating EIP: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	log.Printf("[DEBUG] Waiting for EIP (%s) to become available", resp.ID)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      eipStatusRefreshFunc(client, resp.ID, []string{"DOWN", "ACTIVE"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for EIP (%s) to become ready: %s", resp.ID, err)
+	}
+	return nil
+}
+
+func resourceVpcEipCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	vpcV1Client, err := config.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v1 client: %s", err)
+	}
+	vpcV2Client, err := config.NetworkingV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v2.0 client: %s", err)
+	}
+
+	if d.Get("charging_mode").(string) == "prePaid" {
+		err := createPrePaidEip(ctx, config, vpcV2Client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		err := createPostPaidEip(ctx, config, vpcV1Client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if v, ok := d.GetOk("publicip.0.port_id"); ok {
-		portID := v.(string)
-		err = bindPort(networkingClient, eIP.ID, portID, timeout)
+		err = updateEipPortId(vpcV1Client, d)
 		if err != nil {
-			return fmtp.Errorf("Error binding EIP %s to port %s: %s", eIP.ID, portID, err)
+			return diag.Errorf("error binding EIP (%s) to port %s: %s", d.Id(), v.(string), err)
 		}
 	}
 
@@ -286,256 +364,331 @@ func resourceVpcEIPV1Create(d *schema.ResourceData, meta interface{}) error {
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
 		taglist := utils.ExpandResourceTags(tagRaw)
-		if tagErr := tags.Create(networkingV2Client, "publicips", eIP.ID, taglist).ExtractErr(); tagErr != nil {
-			return fmtp.Errorf("Error setting tags of EIP %s: %s", eIP.ID, tagErr)
+		if tagErr := tags.Create(vpcV2Client, "publicips", d.Id(), taglist).ExtractErr(); tagErr != nil {
+			return diag.Errorf("error setting tags of EIP (%s): %s", d.Id(), tagErr)
 		}
 	}
 
-	return resourceVpcEIPV1Read(d, meta)
+	return resourceVpcEipRead(ctx, d, meta)
 }
 
-func resourceVpcEIPV1Read(d *schema.ResourceData, meta interface{}) error {
+// NormalizeEipStatus is a method to change an incomprehensible status into an easy-to-understand status.
+func NormalizeEipStatus(status string) string {
+	// The 'DOWN' status means the EIP is active but not bound.
+	if status == string(EipStatusDown) {
+		return string(NormalizeStatusUnbound)
+	}
+	if status == string(EipStatusActive) {
+		return string(NormalizeStatusBound)
+	}
+
+	// Other running statuses.
+	return status
+}
+
+func eipStatusRefreshFunc(networkingClient *golangsdk.ServiceClient, eipId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := eips.Get(networkingClient, eipId).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				if len(targets) < 1 {
+					return resp, "COMPLETED", nil
+				}
+				return resp, "PENDING", nil
+			}
+
+			return nil, "", err
+		}
+		log.Printf("[DEBUG] The details of the EIP (%s) is: %+v", eipId, resp)
+
+		if utils.StrSliceContains([]string{"BIND_ERROR", "ERROR"}, resp.Status) {
+			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		}
+		if utils.StrSliceContains(targets, resp.Status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func flattenEipPublicIpDetails(publicIp eips.PublicIp) []map[string]interface{} {
+	if reflect.DeepEqual(publicIp, eips.PublicIp{}) {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"type":       publicIp.Type,
+			"ip_version": publicIp.IpVersion,
+			"ip_address": publicIp.PublicAddress,
+			"port_id":    publicIp.PortID,
+		},
+	}
+}
+
+func flattenEipBandwidthDetails(publicIp eips.PublicIp, bandWidth bandwidths.BandWidth) []map[string]interface{} {
+	if reflect.DeepEqual(publicIp, eips.PublicIp{}) || reflect.DeepEqual(bandWidth, bandwidths.BandWidth{}) {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":        bandWidth.Name,
+			"size":        publicIp.BandwidthSize,
+			"id":          publicIp.BandwidthID,
+			"share_type":  publicIp.BandwidthShareType,
+			"charge_mode": bandWidth.ChargeMode,
+		},
+	}
+}
+
+func resourceVpcEipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	region := config.GetRegion(d)
 	networkingClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating networking client: %s", err)
+		return diag.Errorf("error creating VPC v1 client: %s", err)
 	}
 
-	eIP, err := eips.Get(networkingClient, d.Id()).Extract()
+	resourceId := d.Id()
+	publicIp, err := eips.Get(networkingClient, resourceId).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "eIP")
+		return common.CheckDeletedDiag(d, err, "EIP")
 	}
-	bandWidth, err := bandwidths.Get(networkingClient, eIP.BandwidthID).Extract()
+	bandWidth, err := bandwidths.Get(networkingClient, publicIp.BandwidthID).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error fetching bandwidth: %s", err)
-	}
-
-	// build public ip
-	publicIP := []map[string]interface{}{
-		{
-			"type":       eIP.Type,
-			"ip_version": eIP.IpVersion,
-			"ip_address": eIP.PublicAddress,
-			"port_id":    eIP.PortID,
-		},
-	}
-
-	// build bandwidth
-	bW := []map[string]interface{}{
-		{
-			"name":        bandWidth.Name,
-			"size":        eIP.BandwidthSize,
-			"id":          eIP.BandwidthID,
-			"share_type":  eIP.BandwidthShareType,
-			"charge_mode": bandWidth.ChargeMode,
-		},
+		return diag.Errorf("error fetching bandwidth: %s", err)
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("name", eIP.Alias),
-		d.Set("address", eIP.PublicAddress),
-		d.Set("ipv6_address", eIP.PublicIpv6Address),
-		d.Set("private_ip", eIP.PrivateAddress),
-		d.Set("port_id", eIP.PortID),
-		d.Set("enterprise_project_id", eIP.EnterpriseProjectID),
-		d.Set("status", NormalizeEIPStatus(eIP.Status)),
-		d.Set("publicip", publicIP),
-		d.Set("bandwidth", bW),
+		d.Set("name", publicIp.Alias),
+		d.Set("address", publicIp.PublicAddress),
+		d.Set("ipv6_address", publicIp.PublicIpv6Address),
+		d.Set("private_ip", publicIp.PrivateAddress),
+		d.Set("port_id", publicIp.PortID),
+		d.Set("enterprise_project_id", publicIp.EnterpriseProjectID),
+		d.Set("status", NormalizeEipStatus(publicIp.Status)),
+		d.Set("publicip", flattenEipPublicIpDetails(publicIp)),
+		d.Set("bandwidth", flattenEipBandwidthDetails(publicIp, bandWidth)),
 	)
 
-	if mErr.ErrorOrNil() != nil {
-		return mErr
-	}
-
-	// save tags
+	// Save tags via EIP API.
 	if vpcV2Client, err := config.NetworkingV2Client(region); err == nil {
-		if resourceTags, err := tags.Get(vpcV2Client, "publicips", d.Id()).Extract(); err == nil {
+		if resourceTags, err := tags.Get(vpcV2Client, "publicips", resourceId).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
 			if err := d.Set("tags", tagmap); err != nil {
-				return fmtp.Errorf("Error saving tags for EIP (%s): %s", d.Id(), err)
+				mErr = multierror.Append(mErr, fmt.Errorf("error saving tags for EIP (%s): %s", resourceId, err))
 			}
 		} else {
-			logp.Printf("[WARN] Error fetching tags for EIP (%s): %s", d.Id(), err)
+			log.Printf("[WARN] Error fetching tags for EIP (%s): %s", resourceId, err)
 		}
 	} else {
-		return fmtp.Errorf("Error creating vpc client: %s", err)
+		mErr = multierror.Append(mErr, fmt.Errorf("error creating VPC v2.0 client: %s", err))
+	}
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+	return nil
+}
+
+func updateEipConfig(vpcV1Client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var updateOpts = eips.UpdateOpts{}
+
+	if d.HasChange("name") {
+		newName := d.Get("name").(string)
+		updateOpts.Alias = &newName
+	}
+	if d.HasChange("publicip.0.ip_version") {
+		updateOpts.IPVersion = d.Get("publicip.0.ip_version").(int)
+	}
+
+	if updateOpts != (eips.UpdateOpts{}) {
+		log.Printf("[DEBUG] PublicIP Update Options: %#v", updateOpts)
+		_, err := eips.Update(vpcV1Client, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating public IP: %s", err)
+		}
+	}
+	return nil
+}
+
+func updateEipPortId(vpcV1Client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	resourceId := d.Id()
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	old, new := d.GetChange("publicip.0.port_id")
+	oldPort := old.(string)
+	newPort := new.(string)
+
+	if oldPort != "" {
+		err := unbindPort(vpcV1Client, resourceId, oldPort, timeout)
+		if err != nil {
+			log.Printf("[WARN] Error trying to unbind EIP (%s): %s", resourceId, err)
+		}
+	}
+	if newPort != "" {
+		err := bindPort(vpcV1Client, resourceId, newPort, timeout)
+		if err != nil {
+			return fmt.Errorf("error binding EIP (%s) to port (%s): %s", resourceId, newPort, err)
+		}
+	}
+	return nil
+}
+
+func updateEipBandwidth(vpcV1Client *golangsdk.ServiceClient, config *config.Config, d *schema.ResourceData) error {
+	old, new := d.GetChange("bandwidth")
+	oldRaw := old.([]interface{})
+	newRaw := new.([]interface{})
+	// Bandwidth blocks are required and must be present.
+	oldMap := oldRaw[0].(map[string]interface{})
+	newMap := newRaw[0].(map[string]interface{})
+
+	bandwidthId := oldMap["id"].(string)
+	if d.Get("charging_mode").(string) == "prePaid" {
+		vpcV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
+		if err != nil {
+			return fmt.Errorf("error creating VPC v2.0 client: %s", err)
+		}
+		updateOpts := bandwidthsv2.UpdateOpts{
+			Bandwidth: bandwidthsv2.Bandwidth{
+				Name: newMap["name"].(string),
+				Size: newMap["size"].(int),
+			},
+			ExtendParam: &bandwidthsv2.ExtendParam{
+				IsAutoPay: common.GetAutoPay(d),
+			},
+		}
+		log.Printf("[DEBUG] Bandwidth Update Options: %#v", updateOpts)
+
+		order, err := bandwidthsv2.Update(vpcV2Client, bandwidthId, updateOpts)
+		if err != nil {
+			return fmt.Errorf("error updating bandwidth: %s", err)
+		}
+
+		if orderData, ok := order.(bandwidthsv2.PrePaid); ok {
+			log.Printf("[DEBUG] The orderData is: %#v", orderData)
+			// Wait for order success.
+			bssClient, err := config.BssV2Client(config.GetRegion(d))
+			if err != nil {
+				return fmt.Errorf("error creating BSS v2 client: %s", err)
+			}
+			if err := orders.WaitForOrderSuccess(bssClient, int(d.Timeout(schema.TimeoutUpdate)/time.Second), orderData.OrderID); err != nil {
+				return err
+			}
+		} else if d.HasChange("bandwidth.0.size") {
+			return fmt.Errorf("unable to find order structure in API response: %#v", order)
+		}
+		return nil
+	}
+
+	updateOpts := bandwidths.UpdateOpts{
+		Size: newMap["size"].(int),
+		Name: newMap["name"].(string),
+	}
+	log.Printf("[DEBUG] Bandwidth Update Options: %#v", updateOpts)
+	_, err := bandwidths.Update(vpcV1Client, bandwidthId, updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error updating bandwidth: %s", err)
 	}
 
 	return nil
 }
 
-func resourceVpcEIPV1Update(d *schema.ResourceData, meta interface{}) error {
+func resourceVpcEipUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	region := config.GetRegion(d)
+	vpcV1Client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating networking client: %s", err)
+		return diag.Errorf("error creating VPC v1 client: %s", err)
 	}
 
-	// Update bandwidth change
-	if d.HasChange("bandwidth") {
-		newBWList := d.Get("bandwidth").([]interface{})
-		newMap := newBWList[0].(map[string]interface{})
-
-		// Check if eip exists
-		eIP, err := eips.Get(networkingClient, d.Id()).Extract()
-		if err != nil {
-			return common.CheckDeleted(d, err, "eIP")
-		}
-
-		if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
-			networkingV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
-			if err != nil {
-				return fmtp.Errorf("error creating networking v2 client: %s", err)
-			}
-			bandwidth := bandwidthsv2.Bandwidth{
-				Name: newMap["name"].(string),
-				Size: newMap["size"].(int),
-			}
-			extendParam := &bandwidthsv2.ExtendParam{
-				IsAutoPay: common.GetAutoPay(d),
-			}
-			updateOpts := bandwidthsv2.UpdateOpts{
-				Bandwidth:   bandwidth,
-				ExtendParam: extendParam,
-			}
-			logp.Printf("[DEBUG] Bandwidth Update Options: %#v", updateOpts)
-
-			order, err := bandwidthsv2.Update(networkingV2Client, eIP.BandwidthID, updateOpts)
-			if err != nil {
-				return fmtp.Errorf("error updating bandwidth: %s", err)
-			}
-
-			orderData, ok := order.(bandwidthsv2.PrePaid)
-			if ok {
-				logp.Printf("[DEBUG] The orderData is: %#v", orderData)
-				// wait for order success
-				bssClient, err := config.BssV2Client(config.GetRegion(d))
-				if err != nil {
-					return fmtp.Errorf("error creating BSS v2 client: %s", err)
-				}
-				if err := orders.WaitForOrderSuccess(bssClient, int(d.Timeout(schema.TimeoutCreate)/time.Second), orderData.OrderID); err != nil {
-					return err
-				}
-			}
-		} else {
-			var updateOpts bandwidths.UpdateOpts
-			updateOpts.Size = newMap["size"].(int)
-			updateOpts.Name = newMap["name"].(string)
-			logp.Printf("[DEBUG] Bandwidth Update Options: %#v", updateOpts)
-
-			_, err = bandwidths.Update(networkingClient, eIP.BandwidthID, updateOpts).Extract()
-			if err != nil {
-				return fmtp.Errorf("error updating bandwidth: %s", err)
-			}
-		}
-	}
-
-	newIPList := d.Get("publicip").([]interface{})
-	newMap := newIPList[0].(map[string]interface{})
-
-	// Update publicip port_id
-	if d.HasChange("publicip.0.port_id") {
-		timeout := d.Timeout(schema.TimeoutUpdate)
-		old, new := d.GetChange("publicip.0.port_id")
-		oldPort := old.(string)
-		newPort := new.(string)
-
-		if oldPort != "" {
-			err = unbindPort(networkingClient, d.Id(), oldPort, timeout)
-			if err != nil {
-				logp.Printf("[WARN] Error trying to unbind EIP %s :%s", d.Id(), err)
-			}
-		}
-
-		if newPort != "" {
-			err = bindPort(networkingClient, d.Id(), newPort, timeout)
-			if err != nil {
-				return fmtp.Errorf("Error binding EIP %s to port %s: %s", d.Id(), newPort, err)
-			}
-		}
-	}
-
-	// Update publicip name and ip_version
 	// API limitation: port_id and ip_version cannot be updated at the same time
 	if d.HasChanges("name", "publicip.0.ip_version") {
-		newName := d.Get("name").(string)
-		updateOpts := eips.UpdateOpts{
-			Alias:     &newName,
-			IPVersion: newMap["ip_version"].(int),
-		}
-
-		logp.Printf("[DEBUG] PublicIP Update Options: %#v", updateOpts)
-		_, err = eips.Update(networkingClient, d.Id(), updateOpts).Extract()
+		err = updateEipConfig(vpcV1Client, d)
 		if err != nil {
-			return fmtp.Errorf("Error updating publicip: %s", err)
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("publicip.0.port_id") {
+		err = updateEipPortId(vpcV1Client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("bandwidth") {
+		err = updateEipBandwidth(vpcV1Client, config, d)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
 	// update tags
 	if d.HasChange("tags") {
-		vpcV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
+		vpcV2Client, err := config.NetworkingV2Client(region)
 		if err != nil {
-			return fmtp.Errorf("Error creating Huaweicloud vpc client: %s", err)
+			return diag.Errorf("error creating VPC v2 client: %s", err)
 		}
 
 		tagErr := utils.UpdateResourceTags(vpcV2Client, d, "publicips", d.Id())
 		if tagErr != nil {
-			return fmtp.Errorf("Error updating tags of VPC %s: %s", d.Id(), tagErr)
+			return diag.Errorf("error updating tags of VPC (%s): %s", d.Id(), tagErr)
 		}
 	}
 
-	return resourceVpcEIPV1Read(d, meta)
+	return resourceVpcEipRead(ctx, d, meta)
 }
 
-func resourceVpcEIPV1Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceVpcEipDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	networkingClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
-	id := d.Id()
+	resourceId := d.Id()
 
 	// check whether the eip exists before delete it
 	// because resource could not be found cannot be deleteed
-	_, err = eips.Get(networkingClient, id).Extract()
+	_, err = eips.Get(networkingClient, resourceId).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "Error retrieving HuaweiCloud EIP")
+		return common.CheckDeletedDiag(d, err, "error retrieving EIP")
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
 	if v, ok := d.GetOk("publicip.0.port_id"); ok {
 		portID := v.(string)
-		err = unbindPort(networkingClient, id, portID, timeout)
+		err = unbindPort(networkingClient, resourceId, portID, timeout)
 		if err != nil {
-			logp.Printf("[WARN] Error trying to unbind eip %s :%s", id, err)
+			log.Printf("[WARN] Error trying to unbind eip %s :%s", resourceId, err)
 		}
 	}
 
 	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
-		if err := common.UnsubscribePrePaidResource(d, config, []string{id}); err != nil {
-			return fmtp.Errorf("Error unsubscribe publicip: %s", err)
+		if err := common.UnsubscribePrePaidResource(d, config, []string{resourceId}); err != nil {
+			return diag.Errorf("error unsubscribe publicip: %s", err)
 		}
 	} else {
-		if err := eips.Delete(networkingClient, id).ExtractErr(); err != nil {
-			return fmtp.Errorf("Error deleting publicip: %s", err)
+		if err := eips.Delete(networkingClient, resourceId).ExtractErr(); err != nil {
+			return diag.Errorf("error deleting publicip: %s", err)
 		}
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ACTIVE"},
-		Target:     []string{"DELETED"},
-		Refresh:    waitForEIPDelete(networkingClient, d.Id()),
+		Pending:    []string{"PENDING"},
+		Target:     []string{"COMPLETED"},
+		Refresh:    eipStatusRefreshFunc(networkingClient, resourceId, nil),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf("Error deleting EIP: %s", err)
+		return diag.Errorf("error waiting for EIP (%s) to be deleted: %s", resourceId, err)
 	}
 
 	d.SetId("")
@@ -567,68 +720,4 @@ func resourceBandWidth(d *schema.ResourceData) eips.BandwidthOpts {
 		ChargeMode: rawMap["charge_mode"].(string),
 	}
 	return bandwidth
-}
-
-func NormalizeEIPStatus(status string) string {
-	var ret string = status
-
-	// "DOWN" means the eip is active but unbound
-	if status == "DOWN" {
-		ret = "UNBOUND"
-	} else if status == "ACTIVE" {
-		ret = "BOUND"
-	}
-
-	return ret
-}
-
-func getEIPStatus(networkingClient *golangsdk.ServiceClient, eId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		e, err := eips.Get(networkingClient, eId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil, "PENDING_CREATE", nil
-			}
-
-			return nil, "", err
-		}
-
-		logp.Printf("[DEBUG] EIP: %+v", e)
-		if e.Status == "DOWN" || e.Status == "ACTIVE" {
-			return e, "ACTIVE", nil
-		}
-
-		return e, "", nil
-	}
-}
-
-func waitForEIPActive(networkingClient *golangsdk.ServiceClient, eipID string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
-		Target:     []string{"ACTIVE"},
-		Refresh:    getEIPStatus(networkingClient, eipID),
-		Timeout:    timeout,
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-	return err
-}
-
-func waitForEIPDelete(networkingClient *golangsdk.ServiceClient, eId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		logp.Printf("[DEBUG] Attempting to delete EIP %s.\n", eId)
-
-		e, err := eips.Get(networkingClient, eId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[DEBUG] Successfully deleted EIP %s", eId)
-				return e, "DELETED", nil
-			}
-			return nil, "ERROR", err
-		}
-
-		logp.Printf("[DEBUG] EIP %s still active.\n", eId)
-		return e, "ACTIVE", nil
-	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource codes of the EIP have some problems:
- Creation is now supported in some regions, but the code is limited.
- If the name needs to be updated and the EIP is in prepaid mode, the order id is empty, but the code fetches the order id and throws an error.
The resource codes is old school.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust resource codes of the EIP and update related test
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== RUN   TestAccVpcEipsDataSource_byTag
=== PAUSE TestAccVpcEipsDataSource_byTag
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== RUN   TestAccEIPAssociate_port
=== PAUSE TestAccEIPAssociate_port
=== RUN   TestAccEIPAssociate_compatible
=== PAUSE TestAccEIPAssociate_compatible
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== RUN   TestAccVpcBandWidth_WithEpsId
=== PAUSE TestAccVpcBandWidth_WithEpsId
=== RUN   TestAccVpcEip_basic
=== PAUSE TestAccVpcEip_basic
=== RUN   TestAccVpcEip_share
=== PAUSE TestAccVpcEip_share
=== RUN   TestAccVpcEip_WithEpsId
=== PAUSE TestAccVpcEip_WithEpsId
=== RUN   TestAccVpcEip_prePaid
=== PAUSE TestAccVpcEip_prePaid
=== RUN   TestAccVpcEip_deprecated
=== PAUSE TestAccVpcEip_deprecated
=== CONT  TestAccVpcEip_deprecated
=== CONT  TestAccVpcEip_prePaid
=== CONT  TestAccEIPAssociate_compatible
=== CONT  TestAccBandWidthDataSource_basic
--- PASS: TestAccBandWidthDataSource_basic (34.73s)
=== CONT  TestAccVpcEipsDataSource_byTag
--- PASS: TestAccVpcEipsDataSource_byTag (33.11s)
=== CONT  TestAccEIPAssociate_port
--- PASS: TestAccEIPAssociate_compatible (83.54s)
=== CONT  TestAccEIPAssociate_basic
--- PASS: TestAccVpcEip_deprecated (94.55s)
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (28.40s)
=== CONT  TestAccVpcEip_basic
--- PASS: TestAccEIPAssociate_port (80.07s)
=== CONT  TestAccVpcEip_WithEpsId
--- PASS: TestAccVpcEip_basic (38.03s)
=== CONT  TestAccVpcEip_share
--- PASS: TestAccVpcEip_WithEpsId (28.82s)
=== CONT  TestAccVpcBandWidth_WithEpsId
--- PASS: TestAccVpcEip_prePaid (193.10s)
=== CONT  TestAccVpcBandWidth_basic
--- PASS: TestAccVpcBandWidth_WithEpsId (16.90s)
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEip_share (35.02s)
--- PASS: TestAccVpcBandWidth_basic (24.89s)
--- PASS: TestAccVpcEipDataSource_basic (25.02s)
--- PASS: TestAccEIPAssociate_basic (266.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       349.686s
```
