### PR TITLE
chore: get rid of ioutil package

### DIFF
--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -256,7 +256,7 @@ func buildClientByConfig(c *Config) error {
 		return fmt.Errorf("The specified shared config file %s does not exist", profilePath)
 	}
 
-	data, err := ioutil.ReadFile(profilePath)
+	data, err := os.ReadFile(profilePath)
 	if err != nil {
 		return fmt.Errorf("Err reading from shared config file: %s", err)
 	}
@@ -409,7 +409,7 @@ func getAuthConfigByMeta(c *Config) error {
 	var parsedBody interface{}
 
 	defer resp.Body.Close()
-	rawBody, err := ioutil.ReadAll(resp.Body)
+	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("Error parsing metadata API response: %s", err.Error())
 	}

--- a/huaweicloud/config/config_test.go
+++ b/huaweicloud/config/config_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"testing"
@@ -27,7 +27,7 @@ func testRequestRetry(t *testing.T, count int) {
 
 	th.Mux.HandleFunc("/route/", func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Error hadling test request")
 		}

--- a/huaweicloud/config/logger.go
+++ b/huaweicloud/config/logger.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -113,7 +112,7 @@ func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, contentType strin
 		log.Printf("[DEBUG] Not logging because the request body isn't JSON")
 	}
 
-	return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+	return io.NopCloser(strings.NewReader(bs.String())), nil
 }
 
 // logResponse will log the HTTP Response details.
@@ -130,7 +129,7 @@ func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, contentType stri
 		if debugInfo != "" {
 			log.Printf("[DEBUG] API Response Body: %s", debugInfo)
 		}
-		return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+		return io.NopCloser(strings.NewReader(bs.String())), nil
 	}
 
 	log.Printf("[DEBUG] Not logging because the response body isn't JSON")

--- a/huaweicloud/helper/pathorcontents/pathorcontents.go
+++ b/huaweicloud/helper/pathorcontents/pathorcontents.go
@@ -1,7 +1,6 @@
 package pathorcontents
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/mitchellh/go-homedir"
@@ -28,7 +27,7 @@ func Read(poc string) (string, bool, error) {
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return string(contents), true, err
 		}

--- a/huaweicloud/provider_test.go
+++ b/huaweicloud/provider_test.go
@@ -2,7 +2,6 @@ package huaweicloud
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -337,7 +336,7 @@ func envVarFile(varName string) (string, error) {
 		return "", err
 	}
 
-	tmpFile, err := ioutil.TempFile("", varName)
+	tmpFile, err := os.CreateTemp("", varName)
 	if err != nil {
 		return "", fmtp.Errorf("Error creating temp file: %s", err)
 	}

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -2,7 +2,6 @@ package obs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -47,7 +46,7 @@ func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 
 func TestAccObsBucketObjectDataSource_source(t *testing.T) {
 	dataSourceName := "data.huaweicloud_obs_bucket_object.obj"
-	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
+	tmpFile, err := os.CreateTemp("", "tf-acc-obs-obj-source")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -2,7 +2,6 @@ package obs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -19,14 +18,14 @@ func TestAccObsBucketObject_source(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "huaweicloud_obs_bucket_object.object"
 
-	tmpFile, err := ioutil.TempFile("", "tf-acc-obs-obj-source")
+	tmpFile, err := os.CreateTemp("", "tf-acc-obs-obj-source")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(tmpFile.Name())
 
 	// write some data to the tempfile
-	err = ioutil.WriteFile(tmpFile.Name(), []byte("initial object state"), 0644)
+	err = os.WriteFile(tmpFile.Name(), []byte("initial object state"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/huaweicloud/services/apm/resource_huaweicloud_apm_aksk.go
+++ b/huaweicloud/services/apm/resource_huaweicloud_apm_aksk.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"io/ioutil"
-	"time"
 )
 
 func ResourceApmAkSk() *schema.Resource {
@@ -64,7 +65,7 @@ func ResourceApmAkSkCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s to %v : %s", string(body), opts, err)
 	}
@@ -149,7 +150,7 @@ func ResourceApmAkSkDelete(ctx context.Context, d *schema.ResourceData, meta int
 	mErr := &multierror.Error{}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		mErr = multierror.Append(mErr, err)
 	}

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_application.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_application.go
@@ -3,15 +3,16 @@ package cmdb
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"io/ioutil"
-	"strings"
-	"time"
 )
 
 func ResourceAomApplication() *schema.Resource {
@@ -113,7 +114,7 @@ func ResourceAomApplicationCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error create Application %s: %s", opts.Name, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}
@@ -194,7 +195,7 @@ func ResourceAomApplicationUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error update Application %s: %s", string(body), err)
 	}
@@ -221,7 +222,7 @@ func ResourceAomApplicationDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error delete Application %s: %s", d.Id(), err)
 	}

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_component.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_component.go
@@ -3,15 +3,16 @@ package cmdb
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	entity2 "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"io/ioutil"
-	"strings"
-	"time"
 )
 
 func ResourceAomComponent() *schema.Resource {
@@ -114,7 +115,7 @@ func ResourceAomComponentCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error create Component %s: %s", opts.Name, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}
@@ -196,7 +197,7 @@ func ResourceAomComponentUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error update Component %s: %s", string(body), err)
 	}
@@ -223,7 +224,7 @@ func ResourceAomComponentDelete(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error delete Component %s: %s", d.Id(), err)
 	}

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_environment.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_environment.go
@@ -3,15 +3,16 @@ package cmdb
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	entity2 "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"io/ioutil"
-	"strings"
-	"time"
 )
 
 func ResourceAomEnvironment() *schema.Resource {
@@ -144,7 +145,7 @@ func ResourceAomEnvironmentCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error create Environment fields %s: %s", opts, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}
@@ -238,7 +239,7 @@ func ResourceAomEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error update Environment %s: %s", string(body), err)
 	}
@@ -264,7 +265,7 @@ func ResourceAomEnvironmentDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error delete Environment %s: %s", d.Id(), err)
 	}

--- a/huaweicloud/services/cmdb/resource_huaweicloud_aom_resource_relationships.go
+++ b/huaweicloud/services/cmdb/resource_huaweicloud_aom_resource_relationships.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -144,7 +144,7 @@ func ResourceResourceCiRelationshipsCreate(ctx context.Context, d *schema.Resour
 		return diag.Errorf("error Associate Resource field %s: client do error : %s", opts, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}
@@ -228,7 +228,7 @@ func ResourceResourceCiRelationshipsDelete(ctx context.Context, d *schema.Resour
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error delete Resource convert data %s to %v: %s", string(body), opts, err)
 	}

--- a/huaweicloud/services/internal/httpclient_go/httpclient_go.go
+++ b/huaweicloud/services/internal/httpclient_go/httpclient_go.go
@@ -3,13 +3,14 @@ package httpclient_go
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"io/ioutil"
-	"net/http"
-	"strings"
 )
 
 const (
@@ -98,7 +99,7 @@ func (client HttpClientGo) CheckDeletedDiag(d *schema.ResourceData, err error, r
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, diag.Errorf("error convert data %s: %s", string(body), err)
 	}

--- a/huaweicloud/services/internal/httpclient_go/signer.go
+++ b/huaweicloud/services/internal/httpclient_go/signer.go
@@ -5,7 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -105,11 +105,11 @@ func RequestPayload(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
 		return []byte(""), nil
 	}
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return []byte(""), err
 	}
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+	r.Body = io.NopCloser(bytes.NewBuffer(b))
 	return b, err
 }
 

--- a/huaweicloud/services/lts/resource_hauweicloud_lts_struct_template.go
+++ b/huaweicloud/services/lts/resource_hauweicloud_lts_struct_template.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -170,7 +170,7 @@ func resourceLtsStructTemplateCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s , %s", string(body), err)
 	}
@@ -244,7 +244,7 @@ func resourceLtsStructTemplateDelete(_ context.Context, d *schema.ResourceData, 
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return diag.Errorf("error delete StructTemplate %s: %s", d.Id(), string(body))
 	}
@@ -280,7 +280,7 @@ func resourceLtsStructTemplateUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s , %s", string(body), err)
 	}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_access_rule.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_access_rule.go
@@ -3,6 +3,9 @@ package lts
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -10,8 +13,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"io/ioutil"
-	"strings"
 )
 
 func ResourceAomMappingRule() *schema.Resource {
@@ -141,7 +142,7 @@ func resourceAomMappingRuleCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s , %s", string(body), err)
 	}
@@ -205,7 +206,7 @@ func resourceAomMappingRuleDelete(_ context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error delete AomMappingRule %s: %s", d.Id(), err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error delete AomMappingRule %s: %s", d.Id(), err)
 	}
@@ -242,7 +243,7 @@ func resourceAomMappingRuleUpdate(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(Opts.RuleId)
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error update AomMappingRule %s: %s", string(body), err)
 	}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_dashboard.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_dashboard.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -11,8 +14,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"io/ioutil"
-	"strings"
 )
 
 func ResourceLtsDashboard() *schema.Resource {
@@ -109,7 +110,7 @@ func resourceLtsDashBoardCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating LtsDashBoard fields %s: %s", dashBoardRequest.LogGroupId, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}
@@ -174,7 +175,7 @@ func resourceLtsDashBoardDelete(_ context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error delete LtsDashBoard %s: %s", d.Id(), err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error delete LtsDashBoard %s: %s", d.Id(), err)
 	}
@@ -209,7 +210,7 @@ func resourceDashBoardUpdate(_ context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error update LtsDashBoard fields %s: %s", dashBoardRequest.LogGroupId, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_elb_log.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_elb_log.go
@@ -3,13 +3,14 @@ package lts
 import (
 	"context"
 	"encoding/json"
+	"io"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"io/ioutil"
 )
 
 func ResourceLtsElb() *schema.Resource {
@@ -69,7 +70,7 @@ func resourceLtsElbCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error creating LogTank fields %s: %s", LogTankRequest.Logtank.LogGroupId, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error convert data %s, %s", string(body), err)
 	}
@@ -133,7 +134,7 @@ func resourceLtsElbDelete(_ context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error delete LogTank %s: %s", d.Id(), err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return diag.Errorf("error delete LogTank %s: %s", d.Id(), err)
 	}
@@ -163,7 +164,7 @@ func resourceLtsElbUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error update LogTank fields %s: %s", LogTankRequest, err)
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return diag.Errorf("error update LogTank %s: %s", string(body), err)
 	}

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net/http"
@@ -358,7 +357,7 @@ func hasMapContain(rawMap map[string]string, filterKey, filterValue string) bool
 // WriteToPemFile is used to write the keypair to Pem file.
 func WriteToPemFile(path, privateKey string) (err error) {
 	// If the private key exists, give it write permission for editing (-rw-------) for root user.
-	if _, err = ioutil.ReadFile(path); err == nil {
+	if _, err = os.ReadFile(path); err == nil {
 		err = os.Chmod(path, 0600)
 		if err != nil {
 			return
@@ -370,7 +369,7 @@ func WriteToPemFile(path, privateKey string) (err error) {
 			err = mErr.ErrorOrNil()
 		}()
 	}
-	if err = ioutil.WriteFile(path, []byte(privateKey), 0600); err != nil {
+	if err = os.WriteFile(path, []byte(privateKey), 0600); err != nil {
 		return err
 	}
 	return nil
@@ -466,7 +465,7 @@ func FlattenResponse(resp *http.Response) (interface{}, error) {
 	defer resp.Body.Close()
 	// Don't decode JSON when there is no content
 	if resp.StatusCode == http.StatusNoContent {
-		_, err := io.Copy(ioutil.Discard, resp.Body)
+		_, err := io.Copy(io.Discard, resp.Body)
 		return resp, err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

package **io/ioutil** is deprecated.
 As of Go 1.16, the same functionality is now provided by package **io** or package **os**,
and those implementations should be preferred in new code.

- ioutil.ReadFile	--> os.ReadFile
- ioutil.WriteFile	--> os.WriteFile
- ioutil.TempFile	--> os.CreateTemp
- ioutil.Discard		--> io.Discard
- ioutil.ReadAll		--> io.ReadAll
- ioutil.NopCloser	--> io.NopCloser

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/config'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/config -v  -timeout 360m -parallel 4
=== RUN   TestRequestRetry
=== RUN   TestRequestRetry/TestRequestMultipleRetries
=== RUN   TestRequestRetry/TestRequestSingleRetry
=== RUN   TestRequestRetry/TestRequestZeroRetry
--- PASS: TestRequestRetry (30.01s)
    --- PASS: TestRequestRetry/TestRequestMultipleRetries (30.01s)
    --- PASS: TestRequestRetry/TestRequestSingleRetry (0.00s)
    --- PASS: TestRequestRetry/TestRequestZeroRetry (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config        30.033s

$ make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run=TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run=TestAccObsBucketObject_source -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (27.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       27.655s

$ make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run=TestAccKpsKeypair_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run=TestAccKpsKeypair_basic -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_basic
--- PASS: TestAccKpsKeypair_basic (18.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       18.313s
```
