### PR TITLE
refactor(dms): add a lock to DMS resources

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -266,8 +266,8 @@ The `cross_vpc_accesses` block supports:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 30 minute.
-* `update` - Default is 20 minute.
+* `create` - Default is 50 minute.
+* `update` - Default is 50 minute.
 * `delete` - Default is 15 minute.
 
 ## Import

--- a/docs/resources/dms_rabbitmq_instance.md
+++ b/docs/resources/dms_rabbitmq_instance.md
@@ -144,8 +144,8 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 30 minute.
-* `update` - Default is 20 minute.
+* `create` - Default is 50 minute.
+* `update` - Default is 50 minute.
 * `delete` - Default is 15 minute.
 
 ## Import

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -34,7 +34,7 @@ func TestAccKafkaInstance_basic(t *testing.T) {
 	)
 
 	// DMS instances use the tenant-level shared lock, the instances cannot be created or modified in parallel.
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -85,7 +85,7 @@ func TestAccKafkaInstance_withEpsId(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -115,7 +115,7 @@ func TestAccKafkaInstance_compatible(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -145,7 +145,7 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 		getKafkaInstanceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
@@ -34,7 +34,7 @@ func TestAccDmsRabbitmqInstances_basic(t *testing.T) {
 	)
 
 	// DMS instances use the tenant-level shared lock, the instances cannot be created or modified in parallel.
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -82,7 +82,7 @@ func TestAccDmsRabbitmqInstances_withEpsId(t *testing.T) {
 		getDmsRabitMqInstanceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -112,7 +112,7 @@ func TestAccDmsRabbitmqInstances_compatible(t *testing.T) {
 		getDmsRabitMqInstanceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -149,7 +149,7 @@ func TestAccDmsRabbitmqInstances_single(t *testing.T) {
 		getDmsRabitMqInstanceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
@@ -38,8 +38,8 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(50 * time.Minute),
+			Update: schema.DefaultTimeout(50 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 
@@ -383,6 +383,9 @@ func updateCrossVpcAccesses(client *golangsdk.ServiceClient, d *schema.ResourceD
 }
 
 func resourceDmsKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config.MutexKV.Lock(lockKey)
+	defer config.MutexKV.Unlock(lockKey)
+
 	var dErr diag.Diagnostics
 	if _, ok := d.GetOk("flavor_id"); ok {
 		dErr = newKafkaInstanceCreate(ctx, d, meta)
@@ -783,6 +786,9 @@ func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, met
 }
 
 func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config.MutexKV.Lock(lockKey)
+	defer config.MutexKV.Unlock(lockKey)
+
 	config := meta.(*config.Config)
 	dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add locks to DMS resources to ensure that creations and changes do not run concurrently.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccKafkaInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccKafkaInstance -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstancesDataSource_basic
--- PASS: TestAccKafkaInstancesDataSource_basic (653.60s)
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_withEpsId
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_withEpsId (1130.75s)
--- PASS: TestAccKafkaInstance_compatible (1551.41s)
--- PASS: TestAccKafkaInstance_newFormat (2581.09s)
--- PASS: TestAccKafkaInstance_basic (3148.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3801.699s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsRabbitmq'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRabbitmq -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
--- PASS: TestAccDmsRabbitmqInstances_compatible (1252.24s)
--- PASS: TestAccDmsRabbitmqInstances_single (1743.08s)
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (2284.04s)
--- PASS: TestAccDmsRabbitmqInstances_basic (2607.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       2608.048s
```
