### PR TITLE
fix: support ipv6 addresses in an address group

### DIFF
--- a/docs/resources/vpc_address_group.md
+++ b/docs/resources/vpc_address_group.md
@@ -8,12 +8,28 @@ Manages a VPC IP address group resource within HuaweiCloud.
 
 ## Example Usage
 
+### IPv4 Address Group
+
 ```hcl
-resource "huaweicloud_vpc_address_group" "test" {
-  name      = "group-test"
+resource "huaweicloud_vpc_address_group" "ipv4" {
+  name = "group-ipv4"
+
   addresses = [
     "192.168.10.10",
     "192.168.1.1-192.168.1.50"
+  ]
+}
+```
+
+### IPv6 Address Group
+
+```hcl
+resource "huaweicloud_vpc_address_group" "ipv6" {
+  name       = "group-ipv6"
+  ip_version = 6
+
+  addresses = [
+    "2001:db8:a583:6e::/64"
   ]
 }
 ```
@@ -28,10 +44,12 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the IP address group name. The value is a string of 1 to 64 characters that can contain
   letters, digits, underscores (_), hyphens (-) and periods (.).
 
-* `addresses` - (Required, List) Specifies an array of one or more IPv4 addresses. The address can be a single IP
-  address (such as 192.168.10.10), IP address range (such as 192.168.1.1-192.168.1.50) or IP address CIDR (such as 192.168.0.0/16).
-  The maximum length is 20.
-  
+* `addresses` - (Required, List) Specifies an array of one or more IP addresses. The address can be a single IP
+  address, IP address range or IP address CIDR. The maximum length is 20.
+
+* `ip_version` - (Optional, Int, ForceNew) Specifies the IP version, either `4` (default) or `6`.
+  Changing this creates a new address group.
+
 * `description` - (Optional, String) Specifies the supplementary information about the IP address group.
   The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
   
@@ -40,7 +58,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
-* `ip_version` - The IP version of the address group. The value is 4.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_address_group_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_address_group_test.go
@@ -37,7 +37,7 @@ func TestAccVpcAddressGroup_basic(t *testing.T) {
 		getVpcAddressGroupResourceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -58,6 +58,51 @@ func TestAccVpcAddressGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
 					resource.TestCheckResourceAttr(resourceName, "description", "updated by acc test"),
 					resource.TestCheckResourceAttr(resourceName, "addresses.#", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVpcAddressGroup_ipv6(t *testing.T) {
+	var group vpc_model.ShowAddressGroupResponse
+
+	rName := acceptance.RandomAccResourceName()
+	rNameUpdate := rName + "_updated"
+	resourceName := "huaweicloud_vpc_address_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&group,
+		getVpcAddressGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testVpcAdressGroup_ipv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "6"),
+					resource.TestCheckResourceAttr(resourceName, "addresses.#", "1"),
+				),
+			},
+			{
+				Config: testVpcAdressGroup_ipv6_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by acc test"),
+					resource.TestCheckResourceAttr(resourceName, "addresses.#", "2"),
 				),
 			},
 			{
@@ -91,6 +136,33 @@ resource "huaweicloud_vpc_address_group" "test" {
     "192.168.5.0/24",
     "192.168.3.2",
     "192.168.3.20-192.168.3.100"
+  ]
+}
+`, rName)
+}
+
+func testVpcAdressGroup_ipv6(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_address_group" "test" {
+  name        = "%s"
+  description = "created by acc test"
+  ip_version  = 6
+  addresses   = [
+    "2001:db8:a583:6e::/64"
+  ]
+}
+`, rName)
+}
+
+func testVpcAdressGroup_ipv6_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_address_group" "test" {
+  name        = "%s"
+  description = "updated by acc test"
+  ip_version  = 6
+  addresses   = [
+    "2001:db8:a583:8e::1-2001:db8:a583:8e::50",
+    "2001:db8:a583:6e::/64"
   ]
 }
 `, rName)

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	vpc_model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -48,13 +49,16 @@ func ResourceVpcAddressGroup() *schema.Resource {
 				MaxItems: 20,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"ip_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      4,
+				ValidateFunc: validation.IntInSlice([]int{4, 6}),
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"ip_version": {
-				Type:     schema.TypeInt,
-				Computed: true,
 			},
 		},
 	}
@@ -77,7 +81,7 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	addressGroupBody := &vpc_model.CreateAddressGroupOption{
 		Name:      d.Get("name").(string),
 		IpSet:     &ipSet,
-		IpVersion: 4,
+		IpVersion: int32(d.Get("ip_version").(int)),
 	}
 	if v, ok := d.GetOk("description"); ok {
 		desc := v.(string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- the API and SDK can support setting ipv6 address group, add this feature in provider.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcAddressGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcAddressGroup -timeout 360m -parallel 4
=== RUN   TestAccVpcAddressGroup_basic
=== PAUSE TestAccVpcAddressGroup_basic
=== RUN   TestAccVpcAddressGroup_ipv6
=== PAUSE TestAccVpcAddressGroup_ipv6
=== CONT  TestAccVpcAddressGroup_basic
=== CONT  TestAccVpcAddressGroup_ipv6
--- PASS: TestAccVpcAddressGroup_basic (17.52s)
--- PASS: TestAccVpcAddressGroup_ipv6 (17.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       17.768s
```
