### PR TITLE
feat(er/attachment): Support new resource for ER service

### DIFF
--- a/docs/resources/er_vpc_attachment.md
+++ b/docs/resources/er_vpc_attachment.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_vpc_attachment
+
+Manages a VPC attachment resource under the ER instance within HuaweiCloud.
+
+## Example Usage
+
+```HCL
+variable "instance_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "attachment_name" {}
+
+resource "huaweicloud_er_vpc_attachment" "test" {
+  instance_id = var.instance_id
+  vpc_id      = var.vpc_id
+  subnet_id   = var.subnet_id
+
+  name                   = var.attachment_name
+  description            = "VPC attachment created by terraform"
+  auto_create_vpc_routes = true
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the ER instance and the VPC attachment are
+  located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the ER instance to which the VPC attachment
+  belongs.  
+  Changing this parameter will create a new resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC to which the VPC attachment belongs.  
+  Changing this parameter will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the VPC subnet to which the VPC attachment belongs.  
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the VPC attachment.  
+  The name can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-) and
+  dots (.) allowed.
+
+* `description` - (Optional, String) Specifies the description of the VPC attachment.  
+  The description contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+
+* `auto_create_vpc_routes` - (Optional, Bool, ForceNew) Specifies whether to automatically configure routes for the VPC
+  which pointing to the ER instance.  
+  The destination CIDRs of the routes are fixed as follows:
+  + **10.0.0.0/8**
+  + **172.16.0.0/12**
+  + **192.168.0.0/16**
+
+  The default value is false. Changing this parameter will create a new resource.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the VPC attachment.  
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The current status of the VPC attachment.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 2 minutes.
+
+## Import
+
+VPC attachments can be imported using their `id` and the related `instance_id`, e.g.
+
+```
+$ terraform import huaweicloud_er_vpc_attachment.test &ltinstance_id&gt/&ltid&gt
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20221115092150-d2a1a2f61683
+	github.com/chnsz/golangsdk v0.0.0-20221117084452-b4a42388f511
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20221115092150-d2a1a2f61683 h1:N5MmIwhqV2SI9caDpiwje/QSdHCPXZdc9CJd3bD94g0=
-github.com/chnsz/golangsdk v0.0.0-20221115092150-d2a1a2f61683/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221117084452-b4a42388f511 h1:Z7TvQnI5jjXdi+l7nDG6g8PBWkmqjKFXpg6V5fOKhTo=
+github.com/chnsz/golangsdk v0.0.0-20221117084452-b4a42388f511/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -637,6 +637,10 @@ func (c *Config) DnsWithRegionClient(region string) (*golangsdk.ServiceClient, e
 	return c.NewServiceClient("dns_region", region)
 }
 
+func (c *Config) ErV3Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("er", region)
+}
+
 // ********** client for Management **********
 func (c *Config) CtsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("cts", region)

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -868,6 +868,18 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 		t.Fatalf("VPCEP endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
 	t.Logf("VPCEP endpoint:\t %s", actualURL)
+
+	// Test the endpoint of ER endpoint (ver.3)
+	serviceClient, err = config.ErV3Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating ER v3 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://er.%s.%s/v3/%s/", HW_REGION_NAME, config.Cloud, config.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("ER endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("ER endpoint:\t %s", actualURL)
 }
 
 func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -685,7 +685,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_enterprise_project": eps.ResourceEnterpriseProject(),
 
-			"huaweicloud_er_instance": er.ResourceInstance(),
+			"huaweicloud_er_instance":       er.ResourceInstance(),
+			"huaweicloud_er_vpc_attachment": er.ResourceVpcAttachment(),
 
 			"huaweicloud_evs_snapshot": ResourceEvsSnapshotV2(),
 			"huaweicloud_evs_volume":   evs.ResourceEvsVolume(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
@@ -1,0 +1,170 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getVpcAttachmentResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	return vpcattachments.Get(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+func TestAccVpcAttachment_basic(t *testing.T) {
+	var (
+		obj        vpcattachments.Attachment
+		rName      = "huaweicloud_er_vpc_attachment.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		bgpAsNum   = acctest.RandIntRange(64512, 65534)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getVpcAttachmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testVpcAttachment_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Create by acc test"),
+					resource.TestCheckResourceAttr(rName, "auto_create_vpc_routes", "true"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckOutput("er_route_count", "3"),
+				),
+			},
+			{
+				Config: testVpcAttachment_basic_update(updateName, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcAttachmentImportStateFunc(),
+			},
+		},
+	})
+}
+
+func testAccVpcAttachmentImportStateFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, attachmentId string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_er_vpc_attachment" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				attachmentId = rs.Primary.ID
+			}
+		}
+		if instanceId == "" || attachmentId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<instance_id>/<attachment_id>', but '%s/%s'",
+				instanceId, attachmentId)
+		}
+		return fmt.Sprintf("%s/%s", instanceId, attachmentId), nil
+	}
+}
+
+func testVpcAttachment_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id = huaweicloud_vpc.test.id
+
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = ["%[2]s"]
+
+  name = "%[1]s"
+  asn  = %[3]d
+}
+`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+}
+
+func testVpcAttachment_basic(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_vpc_attachment" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+
+  name                   = "%[2]s"
+  description            = "Create by acc test"
+  auto_create_vpc_routes = true
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+data "huaweicloud_vpc_route_table" "test" {
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test
+  ]
+
+  vpc_id = huaweicloud_vpc.test.id
+  name   = "rtb-%[2]s"
+}
+
+output "er_route_count" {
+  value = length([for route in data.huaweicloud_vpc_route_table.test.route : route.type == "er"])
+}
+`, testVpcAttachment_base(name, bgpAsNum), name)
+}
+
+func testVpcAttachment_basic_update(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_vpc_attachment" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+
+  name                   = "%[2]s"
+  auto_create_vpc_routes = true
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testVpcAttachment_base(name, bgpAsNum), name)
+}

--- a/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
@@ -1,0 +1,294 @@
+package er
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceVpcAttachment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVpcAttachmentCreate,
+		UpdateContext: resourceVpcAttachmentUpdate,
+		ReadContext:   resourceVpcAttachmentRead,
+		DeleteContext: resourceVpcAttachmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVpcAttachmentImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the ER instance and the VPC attachment are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the ER instance to which the VPC attachment belongs.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the VPC to which the VPC attachment belongs.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the VPC subnet to which the VPC attachment belongs.`,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa5\\w.-]*$"), "The name only english and "+
+						"chinese letters, digits, underscore (_), hyphens (-) and dots (.) are allowed."),
+				),
+				Description: `The name of the VPC attachment.`,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile(`^[^<>]*$`),
+						"The angle brackets (< and >) are not allowed."),
+				),
+				Description: `The description of the VPC attachment.`,
+			},
+			"auto_create_vpc_routes": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Whether to automatically configure routes for the VPC which pointing to the ER instance.`,
+			},
+			"tags": common.TagsForceNewSchema(),
+			// Attributes
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the VPC attachment.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time.`,
+			},
+		},
+	}
+}
+
+func resourceVpcAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	opts := vpcattachments.CreateOpts{
+		VpcId:               d.Get("vpc_id").(string),
+		SubnetId:            d.Get("subnet_id").(string),
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		AutoCreateVpcRoutes: utils.Bool(d.Get("auto_create_vpc_routes").(bool)),
+		Tags:                utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+	}
+	instanceId := d.Get("instance_id").(string)
+	resp, err := vpcattachments.Create(client, instanceId, opts)
+	if err != nil {
+		return diag.Errorf("error creating VPC attachment: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      vpcAttachmentStatusRefreshFunc(client, instanceId, d.Id(), []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceVpcAttachmentRead(ctx, d, meta)
+}
+
+func resourceVpcAttachmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		config       = meta.(*config.Config)
+		region       = config.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		attachmentId = d.Id()
+	)
+
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	resp, err := vpcattachments.Get(client, instanceId, attachmentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "ER VPC attachment")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("vpc_id", resp.VpcId),
+		d.Set("subnet_id", resp.SubnetId),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("auto_create_vpc_routes", resp.AutoCreateVpcRoutes),
+		d.Set("tags", utils.TagsToMap(resp.Tags)),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving VPC attachment (%s) fields: %s", d.Id(), mErr)
+	}
+	return nil
+}
+
+func updateVpcAttachmentBasicInfo(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		instanceId   = d.Get("instance_id").(string)
+		attachmentId = d.Id()
+	)
+
+	opts := vpcattachments.UpdateOpts{
+		Name:        d.Get("name").(string),
+		Description: utils.String(d.Get("description").(string)),
+	}
+
+	_, err := vpcattachments.Update(client, instanceId, d.Id(), opts)
+	if err != nil {
+		return fmt.Errorf("error getting VPC attachment (%s) details: %s", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      vpcAttachmentStatusRefreshFunc(client, instanceId, attachmentId, []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func vpcAttachmentStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, attachmentId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := vpcattachments.Get(client, instanceId, attachmentId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return resp, "COMPLETED", nil
+			}
+
+			return nil, "", err
+		}
+		log.Printf("[DEBUG] The details of the VPC attachment (%s) is: %#v", attachmentId, resp)
+
+		if utils.StrSliceContains([]string{"failed"}, resp.Status) {
+			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		}
+		if utils.StrSliceContains(targets, resp.Status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceVpcAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		if err = updateVpcAttachmentBasicInfo(ctx, client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceVpcAttachmentRead(ctx, d, meta)
+}
+
+func resourceVpcAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	attachmentId := d.Id()
+
+	err = vpcattachments.Delete(client, instanceId, attachmentId)
+	if err != nil {
+		return diag.Errorf("error deleting VPC attachment (%s) form the ER instance: %s", attachmentId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      vpcAttachmentStatusRefreshFunc(client, instanceId, attachmentId, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceVpcAttachmentImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<attachment_id>', but '%s'", d.Id())
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments/requests.go
@@ -1,0 +1,133 @@
+package vpcattachments
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure required by the Create method to create a VPC attachment under the ER instance.
+type CreateOpts struct {
+	// The VPC ID corresponding to the VPC attachment.
+	VpcId string `json:"vpc_id" required:"true"`
+	// The VPC subnet ID corresponding to the VPC attachment.
+	SubnetId string `json:"virsubnet_id" required:"true"`
+	// The name of the VPC attachment.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name" required:"true"`
+	// The description of the VPC attachment.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description string `json:"description,omitempty"`
+	// Whether automatically configure a route pointing to the ER instance for the VPC, defaults to false.
+	AutoCreateVpcRoutes *bool `json:"auto_create_vpc_routes,omitempty"`
+	// The key/value pairs to associate with the VPC attachment.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a VPC attachment under the ER instance using create option.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts CreateOpts) (*Attachment, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "vpc_attachment")
+	if err != nil {
+		return nil, err
+	}
+
+	var r SingleResp
+	_, err = client.Post(rootURL(client, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Attachment, err
+}
+
+// Get is a method to obtain the details of a specified VPC attachment under ER instance using its ID.
+func Get(client *golangsdk.ServiceClient, instanceId, attachmentId string) (*Attachment, error) {
+	var r SingleResp
+	_, err := client.Get(resourceURL(client, instanceId, attachmentId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Attachment, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the VPC attachment of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of VPC IDs corresponding to the VPC attachments, support for querying multiple VPC attachments.
+	VpcId []string `q:"vpc_id"`
+	// The list of VPC attachment IDs, support for querying multiple VPC attachments.
+	AttachmentId []string `q:"id"`
+	// The list of current status of the VPC attachments, support for querying multiple VPC attachments.
+	Status []string `q:"state"`
+	// The list of keyword to sort the VPC attachments result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the VPC attachments under specified ER instance using given opts.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOpts) ([]Attachment, error) {
+	url := rootURL(client, instanceId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := AttachmentPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	return ExtractAttachments(pages)
+}
+
+// UpdateOpts is the structure required by the Update method to update the VPC attachment configuration.
+type UpdateOpts struct {
+	// The name of the VPC attachment.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name,omitempty"`
+	// The description of the VPC attachment.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description *string `json:"description,omitempty"`
+}
+
+// Update is a method to update the VPC attachment under the ER instance using update option.
+func Update(client *golangsdk.ServiceClient, instanceId, attachmentId string, opts UpdateOpts) (*Attachment, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "vpc_attachment")
+	if err != nil {
+		return nil, err
+	}
+
+	var r SingleResp
+	_, err = client.Put(resourceURL(client, instanceId, attachmentId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Attachment, err
+}
+
+// Delete is a method to remove an existing VPC attachment under specified ER instance.
+func Delete(client *golangsdk.ServiceClient, instanceId, attachmentId string) error {
+	_, err := client.Delete(resourceURL(client, instanceId, attachmentId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments/results.go
@@ -1,0 +1,116 @@
+package vpcattachments
+
+import (
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// SingleResp is the structure that represents the VPC attachment detail and the request information of the API request.
+type SingleResp struct {
+	// The response detail of the VPC attachment.
+	Attachment Attachment `json:"vpc_attachment"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Attachment is the structure that represents the details of the VPC attachment for ER service.
+type Attachment struct {
+	// The project ID.
+	ProjectId string `json:"project_id"`
+	// The ID of the project where the VPC is located.
+	VpcProjectId string `json:"vpc_project_id"`
+	// The ID of the VPC attachment.
+	ID string `json:"id"`
+	// The name of the VPC attachment.
+	Name string `json:"name"`
+	// The description of the VPC attachment.
+	Description string `json:"description"`
+	// The VPC ID corresponding to the VPC attachment.
+	VpcId string `json:"vpc_id"`
+	// The VPC subnet ID corresponding to the VPC attachment.
+	SubnetId string `json:"virsubnet_id"`
+	// Whether automatically configure a route pointing to the ER instance for the VPC.
+	AutoCreateVpcRoutes bool `json:"auto_create_vpc_routes"`
+	// The current status of the VPC attachment.
+	Status string `json:"state"`
+	// The creation time of the VPC attachment.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the VPC attachment.
+	UpdatedAt string `json:"updated_at"`
+	// The key/value pairs to associate with the VPC attachment.
+	Tags []tags.ResourceTag `json:"tags"`
+}
+
+// MultipleResp is the structure that represents the VPC attachment list, page detail and the request information.
+type MultipleResp struct {
+	// The list of the VPC attachment.
+	Attachments []Attachment `json:"vpc_attachments"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo PageInfo `json:"page_info"`
+}
+
+// PageInfo is the structure that represents the page information.
+type PageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the VPC attahcment in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// AttachmentPage represents the response pages of the List method.
+type AttachmentPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if current page no VPC attachment.
+func (r AttachmentPage) IsEmpty() (bool, error) {
+	resp, err := ExtractAttachments(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index during current page.
+func (r AttachmentPage) LastMarker() (string, error) {
+	resp, err := ExtractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r AttachmentPage) NextPageURL() (string, error) {
+	currentURL := r.URL
+
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == "" {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// ExtractPageInfo is a method which to extract the response of the page information.
+func ExtractPageInfo(r pagination.Page) (*PageInfo, error) {
+	var s MultipleResp
+	err := r.(AttachmentPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// ExtractAttachments is a method which to extract the response to an attachment list.
+func ExtractAttachments(r pagination.Page) ([]Attachment, error) {
+	var s MultipleResp
+	err := r.(AttachmentPage).Result.ExtractInto(&s)
+	return s.Attachments, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments/urls.go
@@ -1,0 +1,11 @@
+package vpcattachments
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "vpc-attachments")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, instanceId, attachmentId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "vpc-attachments", attachmentId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20221115092150-d2a1a2f61683
+# github.com/chnsz/golangsdk v0.0.0-20221117084452-b4a42388f511
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -148,6 +148,7 @@ github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers
 github.com/chnsz/golangsdk/openstack/elb/v3/monitors
 github.com/chnsz/golangsdk/openstack/elb/v3/pools
 github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects
+github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new ER resource 'huaweicloud_er_vpc_attachment'.
- Only name and description can be updated, the tags API will be released at the end of November.
- The parameter 'auto_create_vpc_routes' can automatically create three route to the default routing table of the VPC network to which the attachment associated.  

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new ER resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccVpcAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccVpcAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcAttachment_basic
=== PAUSE TestAccVpcAttachment_basic
=== CONT  TestAccVpcAttachment_basic
--- PASS: TestAccVpcAttachment_basic (132.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        132.255s
```
