### PR TITLE
feat(cce): support prePaid in node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -122,6 +122,20 @@ extend_param = {
 * `data_volumes` - (Required, List, ForceNew) Specifies the configuration of the data disks.
   The structure is described below. Changing this parameter will create a new resource.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CCE node pool. Valid values are
+  *prePaid* and *postPaid*, defaults to *postPaid*. Changing this parameter will create a new resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the CCE node pool.
+  Valid values are *month* and *year*. This parameter is mandatory if `charging_mode` is set to *prePaid*.
+  Changing this parameter will create a new resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the CCE node pool. If `period_unit` is set to
+  *month*, the value ranges from 1 to 9. If `period_unit` is set to *year*, the value ranges from 1 to 3. This parameter
+  is mandatory if `charging_mode` is set to *prePaid*. Changing this parameter will create a new resource.
+
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled. Valid values are "true" and "false".
+  Changing this parameter will create a new resource.
+
 * `taints` - (Optional, List) Specifies the taints configuration of the nodes to set anti-affinity.
   The structure is described below.
 

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -242,7 +242,7 @@ func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
 //
 // Before using this function, make sure the parameter behavior is auto pay (the default value is "true").
 func GetAutoPay(d *schema.ResourceData) string {
-	if d.Get("auto_pay").(string) == "false" {
+	if val, ok := d.GetOk("auto_pay"); ok && val.(string) == "false" {
 		return "false"
 	}
 	return "true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support prePaid in node pool
we don't need to unsubscribe to resource before delete the nodepool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support prePaid in node pool
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1558.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1559.114s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_prePaid -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_prePaid
=== PAUSE TestAccCCENodePool_prePaid
=== CONT  TestAccCCENodePool_prePaid
--- PASS: TestAccCCENodePool_prePaid (953.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       954.052s
```
