### PR TITLE
feat: Add allowed ips in networking port datasource output

### DIFF
--- a/docs/data-sources/networking_port.md
+++ b/docs/data-sources/networking_port.md
@@ -46,6 +46,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `device_id` - The ID of the device the port belongs to.
 
+* `all_allowed_ips` - The collection of allowed IP addresses on the port.
+
 * `all_fixed_ips` - The collection of Fixed IP addresses on the port.
 
 * `all_security_group_ids` - The collection of security group IDs applied on the port.

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
@@ -86,6 +86,11 @@ func DataSourceNetworkingPortV2() *schema.Resource {
 			},
 
 			// Computed
+			"all_allowed_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"all_fixed_ips": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -214,9 +219,19 @@ func dataSourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) er
 	d.Set("device_id", port.DeviceID)
 	d.Set("region", config.GetRegion(d))
 	d.Set("all_security_group_ids", port.SecurityGroups)
+	d.Set("all_allowed_ips", expandNetworkingPortAllowedAddressPairToStringSlice(port.AllowedAddressPairs))
 	d.Set("all_fixed_ips", expandNetworkingPortFixedIPToStringSlice(port.FixedIPs))
 
 	return nil
+}
+
+func expandNetworkingPortAllowedAddressPairToStringSlice(addressPairs []ports.AddressPair) []string {
+	s := make([]string, len(addressPairs))
+	for i, addressPair := range addressPairs {
+		s[i] = addressPair.IPAddress
+	}
+
+	return s
 }
 
 func expandNetworkingPortFixedIPToStringSlice(fixedIPs []ports.IP) []string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `all_allowed_ips` computed field in networking port datasource output.
This allows to get IPs attached to an existing VIP for example.

**Release note**:
```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
