### PR TITLE
feat(er/routetable): Support route table resource

### DIFF
--- a/docs/data-sources/er_route_tables.md
+++ b/docs/data-sources/er_route_tables.md
@@ -1,0 +1,121 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_route_tables
+
+Use this data source to query the route tables under the ER instance within HuaweiCloud.
+
+## Example Usage
+
+### Querying specified route tables under ER instance using name
+
+```HCL
+variable "instance_id" {}
+variable "route_table_name" {}
+
+data "huaweicloud_er_route_tables" "test" {
+  instance_id = var.instance_id
+  name        = var.route_table_name
+}
+```
+
+### Querying specified route tables under ER instance using tags
+
+```HCL
+variable "instance_id" {}
+
+data "huaweicloud_er_route_tables" "test" {
+  instance_id = var.instance_id
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the ER instance and route table are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the ER instance to which the route tables belongs.
+
+* `route_table_id` - (Optional, String) Specifies the route table ID used to query specified route table.
+
+* `name` - (Optional, String) Specifies the name used to filter the route tables.  
+  The name can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-) and
+  dots (.) allowed.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs used to filter the route tables.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `route_tables` - All route tables that match the filter parameters.  
+  The [object](#route_tables) structure is documented below.
+
+<a name="route_tables"></a>
+The `route_tables` block supports:
+
+* `id` - The route table ID.
+
+* `name` - The name of the route table.
+
+* `description` - The description of the route table.
+
+* `associations` - The association configurations of the route table.  
+  The [object](#route_table_relationship) structure is documented below.
+
+* `propagations` - The propagation configurations of the route table.  
+  The [object](#route_table_relationship) structure is documented below.
+
+* `routes` - The route details of the route table.  
+  The [object](#route_table_routes) structure is documented below.
+
+* `is_default_association` - Whether this route table is the default association route table.
+
+* `is_default_propagation` - Whether this route table is the default propagation route table.
+
+* `status` - The current status of the route table.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+<a name="route_table_relationship"></a>
+The `associations` or `propagations` block supports:
+
+* `id` - The ID of the association/propagation.
+
+* `attachment_id` - The attachment ID corresponding to the routing association/propagation.
+
+* `attachment_type` - The attachment type corresponding to the routing association/propagation.
+
+<a name="route_table_routes"></a>
+The `routes` block supports:
+
+* `id` - The route ID.
+
+* `destination` - The destination address (CIDR) of the route.
+
+* `is_blackhole` - Whether route is the black hole route.
+
+* `attachments` - The details of the attachment corresponding to the route.  
+  The [object](#route_table_route_attachments) structure is documented below.
+
+* `status` - The current status of the route.
+
+<a name="route_table_route_attachments"></a>
+The `attachments` block supports:
+
+* `attachment_id` - The ID of the nexthop attachment.
+
+* `attachment_type` - The type of the nexthop attachment.
+
+* `resource_id` - The ID of the resource associated with the attachment.

--- a/docs/resources/er_route_table.md
+++ b/docs/resources/er_route_table.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_route_table
+
+Manages a route table resource under the ER instance within HuaweiCloud.
+
+## Example Usage
+
+```HCL
+variable "instance_id" {}
+variable "route_table_name" {}
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = var.instance_id
+  name        = var.route_table_name
+  description = "Route table created by terraform"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the ER instance and route table are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the ER instance to which the route table belongs.  
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the route table.  
+  The name can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-) and
+  dots (.) allowed.
+
+* `description` - (Optional, String) Specifies the description of the route table.  
+  The description contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the route table.  
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `is_default_association` - Whether this route table is the default association route table.
+
+* `is_default_propagation` - Whether this route table is the default propagation route table.
+
+* `status` - The current status of the route table.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+Route tables can be imported using their `id` and the related `instance_id`, separated by slashes (/), e.g.
+
+```
+$ terraform import huaweicloud_er_route_table.test &ltinstance_id&gt/&ltid&gt
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -400,8 +400,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
 
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
-			"huaweicloud_evs_volumes":        evs.DataSourceEvsVolumesV2(),
-			"huaweicloud_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
+
+			"huaweicloud_er_route_tables": er.DataSourceRouteTables(),
+
+			"huaweicloud_evs_volumes":      evs.DataSourceEvsVolumesV2(),
+			"huaweicloud_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
 
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": gaussdb.DataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_flavors":            gaussdb.DataSourceCassandraFlavors(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -690,6 +690,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_enterprise_project": eps.ResourceEnterpriseProject(),
 
 			"huaweicloud_er_instance":       er.ResourceInstance(),
+			"huaweicloud_er_route_table":    er.ResourceRouteTable(),
 			"huaweicloud_er_vpc_attachment": er.ResourceVpcAttachment(),
 
 			"huaweicloud_evs_snapshot": ResourceEvsSnapshotV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -90,6 +90,8 @@ var (
 	HW_FGS_TRIGGER_LTS_AGENCY = os.Getenv("HW_FGS_TRIGGER_LTS_AGENCY")
 
 	HW_KMS_ENVIRONMENT = os.Getenv("HW_KMS_ENVIRONMENT")
+
+	HW_ER_TEST_ON = os.Getenv("HW_ER_TEST_ON") // Whether to run the ER related tests.
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -414,5 +416,12 @@ func TestAccPreCheckWorkspaceAD(t *testing.T) {
 	if HW_WORKSPACE_AD_DOMAIN_NAME == "" || HW_WORKSPACE_AD_SERVER_PWD == "" || HW_WORKSPACE_AD_DOMAIN_IP == "" ||
 		HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" {
 		t.Skip("The configuration of AD server is not completed for Workspace service acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckER(t *testing.T) {
+	if HW_ER_TEST_ON == "" {
+		t.Skip("Skip all ER acceptance tests.")
 	}
 }

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
@@ -1,0 +1,223 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRouteTablesDataSource_basic(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dName, "route_tables.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRouteTablesDataSource_byName(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_byName(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("route_tables_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRouteTablesDataSource_byId(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_byId(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("route_tables_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRouteTablesDataSource_byTags(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_route_tables.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTablesDataSource_byTags(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("route_tables_count", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRouteTablesDataSource_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = ["%[1]s"]
+
+  name = "%[2]s"
+  asn  = %[3]d
+}
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+
+resource "huaweicloud_er_route_table" "another" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s_another"
+
+  tags = {
+    owner = "terraform"
+  }
+}
+`, acceptance.HW_AVAILABILITY_ZONE, name, bgpAsNum)
+}
+
+func testAccRouteTablesDataSource_basic(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_route_tables" "test" {
+  depends_on = [
+    huaweicloud_er_route_table.test
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}
+
+func testAccRouteTablesDataSource_byName(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_route_tables" "test" {
+  depends_on = [
+    huaweicloud_er_route_table.test
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+}
+
+output "route_tables_count" {
+  value = length(data.huaweicloud_er_route_tables.test.route_tables)
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}
+
+func testAccRouteTablesDataSource_byId(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_route_tables" "test" {
+  depends_on = [
+    huaweicloud_er_route_table.test
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+}
+
+output "route_tables_count" {
+  value = length(data.huaweicloud_er_route_tables.test.route_tables)
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}
+
+func testAccRouteTablesDataSource_byTags(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_route_tables" "test" {
+  depends_on = [
+    huaweicloud_er_route_table.test
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+
+  tags = {
+    owner = "terraform"
+  }
+}
+
+output "route_tables_count" {
+  value = length(data.huaweicloud_er_route_tables.test.route_tables)
+}
+`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+}

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
@@ -1,0 +1,135 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/routetables"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getRouteTableResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	return routetables.Get(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+func TestAccRouteTable_basic(t *testing.T) {
+	var (
+		obj routetables.RouteTable
+
+		rName      = "huaweicloud_er_route_table.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		bgpAsNum   = acctest.RandIntRange(64512, 65534)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRouteTableResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRouteTable_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Create by acc test"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testRouteTable_basic_update(updateName, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRouteTableImportStateFunc(),
+			},
+		},
+	})
+}
+
+func testAccRouteTableImportStateFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, routeTableId string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_er_route_table" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				routeTableId = rs.Primary.ID
+			}
+		}
+		if instanceId == "" || routeTableId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<instance_id>/<route_table_id>', but '%s/%s'",
+				instanceId, routeTableId)
+		}
+		return fmt.Sprintf("%s/%s", instanceId, routeTableId), nil
+	}
+}
+
+func testRouteTable_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = ["%[2]s"]
+  name               = "%[1]s"
+  asn                = %[3]d
+}
+`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+}
+
+func testRouteTable_basic(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+  description = "Create by acc test"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testRouteTable_base(name, bgpAsNum), name)
+}
+
+func testRouteTable_basic_update(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testRouteTable_base(name, bgpAsNum), name)
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
@@ -1,0 +1,368 @@
+package er
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
+	"github.com/chnsz/golangsdk/openstack/er/v3/propagations"
+	"github.com/chnsz/golangsdk/openstack/er/v3/routes"
+	"github.com/chnsz/golangsdk/openstack/er/v3/routetables"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceRouteTables() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRouteTablesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the ER instance and route table are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the ER instance to which the route table belongs.`,
+			},
+			"route_table_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The route table ID used to query specified route table.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name used to filter the route tables.`,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa5\\w.-]*$"), "The name only english and "+
+						"chinese letters, digits, underscore (_), hyphens (-) and dots (.) are allowed."),
+				),
+			},
+			"tags": common.TagsSchema(),
+			// Attributes
+			"route_tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The route table ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the route table.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the route table.`,
+						},
+						"associations": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        routeTableRelationshipSchemaResource(),
+							Description: `The association configuration of the route table.`,
+						},
+						"propagations": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        routeTableRelationshipSchemaResource(),
+							Description: `The propagation configuration of the route table.`,
+						},
+						"routes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The route ID.`,
+									},
+									"destination": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The destination address (CIDR) of the route.`,
+									},
+									"is_blackhole": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether route is the black hole route.`,
+									},
+									"attachments": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"attachment_id": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The ID of the nexthop attachment.`,
+												},
+												"attachment_type": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The type of the nexthop attachment.`,
+												},
+												"resource_id": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The ID of the resource associated with the attachment.`,
+												},
+											},
+										},
+										Description: `The details of the attachment corresponding to the route.`,
+									},
+									"status": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The current status of the route.`,
+									},
+								},
+							},
+							Description: `The route details of the route table.`,
+						},
+						"is_default_association": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether this route table is the default association route table.`,
+						},
+						"is_default_propagation": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether this route table is the default propagation route table.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current status of the route table.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time.`,
+						},
+						"tags": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The tags configuration of the route table.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func routeTableRelationshipSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the association/propagation.`,
+			},
+			"attachment_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The attachment ID corresponding to the routing association/propagation.`,
+			},
+			"attachment_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The attachment type corresponding to the routing association/propagation.`,
+			},
+		},
+	}
+}
+
+func queryRouteTableAssociations(client *golangsdk.ServiceClient, instanceId, routeTableId string) ([]map[string]interface{},
+	error) {
+	resp, err := associations.List(client, instanceId, routeTableId, associations.ListOpts{})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(resp))
+	for i, association := range resp {
+		result[i] = map[string]interface{}{
+			"attachment_id":   association.AttachmentId,
+			"id":              association.ID,
+			"attachment_type": association.ResourceType,
+		}
+	}
+	return result, nil
+}
+
+func queryRouteTablePropagations(client *golangsdk.ServiceClient, instanceId, routeTableId string) ([]map[string]interface{},
+	error) {
+	resp, err := propagations.List(client, instanceId, routeTableId, propagations.ListOpts{})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(resp))
+	for i, propagation := range resp {
+		result[i] = map[string]interface{}{
+			"attachment_id":   propagation.AttachmentId,
+			"id":              propagation.ID,
+			"attachment_type": propagation.ResourceType,
+		}
+	}
+	return result, nil
+}
+
+func queryRouteTableRoutes(client *golangsdk.ServiceClient, routeTableId string) ([]map[string]interface{},
+	error) {
+	resp, err := routes.List(client, routeTableId, routes.ListOpts{})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(resp))
+	for i, route := range resp {
+		rr := map[string]interface{}{
+			"destination":  route.Destination,
+			"is_blackhole": route.IsBlackHole,
+			"id":           route.ID,
+			"status":       route.Status,
+		}
+		if len(route.Attachments) < 1 {
+			result[i] = rr
+			continue
+		}
+
+		attachments := make([]map[string]interface{}, len(route.Attachments))
+		for i, attachment := range route.Attachments {
+			attachments[i] = map[string]interface{}{
+				"attachment_id":   attachment.AttachmentId,
+				"attachment_type": attachment.AttachmentId,
+				"resource_id":     attachment.AttachmentId,
+			}
+		}
+		rr["attachments"] = attachments
+		result[i] = rr
+	}
+	return result, nil
+}
+
+func filterRouteTablesByTags(d *schema.ResourceData, all []routetables.RouteTable) ([]routetables.RouteTable, error) {
+	filter := map[string]interface{}{
+		"ID":   d.Get("route_table_id"),
+		"Name": d.Get("name"),
+	}
+	filterResult, err := utils.FilterSliceWithField(all, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error filting security groups list: %s", err)
+	}
+
+	tagFilter := d.Get("tags").(map[string]interface{})
+	result := make([]routetables.RouteTable, 0, len(filterResult))
+	for _, val := range filterResult {
+		item := val.(routetables.RouteTable)
+		tagmap := utils.TagsToMap(item.Tags)
+
+		if !utils.HasMapContains(tagmap, tagFilter) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func flattenRouteTables(client *golangsdk.ServiceClient, instanceId string,
+	all []routetables.RouteTable) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, routeTable := range all {
+		routeTableId := routeTable.ID
+
+		associationList, _ := queryRouteTableAssociations(client, instanceId, routeTableId)
+		propagationList, _ := queryRouteTablePropagations(client, instanceId, routeTableId)
+		routeList, _ := queryRouteTableRoutes(client, routeTableId)
+
+		result[i] = map[string]interface{}{
+			"id":                     routeTableId,
+			"description":            routeTable.Description,
+			"associations":           associationList,
+			"propagations":           propagationList,
+			"routes":                 routeList,
+			"is_default_association": routeTable.IsDefaultAssociation,
+			"is_default_propagation": routeTable.IsDefaultPropagation,
+			"status":                 routeTable.Status,
+			"created_at":             routeTable.CreatedAt,
+			"updated_at":             routeTable.UpdatedAt,
+			"tags":                   utils.TagsToMap(routeTable.Tags),
+		}
+	}
+	return result
+}
+
+func dataSourceRouteTablesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	resp, err := routetables.List(client, instanceId, routetables.ListOpts{})
+	if err != nil {
+		return diag.Errorf("error retrieving route tables: %s", err)
+	}
+	filterResult, err := filterRouteTablesByTags(d, resp)
+	if err != nil {
+		return diag.Errorf("error retrieving route tables: %s", err)
+	}
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("route_tables", flattenRouteTables(client, instanceId, filterResult)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving route table list field: %s", mErr)
+	}
+	return nil
+}

--- a/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
@@ -1,0 +1,334 @@
+package er
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
+	"github.com/chnsz/golangsdk/openstack/er/v3/propagations"
+	"github.com/chnsz/golangsdk/openstack/er/v3/routetables"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceRouteTable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRouteTableCreate,
+		UpdateContext: resourceRouteTableUpdate,
+		ReadContext:   resourceRouteTableRead,
+		DeleteContext: resourceRouteTableDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceRouteTableImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the ER instance and route table are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the ER instance to which the route table belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the route table.`,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa5\\w.-]*$"), "The name only english and "+
+						"chinese letters, digits, underscore (_), hyphens (-) and dots (.) are allowed."),
+				),
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the ER route table.`,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile(`^[^<>]*$`),
+						"The angle brackets (< and >) are not allowed."),
+				),
+			},
+			"tags": common.TagsForceNewSchema(),
+			// Attributes
+			"is_default_association": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether this route table is the default association route table.`,
+			},
+			"is_default_propagation": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether this route table is the default propagation route table.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the route table.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time.`,
+			},
+		},
+	}
+}
+
+func buildRouteTableCreateOpts(d *schema.ResourceData) routetables.CreateOpts {
+	return routetables.CreateOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Tags:        utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+	}
+}
+
+func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	opts := buildRouteTableCreateOpts(d)
+	resp, err := routetables.Create(client, instanceId, opts)
+	if err != nil {
+		return diag.Errorf("error creating route table: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      routeTableStatusRefreshFunc(client, instanceId, d.Id(), []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceRouteTableRead(ctx, d, meta)
+}
+
+func routeTableStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, routeTableId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := routetables.Get(client, instanceId, routeTableId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return resp, "COMPLETED", nil
+			}
+
+			return nil, "", err
+		}
+		log.Printf("[DEBUG] The details of the route table (%s) is: %#v", routeTableId, resp)
+
+		if utils.StrSliceContains([]string{"failed"}, resp.Status) {
+			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		}
+		if utils.StrSliceContains(targets, resp.Status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceRouteTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	routeTableId := d.Id()
+	resp, err := routetables.Get(client, instanceId, routeTableId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "ER route table")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("is_default_association", resp.IsDefaultAssociation),
+		d.Set("is_default_propagation", resp.IsDefaultPropagation),
+		d.Set("tags", utils.TagsToMap(resp.Tags)),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving route table (%s) fields: %s", routeTableId, mErr)
+	}
+	return nil
+}
+
+func updateRouteTableBasicInfo(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		instanceId   = d.Get("instance_id").(string)
+		routeTableId = d.Id()
+	)
+
+	opts := routetables.UpdateOpts{
+		Name:        d.Get("name").(string),
+		Description: utils.String(d.Get("description").(string)),
+	}
+
+	_, err := routetables.Update(client, instanceId, routeTableId, opts)
+	if err != nil {
+		return fmt.Errorf("error updating route table (%s): %s", routeTableId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      routeTableStatusRefreshFunc(client, instanceId, routeTableId, []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		if err = updateRouteTableBasicInfo(ctx, client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceRouteTableRead(ctx, d, meta)
+}
+
+func releaseRouteTableAssociations(client *golangsdk.ServiceClient, instanceId, routeTableId string) error {
+	resp, err := associations.List(client, instanceId, routeTableId, associations.ListOpts{})
+	if err != nil {
+		return fmt.Errorf("error getting association list from the specified route table (%s): %s", routeTableId, err)
+	}
+	for _, association := range resp {
+		opts := associations.DeleteOpts{
+			AttachmentId: association.AttachmentId,
+		}
+		err := associations.Delete(client, instanceId, routeTableId, opts)
+		if err != nil {
+			return fmt.Errorf("error disable the association: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func releaseRouteTablePropagations(client *golangsdk.ServiceClient, instanceId, routeTableId string) error {
+	resp, err := propagations.List(client, instanceId, routeTableId, propagations.ListOpts{})
+	if err != nil {
+		return fmt.Errorf("error getting association list from the specified route table (%s): %s", routeTableId, err)
+	}
+	for _, propagation := range resp {
+		opts := propagations.DeleteOpts{
+			AttachmentId: propagation.AttachmentId,
+		}
+		err := propagations.Delete(client, instanceId, routeTableId, opts)
+		if err != nil {
+			return fmt.Errorf("error disable the propagation: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	routeTableId := d.Id()
+	// Before delete route table, release all associations and propagations.
+	err = releaseRouteTableAssociations(client, instanceId, routeTableId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = releaseRouteTablePropagations(client, instanceId, routeTableId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = routetables.Delete(client, instanceId, routeTableId)
+	if err != nil {
+		return diag.Errorf("error deleting route table (%s): %s", routeTableId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      routeTableStatusRefreshFunc(client, instanceId, routeTableId, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceRouteTableImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid format for import ID, want '<instance_id>/<route_table_id>', but '%s'", d.Id())
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/associations/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/associations/requests.go
@@ -1,0 +1,107 @@
+package associations
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create an association to a specified route table.
+type CreateOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ExportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// ExportRoutePolicy is an object that represents the configuration of the export routing policy.
+type ExportRoutePolicy struct {
+	// The export routing policy ID.
+	ExportPoilicyId string `json:"export_policy_id,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new association under a specified route table.
+func Create(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts CreateOpts) (*Association, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(enableURL(client, instanceId, routeTableId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Association, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the association of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of attachment IDs, support for querying multiple associations.
+	AttachmentIds []string `q:"attachment_id"`
+	// The list of attachment resource types, support for querying multiple associations.
+	ResourceTypes []string `q:"resource_type"`
+	// The list of current status of the associations, support for querying multiple associations.
+	Statuses []string `q:"state"`
+	// The list of keyword to sort the associations result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the associations under specified route table using given parameters.
+func List(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts ListOpts) ([]Association, error) {
+	url := queryURL(client, instanceId, routeTableId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := AssociationPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractAssociations(pages)
+}
+
+// DeleteOpts is the structure used to remove an association from a specified route table.
+type DeleteOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ExportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// Delete is a method to remove an existing association from a specified route table.
+func Delete(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts DeleteOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(disableURL(client, instanceId, routeTableId), b, nil,
+		&golangsdk.RequestOpts{
+			MoreHeaders: requestOpts.MoreHeaders,
+		})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/associations/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/associations/results.go
@@ -1,0 +1,92 @@
+package associations
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains association
+// details and the request information.
+type createResp struct {
+	// The response detail of the association.
+	Association Association `json:"association"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Association is the structure that represents the details of the association under route table.
+type Association struct {
+	// The ID of the association.
+	ID string `json:"id"`
+	// The ID of the route table to which the association belongs.
+	RouteTableId string `json:"route_table_id"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id"`
+	// The resource type for the corresponding attachment.
+	ResourceType string `json:"resource_type"`
+	// The resource ID for the corresponding attachment.
+	ResourceId string `json:"resource_id"`
+	// The configuration of the export routing policy.
+	RoutePolicy ExportRoutePolicy `json:"route_policy"`
+	// The current status of the association.
+	Status string `json:"state"`
+	// The creation time of the association.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the association.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains association list,
+// page details and the request information.
+type listResp struct {
+	// The list of the associations.
+	Associations []Association `json:"associations"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the associations in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// AssociationPage represents the response pages of the List method.
+type AssociationPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no association.
+func (r AssociationPage) IsEmpty() (bool, error) {
+	resp, err := extractAssociations(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r AssociationPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(AssociationPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// ExtractAssociations is a method which to extract the response to a association list.
+func extractAssociations(r pagination.Page) ([]Association, error) {
+	var s listResp
+	err := r.(AssociationPage).Result.ExtractInto(&s)
+	return s.Associations, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/associations/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/associations/urls.go
@@ -1,0 +1,15 @@
+package associations
+
+import "github.com/chnsz/golangsdk"
+
+func enableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "associate")
+}
+
+func queryURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "associations")
+}
+
+func disableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "disassociate")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/propagations/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/propagations/requests.go
@@ -1,0 +1,108 @@
+package propagations
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create a propagation to a specified route table.
+type CreateOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ImportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// ImportRoutePolicy is an object that represents the configuration of the import routing policy.
+type ImportRoutePolicy struct {
+	// The import routing policy ID.
+	ImportPoilicyId string `json:"import_policy_id,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new propagation under the route table.
+func Create(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts CreateOpts) (*Propagation, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(enableURL(client, instanceId, routeTableId), b, &r,
+		&golangsdk.RequestOpts{
+			MoreHeaders: requestOpts.MoreHeaders,
+		})
+	return &r.Propagation, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the propagation of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of attachment IDs, support for querying multiple propagations.
+	AttachmentIds []string `q:"attachment_id"`
+	// The list of attachment resource types, support for querying multiple propagations.
+	ResourceTypes []string `q:"resource_type"`
+	// The list of current status of the propagations, support for querying multiple propagations.
+	Statuses []string `q:"state"`
+	// The list of keyword to sort the propagations result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the propagations under specified route table using given opts.
+func List(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts ListOpts) ([]Propagation, error) {
+	url := queryURL(client, instanceId, routeTableId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := PropagationPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractPropagations(pages)
+}
+
+// DeleteOpts is the structure used to remove a propagation from a specified route table.
+type DeleteOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ImportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// Delete is a method to remove an existing propagation from a specified route table.
+func Delete(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts DeleteOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(disableURL(client, instanceId, routeTableId), b, nil,
+		&golangsdk.RequestOpts{
+			MoreHeaders: requestOpts.MoreHeaders,
+		})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/propagations/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/propagations/results.go
@@ -1,0 +1,96 @@
+package propagations
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains propagation
+// details and the request information.
+type createResp struct {
+	// The response detail of the propagation.
+	Propagation Propagation `json:"propagation"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Propagation is the structure that represents the details of the propagation under route table.
+type Propagation struct {
+	// The ID of the propagation.
+	ID string `json:"id"`
+	// The ID of the project where the propagation is located.
+	ProjectId string `json:"project_id"`
+	// The ID of the ER instance to which the propagation belongs.
+	InstanceId string `json:"er_id"`
+	// The ID of the route table to which the association belongs.
+	RouteTableId string `json:"route_table_id"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id"`
+	// The resource type for the corresponding attachment.
+	ResourceType string `json:"resource_type"`
+	// The resource ID for the corresponding attachment.
+	ResourceId string `json:"resource_id"`
+	// The configuration of the import routing policy.
+	RoutePolicy ImportRoutePolicy `json:"route_policy"`
+	// The current status of the propagation.
+	Status string `json:"state"`
+	// The creation time of the propagation.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the propagation.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains propagation list,
+// page details and the request information.
+type listResp struct {
+	// The list of the propagations.
+	Propagations []Propagation `json:"propagations"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the propagations in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// PropagationPage represents the response pages of the List method.
+type PropagationPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no propagation.
+func (r PropagationPage) IsEmpty() (bool, error) {
+	resp, err := extractPropagations(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r PropagationPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(PropagationPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// ExtractPropagations is a method which to extract the response to a propagation list.
+func extractPropagations(r pagination.Page) ([]Propagation, error) {
+	var s listResp
+	err := r.(PropagationPage).Result.ExtractInto(&s)
+	return s.Propagations, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/propagations/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/propagations/urls.go
@@ -1,0 +1,15 @@
+package propagations
+
+import "github.com/chnsz/golangsdk"
+
+func enableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "enable-propagations")
+}
+
+func queryURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "propagations")
+}
+
+func disableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "disable-propagations")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routes/requests.go
@@ -1,0 +1,120 @@
+package routes
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create the route under a specified route table.
+type CreateOpts struct {
+	// The destination of the route.
+	Destination string `json:"destination" required:"true"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// Whether route is the black hole route.
+	IsBlackHole *bool `json:"is_blackhole,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new route under a specified route table.
+func Create(client *golangsdk.ServiceClient, routeTableId string, opts CreateOpts) (*Route, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(rootURL(client, routeTableId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Route, err
+}
+
+// Get is a method to obtain the route details using given parameters.
+func Get(client *golangsdk.ServiceClient, routeTableId, routeId string) (*Route, error) {
+	var r getResp
+	_, err := client.Get(resourceURL(client, routeId, routeTableId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Route, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the route of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of the destinations, support for querying multiple routes.
+	Destination []string `q:"destination"`
+	// The list of attachment IDs, support for querying multiple routes.
+	AttachmentIds []string `json:"attachment_id"`
+	// The list of attachment resource types, support for querying multiple routes.
+	ResourceType []string `json:"resource_type"`
+	// The list of keyword to sort the associations result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the routes under a specified route table using given parameters.
+func List(client *golangsdk.ServiceClient, routeTableId string, opts ListOpts) ([]Route, error) {
+	url := rootURL(client, routeTableId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := RoutePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractRoutes(pages)
+}
+
+// UpdateOpts is the structure used to update the route configuration.
+type UpdateOpts struct {
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// Whether route is the black hole route.
+	IsBlackHole *bool `json:"is_blackhole,omitempty"`
+}
+
+// Update is a method to update route configuration using update option.
+func Update(client *golangsdk.ServiceClient, routeTableId, routeId string, opts UpdateOpts) (*Route, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	var r updateResp
+	_, err = client.Put(resourceURL(client, routeTableId, routeId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Route, err
+}
+
+// Delete is a method to remove an existing route from a specified route table.
+func Delete(client *golangsdk.ServiceClient, routeTableId, routeId string) error {
+	_, err := client.Delete(resourceURL(client, routeTableId, routeId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routes/results.go
@@ -1,0 +1,120 @@
+package routes
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains route details and
+// the request information.
+type createResp struct {
+	// The response detail of the route.
+	Route Route `json:"route"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Route is the structure that represents the details of the route under a specified route table.
+type Route struct {
+	// The ID of the route.
+	ID string `json:"id"`
+	// The type of the route.
+	Type string `json:"type"`
+	// Whether route is the black hole route.
+	IsBlackHole bool `json:"is_blackhole"`
+	// The destination of the route.
+	Destination string `json:"destination"`
+	// The corresponding attachments.
+	Attachments []Attachment `json:"attachments"`
+	// The ID of the route table to which the route belongs.
+	RouteTableId string `json:"route_table_id"`
+	// The current status of the route.
+	Status string `json:"state"`
+	// The creation time of the association.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the association.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Attachment is an object that represents the details of the corresponding route.
+type Attachment struct {
+	// The resource ID for the corresponding attachment.
+	ResourceId string `json:"resource_id"`
+	// The resource type for the corresponding attachment.
+	ResourceType string `json:"resource_type"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id"`
+}
+
+// getResp is the structure that represents the API response of the 'Get' method, which contains route details and the
+// request information.
+type getResp struct {
+	// The response detail of the route.
+	Route Route `json:"route"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains route list, page
+// details and the request information.
+type listResp struct {
+	// The list of the routes.
+	Routes []Route `json:"routes"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the associations in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// RoutePage represents the response pages of the List method.
+type RoutePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no route.
+func (r RoutePage) IsEmpty() (bool, error) {
+	resp, err := extractRoutes(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r RoutePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractRoutes is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(RoutePage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractRoutes is a method which to extract the response to a route list.
+func extractRoutes(r pagination.Page) ([]Route, error) {
+	var s listResp
+	err := r.(RoutePage).Result.ExtractInto(&s)
+	return s.Routes, err
+}
+
+// updateResp is the structure that represents the API response of the 'Update' method, which contains route details and
+// the request information.
+type updateResp struct {
+	// The response detail of the route.
+	Route Route `json:"route"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routes/utls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routes/utls.go
@@ -1,0 +1,11 @@
+package routes
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, routeTableId string) string {
+	return client.ServiceURL("enterprise-router/route-tables", routeTableId, "static-routes")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, routeId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router/route-tables", routeTableId, "static-routes", routeId)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routetables/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routetables/requests.go
@@ -1,0 +1,137 @@
+package routetables
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure required by the 'Create' method to create a route table under a specified ER instance.
+type CreateOpts struct {
+	// The name of the route table.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name" required:"true"`
+	// The description of the route table.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description string `json:"description,omitempty"`
+	// The configuration of the BGP route selection.
+	BgpOptions BgpOptions `json:"bgp_options,omitempty"`
+	// The key/value pairs to associate with the route table.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// BgpOptions is an object that represents the BGP configuration for routing.
+type BgpOptions struct {
+	// Whether the AS path attributes of the routes are not compared during load balancing.
+	LoadBalancingAsPathIgnore *bool `json:"load_balancing_as_path_ignore,omitempty"`
+	// Whether the AS path attributes of the same length are not compared during load balancing.
+	LoadBalancingAsPathRelax *bool `json:"load_balancing_as_path_relax,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new route table under a specified ER instance using given parameters.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts CreateOpts) (*RouteTable, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(rootURL(client, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.RouteTable, err
+}
+
+// Get is a method to obtain the route table details under a specified ER instance.
+func Get(client *golangsdk.ServiceClient, instanceId, routeTableId string) (*RouteTable, error) {
+	var r getResp
+	_, err := client.Get(resourceURL(client, instanceId, routeTableId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.RouteTable, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the route table of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of current status of the route tables, support for querying multiple route tables.
+	Status []string `q:"state"`
+	// Whether this route table is the default association route table.
+	IsDefaultAssociation bool `q:"is_default_association"`
+	// Whether this route table is the default propagation route table.
+	IsDefaultPropagation bool `q:"is_default_propagation"`
+	// The list of keyword to sort the route tables result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the route tables under a specified ER instance using given parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOpts) ([]RouteTable, error) {
+	url := rootURL(client, instanceId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := RouteTablePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractRouteTables(pages)
+}
+
+// UpdateOpts is the structure required by the 'Update' method to update the route table configuration.
+type UpdateOpts struct {
+	// The name of the route table.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name,omitempty"`
+	// The description of the route table.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description *string `json:"description,omitempty"`
+}
+
+// Update is a method to update the route table under a specified ER instance using parameters.
+func Update(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts UpdateOpts) (*RouteTable, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	var r updateResp
+	_, err = client.Put(resourceURL(client, instanceId, routeTableId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.RouteTable, err
+}
+
+// Delete is a method to remove an existing route table under a specified ER instance.
+func Delete(client *golangsdk.ServiceClient, instanceId, routeTableId string) error {
+	_, err := client.Delete(resourceURL(client, instanceId, routeTableId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routetables/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routetables/results.go
@@ -1,0 +1,116 @@
+package routetables
+
+import (
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains route table
+// details and the request information.
+type createResp struct {
+	// The response detail of the route table.
+	RouteTable RouteTable `json:"route_table"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// RouteTable is the structure that represents the details of the route table for ER service.
+type RouteTable struct {
+	// The ID of the route table.
+	ID string `json:"id"`
+	// The name of the route table.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name"`
+	// The description of the route table.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description string `json:"description"`
+	// The configuration of the BGP route selection.
+	BgpOptions BgpOptions `json:"bgp_options"`
+	// The key/value pairs to associate with the route table.
+	Tags []tags.ResourceTag `json:"tags"`
+	// Whether this route table is the default association route table.
+	IsDefaultAssociation bool `json:"is_default_association"`
+	// Whether this route table is the default propagation route table.
+	IsDefaultPropagation bool `json:"is_default_propagation"`
+	// The current status of the route table.
+	Status string `json:"state"`
+	// The creation time of the route table.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the route table.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// getResp is the structure that represents the API response of the 'Get' method, which contains route table details and
+// the request information.
+type getResp struct {
+	// The response detail of the route table.
+	RouteTable RouteTable `json:"route_table"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains route table list,
+// page details and the request information.
+type listResp struct {
+	// The list of the route tables.
+	RouteTables []RouteTable `json:"route_tables"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the route table in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// RouteTablePage represents the response pages of the List method.
+type RouteTablePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no route table.
+func (r RouteTablePage) IsEmpty() (bool, error) {
+	resp, err := extractRouteTables(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r RouteTablePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(RouteTablePage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractRouteTables is a method which to extract the response to a route table list.
+func extractRouteTables(r pagination.Page) ([]RouteTable, error) {
+	var s listResp
+	err := r.(RouteTablePage).Result.ExtractInto(&s)
+	return s.RouteTables, err
+}
+
+// updateResp is the structure that represents the API response of the 'Update' method, which contains route table
+// details and the request information.
+type updateResp struct {
+	// The response detail of the route table.
+	RouteTable RouteTable `json:"route_table"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routetables/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/routetables/urls.go
@@ -1,0 +1,11 @@
+package routetables
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,6 +149,10 @@ github.com/chnsz/golangsdk/openstack/elb/v3/logtanks
 github.com/chnsz/golangsdk/openstack/elb/v3/monitors
 github.com/chnsz/golangsdk/openstack/elb/v3/pools
 github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects
+github.com/chnsz/golangsdk/openstack/er/v3/associations
+github.com/chnsz/golangsdk/openstack/er/v3/propagations
+github.com/chnsz/golangsdk/openstack/er/v3/routes
+github.com/chnsz/golangsdk/openstack/er/v3/routetables
 github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The new resource has been supproted and name as 'huaweicloud_er_route_table'.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new resource.
2. support related documentation and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccRouteTable_basic -timeout 360m -parallel 4
=== RUN   TestAccRouteTable_basic
=== PAUSE TestAccRouteTable_basic
=== CONT  TestAccRouteTable_basic
--- PASS: TestAccRouteTable_basic (101.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        101.162s
```
