### PR TITLE
feat(as/policy): add status attribute and support importing

### DIFF
--- a/docs/resources/as_policy.md
+++ b/docs/resources/as_policy.md
@@ -17,7 +17,6 @@ resource "huaweicloud_as_policy" "my_aspolicy" {
   scaling_policy_name = "my_aspolicy"
   scaling_policy_type = "RECURRENCE"
   scaling_group_id    = var.as_group_id
-  cool_down_time      = 900
 
   scaling_policy_action {
     operation       = "ADD"
@@ -41,7 +40,6 @@ resource "huaweicloud_as_policy" "my_aspolicy_1" {
   scaling_policy_name = "my_aspolicy_1"
   scaling_policy_type = "SCHEDULED"
   scaling_group_id    = var.as_group_id
-  cool_down_time      = 900
 
   scaling_policy_action {
     operation       = "REMOVE"
@@ -125,7 +123,8 @@ The following arguments are supported:
 * `scaling_policy_action` - (Optional, List) Specifies the action of the AS policy.
   The [object](#scaling_policy_action_object) structure is documented below.
 
-* `cool_down_time` - (Optional, Int) Specifies the cooling duration (in seconds), and the default value is 900.
+* `cool_down_time` - (Optional, Int) Specifies the cooling duration (in seconds).
+  The value ranges from 0 to 86400 and is 300 by default.
 
 <a name="scheduled_policy_object"></a>
 The `scheduled_policy` block supports:

--- a/docs/resources/as_policy.md
+++ b/docs/resources/as_policy.md
@@ -149,3 +149,12 @@ The `scaling_policy_action` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
+* `status` - The AS policy status. The value can be *INSERVICE*, *PAUSED*, *EXECUTING*.
+
+## Import
+
+AS policies can be imported by their `id`, e.g.
+
+```
+$ terraform import huaweicloud_as_policy.test 9fcb65fe-fd79-4407-8fa0-07602044e1c3
+```

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccASPolicy_basic(t *testing.T) {
 	var asPolicy policies.Policy
 	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_as_policy.acc_as_policy"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -24,8 +25,14 @@ func TestAccASPolicy_basic(t *testing.T) {
 			{
 				Config: testASPolicy_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckASPolicyExists("huaweicloud_as_policy.acc_as_policy", &asPolicy),
+					testAccCheckASPolicyExists(resourceName, &asPolicy),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -27,6 +27,7 @@ func TestAccASPolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASPolicyExists(resourceName, &asPolicy),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "300"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.instance_number", "1"),
@@ -37,6 +38,7 @@ func TestAccASPolicy_basic(t *testing.T) {
 				Config: testASPolicy_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "900"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "REMOVE"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.instance_number", "1"),
@@ -46,6 +48,7 @@ func TestAccASPolicy_basic(t *testing.T) {
 				Config: testASPolicy_recurrence(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "900"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "RECURRENCE"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.instance_number", "1"),
@@ -78,6 +81,7 @@ func TestAccASPolicy_Alarm(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASPolicyExists(resourceName, &asPolicy),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "600"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "ALARM"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.instance_number", "1"),
@@ -232,6 +236,7 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
   scaling_policy_name = "%[2]s"
   scaling_policy_type = "SCHEDULED"
   scaling_group_id    = huaweicloud_as_group.acc_as_group.id
+  cool_down_time      = 900
 
   scaling_policy_action {
     operation       = "REMOVE"
@@ -301,6 +306,7 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
   scaling_policy_type = "ALARM"
   scaling_group_id    = huaweicloud_as_group.acc_as_group.id
   alarm_id            = huaweicloud_ces_alarmrule.alarm_rule.id
+  cool_down_time      = 600
 
   scaling_policy_action {
     operation       = "ADD"

--- a/huaweicloud/services/as/resource_huaweicloud_as_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_policy.go
@@ -120,9 +120,10 @@ func ResourceASPolicy() *schema.Resource {
 				},
 			},
 			"cool_down_time": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  900,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 86400),
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -303,11 +304,14 @@ func resourceASPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error updating AS policy: %s", err)
 	}
 	updateOpts := policies.UpdateOpts{
-		Name:         d.Get("scaling_policy_name").(string),
-		Type:         d.Get("scaling_policy_type").(string),
-		AlarmID:      d.Get("alarm_id").(string),
-		CoolDownTime: d.Get("cool_down_time").(int),
+		Name:    d.Get("scaling_policy_name").(string),
+		Type:    d.Get("scaling_policy_type").(string),
+		AlarmID: d.Get("alarm_id").(string),
 	}
+	if d.HasChange("cool_down_time") {
+		updateOpts.CoolDownTime = d.Get("cool_down_time").(int)
+	}
+
 	scheduledPolicyList := d.Get("scheduled_policy").([]interface{})
 	if len(scheduledPolicyList) == 1 {
 		scheduledPolicyMap := scheduledPolicyList[0].(map[string]interface{})

--- a/huaweicloud/services/as/resource_huaweicloud_as_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_policy.go
@@ -29,6 +29,9 @@ func ResourceASPolicy() *schema.Resource {
 		ReadContext:   resourceASPolicyRead,
 		UpdateContext: resourceASPolicyUpdate,
 		DeleteContext: resourceASPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -120,6 +123,10 @@ func ResourceASPolicy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  900,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -250,6 +257,7 @@ func resourceASPolicyRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("scaling_group_id", asPolicy.ID),
 		d.Set("alarm_id", asPolicy.AlarmID),
 		d.Set("cool_down_time", asPolicy.CoolDownTime),
+		d.Set("status", asPolicy.Status),
 		d.Set("scaling_policy_action", flattenPolicyAction(asPolicy.Action)),
 		d.Set("scheduled_policy", flattenSchedulePolicy(asPolicy.SchedulePolicy)),
 	)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

do the following changes on `huaweicloud_as_policy`:
- set the default value of `start_time` if necessary
- set the default value of `cool_down_time` to 300
- add status attribute and support importing
- add more acceptance test
- improve on the docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccASPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASPolicy_ -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== RUN   TestAccASPolicy_Alarm
=== PAUSE TestAccASPolicy_Alarm
=== CONT  TestAccASPolicy_basic
=== CONT  TestAccASPolicy_Alarm
--- PASS: TestAccASPolicy_Alarm (48.02s)
--- PASS: TestAccASPolicy_basic (75.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        76.032s
```
