### PR TITLE
feat(er/association): add new resource support

### DIFF
--- a/docs/resources/er_association.md
+++ b/docs/resources/er_association.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_association
+
+Manages an association resource under the route table for ER service within HuaweiCloud.
+
+## Example Usage
+
+```HCL
+variable "instance_id" {}
+variable "route_table_id" {}
+variable "attachment_id" {}
+
+resource "huaweicloud_er_association" "test" {
+  instance_id    = var.instance_id
+  route_table_id = var.route_table_id
+  attachment_id  = var.attachment_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the ER instance and route table are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the ER instance to which the route table and the
+  attachment belongs.  
+  Changing this parameter will create a new resource.
+
+* `route_table_id` - (Required, String, ForceNew) Specifies the ID of the route table to which the association
+  belongs.  
+  Changing this parameter will create a new resource.
+
+* `attachment_id` - (Required, String, ForceNew) Specifies the ID of the attachment corresponding to the association.  
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `attachment_type` - The type of the attachment corresponding to the association.
+
+* `status` - The current status of the association.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 2 minutes.
+
+## Import
+
+Associations can be imported using their `id` and the related `instance_id` and `route_table_id`, separated by
+slashes (/), e.g.
+
+```
+$ terraform import huaweicloud_er_association.test &ltinstance_id&gt/&ltroute_table_id&gt/&ltid&gt
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -692,6 +692,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_enterprise_project": eps.ResourceEnterpriseProject(),
 
+			"huaweicloud_er_association":    er.ResourceAssociation(),
 			"huaweicloud_er_instance":       er.ResourceInstance(),
 			"huaweicloud_er_route_table":    er.ResourceRouteTable(),
 			"huaweicloud_er_vpc_attachment": er.ResourceVpcAttachment(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -1,0 +1,141 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
+)
+
+func getAssociationResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	return er.QueryAssociationById(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["route_table_id"], state.Primary.ID)
+}
+
+func TestAccAssociation_basic(t *testing.T) {
+	var (
+		obj associations.Association
+
+		rName    = "huaweicloud_er_association.test"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAssociationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssociation_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id",
+						"huaweicloud_er_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttr(rName, "attachment_type", "vpc"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAssociationImportStateFunc(),
+			},
+		},
+	})
+}
+
+func testAccAssociationImportStateFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, routeTableId, associationId string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_er_association" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				routeTableId = rs.Primary.Attributes["route_table_id"]
+				associationId = rs.Primary.ID
+			}
+		}
+		if instanceId == "" || routeTableId == "" || associationId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want "+
+				"'<instance_id>/<route_table_id>/<association_id>', but '%s/%s/%s'",
+				instanceId, routeTableId, associationId)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, routeTableId, associationId), nil
+	}
+}
+
+func testAccAssociation_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id = huaweicloud_vpc.test.id
+
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = ["%[2]s"]
+
+  name = "%[1]s"
+  asn  = %[3]d
+}
+
+resource "huaweicloud_er_vpc_attachment" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+
+  name                   = "%[1]s"
+  auto_create_vpc_routes = true
+}
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+
+  name = "%[1]s"
+}
+`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+}
+
+func testAccAssociation_basic(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_association" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  attachment_id  = huaweicloud_er_vpc_attachment.test.id
+}
+`, testAccAssociation_base(name, bgpAsNum))
+}

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -1,0 +1,264 @@
+package er
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAssociationCreate,
+		ReadContext:   resourceAssociationRead,
+		DeleteContext: resourceAssociationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAssociationImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the ER instance and route table are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the ER instance to which the route table and the attachment belongs.`,
+			},
+			"route_table_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the route table to which the association belongs.`,
+			},
+			"attachment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the attachment corresponding to the association.`,
+			},
+			"attachment_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the attachment corresponding to the association.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the association.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time.`,
+			},
+		},
+	}
+}
+
+func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		instanceId   = d.Get("instance_id").(string)
+		routeTableId = d.Get("route_table_id").(string)
+
+		opts = associations.CreateOpts{
+			AttachmentId: d.Get("attachment_id").(string),
+		}
+	)
+
+	resp, err := associations.Create(client, instanceId, routeTableId, opts)
+	if err != nil {
+		return diag.Errorf("error creating the association to the route table: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceAssociationRead(ctx, d, meta)
+}
+
+// QueryAssociationById is a method to query association details from a specified route table using given parameters.
+func QueryAssociationById(client *golangsdk.ServiceClient, instanceId, routeTableId,
+	associationId string) (*associations.Association, error) {
+	resp, err := associations.List(client, instanceId, routeTableId, associations.ListOpts{})
+	if err != nil {
+		return nil, err
+	}
+
+	filter := map[string]interface{}{
+		"ID": associationId,
+	}
+	result, err := utils.FilterSliceWithField(resp, filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp) < 1 {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("the association (%s) does not exist", associationId)),
+			},
+		}
+	}
+
+	association := result[0].(associations.Association)
+	log.Printf("[DEBUG] The details of the association (%s) is: %#v", associationId, association)
+
+	return &association, nil
+}
+
+func associationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, routeTableId, associationId string,
+	targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := QueryAssociationById(client, instanceId, routeTableId, associationId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return resp, "COMPLETED", nil
+			}
+
+			return nil, "", err
+		}
+
+		if utils.StrSliceContains([]string{"failed"}, resp.Status) {
+			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		}
+		if utils.StrSliceContains(targets, resp.Status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		instanceId    = d.Get("instance_id").(string)
+		routeTableId  = d.Get("route_table_id").(string)
+		associationId = d.Id()
+	)
+
+	resp, err := QueryAssociationById(client, instanceId, routeTableId, associationId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "ER association")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("route_table_id", resp.RouteTableId),
+		d.Set("attachment_id", resp.AttachmentId),
+		d.Set("attachment_type", resp.ResourceType),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving association (%s) fields: %s", associationId, mErr)
+	}
+	return nil
+}
+
+func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		instanceId    = d.Get("instance_id").(string)
+		routeTableId  = d.Get("instance_id").(string)
+		associationId = d.Id()
+
+		opts = associations.DeleteOpts{
+			AttachmentId: d.Get("attachment_id").(string),
+		}
+	)
+	err = associations.Delete(client, instanceId, routeTableId, opts)
+	if err != nil {
+		return diag.Errorf("error deleting association (%s): %s", associationId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceAssociationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid format for import ID, want '<instance_id>/<route_table_id>/<association_id>', "+
+			"but '%s'", d.Id())
+	}
+
+	d.SetId(parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("route_table_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new resource to manage associations for routing relationship.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new ER resource.
2. support related documentation and acc test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAssociation_basic -timeout 360m -parallel 4
=== RUN   TestAccAssociation_basic
=== PAUSE TestAccAssociation_basic
=== CONT  TestAccAssociation_basic
--- PASS: TestAccAssociation_basic (117.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        118.108s
```
