### PR TITLE
feat(cce): support pod_security_groups in node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -112,6 +112,9 @@ extend_param = {
 * `priority` - (Optional, Int) Specifies the weight of the node pool.
   A node pool with a higher weight has a higher priority during scaling.
 
+* `pod_security_groups` - (Optional, List, ForceNew) Specifies the list of security group IDs for the pod.
+  Only supported in CCE Turbo clusters of v1.19 and above. Changing this parameter will create a new resource.
+
 * `labels` - (Optional, Map) Specifies the tags of a Kubernetes node, key/value pair format.
 
 * `tags` - (Optional, Map) Specifies the tags of a VM node, key/value pair format.
@@ -202,7 +205,7 @@ $ terraform import huaweicloud_cce_node_pool.my_node_pool 5c20fdad-7288-11eb-b81
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`, `subnet_id`, `preinstall`, `posteinstall`, `taints` and `initial_node_count`.
+`password`, `subnet_id`, `preinstall`, `posteinstall`, `taints`, `initial_node_count` and `pod_security_groups`.
 It is generally recommended running `terraform plan` after importing a node pool.
 You can then decide if changes should be applied to the node pool, or the resource
 definition should be updated to align with the node pool. Also you can ignore changes as below.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support pod_security_groups in node pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support pod_security_groups in node pool
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_podSecurityGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_podSecurityGroups -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_podSecurityGroups
=== PAUSE TestAccCCENodePool_podSecurityGroups
=== CONT  TestAccCCENodePool_podSecurityGroups
--- PASS: TestAccCCENodePool_podSecurityGroups (941.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       941.492s
```
