### PR TITLE
feat(as/configuration): add more parameters and support importing

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -74,15 +74,17 @@ resource "huaweicloud_as_configuration" "my_as_config" {
 variable "flavor_id" {}
 variable "image_id" {}
 variable "ssh_key" {}
+variable "security_group_id" {}
 
 resource "huaweicloud_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
-    flavor    = var.flavor_id
-    image     = var.image_id
-    key_name  = var.ssh_key
-    user_data = file("userdata.txt")
+    flavor             = var.flavor_id
+    image              = var.image_id
+    key_name           = var.ssh_key
+    security_group_ids = [var.security_group_id]
+    user_data          = file("userdata.txt")
 
     disk {
       size        = 40
@@ -102,13 +104,15 @@ resource "huaweicloud_as_configuration" "my_as_config" {
 ```hcl
 variable "instance_id" {}
 variable "ssh_key" {}
+variable "security_group_id" {}
 
 resource "huaweicloud_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
-    instance_id = var.instance_id
-    key_name    = var.ssh_key
+    instance_id        = var.instance_id
+    key_name           = var.ssh_key
+    security_group_ids = [var.security_group_id]
   }
 }
 ```
@@ -146,6 +150,9 @@ The `instance_config` block supports:
 * `key_name` - (Required, String, ForceNew) Specifies the name of the SSH key pair used to log in to the instance.
   Changing this will create a new resource.
 
+* `security_group_ids` - (Required, List, ForceNew) Specifies an array of one or more security group IDs.
+  Changing this will create a new resource.
+
 * `flavor_priority_policy` - (Optional, String, ForceNew) Specifies the priority policy used when there are multiple flavors
   and instances to be created using an AS configuration. The value can be `PICK_FIRST` and `COST_FIRST`.
 
@@ -156,9 +163,6 @@ The `instance_config` block supports:
   Changing this will create a new resource.
 
 * `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. Changing this will create a new resource.
-
-* `security_group_ids` - (Optional, List, ForceNew) Specifies an array of one or more security group IDs.
-  Changing this will create a new resource.
 
 * `user_data` - (Optional, String, ForceNew) Specifies the user data to provide when launching the instance.
   The file content must be encoded with Base64. Changing this will create a new resource.

--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -11,20 +11,25 @@ Manages an AS configuration resource within HuaweiCloud.
 ### Basic AS Configuration
 
 ```hcl
+variable "flavor_id" {}
+variable "image_id" {}
+variable "ssh_key" {}
+variable "security_group_id" {}
+
 resource "huaweicloud_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
-    flavor = var.flavor
-    image  = var.image_id
+    flavor             = var.flavor_id
+    image              = var.image_id
+    key_name           = var.ssh_key
+    security_group_ids = [var.security_group_id]
 
     disk {
       size        = 40
       volume_type = "SSD"
       disk_type   = "SYS"
     }
-    key_name  = var.keyname
-    user_data = file("userdata.txt")
   }
 }
 ```
@@ -32,12 +37,20 @@ resource "huaweicloud_as_configuration" "my_as_config" {
 ### AS Configuration With Encrypted Data Disk
 
 ```hcl
+variable "flavor_id" {}
+variable "image_id" {}
+variable "ssh_key" {}
+variable "kms_id" {}
+variable "security_group_id" {}
+
 resource "huaweicloud_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
-    flavor = var.flavor
-    image  = var.image_id
+    flavor             = var.flavor_id
+    image              = var.image_id
+    key_name           = var.ssh_key
+    security_group_ids = [var.security_group_id]
 
     disk {
       size        = 40
@@ -51,8 +64,6 @@ resource "huaweicloud_as_configuration" "my_as_config" {
       disk_type   = "DATA"
       kms_id      = var.kms_id
     }
-    key_name  = var.keyname
-    user_data = file("userdata.txt")
   }
 }
 ```
@@ -60,12 +71,18 @@ resource "huaweicloud_as_configuration" "my_as_config" {
 ### AS Configuration With User Data and Metadata
 
 ```hcl
+variable "flavor_id" {}
+variable "image_id" {}
+variable "ssh_key" {}
+
 resource "huaweicloud_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
-    flavor = var.flavor
-    image  = var.image_id
+    flavor    = var.flavor_id
+    image     = var.image_id
+    key_name  = var.ssh_key
+    user_data = file("userdata.txt")
 
     disk {
       size        = 40
@@ -73,8 +90,6 @@ resource "huaweicloud_as_configuration" "my_as_config" {
       disk_type   = "SYS"
     }
 
-    key_name  = var.keyname
-    user_data = file("userdata.txt")
     metadata  = {
       some_key = "some_value"
     }
@@ -85,12 +100,15 @@ resource "huaweicloud_as_configuration" "my_as_config" {
 ### AS Configuration uses the existing instance specifications as the template
 
 ```hcl
+variable "instance_id" {}
+variable "ssh_key" {}
+
 resource "huaweicloud_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
-    instance_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"
-    key_name    = var.keyname
+    instance_id = var.instance_id
+    key_name    = var.ssh_key
   }
 }
 ```
@@ -126,6 +144,20 @@ The `instance_config` block supports:
   Changing this will create a new resource.
 
 * `key_name` - (Required, String, ForceNew) Specifies the name of the SSH key pair used to log in to the instance.
+  Changing this will create a new resource.
+
+* `flavor_priority_policy` - (Optional, String, ForceNew) Specifies the priority policy used when there are multiple flavors
+  and instances to be created using an AS configuration. The value can be `PICK_FIRST` and `COST_FIRST`.
+
+  + **PICK_FIRST** (default): When an ECS is added for capacity expansion, the target flavor is determined in the order
+    in the flavor list.
+  + **COST_FIRST**: When an ECS is added for capacity expansion, the target flavor is determined for minimal expenses.
+
+  Changing this will create a new resource.
+
+* `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. Changing this will create a new resource.
+
+* `security_group_ids` - (Optional, List, ForceNew) Specifies an array of one or more security group IDs.
   Changing this will create a new resource.
 
 * `user_data` - (Optional, String, ForceNew) Specifies the user data to provide when launching the instance.
@@ -201,6 +233,7 @@ The `personality` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
+* `status` - The AS configuration status, the value can be **Bound** or **Unbound**.
 
 ## Import
 

--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -4,7 +4,7 @@ subcategory: "Auto Scaling"
 
 # huaweicloud_as_configuration
 
-Manages an AS Configuration resource within HuaweiCloud.
+Manages an AS configuration resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -100,7 +100,7 @@ resource "huaweicloud_as_configuration" "my_as_config" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the AS configuration.
-  If omitted, the `region` argument of the provider is used. Changing this will create a new resource.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
 
 * `scaling_configuration_name` - (Required, String, ForceNew) Specifies the AS configuration name.
   The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
@@ -195,3 +195,30 @@ The `personality` block supports:
 
 * `contents` - (Required, String, ForceNew) Specifies the content of the injected file, which must be encoded with base64.
   Changing this creates a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+AS configurations can be imported by their `id`, e.g.
+
+```
+$ terraform import huaweicloud_as_configuration.test 18518c8a-9d15-416b-8add-2ee874751d18
+```
+
+Note that the imported state may not be identical to your resource definition, due to `instance_config.0.instance_id`
+is missing from the API response. You can ignore changes after importing an AS configuration as below.
+
+```
+resource "huaweicloud_as_configuration" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [ instance_config.0.instance_id ]
+  }
+}
+```

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
@@ -30,6 +30,7 @@ func TestAccASConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_config.0.metadata.some_key", "some_value"),
 					resource.TestCheckResourceAttr(resourceName, "instance_config.0.disk.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instance_config.0.public_ip.0.eip.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_config.0.security_group_ids.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_config.0.user_data"),
 				),
 			},
@@ -164,9 +165,10 @@ func testAccASConfiguration_basic(rName string) string {
 resource "huaweicloud_as_configuration" "acc_as_config"{
   scaling_configuration_name = "%s"
   instance_config {
-    image    = data.huaweicloud_images_image.test.id
-    flavor   = data.huaweicloud_compute_flavors.test.ids[0]
-    key_name = huaweicloud_compute_keypair.acc_key.id
+    image              = data.huaweicloud_images_image.test.id
+    flavor             = data.huaweicloud_compute_flavors.test.ids[0]
+    key_name           = huaweicloud_compute_keypair.acc_key.id
+    security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
 
     metadata = {
       some_key = "some_value"

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
@@ -89,6 +89,14 @@ func ResourceASConfiguration() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"security_group_ids": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: "schema: Required",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
 						"charging_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -112,13 +120,6 @@ func ResourceASConfiguration() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
-						},
-						"security_group_ids": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"disk": {
 							Type:         schema.TypeList,

--- a/huaweicloud/utils/diff_suppress_funcs.go
+++ b/huaweicloud/utils/diff_suppress_funcs.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"log"
 	"reflect"
@@ -36,6 +37,23 @@ func SuppressCaseDiffs(k, old, new string, d *schema.ResourceData) bool {
 // Suppress changes if we get a computed min_disk_gb if value is unspecified (default 0)
 func SuppressMinDisk(k, old, new string, d *schema.ResourceData) bool {
 	return new == "0" || old == new
+}
+
+// Suppress changes if we get a base64 format or plaint text user_data
+func SuppressUserData(k, old, new string, d *schema.ResourceData) bool {
+	// user_data is in base64 format
+	if HashAndHexEncode(old) == new {
+		return true
+	}
+
+	// user_data is plaint text
+	if plaint, err := base64.StdEncoding.DecodeString(old); err == nil {
+		if HashAndHexEncode(string(plaint)) == new {
+			return true
+		}
+	}
+
+	return false
 }
 
 func SuppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

do the following changes on `huaweicloud_as_configuration`:

- support importing
- add parameters in `instance_config`: **security_group_ids**, **flavor_priority_policy**, **ecs_group_id**, **charging_mode**
- add `status` attribute

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccASConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASConfiguration -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== RUN   TestAccASConfiguration_instance
=== PAUSE TestAccASConfiguration_instance
=== CONT  TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_instance
--- PASS: TestAccASConfiguration_basic (31.44s)
--- PASS: TestAccASConfiguration_instance (158.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        158.734s
```
