### PR TITLE
feat(as/group): add more parameters and depreacate notifications param

### DIFF
--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -4,25 +4,29 @@ subcategory: "Auto Scaling"
 
 # huaweicloud_as_group
 
-Manages a Autoscaling Group resource within HuaweiCloud.
+Manages an AS group resource within HuaweiCloud.
 
 ## Example Usage
 
 ### Basic Autoscaling Group
 
 ```hcl
+variable "configuration_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
 resource "huaweicloud_as_group" "my_as_group" {
   scaling_group_name       = "my_as_group"
-  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  scaling_configuration_id = var.configuration_id
   desire_instance_number   = 2
   min_instance_number      = 0
   max_instance_number      = 10
-  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  vpc_id                   = var.vpc_id
   delete_publicip          = true
   delete_instances         = "yes"
 
   networks {
-    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+    id = var.subnet_id
   }
 }
 ```
@@ -30,18 +34,22 @@ resource "huaweicloud_as_group" "my_as_group" {
 ### Autoscaling Group with tags
 
 ```hcl
+variable "configuration_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
 resource "huaweicloud_as_group" "my_as_group_tags" {
   scaling_group_name       = "my_as_group_tags"
-  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  scaling_configuration_id = var.configuration_id
   desire_instance_number   = 2
   min_instance_number      = 0
   max_instance_number      = 10
-  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  vpc_id                   = var.vpc_id
   delete_publicip          = true
   delete_instances         = "yes"
 
   networks {
-    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+    id = var.subnet_id
   }
   tags = {
     foo = "bar"
@@ -53,28 +61,37 @@ resource "huaweicloud_as_group" "my_as_group_tags" {
 ### Autoscaling Group Only Remove Members When Scaling Down
 
 ```hcl
+variable "configuration_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
 resource "huaweicloud_as_group" "my_as_group_only_remove_members" {
   scaling_group_name       = "my_as_group_only_remove_members"
-  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  scaling_configuration_id = var.configuration_id
   desire_instance_number   = 2
   min_instance_number      = 0
   max_instance_number      = 10
-  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  vpc_id                   = var.vpc_id
   delete_publicip          = true
   delete_instances         = "no"
 
   networks {
-    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+    id = var.subnet_id
   }
 }
 ```
 
-### Autoscaling Group With Enhanced Load Balancer Listener
+### Autoscaling Group With Elastic Load Balancer Listener
 
 ```hcl
+variable "configuration_id" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "ipv4_subnet_id" {}
+
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "loadbalancer_1"
-  vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+  vip_subnet_id = var.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {
@@ -93,14 +110,14 @@ resource "huaweicloud_lb_pool" "pool_1" {
 
 resource "huaweicloud_as_group" "my_as_group_with_enhanced_lb" {
   scaling_group_name       = "my_as_group_with_enhanced_lb"
-  scaling_configuration_id = "37e310f5-db9d-446e-9135-c625f9c2bbfc"
+  scaling_configuration_id = var.configuration_id
   desire_instance_number   = 2
   min_instance_number      = 0
   max_instance_number      = 10
-  vpc_id                   = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  vpc_id                   = var.vpc_id
 
   networks {
-    id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+    id = var.subnet_id
   }
   lbaas_listeners {
     pool_id       = huaweicloud_lb_pool.pool_1.id
@@ -113,105 +130,117 @@ resource "huaweicloud_as_group" "my_as_group_with_enhanced_lb" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the AS group. If omitted, the `region` argument
-  of the provider is used. Changing this creates a new AS group.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the AS group.
+  If omitted, the provider-level region will be used. Changing this creates a new group.
 
-* `scaling_group_name` - (Required, String) The name of the scaling group. The name can contain letters, digits,
-  underscores(_), and hyphens(-),and cannot exceed 64 characters.
+* `scaling_group_name` - (Required, String) Specifies the name of the scaling group. The name can contain
+  letters, digits, underscores(_), and hyphens(-),and cannot exceed 64 characters.
 
-* `scaling_configuration_id` - (Required, String) The configuration ID which defines configurations of instances in the
-  AS group.
+* `scaling_configuration_id` - (Required, String) Specifies the configuration ID which defines configurations
+  of instances in the AS group.
 
-* `desire_instance_number` - (Optional, Int) The expected number of instances. The default value is the minimum number
-  of instances. The value ranges from the minimum number of instances to the maximum number of instances.
+* `desire_instance_number` - (Optional, Int) Specifies the expected number of instances. The default value is the
+  minimum number of instances. The value ranges from the minimum number of instances to the maximum number of instances.
 
-* `min_instance_number` - (Optional, Int) The minimum number of instances. The default value is 0.
+* `min_instance_number` - (Optional, Int) Specifies the minimum number of instances. The default value is 0.
 
-* `max_instance_number` - (Optional, Int) The maximum number of instances. The default value is 0.
+* `max_instance_number` - (Optional, Int) Specifies the maximum number of instances. The default value is 0.
 
-* `cool_down_time` - (Optional, Int) The cooling duration (in seconds). The value ranges from 0 to 86400, and is 300 by
-  default.
+* `cool_down_time` - (Optional, Int) Specifies the cooling duration (in seconds). The value ranges from 0 to 86400,
+  and is 300 by default.
 
-* `lbaas_listeners` - (Optional, List) An array of one or more enhanced load balancer. The system supports the binding
-  of up to six load balancers. The object structure is documented below.
+* `availability_zones` - (Optional, List) Specifies the availability zones in which to create the instances in the
+  autoscaling group.
 
-* `availability_zones` - (Optional, List) The availability zones in which to create the instances in the autoscaling group.
-
-* `multi_az_scaling_policy` - (Optional, String) The priority policy used to select target AZs when adjusting the number
-  of instances in an AS group. The value can be `EQUILIBRIUM_DISTRIBUTE` and `PICK_FIRST`.
+* `multi_az_scaling_policy` - (Optional, String) Specifies the priority policy used to select target AZs when adjusting
+  the number of instances in an AS group. The value can be `EQUILIBRIUM_DISTRIBUTE` and `PICK_FIRST`.
 
   + **EQUILIBRIUM_DISTRIBUTE** (default): When adjusting the number of instances, ensure that instances in each AZ in the
     availability_zones list is evenly distributed. If instances cannot be added in the target AZ, select another AZ based
     on the PICK_FIRST policy.
-  + **PICK_FIRST**: When adjusting the number of instances, target AZs are determined in the order in the availability_zones list.
+  + **PICK_FIRST**: When adjusting the number of instances, target AZs are determined in the order in the
+    availability_zones list.
 
-* `vpc_id` - (Required, String, ForceNew) The VPC ID. Changing this creates a new group.
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this creates a new group.
 
-* `networks` - (Required, List) An array of one or more network IDs. The system supports up to five networks. The
-  networks object structure is documented below.
+* `networks` - (Required, List) Specifies an array of one or more network IDs. The system supports up to five networks.
+  The [object](#group_network_object) structure is documented below.
 
-* `security_groups` - (Optional, List) An array of one or more security group IDs to associate with the group. The
-  security_groups object structure is documented below.
+* `security_groups` - (Optional, List) Specifies an array of one or more security group IDs to associate with the group.
+  The [object](#group_security_group_object) structure is documented below.
 
   -> If the security group is specified both in the AS configuration and AS group, scaled ECS instances will be added to
   the security group specified in the AS configuration. If the security group is not specified in either of them, scaled
   ECS instances will be added to the default security group. For your convenience, you are advised to specify the security
   group in the AS configuration.
 
-* `health_periodic_audit_method` - (Optional, String) The health check method for instances in the AS group. The health
-  check methods include `ELB_AUDIT` and `NOVA_AUDIT`. If load balancing is configured, the default value of this
-  parameter is `ELB_AUDIT`. Otherwise, the default value is `NOVA_AUDIT`.
+* `lbaas_listeners` - (Optional, List) Specifies an array of one or more enhanced load balancer. The system supports
+  the binding of up to six load balancers. The [object](#group_lbaas_listener_object) structure is documented below.
 
-* `health_periodic_audit_time` - (Optional, Int) The health check period for instances. The period has four options: 5
-  minutes (default), 15 minutes, 60 minutes, and 180 minutes.
+* `health_periodic_audit_method` - (Optional, String) Specifies the health check method for instances in the AS group.
+  The health check methods include `ELB_AUDIT` and `NOVA_AUDIT`. If load balancing is configured, the default value of
+  this parameter is `ELB_AUDIT`. Otherwise, the default value is `NOVA_AUDIT`.
 
-* `health_periodic_audit_grace_period` - (Optional, Int) The health check grace period for instances. The unit is second
-  and the value ranges from 0 to 86400. The default value is 600.
+* `health_periodic_audit_time` - (Optional, Int) Specifies the health check period for instances. The unit is minute
+  and value includes 0, 1, 5 (default), 15, 60, and 180. If the value is set to 0, health check is performed every 10 seconds.
+
+* `health_periodic_audit_grace_period` - (Optional, Int) Specifies the health check grace period for instances.
+  The unit is second and the value ranges from 0 to 86400. The default value is 600.
 
   -> This parameter is valid only when the instance health check method of the AS group is `ELB_AUDIT`.
 
-* `instance_terminate_policy` - (Optional, String) The instance removal policy. The policy has four
-  options: `OLD_CONFIG_OLD_INSTANCE` (default), `OLD_CONFIG_NEW_INSTANCE`,
-  `OLD_INSTANCE`, and `NEW_INSTANCE`.
+* `instance_terminate_policy` - (Optional, String) Specifies the instance removal policy. The policy has four
+  options: `OLD_CONFIG_OLD_INSTANCE` (default), `OLD_CONFIG_NEW_INSTANCE`, `OLD_INSTANCE`, and `NEW_INSTANCE`.
 
-* `tags` - (Optional, Map) The key/value pairs to associate with the scaling group.
+  + **OLD_CONFIG_OLD_INSTANCE** (default): The earlier-created instances based on the earlier-created AS configurations
+    are removed first.
+  + **OLD_CONFIG_NEW_INSTANCE**: The later-created instances based on the earlier-created AS configurations are removed first.
+  + **OLD_INSTANCE**: The earlier-created instances are removed first.
+  + **NEW_INSTANCE**: The later-created instances are removed first.
 
-* `description` (Optional, String) The description of the AS group. The value can contain 0 to 256 characters.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the AS group.
 
-* `notifications` - (Optional, List) The notification mode. The system only supports `EMAIL`
+* `description` (Optional, String) Specifies the description of the AS group. The value can contain 0 to 256 characters.
+
+* `notifications` - (Optional, List) Specifies the notification mode. The system only supports `EMAIL`
   mode which refers to notification by email.
 
-* `delete_publicip` - (Optional, Bool) Whether to delete the elastic IP address bound to the instances of AS group when
-  deleting the instances. The options are `true` and `false`.
+* `delete_publicip` - (Optional, Bool) Specifies whether to delete the elastic IP address bound to the instances of
+  AS group when deleting the instances. The options are `true` and `false`.
 
-* `delete_instances` - (Optional, String) Whether to delete the instances in the AS group when deleting the AS group.
-  The options are `yes` and `no`.
+* `delete_instances` - (Optional, String) Specifies whether to delete the instances in the AS group when deleting
+  the AS group. The options are `yes` and `no`.
 
-* `force_delete` - (Optional, Bool) Whether to forcibly delete the AS group, remove the ECS instances and release them.
-  The default value is `false`.
+* `force_delete` - (Optional, Bool) Specifies whether to forcibly delete the AS group, remove the ECS instances and
+  release them. The default value is `false`.
 
-* `enable` - (Optional, Bool) Whether to enable the AS Group. The options are `true` and `false`. The default value
-  is `true`.
+* `enable` - (Optional, Bool) Specifies whether to enable the AS Group. The options are `true` and `false`.
+  The default value is `true`.
 
-* `enterprise_project_id` - (Optional, String) The enterprise project id of the AS group.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the AS group.
 
+<a name="group_network_object"></a>
 The `networks` block supports:
 
-* `id` - (Required, String) The network UUID.
+* `id` - (Required, String) Specifies the subnet ID.
 
-* `ipv6_enable` - (Optional, Bool) Whether to support IPv6 addresses. The default value is false.
+* `ipv6_enable` - (Optional, Bool) Specifies whether to support IPv6 addresses. The default value is `false`.
 
-* `ipv6_bandwidth_id` - (Optional, String) The ID of the shared bandwidth of an IPv6 address.
+* `ipv6_bandwidth_id` - (Optional, String) Specifies the ID of the shared bandwidth of an IPv6 address.
 
+<a name="group_security_group_object"></a>
 The `security_groups` block supports:
 
-* `id` - (Required, String) The UUID of the security group.
+* `id` - (Required, String) Specifies the ID of the security group.
 
+<a name="group_lbaas_listener_object"></a>
 The `lbaas_listeners` block supports:
 
 * `pool_id` - (Required, String) Specifies the backend ECS group ID.
+
 * `protocol_port` - (Required, Int) Specifies the backend protocol, which is the port on which a backend ECS listens for
   traffic. The number of the port ranges from 1 to 65535.
+
 * `weight` - (Optional, Int) Specifies the weight, which determines the portion of requests a backend ECS processes
   compared to other backend ECSs added to the same listener. The value of this parameter ranges from 0 to 100. The
   default value is 1.
@@ -222,9 +251,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The AS group ID.
 
-* `status` - Indicates the status of the AS group.
+* `status` - The status of the AS group.
 
-* `current_instance_number` - Indicates the number of current instances in the AS group.
+* `current_instance_number` - The number of current instances in the AS group.
 
 * `instances` - The instances IDs of the AS group.
 

--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -24,9 +24,6 @@ resource "huaweicloud_as_group" "my_as_group" {
   networks {
     id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   }
-  security_groups {
-    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
-  }
 }
 ```
 
@@ -45,9 +42,6 @@ resource "huaweicloud_as_group" "my_as_group_tags" {
 
   networks {
     id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  }
-  security_groups {
-    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
   }
   tags = {
     foo = "bar"
@@ -71,9 +65,6 @@ resource "huaweicloud_as_group" "my_as_group_only_remove_members" {
 
   networks {
     id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  }
-  security_groups {
-    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
   }
 }
 ```
@@ -111,9 +102,6 @@ resource "huaweicloud_as_group" "my_as_group_with_enhanced_lb" {
   networks {
     id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   }
-  security_groups {
-    id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
-  }
   lbaas_listeners {
     pool_id       = huaweicloud_lb_pool.pool_1.id
     protocol_port = huaweicloud_lb_listener.listener_1.protocol_port
@@ -149,13 +137,26 @@ The following arguments are supported:
 
 * `availability_zones` - (Optional, List) The availability zones in which to create the instances in the autoscaling group.
 
+* `multi_az_scaling_policy` - (Optional, String) The priority policy used to select target AZs when adjusting the number
+  of instances in an AS group. The value can be `EQUILIBRIUM_DISTRIBUTE` and `PICK_FIRST`.
+
+  + **EQUILIBRIUM_DISTRIBUTE** (default): When adjusting the number of instances, ensure that instances in each AZ in the
+    availability_zones list is evenly distributed. If instances cannot be added in the target AZ, select another AZ based
+    on the PICK_FIRST policy.
+  + **PICK_FIRST**: When adjusting the number of instances, target AZs are determined in the order in the availability_zones list.
+
+* `vpc_id` - (Required, String, ForceNew) The VPC ID. Changing this creates a new group.
+
 * `networks` - (Required, List) An array of one or more network IDs. The system supports up to five networks. The
   networks object structure is documented below.
 
-* `security_groups` - (Required, List) An array of one or more security group IDs to associate with the group. The
+* `security_groups` - (Optional, List) An array of one or more security group IDs to associate with the group. The
   security_groups object structure is documented below.
 
-* `vpc_id` - (Required, String, ForceNew) The VPC ID. Changing this creates a new group.
+  -> If the security group is specified both in the AS configuration and AS group, scaled ECS instances will be added to
+  the security group specified in the AS configuration. If the security group is not specified in either of them, scaled
+  ECS instances will be added to the default security group. For your convenience, you are advised to specify the security
+  group in the AS configuration.
 
 * `health_periodic_audit_method` - (Optional, String) The health check method for instances in the AS group. The health
   check methods include `ELB_AUDIT` and `NOVA_AUDIT`. If load balancing is configured, the default value of this
@@ -164,11 +165,18 @@ The following arguments are supported:
 * `health_periodic_audit_time` - (Optional, Int) The health check period for instances. The period has four options: 5
   minutes (default), 15 minutes, 60 minutes, and 180 minutes.
 
+* `health_periodic_audit_grace_period` - (Optional, Int) The health check grace period for instances. The unit is second
+  and the value ranges from 0 to 86400. The default value is 600.
+
+  -> This parameter is valid only when the instance health check method of the AS group is `ELB_AUDIT`.
+
 * `instance_terminate_policy` - (Optional, String) The instance removal policy. The policy has four
   options: `OLD_CONFIG_OLD_INSTANCE` (default), `OLD_CONFIG_NEW_INSTANCE`,
   `OLD_INSTANCE`, and `NEW_INSTANCE`.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the scaling group.
+
+* `description` (Optional, String) The description of the AS group. The value can contain 0 to 256 characters.
 
 * `notifications` - (Optional, List) The notification mode. The system only supports `EMAIL`
   mode which refers to notification by email.
@@ -190,6 +198,10 @@ The following arguments are supported:
 The `networks` block supports:
 
 * `id` - (Required, String) The network UUID.
+
+* `ipv6_enable` - (Optional, Bool) Whether to support IPv6 addresses. The default value is false.
+
+* `ipv6_bandwidth_id` - (Optional, String) The ID of the shared bandwidth of an IPv6 address.
 
 The `security_groups` block supports:
 

--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -202,9 +202,6 @@ The following arguments are supported:
 
 * `description` (Optional, String) Specifies the description of the AS group. The value can contain 0 to 256 characters.
 
-* `notifications` - (Optional, List) Specifies the notification mode. The system only supports `EMAIL`
-  mode which refers to notification by email.
-
 * `delete_publicip` - (Optional, Bool) Specifies whether to delete the elastic IP address bound to the instances of
   AS group when deleting the instances. The options are `true` and `false`.
 

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -32,6 +32,10 @@ func TestAccASGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "multi_az_scaling_policy", "EQUILIBRIUM_DISTRIBUTE"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "300"),
+					resource.TestCheckResourceAttr(resourceName, "health_periodic_audit_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "health_periodic_audit_grace_period", "600"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zones.#"),
 				),
@@ -55,6 +59,10 @@ func TestAccASGroup_basic(t *testing.T) {
 				Config: testASGroup_basic_enable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASGroupExists(resourceName, &asGroup),
+					resource.TestCheckResourceAttr(resourceName, "multi_az_scaling_policy", "PICK_FIRST"),
+					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "600"),
+					resource.TestCheckResourceAttr(resourceName, "health_periodic_audit_time", "15"),
+					resource.TestCheckResourceAttr(resourceName, "health_periodic_audit_grace_period", "900"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 				),
 			},
@@ -292,6 +300,11 @@ resource "huaweicloud_as_group" "acc_as_group"{
   scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
   vpc_id                   = data.huaweicloud_vpc.test.id
   enable                   = true
+
+  multi_az_scaling_policy            = "PICK_FIRST"
+  cool_down_time                     = 600
+  health_periodic_audit_time         = 15
+  health_periodic_audit_grace_period = 900
 
   networks {
     id = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -188,11 +188,6 @@ func ResourceASGroup() *schema.Resource {
 				Default:      "OLD_CONFIG_OLD_INSTANCE",
 				ValidateFunc: validation.StringInSlice(TerminatePolices, false),
 			},
-			"notifications": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 			"delete_publicip": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -251,7 +246,13 @@ func ResourceASGroup() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "schema: Deprecated",
+				Description: "schema: Deprecated; use availability_zones instead",
+			},
+			"notifications": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "schema: Deprecated; The notification mode has been canceled",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

do the following changes on `huaweicloud_as_group`:

- add parameters: **multi_az_scaling_policy**, **health_periodic_audit_grace_period**, **description**, **network.0.ipv6_enable**, **network.0.ipv6_bandwidth_id**
- depreacate `notifications` param in docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (171.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        171.881s
```
