### PR TITLE
chore(as): improve on lifecycle_hook reesource

### DIFF
--- a/docs/resources/as_lifecycle_hook.md
+++ b/docs/resources/as_lifecycle_hook.md
@@ -8,19 +8,15 @@ Manages an AS Lifecycle Hook resource within HuaweiCloud.
 
 ## Example Usage
 
-### Basic Lifecycle Hook
-
 ```hcl
 variable "hook_name" {}
-
 variable "as_group_id" {}
-
 variable "smn_topic_urn" {}
 
 resource "huaweicloud_as_lifecycle_hook" "test" {
+  scaling_group_id       = var.as_group_id
   name                   = var.hook_name
   type                   = "ADD"
-  scaling_group_id       = var.as_group_id
   default_result         = "ABANDON"
   notification_topic_urn = var.smn_topic_urn
   notification_message   = "This is a test message"
@@ -31,8 +27,11 @@ resource "huaweicloud_as_lifecycle_hook" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the AS lifecycle hook. If omitted, the `region`
-  argument of the provider is used. Changing this creates a new AS lifecycle hook.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the AS lifecycle hook.
+  If omitted, the provider-level region will be used. Changing this creates a new AS lifecycle hook.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the ID of the AS group in UUID format.
+  Changing this creates a new AS lifecycle hook.
 
 * `name` - (Required, String) Specifies the lifecycle hook name. This parameter can contain a maximum of 32 characters,
   which may consist of letters, digits, underscores (_) and hyphens (-).
@@ -42,9 +41,6 @@ The following arguments are supported:
   + `REMOVE`: The hook suspends the instance when the instance is terminated.
 
 * `notification_topic_urn` - (Required, String) Specifies a unique topic in SMN.
-
-* `scaling_group_id` - (Required, String, ForceNew) Specifies the ID of the AS group in UUID format. Changing this
-  creates a new AS lifecycle hook.
 
 * `default_result` - (Optional, String) Specifies the default lifecycle hook callback operation. This operation is
   performed when the timeout duration expires. The valid values are *ABANDON* and *CONTINUE*, default to *ABANDON*.
@@ -70,5 +66,5 @@ In addition to all arguments above, the following attributes are exported:
 Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.
 
 ```
-$ terraform import huaweicloud_as_lifecycle_hook.test <AS group ID>/<Lifecycle hook ID>
+$ terraform import huaweicloud_as_lifecycle_hook.test &ltAS group ID&gt/&ltLifecycle hook ID&gt
 ```

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go
@@ -34,7 +34,7 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceHookName, "timeout", "3600"),
 					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a test message"),
 					resource.TestMatchResourceAttr(resourceHookName, "notification_topic_urn",
-						regexp.MustCompile(fmt.Sprintf("^(urn:smn:%s:[0-9a-z]{32}:%s)$", acceptance.HW_REGION_NAME, rName))),
+						regexp.MustCompile(fmt.Sprintf(`^(urn:smn:%s:[0-9a-z]{32}:%s)$`, acceptance.HW_REGION_NAME, rName))),
 				),
 			},
 			{
@@ -47,7 +47,7 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceHookName, "timeout", "600"),
 					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a update message"),
 					resource.TestMatchResourceAttr(resourceHookName, "notification_topic_urn",
-						regexp.MustCompile(fmt.Sprintf("^(urn:smn:%s:[0-9a-z]{32}:%s-update)$", acceptance.HW_REGION_NAME, rName))),
+						regexp.MustCompile(fmt.Sprintf(`^(urn:smn:%s:[0-9a-z]{32}:%s-update)$`, acceptance.HW_REGION_NAME, rName))),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

add log message on **huaweicloud_as_lifecycle_hook** resource and update docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccASLifecycleHook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASLifecycleHook_basic -timeout 360m -parallel 4
=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (141.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        141.572s
```
