### PR TITLE
feat: add elb param timeout of persistence

### DIFF
--- a/docs/resources/elb_pool.md
+++ b/docs/resources/elb_pool.md
@@ -62,6 +62,11 @@ The `persistence` argument supports:
 * `cookie_name` - (Optional, String, ForceNew) The name of the cookie if persistence mode is set appropriately. Required
   if `type = APP_COOKIE`.
 
+* `timeout` - (Optional, Int, ForceNew) Specifies the sticky session timeout duration in minutes. This parameter is
+  invalid when type is set to APP_COOKIE. The value range varies depending on the protocol of the backend server group:
+  + When the protocol of the backend server group is TCP or UDP, the value ranges from 1 to 60.
+  + When the protocol of the backend server group is HTTP or HTTPS, the value ranges from 1 to 1440.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20221124083311-ffb72767d7a1
+	github.com/chnsz/golangsdk v0.0.0-20221128071855-651bfd80c58c
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chnsz/golangsdk v0.0.0-20221124083311-ffb72767d7a1 h1:6RCL31mrAWvhHv9Xijd+0Rp+atj3qjuGyY/ahNgvDh4=
 github.com/chnsz/golangsdk v0.0.0-20221124083311-ffb72767d7a1/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221128071855-651bfd80c58c h1:/0wEQhR+aqvSf1K6uwENfX9GomcMW5cWWsZBe1NBv4U=
+github.com/chnsz/golangsdk v0.0.0-20221128071855-651bfd80c58c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/pools/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/pools/results.go
@@ -26,6 +26,10 @@ type SessionPersistence struct {
 
 	// Name of cookie if persistence mode is set appropriately.
 	CookieName string `json:"cookie_name,omitempty"`
+
+	// Specifies the sticky session timeout duration in minutes.
+	// This parameter is invalid when type is set to APP_COOKIE.
+	PersistenceTimeout int `json:"persistence_timeout,omitempty"`
 }
 
 // LoadBalancerID represents a load balancer.
@@ -55,7 +59,7 @@ type Pool struct {
 	Description string `json:"description"`
 
 	// A list of listeners objects IDs.
-	Listeners []ListenerID `json:"listeners"` //[]map[string]interface{}
+	Listeners []ListenerID `json:"listeners"` // []map[string]interface{}
 
 	// A list of member objects IDs.
 	Members []Member `json:"members"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20221124083311-ffb72767d7a1
+# github.com/chnsz/golangsdk v0.0.0-20221128071855-651bfd80c58c
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add param timeout to huaweicloud_lb_pool and huaweicloud_elb_pool
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add param timeout to huaweicloud_lb_pool and huaweicloud_elb_pool
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=
'./huaweicloud/services/acceptance/elb' TESTARGS='-run TestAccElbV3Pool_basic'                                               
=== RUN   TestAccElbV3Pool_basic
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       83.839s

make testacc TEST=
'./huaweicloud/services/acceptance/lb' TESTARGS='-run TestAccLBV2Pool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run TestAccLBV2Pool_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (125.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        125.207s
```
