### PR TITLE
fix: fix elb member v3 param

### DIFF
--- a/docs/resources/elb_member.md
+++ b/docs/resources/elb_member.md
@@ -26,7 +26,11 @@ The following arguments are supported:
 
 * `pool_id` - (Required, String, ForceNew) The id of the pool that this member will be assigned to.
 
-* `subnet_id` - (Required, String, ForceNew) The subnet in which to access the member
+* `subnet_id` - (Optional, String, ForceNew) The subnet in which to access the member.
+  The IPv4 or IPv6 subnet must be in the same VPC as the subnet of the load balancer.
+  If this parameter is not passed, cross-VPC backend has been enabled for the load balancer. In this case,
+  cross-VPC backend servers must use private IPv4 addresses, and the protocol of the backend server group
+  must be TCP, HTTP, or HTTPS.
 
 * `name` - (Optional, String) Human-readable name for the member.
 

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_member_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_member_test.go
@@ -48,6 +48,40 @@ func TestAccElbV3Member_basic(t *testing.T) {
 	})
 }
 
+func TestAccElbV3Member_crossVpcBackend(t *testing.T) {
+	var member_1 pools.Member
+	var member_2 pools.Member
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckElbV3MemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3MemberConfig_crossVpcBackend_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElbV3MemberExists("huaweicloud_elb_member.member_1", &member_1),
+					testAccCheckElbV3MemberExists("huaweicloud_elb_member.member_2", &member_2),
+				),
+			},
+			{
+				Config: testAccElbV3MemberConfig_crossVpcBackend_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("huaweicloud_elb_member.member_1", "weight", "10"),
+					resource.TestCheckResourceAttr("huaweicloud_elb_member.member_2", "weight", "15"),
+				),
+			},
+			{
+				ResourceName:      "huaweicloud_elb_member.member_1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccELBMemberImportStateIdFunc(),
+			},
+		},
+	})
+}
+
 func testAccCheckElbV3MemberDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
@@ -164,12 +198,6 @@ resource "huaweicloud_elb_member" "member_1" {
   protocol_port = 8080
   pool_id       = huaweicloud_elb_pool.test.id
   subnet_id     = data.huaweicloud_vpc_subnet.test.subnet_id
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 
 resource "huaweicloud_elb_member" "member_2" {
@@ -177,12 +205,6 @@ resource "huaweicloud_elb_member" "member_2" {
   protocol_port = 8080
   pool_id       = huaweicloud_elb_pool.test.id
   subnet_id     = data.huaweicloud_vpc_subnet.test.subnet_id
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, rName, rName, rName)
 }
@@ -232,12 +254,6 @@ resource "huaweicloud_elb_member" "member_1" {
   weight         = 10
   pool_id        = huaweicloud_elb_pool.test.id
   subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 
 resource "huaweicloud_elb_member" "member_2" {
@@ -246,12 +262,116 @@ resource "huaweicloud_elb_member" "member_2" {
   weight         = 15
   pool_id        = huaweicloud_elb_pool.test.id
   subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+}
+`, rName, rName, rName)
+}
 
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+func testAccElbV3MemberConfig_crossVpcBackend_basic(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name              = "%s"
+  cross_vpc_backend = true
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv6_network_id   = data.huaweicloud_vpc_subnet.test.id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+}
+
+resource "huaweicloud_elb_listener" "test" {
+  name            = "%s"
+  description     = "test description"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+
+  forward_eip = true
+
+  idle_timeout = 60
+  request_timeout = 60
+  response_timeout = 60
+}
+
+resource "huaweicloud_elb_pool" "test" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = huaweicloud_elb_listener.test.id
+}
+
+resource "huaweicloud_elb_member" "member_1" {
+  address       = "121.121.0.120"
+  protocol_port = 8080
+  pool_id       = huaweicloud_elb_pool.test.id
+}
+
+resource "huaweicloud_elb_member" "member_2" {
+  address       = "121.121.0.121"
+  protocol_port = 8080
+  pool_id       = huaweicloud_elb_pool.test.id
+}
+`, rName, rName, rName)
+}
+
+func testAccElbV3MemberConfig_crossVpcBackend_update(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name              = "%s"
+  cross_vpc_backend = true
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv6_network_id   = data.huaweicloud_vpc_subnet.test.id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+}
+
+resource "huaweicloud_elb_listener" "test" {
+  name            = "%s"
+  description     = "test description"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+
+  forward_eip = true
+
+  idle_timeout = 60
+  request_timeout = 60
+  response_timeout = 60
+}
+
+resource "huaweicloud_elb_pool" "test" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = huaweicloud_elb_listener.test.id
+}
+
+resource "huaweicloud_elb_member" "member_1" {
+  address        = "121.121.0.120"
+  protocol_port  = 8080
+  weight         = 10
+  pool_id        = huaweicloud_elb_pool.test.id
+}
+
+resource "huaweicloud_elb_member" "member_2" {
+  address        = "121.121.0.121"
+  protocol_port  = 8080
+  weight         = 15
+  pool_id        = huaweicloud_elb_pool.test.id
 }
 `, rName, rName, rName)
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_member.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_member.go
@@ -73,7 +73,7 @@ func ResourceMemberV3() *schema.Resource {
 
 			"subnet_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix elb member param subnet_id from required to optional
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix elb member param subnet_id from required to optional
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=
'./huaweicloud/services/acceptance/elb' TESTARGS='-run TestAccElbV3Member_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccElbV3Member_* -timeout 360m -parallel 4
=== RUN   TestAccElbV3Member_basic
=== PAUSE TestAccElbV3Member_basic
=== RUN   TestAccElbV3Member_crossVpcBackend
=== PAUSE TestAccElbV3Member_crossVpcBackend
=== CONT  TestAccElbV3Member_basic
=== CONT  TestAccElbV3Member_crossVpcBackend
--- PASS: TestAccElbV3Member_basic (79.65s) 
--- PASS: TestAccElbV3Member_crossVpcBackend (80.91s) 
PASS                                                                                                            
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       80.970s
```
