### PR TITLE
feat(rf/stack): add new resource support

### DIFF
--- a/docs/resources/rf_stack.md
+++ b/docs/resources/rf_stack.md
@@ -1,0 +1,220 @@
+---
+subcategory: "Application Orchestration Service (AOS)"
+---
+
+# huaweicloud_rf_stack
+
+Provides an RF resource stack.
+
+## Example Usage
+
+### Create an RF resource stack with resource deployment (using OBS URIs)
+
+```HCL
+variable "stack_name" {}
+variable "agency_name" {}
+variable "template_obs_uri" {}
+variable "variable_obs_uri" {}
+
+resource "huaweicloud_rf_stack" "test" {
+  name = var.stack_name
+
+  agency {
+    name          = var.agency_name
+    provider_name = "huaweicloud"
+  }
+
+  template_uri = var.template_obs_uri
+  vars_uri     = var.variable_obs_uri
+```
+
+### Create an RF resource stack with VPC deployment (using template and variable files)
+
+```HCL
+variable "stack_name" {}
+variable "agency_name" {}
+variable "template_path" {}
+variable "variable_path" {}
+
+resource "huaweicloud_rf_stack" "test" {
+  name = var.stack_name
+
+  agency {
+    name          = var.agency_name
+    provider_name = "huaweicloud"
+  }
+
+  template_body = file(var.template_path) // local storage path of HCL/JSON script
+  vars_body     = file(var.variable_path) // local storage path of .vars file
+}
+```
+
+The content of the template file (in JSON format) is as follows:
+
+```json
+{
+  "terraform": {
+    "required_providers": [
+      {
+        "huaweicloud": {
+          "source": "huawei.com/provider/huaweicloud",
+          "version": "&gt= 1.41.0"
+        }
+      }
+    ]
+  },
+  "provider": {
+    "huaweicloud": {
+      "region": "${var.region_name}"
+    }
+  },
+  "resource": {
+    "huaweicloud_vpc": {
+      "test": {
+        "name": "${var.vpc_name}",
+        "cidr": "192.168.0.0/16"
+      }
+    },
+    "huaweicloud_vpc_subnet": {
+      "test": {
+        "vpc_id": "${huaweicloud_vpc.test.id}",
+        "name": "${var.subnet_name}",
+        "cidr": "${cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)}",
+        "gateway_ip": "${cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)}"
+      }
+    }
+  },
+  "variable": {
+    "region_name": {
+      "type": "string"
+    },
+    "vpc_name": {
+      "type": "string"
+    },
+    "subnet_name": {
+      "type": "string"
+    }
+  }
+}
+```
+
+The content of the `.vars` file is as follows:
+
+```HCL
+region_name = "cn-north-4"
+vpc_name    = "tf-example-vpc"
+subnet_name = "tf-example-vpc-subnet"
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the RF resource stack is located.  
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the resource stack.  
+  The valid length is limited from can contain `1` to `64`, only letters, digits and hyphens (-) are allowed.
+  The name must start with a lowercase letter and end with a lowercase letter or digit.
+  Change this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the resource stack, which contain maximum of
+  255 characters.  
+  Change this parameter will create a new resource.
+
+* `agency` - (Optional, String, ForceNew) Specifies the configuration of the agencies authorized to IAC.  
+  Change this parameter will create a new resource.
+  The [object](#stack_agency) structure is documented below.
+
+* `template_body` - (Optional, String) Specifies the HCL/JSON template content for deployment resources.  
+  This parameter and `template_uri` are alternative and required if `vars_body` is set.
+
+* `vars_body` - (Optional, String) Specifies the variable content for deployment resources.  
+  This parameter and `vars_uri` are alternative.
+
+* `template_uri` - (Optional, String) Specifies the OBS address where the HCL/JSON template archive (**.zip** file,
+  which contains all resource **.tf.json** script files to be deployed) or **.tf.json** file is located, which describes
+  the target status of the deployment resources.
+
+* `vars_uri` - (Optional, String) Specifies the OBS address where the variable (**.tfvars**) file corresponding to the
+  HCL/JSON template located, which describes the target status of the deployment resources.
+
+* `enable_auto_rollback` - (Optional, Bool, ForceNew) Specifies whether to enable automatic rollback.  
+  If enabled, the stack resources will rollback automatically to the last stable state with deployment failure.
+  The default value is **false**.
+  Change this parameter will create a new resource.
+
+* `enable_deletion_protection` - (Optional, Bool, ForceNew) Specifies whether to enable delete protection.  
+  The default value is **false**.
+  Change this parameter will create a new resource.
+
+<a name="stack_agency"></a>
+The `agency` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the name of IAM agency authorized to IAC account.  
+  Change this parameter will create a new resource.
+
+* `provider_name` - (Required, String, ForceNew) Specifies the name of the provider corresponding to the IAM agency.  
+  Change this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The stack ID.
+
+* `status` - The current status of the resource stack.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `update` - Default is 20 minutes.
+* `delete` - Default is 5 minutes.
+
+For most HCL templates, the timeout parameters needs to be manually configured by the user to ensure that resources can
+be deployed successfully on the RF resource stack, e.g.
+
+```HCL
+resource "huaweicloud_rf_stack" "test" {
+  ...
+
+  timeouts {
+    create = "1h" // Such as the creation of GaussDB instances.
+    update = "1h"
+  }
+}
+```
+
+## Import
+
+Stacks can be imported using their `id`, e.g.
+
+```
+$ terraform import huaweicloud_rf_stack.test edd2f099-e1ac-4bd0-be32-8b2185620a90
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `agency`, `template_body`, `vars_body`, `template_uri`, `vars_uri`,
+`enable_auto_rollback` and `enable_deletion_protection`. It is generally recommended running `terraform plan` after
+importing a stack. You can keep the resource the same with its definition bo choosing any of them to update.
+Also you can ignore changes as below.
+
+```HCL
+resource "huaweicloud_rf_stack" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      agency,
+      template_body,
+      ...
+    ]
+  }
+}
+```

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/identity/v3/projects"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/users"
 	"github.com/chnsz/golangsdk/openstack/obs"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 
@@ -554,6 +555,23 @@ func (c *Config) SwrV2Client(region string) (*golangsdk.ServiceClient, error) {
 
 func (c *Config) BmsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("bms", region)
+}
+
+func (c *Config) AosV1Client(region string) (*golangsdk.ServiceClient, error) {
+	client, err := c.NewServiceClient("aos", region)
+	if err != nil {
+		return nil, err
+	}
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, err
+	}
+	client.MoreHeaders = map[string]string{
+		"Content-Type":      "application/json",
+		"X-Language":        "en-us",
+		"Client-Request-Id": u,
+	}
+	return client, nil
 }
 
 // ********** client for Storage **********

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -185,6 +185,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version: "v1",
 		Product: "BMS",
 	},
+	"aos": {
+		Name:    "aos",
+		Version: "v1",
+		Product: "AOS",
+	},
 
 	// ******* catalog for storage ******
 	"evs": {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -64,6 +64,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/oms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/projectman"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rf"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
@@ -571,6 +572,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_aom_alarm_rule":             aom.ResourceAlarmRule(),
 			"huaweicloud_aom_service_discovery_rule": aom.ResourceServiceDiscoveryRule(),
+
+			"huaweicloud_rf_stack": rf.ResourceStack(),
 
 			"huaweicloud_api_gateway_api":   ResourceAPIGatewayAPI(),
 			"huaweicloud_api_gateway_group": ResourceAPIGatewayGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -92,6 +92,13 @@ var (
 	HW_KMS_ENVIRONMENT = os.Getenv("HW_KMS_ENVIRONMENT")
 
 	HW_ER_TEST_ON = os.Getenv("HW_ER_TEST_ON") // Whether to run the ER related tests.
+
+	// The OBS address where the HCL/JSON template archive (No variables) is located.
+	HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI = os.Getenv("HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI")
+	// The OBS address where the HCL/JSON template archive is located.
+	HW_RF_TEMPLATE_ARCHIVE_URI = os.Getenv("HW_RF_TEMPLATE_ARCHIVE_URI")
+	// The OBS address where the variable archive corresponding to the HCL/JSON template is located.
+	HW_RF_VARIABLES_ARCHIVE_URI = os.Getenv("HW_RF_VARIABLES_ARCHIVE_URI")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -423,5 +430,13 @@ func TestAccPreCheckWorkspaceAD(t *testing.T) {
 func TestAccPreCheckER(t *testing.T) {
 	if HW_ER_TEST_ON == "" {
 		t.Skip("Skip all ER acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRfArchives(t *testing.T) {
+	if HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI == "" || HW_RF_TEMPLATE_ARCHIVE_URI == "" ||
+		HW_RF_VARIABLES_ARCHIVE_URI == "" {
+		t.Skip("Skip the archive URI parameters acceptance test for RF resource stack.")
 	}
 }

--- a/huaweicloud/services/acceptance/rf/resource_huaweicloud_rf_stack_test.go
+++ b/huaweicloud/services/acceptance/rf/resource_huaweicloud_rf_stack_test.go
@@ -1,0 +1,605 @@
+package rf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/rf/v1/stacks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rf"
+)
+
+func getStackesourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.AosV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOS v3 client: %s", err)
+	}
+
+	return rf.QueryStackById(client, state.Primary.ID)
+}
+
+func TestAccStack_basic(t *testing.T) { // the template file is json format.
+	var (
+		obj stacks.Stack
+
+		rName = "huaweicloud_rf_stack.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStackesourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStack_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Create by acc test"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccStack_withBody_step1(name, basicTemplateInJsonFormat(name)),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccStack_withBody_step2(name, updateTemplateInJsonFormat(name), variableContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"agency",
+					"template_body",
+					"vars_body",
+				},
+			},
+		},
+	})
+}
+
+func testAccStack_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rf_stack" "test" {
+  name        = "%[1]s"
+  description = "Create by acc test"
+}
+`, name)
+}
+
+func testAccStack_withBody_step1(name, template string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rf_stack" "test" {
+  name        = "%[1]s"
+  description = "Create by acc test"
+
+  agency {
+    name          = "rf_admin_trust" // System RF agency
+    provider_name = "huaweicloud"
+  }
+
+  template_body = %[2]s
+}
+`, name, template)
+}
+
+func testAccStack_withBody_step2(name, template, vars string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rf_stack" "test" {
+  name        = "%[1]s"
+  description = "Create by acc test"
+
+  agency {
+    name          = "rf_admin_trust" // System RF agency
+    provider_name = "huaweicloud"
+  }
+
+  template_body = %[2]s
+  vars_body     = %[3]s
+}
+`, name, updateTemplateInJsonFormat(name), variableContent)
+}
+
+func TestAccStack_withBody_HCL(t *testing.T) {
+	var (
+		obj stacks.Stack
+
+		rName = "huaweicloud_rf_stack.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStackesourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStack_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Create by acc test"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccStack_withBody_step1(name, basicTemplateInHclFormat(name)),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccStack_withBody_step2(name, updateTemplateInHclFormat(name), variableContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"agency",
+					"template_body",
+					"vars_body",
+				},
+			},
+		},
+	})
+}
+
+func TestAccStack_withUri_JSON(t *testing.T) {
+	var (
+		obj stacks.Stack
+
+		rName = "huaweicloud_rf_stack.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStackesourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStack_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccStack_withUri_step1(name, basicTemplateInJsonFormat(name), variableContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccStack_withUri_step2(name, basicTemplateInJsonFormat(name), variableContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"agency",
+					"template_uri",
+					"vars_uri",
+				},
+			},
+		},
+	})
+}
+
+func testAccStack_withUri_base(name, template, vars string) string {
+	return fmt.Sprintf(`
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket = "%[1]s"
+  acl    = "private"
+}
+
+resource "huaweicloud_obs_bucket_policy" "test" {
+  bucket = huaweicloud_obs_bucket.test.bucket
+  policy = <<EOT
+{
+  "Statement": [
+    {
+      "Sid": "RF-Access",
+      "Effect": "Allow",
+      "Principal": {
+        "ID": ["*"]
+      },
+      "Action": [
+        "GetObject"
+      ],
+      "Resource": [
+        "${huaweicloud_obs_bucket.test.bucket}/rf/resource_stack/uri_test/*"
+      ]
+    }
+  ]
+}
+EOT
+}
+
+resource "huaweicloud_obs_bucket_object" "template" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "rf/resource_stack/uri_test/template.tf.json"
+  content_type = "application/json"
+  content      = %[2]s
+}
+
+resource "huaweicloud_obs_bucket_object" "variable" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "rf/resource_stack/uri_test/resource.tfvars"
+  content_type = "application/octet-stream"
+  content      = %[3]s
+}
+`, name, template, vars)
+}
+
+func testAccStack_withUri_step1(name, template, vars string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rf_stack" "test" {
+  name = "%[2]s"
+
+  agency {
+    name          = "rf_admin_trust" // System RF agency
+    provider_name = "huaweicloud"
+  }
+
+  template_uri = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/${huaweicloud_obs_bucket_object.template.id}"
+}
+`, testAccStack_withUri_base(name, template, vars), name)
+}
+
+func testAccStack_withUri_step2(name, template, vars string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rf_stack" "test" {
+  name = "%[2]s"
+
+  agency {
+    name          = "rf_admin_trust" // System RF agency
+    provider_name = "huaweicloud"
+  }
+
+  template_uri = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/${huaweicloud_obs_bucket_object.template.id}"
+  vars_uri     = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/${huaweicloud_obs_bucket_object.variable.id}"
+}
+`, testAccStack_withUri_base(name, template, vars), name)
+}
+
+func TestAccStack_withUri_HCL(t *testing.T) {
+	var (
+		obj stacks.Stack
+
+		rName = "huaweicloud_rf_stack.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStackesourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStack_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccStack_withUri_step1(name, basicTemplateInHclFormat(name), variableContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccStack_withUri_step2(name, basicTemplateInHclFormat(name), variableContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"agency",
+					"template_uri",
+					"vars_uri",
+				},
+			},
+		},
+	})
+}
+
+func TestAccStack_archive(t *testing.T) {
+	var (
+		obj stacks.Stack
+
+		rName = "huaweicloud_rf_stack.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getStackesourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRfArchives(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStack_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccStack_archive_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccStack_archive_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"agency",
+					"template_uri",
+					"vars_uri",
+				},
+			},
+		},
+	})
+}
+
+func testAccStack_archive_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rf_stack" "test" {
+  name = "%[1]s"
+
+  agency {
+    name          = "rf_admin_trust" // System RF agency
+    provider_name = "huaweicloud"
+  }
+
+  template_uri = "%[2]s"
+}
+`, name, acceptance.HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI)
+}
+
+func testAccStack_archive_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rf_stack" "test" {
+  name = "%[1]s"
+
+  agency {
+    name          = "rf_admin_trust" // System RF agency
+    provider_name = "huaweicloud"
+  }
+
+  template_uri = "%[2]s"
+  vars_uri     = "%[3]s"
+}
+`, name, acceptance.HW_RF_TEMPLATE_ARCHIVE_URI, acceptance.HW_RF_VARIABLES_ARCHIVE_URI)
+}
+
+func basicTemplateInJsonFormat(name string) string {
+	return fmt.Sprintf(`<<EOT
+{
+  "terraform": {
+    "required_providers": [
+      {
+        "huaweicloud": {
+          "source": "huawei.com/provider/huaweicloud",
+          "version": ">= 1.41.0"
+        }
+      }
+    ]
+  },
+  "provider": {
+    "huaweicloud": {
+      "region": "%[1]s"
+    }
+  },
+  "resource": {
+    "huaweicloud_vpc": {
+      "test": {
+        "name": "%[2]s",
+        "cidr": "192.168.0.0/16"
+      }
+    }
+  }
+}
+EOT
+`, acceptance.HW_REGION_NAME, name)
+}
+
+func updateTemplateInJsonFormat(name string) string {
+	return fmt.Sprintf(`<<EOT
+{
+  "terraform": {
+    "required_providers": [
+      {
+        "huaweicloud": {
+          "source": "huawei.com/provider/huaweicloud",
+          "version": ">= 1.41.0"
+        }
+      }
+    ]
+  },
+  "provider": {
+    "huaweicloud": {
+      "region": "%[1]s"
+    }
+  },
+  "resource": {
+    "huaweicloud_vpc": {
+      "test": {
+        "name": "%[2]s",
+        "cidr": "192.168.0.0/16"
+      }
+    },
+    "huaweicloud_vpc_subnet": {
+      "test": {
+        "vpc_id": "$${huaweicloud_vpc.test.id}",
+        "name": "$${var.subnet_name}",
+        "cidr": "$${cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)}",
+        "gateway_ip": "$${cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)}"
+      }
+    }
+  },
+  "variable": {
+    "subnet_name": {
+      "type": "string"
+    }
+  }
+}
+EOT
+`, acceptance.HW_REGION_NAME, name)
+}
+
+func basicTemplateInHclFormat(name string) string {
+	// lintignore:AT004
+	return fmt.Sprintf(`<<EOT
+terraform {
+  required_providers {
+    huaweicloud = {
+      source  = "huawei.com/provider/huaweicloud"
+      version = ">= 1.41.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+EOT
+`, acceptance.HW_REGION_NAME, name)
+}
+
+func updateTemplateInHclFormat(name string) string {
+	// lintignore:AT004
+	return fmt.Sprintf(`<<EOT
+terraform {
+  required_providers {
+    huaweicloud = {
+      source  = "huawei.com/provider/huaweicloud"
+      version = ">= 1.41.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s",
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id      = "$${huaweicloud_vpc.test.id}"
+  name        = "$${var.subnet_name}"
+  cidr        = "$${cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)}"
+  gateway_ip" = "$${cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)}"
+}
+
+variable "subnet_name" {
+  type = "string"
+}
+EOT
+`, acceptance.HW_REGION_NAME, name)
+}
+
+const variableContent = `<<EOT
+subnet_name = "tf-test-demo"
+EOT
+`

--- a/huaweicloud/services/rf/resource_huaweicloud_rf_stack.go
+++ b/huaweicloud/services/rf/resource_huaweicloud_rf_stack.go
@@ -1,0 +1,401 @@
+package rf
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/rf/v1/stacks"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceStack() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStackCreate,
+		ReadContext:   resourceStackRead,
+		UpdateContext: resourceStackUpdate,
+		DeleteContext: resourceStackDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: "The region where the RF resource stack is located.",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9-]*$`),
+						"Only letters, digits and hyphens are allowed."),
+					validation.StringMatch(regexp.MustCompile(`^[a-z](.*[a-z0-9])?$`),
+						"The name must start with a letter and end with a letter or a digit."),
+					validation.StringLenBetween(1, 64),
+				),
+				Description: "The name of the resource stack.",
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 255),
+				Description:  "The description of the resource stack.",
+			},
+			"agency": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The name of IAM agency authorized to IAC account for resources modification.`,
+						},
+						"provider_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The name of the provider corresponding to the IAM agency.`,
+						},
+					},
+				},
+				Description: "The configuration of the agencies authorized to IAC.",
+			},
+			"template_body": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"template_uri"},
+				Description:   "The HCL/JSON template content for deployment resources.",
+			},
+			"vars_body": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"vars_uri"},
+				RequiredWith:  []string{"template_body"},
+				Description:   "The variable content for deployment resources.",
+			},
+			"template_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The OBS address where the HCL/JSON template archive (**.zip** file, which contains all " +
+					"resource **.tf.json** script files to be deployed) or **.tf.json** file is located, which " +
+					"describes the target status of the deployment resources.",
+			},
+			"vars_uri": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"template_uri"},
+				Description: "The OBS address where the variable (**.tfvars**) file corresponding to the HCL/JSON " +
+					"template located, which describes the target status of the deployment resources.",
+			},
+			"enable_auto_rollback": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Whether to enable automatic rollback.",
+			},
+			"enable_deletion_protection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Whether to enable delete protection.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the resource stack.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time.`,
+			},
+		},
+	}
+}
+
+func buildStackAgencies(agencies []interface{}) []stacks.Agency {
+	if len(agencies) < 1 {
+		return nil
+	}
+
+	result := make([]stacks.Agency, len(agencies))
+	for i, val := range agencies {
+		agency := val.(map[string]interface{})
+		result[i] = stacks.Agency{
+			AgencyName:   agency["name"].(string),
+			ProviderName: agency["provider_name"].(string),
+		}
+	}
+
+	return result
+}
+
+func buildStackCreateOpts(d *schema.ResourceData) stacks.CreateOpts {
+	return stacks.CreateOpts{
+		Name:                     d.Get("name").(string),
+		Agencies:                 buildStackAgencies(d.Get("agency").([]interface{})),
+		Description:              d.Get("description").(string),
+		EnableAutoRollback:       utils.Bool(d.Get("enable_auto_rollback").(bool)),
+		EnableDeletionProtection: utils.Bool(d.Get("enable_deletion_protection").(bool)),
+	}
+}
+
+func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.AosV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOS v1 client: %s", err)
+	}
+
+	resp, err := stacks.Create(client, buildStackCreateOpts(d))
+	if err != nil {
+		return diag.Errorf("error creating stack: %s", err)
+	}
+	d.SetId(resp.StackId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: stackStatusRefreshFunc(client, d.Id(), []string{
+			string(stacks.StackStatusCreationComplete),
+		}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Get("template_body") != "" || d.Get("template_uri") != "" {
+		if err = deployStack(ctx, client, d, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceStackRead(ctx, d, meta)
+}
+
+func deployStack(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	var (
+		stackId   = d.Id()
+		stackName = d.Get("name").(string)
+
+		opts = stacks.DeployOpts{
+			TemplateBody: d.Get("template_body").(string),
+			TemplateUri:  d.Get("template_uri").(string),
+			VarsBody:     d.Get("vars_body").(string),
+			VarsUri:      d.Get("vars_uri").(string),
+			StackId:      stackId,
+		}
+	)
+
+	deploymentId, err := stacks.Deploy(client, stackName, opts)
+	if err != nil {
+		return fmt.Errorf("error deploying stack resources: %s", err)
+	}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: stackStatusRefreshFunc(client, d.Id(), []string{
+			string(stacks.StackStatusDeploymentComplete),
+		}),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	resp, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		if stack, ok := resp.(stacks.Stack); ok && stack.Status == string(stacks.StackStatusDeploymentFailed) {
+			return queryAllFailedEvents(client, stackId, stackName, deploymentId)
+		}
+	}
+	return err
+}
+
+func queryAllFailedEvents(client *golangsdk.ServiceClient, stackId, stackName,
+	deploymentId string) error {
+	opts := stacks.ListEventsOpts{
+		StackId:      stackId,
+		DeploymentId: deploymentId,
+	}
+	events, err := stacks.ListAllEvents(client, stackName, opts)
+	if err != nil {
+		return err
+	}
+
+	var mErr *multierror.Error
+	for _, event := range events {
+		if event.EventType == string(stacks.EventTypeError) {
+			mErr = multierror.Append(mErr, fmt.Errorf(event.EventMessage))
+		}
+	}
+	return mErr.ErrorOrNil()
+}
+
+// QueryStackById is a method to query stack details using its ID.
+func QueryStackById(client *golangsdk.ServiceClient, stackId string) (*stacks.Stack, error) {
+	resp, err := stacks.ListAll(client)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := map[string]interface{}{
+		"ID": stackId,
+	}
+	result, err := utils.FilterSliceWithField(resp, filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(result) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	stack, ok := result[0].(stacks.Stack)
+	if !ok {
+		return nil, fmt.Errorf("invaid object type, want 'stack.Stack', but '%T'", result[0])
+	}
+	log.Printf("[DEBUG] The details of the stack (%s) is: %#v", stackId, stack)
+
+	return &stack, nil
+}
+
+func stackStatusRefreshFunc(client *golangsdk.ServiceClient, stackId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := QueryStackById(client, stackId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return resp, "COMPLETED", nil
+			}
+
+			return nil, "", err
+		}
+		log.Printf("[DEBUG] The details of the resource stack (%s) is: %#v", stackId, resp)
+
+		errorStatus := []string{
+			string(stacks.StackStatusDeploymentFailed),
+			string(stacks.StackStatusRollbackFailed),
+			string(stacks.StackStatusDeletionFailed),
+		}
+		if utils.StrSliceContains(errorStatus, resp.Status) {
+			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		}
+		if utils.StrSliceContains(targets, resp.Status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceStackRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+	client, err := config.AosV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating AOS v1 client: %s", err)
+	}
+
+	stackId := d.Id()
+	resp, err := QueryStackById(client, stackId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "RF resource stack")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving stack (%s) fields: %s", stackId, mErr)
+	}
+	return nil
+}
+
+func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.AosV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOS v1 client: %s", err)
+	}
+
+	if err = deployStack(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceStackRead(ctx, d, meta)
+}
+
+func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	client, err := config.AosV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOS v1 client: %s", err)
+	}
+
+	var (
+		stackName = d.Get("name").(string)
+		stackId   = d.Id()
+
+		opts = stacks.DeleteOpts{
+			StackId: stackId,
+		}
+	)
+
+	err = stacks.Delete(client, stackName, opts)
+	if err != nil {
+		return diag.Errorf("error deleting stack (%s): %s", stackId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      stackStatusRefreshFunc(client, stackId, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rf/v1/stacks/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rf/v1/stacks/requests.go
@@ -1,0 +1,180 @@
+package stacks
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// CreateOpts is the structure used to create a stack.
+type CreateOpts struct {
+	// The name of the stack.
+	// The value can contain 1 to 64 characters, only letters, digits and hyphens (-) are allowed.
+	// The name must start with a letter and end with a letter or digit.
+	Name string `json:"stack_name" required:"true"`
+	// The agencies authorized to IAC.
+	Agencies []Agency `json:"agencies,omitempty"`
+	// The description of the stack.
+	// The value can contain 0 to 1024 characters.
+	Description string `json:"description,omitempty"`
+	// The flag of the deletion protection.
+	// The resource stack deletion protection is not enabled by default (the resource stack is not allowed to be deleted
+	// after the deletion protection is enabled).
+	EnableDeletionProtection *bool `json:"enable_deletion_protection,omitempty"`
+	// The automatic rollback flag.
+	// The automatic rollback of the resource stack is not enabled by default (after automatic rollback is enabled, if
+	// the deployment fails, it will automatically roll back and return to the previous stable state).
+	EnableAutoRollback *bool `json:"enable_auto_rollback,omitempty"`
+	// The HCL template content for deployment resources.
+	TemplateBody string `json:"template_body,omitempty"`
+	// The OBS address where the HCL template ZIP is located, which describes the target status of the deployment
+	// resources.
+	TemplateUri string `json:"template_uri,omitempty"`
+	// The variable content for deployment resources.
+	VarsBody string `json:"vars_body,omitempty"`
+	// The variable structures for deployment resources.
+	VarsStructure []VarsStructure `json:"vars_structure,omitempty"`
+	// The OBS address where the variable ZIP corresponding to the HCL template is located, which describes the target
+	// status of the deployment resources.
+	VarsUri string `json:"vars_uri,omitempty"`
+}
+
+// Agency is an object that represents the IAC agency configuration.
+type Agency struct {
+	// The name of the provider corresponding to the IAM agency.
+	// If the provider_name given by the user contains duplicate values, return 400.
+	ProviderName string `json:"provider_name" required:"true"`
+	// The name of IAM agency authorized to IAC account.
+	// RF will use the agency authority to access and create resources corresponding to the provider.
+	AgencyName string `json:"agency_name" required:"true"`
+}
+
+// VarsStructure is an object that represents the variable structure details.
+type VarsStructure struct {
+	// The variable key.
+	VarKey string `json:"var_key" required:"true"`
+	// The variable value.
+	VarValue string `json:"var_value" required:"true"`
+	// The encryption configuration.
+	Encryption Encryption `json:"encryption,omitempty"`
+}
+
+// Encryption is an object that represents the KMS usage for variables.
+type Encryption struct {
+	// Encryption configuration for variables.
+	Kms KmsStructure `json:"kms" required:"true"`
+}
+
+// KmsStructure is an object that represents the encrypt structure.
+type KmsStructure struct {
+	// The ID of the KMD secret key.
+	ID string `json:"id" required:"true"`
+	// The ciphertext corresponding to the data encryption key.
+	CipherText string `json:"cipher_text" required:"true"`
+}
+
+// Create is a method to create a stack using create option.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*CreateResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r CreateResp
+	_, err = client.Post(rootURL(client), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: client.MoreHeaders,
+	})
+	return &r, err
+}
+
+// ListAll is a method to query all stacks and returns a stack list.
+func ListAll(client *golangsdk.ServiceClient) ([]Stack, error) {
+	var r listResp
+	_, err := client.Get(rootURL(client), &r, &golangsdk.RequestOpts{
+		MoreHeaders: client.MoreHeaders,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Stacks, nil
+}
+
+// DeployOpts is the structure used to deploy a terraform script.
+type DeployOpts struct {
+	// The HCL template content for terraform resources.
+	TemplateBody string `json:"template_body,omitempty"`
+	// The OBS address where the HCL template ZIP is located, which describes the target status of the terraform
+	// resources.
+	TemplateUri string `json:"template_uri,omitempty"`
+	// The variable content for terraform resources.
+	VarsBody string `json:"vars_body,omitempty"`
+	// The variable structures for terraform resources.
+	VarsStructure []VarsStructure `json:"vars_structure,omitempty"`
+	// The OBS address where the variable ZIP corresponding to the HCL template is located, which describes the target
+	// status of the deployment resources.
+	VarsUri string `json:"vars_uri,omitempty"`
+	// The unique ID of the resource stack.
+	StackId string `json:"stack_id,omitempty"`
+}
+
+// Deploy is a method to deploy a terraform script using given parameters.
+func Deploy(client *golangsdk.ServiceClient, stackName string, opts DeployOpts) (string, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	var r deployResp
+	_, err = client.Post(deploymentURL(client, stackName), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: client.MoreHeaders,
+	})
+	return r.DeploymentId, err
+}
+
+// ListEventsOpts allows to filter list data using given parameters.
+type ListEventsOpts struct {
+	// The unique ID of the resource stack.
+	StackId string `q:"stack_id"`
+	// The unique ID of the resource deployment.
+	DeploymentId string `q:"deployment_id"`
+}
+
+// ListAllEvents is a method to query all events for a specified stack using given parameters.
+func ListAllEvents(client *golangsdk.ServiceClient, stackName string, opts ListEventsOpts) ([]StackEvent, error) {
+	url := eventURL(client, stackName)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var r listEventsResp
+	_, err = client.Get(url, &r, &golangsdk.RequestOpts{
+		MoreHeaders: client.MoreHeaders,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return r.StackEvents, nil
+}
+
+// DeleteOpts is the structure used to remove a stack.
+type DeleteOpts struct {
+	// The stack ID.
+	StackId string `json:"stack_id,omitempty"`
+}
+
+// Delete is a method to remove a stack using stack name and delete option.
+func Delete(client *golangsdk.ServiceClient, stackName string, opts DeleteOpts) error {
+	url := resourceURL(client, stackName)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return err
+	}
+	url += query.String()
+
+	_, err = client.Delete(url, &golangsdk.RequestOpts{
+		MoreHeaders: client.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rf/v1/stacks/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rf/v1/stacks/results.go
@@ -1,0 +1,128 @@
+package stacks
+
+type (
+	StackStatus string
+	EventType   string
+)
+
+var (
+	StackStatusCreationComplete     StackStatus = "CREATION_COMPLETE"
+	StackStatusDeploymentInProgress StackStatus = "DEPLOYMENT_IN_PROGRESS"
+	StackStatusDeploymentFailed     StackStatus = "DEPLOYMENT_FAILED"
+	StackStatusDeploymentComplete   StackStatus = "DEPLOYMENT_COMPLETE"
+	StackStatusRollbackInProgress   StackStatus = "ROLLBACK_IN_PROGRESS"
+	StackStatusRollbackFailed       StackStatus = "ROLLBACK_FAILED"
+	StackStatusRollbackComplete     StackStatus = "ROLLBACK_COMPLETE"
+	StackStatusDeletionInProgress   StackStatus = "DELETION_IN_PROGRESS"
+	StackStatusDeletionFailed       StackStatus = "DELETION_FAILED"
+
+	EventTypeLog                EventType = "LOG"
+	EventTypeError              EventType = "ERROR"
+	EventTypeDrift              EventType = "DRIFT"
+	EventTypeSummary            EventType = "SUMMARY"
+	EventTypeCreationInProgress EventType = "CREATION_IN_PROGRESS"
+	EventTypeCreationFailed     EventType = "CREATION_FAILED"
+	EventTypeCreationComplete   EventType = "CREATION_COMPLETE"
+	EventTypeDeletionInProgress EventType = "DELETION_IN_PROGRESS"
+	EventTypeDeletionFailed     EventType = "DELETION_FAILED"
+	EventTypeDeletionComplete   EventType = "DELETION_COMPLETE"
+	EventTypeDeletionSkipped    EventType = "DELETION_SKIPPED"
+	EventTypeUpdateInProgress   EventType = "UPDATE_IN_PROGRESS"
+	EventTypeUpdateFailed       EventType = "UPDATE_FAILED"
+	EventTypeUpdateComplete     EventType = "UPDATE_COMPLETE"
+)
+
+// CreateResp is the structure that represents the API response of the 'Create' method, which contains stack ID and the
+// deployment ID.
+type CreateResp struct {
+	// The unique ID of the resource stack.
+	StackId string `json:"stack_id"`
+	// The unique ID of the resource deployment.
+	DeploymentId string `json:"deployment_id"`
+}
+
+// listResp is the structure that represents the API response of the 'ListAll' method, which contains the list of stack
+// details.
+type listResp struct {
+	// The list of stack details.
+	Stacks []Stack `json:"stacks"`
+}
+
+// Stack is the structure that represents the details of the resource stack.
+type Stack struct {
+	// The name of the resource stack.
+	Name string `json:"stack_name"`
+	// The description of the resource stack.
+	Description string `json:"description"`
+	// The unique ID of the resource stack.
+	ID string `json:"stack_id"`
+	// The current status of the stack.
+	// The valid values are as follows:
+	// + CREATION_COMPLETE
+	// + DEPLOYMENT_IN_PROGRESS
+	// + DEPLOYMENT_FAILED
+	// + DEPLOYMENT_COMPLETE
+	// + ROLLBACK_IN_PROGRESS
+	// + ROLLBACK_FAILED
+	// + ROLLBACK_COMPLETE
+	// + DELETION_IN_PROGRESS
+	// + DELETION_FAILED
+	Status string `json:"status"`
+	// The creation time.
+	CreatedAt string `json:"create_time"`
+	// The latest update time.
+	UpdatedAt string `json:"update_time"`
+	// The debug message for current deployment operation.
+	StatusMessage string `json:"status_message"`
+}
+
+// deployResp is the structure that represents the API response of the 'Deploy' method, which contains the deployment
+// ID.
+type deployResp struct {
+	// The unique ID of the resource deployment.
+	DeploymentId string `json:"deployment_id"`
+}
+
+// listEventsResp is the structure that represents the API response of the 'ListAllEvents' method, which contains the
+// list of the execution events.
+type listEventsResp struct {
+	// The list of the execution events.
+	StackEvents []StackEvent `json:"stack_events"`
+}
+
+// StackEvent is the structure that represents the details of the current execution event.
+type StackEvent struct {
+	// The id name of the resource, that is, the name of the value used by the corresponding resource as the unique id.
+	// When the resource is not created, resource_id_key is not returned.
+	ResourceIdKey string `json:"resource_id_key"`
+	// The id value of the resource, that is, the value used by the corresponding resource as the unique id.
+	// When the resource is not created, resource_id_value is not returned.
+	ResourceIdValue string `json:"resource_id_value"`
+	// The resource name.
+	ResourceName string `json:"resource_name"`
+	// The resource type.
+	ResourceType string `json:"resource_type"`
+	// The time when the event occurred, the format is: yyyy-mm-ddTHH:MM:SSZ.
+	Time string `json:"time"`
+	// The event type.
+	// The valid values are as follows:
+	// + LOG
+	// + ERROR
+	// + DRIFT
+	// + SUMMARY
+	// + CREATION_IN_PROGRESS
+	// + CREATION_FAILED
+	// + CREATION_COMPLETE
+	// + DELETION_IN_PROGRESS
+	// + DELETION_FAILED
+	// + DELETION_COMPLETE
+	// + DELETION_SKIPPED
+	// + UPDATE_IN_PROGRESS
+	// + UPDATE_FAILED
+	// + UPDATE_COMPLETE
+	EventType string `json:"event_type"`
+	// The message of the current event.
+	EventMessage string `json:"event_message"`
+	// The time spent changing the resource, in seconds.
+	EventSeconds string `json:"event_seconds"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rf/v1/stacks/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rf/v1/stacks/urls.go
@@ -1,0 +1,19 @@
+package stacks
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("stacks")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, stackName string) string {
+	return client.ServiceURL("stacks", stackName)
+}
+
+func deploymentURL(client *golangsdk.ServiceClient, stackName string) string {
+	return client.ServiceURL("stacks", stackName, "deployments")
+}
+
+func eventURL(client *golangsdk.ServiceClient, stackName string) string {
+	return client.ServiceURL("stacks", stackName, "events")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -260,6 +260,7 @@ github.com/chnsz/golangsdk/openstack/rds/v3/configurations
 github.com/chnsz/golangsdk/openstack/rds/v3/flavors
 github.com/chnsz/golangsdk/openstack/rds/v3/instances
 github.com/chnsz/golangsdk/openstack/rds/v3/securities
+github.com/chnsz/golangsdk/openstack/rf/v1/stacks
 github.com/chnsz/golangsdk/openstack/scm/v3/certificates
 github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories
 github.com/chnsz/golangsdk/openstack/servicestage/v2/applications


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource support for AOS service: huaweicloud_rf_stack
Through this resource, users can create a resource stack and execute HCL scripts in it and deploy these resources to the specified environment, e.g. cn-north-4.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource support
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rf' TESTARGS='-run=TestAccStack_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rf -v -run=TestAccStack_ -timeout 360m -parallel 4
=== RUN   TestAccStack_basic
=== PAUSE TestAccStack_basic
=== RUN   TestAccStack_uri
=== PAUSE TestAccStack_uri
=== CONT  TestAccStack_basic
=== CONT  TestAccStack_uri
--- PASS: TestAccStack_basic (121.69s)
--- PASS: TestAccStack_uri (121.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rf 122.093s
```
