### PR TITLE
chore: use ipv4_subent_id instead of subnet_id

### DIFF
--- a/docs/data-sources/cce_cluster.md
+++ b/docs/data-sources/cce_cluster.md
@@ -52,7 +52,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `container_network_type` - The container network type: **overlay_l2** , **underlay_ipvlan**, **vpc-router** or **eni**.
 
-* `eni_subnet_id` - ENI subnet ID. Specified when creating a CCE Turbo cluster.
+* `eni_subnet_id` - The **IPv4 subnet ID** of the subnet where the ENI resides.
+  Specified when creating a CCE Turbo cluster.
 
 * `eni_subnet_cidr` - ENI network segment. Specified when creating a CCE Turbo cluster.
 

--- a/docs/data-sources/cce_clusters.md
+++ b/docs/data-sources/cce_clusters.md
@@ -68,7 +68,7 @@ The `clusters` block supports:
 
 * `container_network_type` - The container network type: **overlay_l2** , **underlay_ipvlan**, **vpc-router** or **eni**.
 
-* `eni_subnet_id` - The ENI subnet ID.
+* `eni_subnet_id` - The **IPv4 subnet ID** of the subnet where the ENI resides.
 
 * `eni_subnet_cidr` - The ENI network segment.
 

--- a/docs/data-sources/lb_loadbalancer.md
+++ b/docs/data-sources/lb_loadbalancer.md
@@ -32,7 +32,7 @@ data "huaweicloud_lb_loadbalancer" "test" {
 
 * `vip_address` - (Optional, String) Specifies the private IP address of the load balancer.
 
-* `vip_subnet_id` - (Optional, String) Specifies the ID of the subnet where the load balancer works.
+* `vip_subnet_id` - (Optional, String) Specifies the **IPv4 subnet ID** of the subnet where the load balancer works.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the load balancer.
 

--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -109,7 +109,7 @@ resource "huaweicloud_cce_cluster" "test" {
   vpc_id                 = huaweicloud_vpc.myvpc.id
   subnet_id              = huaweicloud_vpc_subnet.mysubnet.id
   container_network_type = "eni"
-  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.subnet_id
+  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.ipv4_subnet_id
   eni_subnet_cidr        = huaweicloud_vpc_subnet.eni_test.cidr
 }
 ```
@@ -162,8 +162,8 @@ The following arguments are supported:
 * `service_network_cidr` - (Optional, String, ForceNew) Specifies the service network segment.
   Changing this parameter will create a new cluster resource.
 
-* `eni_subnet_id` - (Optional, String, ForceNew) Specifies the ENI subnet ID. Specified when creating a CCE Turbo
-  cluster. Changing this parameter will create a new cluster resource.
+* `eni_subnet_id` - (Optional, String, ForceNew) Specifies the **IPv4 subnet ID** of the subnet where the ENI resides.
+  Specified when creating a CCE Turbo cluster. Changing this parameter will create a new cluster resource.
 
 * `eni_subnet_cidr` - (Optional, String, ForceNew) Specifies the ENI network segment. Specified when creating a CCE
   Turbo cluster. Changing this parameter will create a new cluster resource.

--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -17,7 +17,7 @@ resource "huaweicloud_elb_loadbalancer" "basic" {
   cross_vpc_backend = true
 
   vpc_id         = "{{ vpc_id }}"
-  ipv4_subnet_id = "{{ subnet_id }}"
+  ipv4_subnet_id = "{{ ipv4_subnet_id }}"
 
   l4_flavor_id = "{{ l4_flavor_id }}"
   l7_flavor_id = "{{ l7_flavor_id }}"
@@ -42,7 +42,7 @@ resource "huaweicloud_elb_loadbalancer" "basic" {
   vpc_id            = "{{ vpc_id }}"
   ipv6_network_id   = "{{ ipv6_network_id }}"
   ipv6_bandwidth_id = "{{ ipv6_bandwidth_id }}"
-  ipv4_subnet_id    = "{{ subnet_id }}"
+  ipv4_subnet_id    = "{{ ipv4_subnet_id }}"
 
   l4_flavor_id = "{{ l4_flavor_id }}"
   l7_flavor_id = "{{ l7_flavor_id }}"
@@ -69,7 +69,7 @@ resource "huaweicloud_elb_loadbalancer" "basic" {
   vpc_id            = "{{ vpc_id }}"
   ipv6_network_id   = "{{ ipv6_network_id }}"
   ipv6_bandwidth_id = "{{ ipv6_bandwidth_id }}"
-  ipv4_subnet_id    = "{{ subnet_id }}"
+  ipv4_subnet_id    = "{{ ipv4_subnet_id }}"
 
   l4_flavor_id = "{{ l4_flavor_id }}"
   l7_flavor_id = "{{ l7_flavor_id }}"
@@ -108,9 +108,10 @@ The following arguments are supported:
 * `vpc_id` - (Optional, String, ForceNew) The vpc on which to create the loadbalancer. Changing this creates a new
   loadbalancer.
 
-* `ipv4_subnet_id` - (Optional, String) The subnet on which to allocate the loadbalancer's ipv4 address.
+* `ipv4_subnet_id` - (Optional, String) The **IPv4 subnet ID** of the subnet on which to allocate the loadbalancer's
+  ipv4 address.
 
-* `ipv6_network_id` - (Optional, String) The network on which to allocate the loadbalancer's ipv6 address.
+* `ipv6_network_id` - (Optional, String) The **ID** of the subnet on which to allocate the loadbalancer's ipv6 address.
 
 * `ipv6_bandwidth_id` - (Optional, String) The ipv6 bandwidth id. Only support shared bandwidth.
 

--- a/docs/resources/elb_member.md
+++ b/docs/resources/elb_member.md
@@ -9,11 +9,14 @@ Manages an ELB member resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
+variable "elb_pool_id" {}
+variable "ipv4_subnet_id" {}
+
 resource "huaweicloud_elb_member" "member_1" {
   address       = "192.168.199.23"
   protocol_port = 8080
-  pool_id       = var.pool_id
-  subnet_id     = var.subnet_id
+  pool_id       = var.elb_pool_id
+  subnet_id     = var.ipv4_subnet_id
 }
 ```
 
@@ -26,11 +29,11 @@ The following arguments are supported:
 
 * `pool_id` - (Required, String, ForceNew) The id of the pool that this member will be assigned to.
 
-* `subnet_id` - (Optional, String, ForceNew) The subnet in which to access the member.
-  The IPv4 or IPv6 subnet must be in the same VPC as the subnet of the load balancer.
-  If this parameter is not passed, cross-VPC backend has been enabled for the load balancer. In this case,
-  cross-VPC backend servers must use private IPv4 addresses, and the protocol of the backend server group
-  must be TCP, HTTP, or HTTPS.
+* `subnet_id` - (Optional, String, ForceNew) The **IPv4 or IPv6 subnet ID** of the subnet in which to access the member.
+  + The IPv4 or IPv6 subnet must be in the same VPC as the subnet of the load balancer.
+  + If this parameter is not specified, **cross-VPC backend** has been enabled for the load balancer.
+    In this case, cross-VPC backend servers must use private IPv4 addresses,
+    and the protocol of the backend server group must be TCP, HTTP, or HTTPS.
 
 * `name` - (Optional, String) Human-readable name for the member.
 

--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -11,8 +11,10 @@ Manages an ELB loadbalancer resource within HuaweiCloud.
 ### Basic Loadbalancer
 
 ```hcl
+variable "ipv4_subnet_id" {}
+
 resource "huaweicloud_lb_loadbalancer" "lb_1" {
-  vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+  vip_subnet_id = var.ipv4_subnet_id
 
   tags = {
     key = "value"
@@ -23,8 +25,10 @@ resource "huaweicloud_lb_loadbalancer" "lb_1" {
 ### Loadbalancer With EIP
 
 ```hcl
+variable "ipv4_subnet_id" {}
+
 resource "huaweicloud_lb_loadbalancer" "lb_1" {
-  vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+  vip_subnet_id = ipv4_subnet_id
 }
 
 resource "huaweicloud_vpc_eip_associate" "eip_1" {
@@ -44,9 +48,8 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Human-readable description for the loadbalancer.
 
-* `vip_subnet_id` - (Required, String, ForceNew) The network on which to allocate the loadbalancer's address. A tenant
-  can only create Loadbalancers on networks authorized by policy (e.g. networks that belong to them or networks that are
-  shared). Changing this creates a new loadbalancer.
+* `vip_subnet_id` - (Required, String, ForceNew) The **IPv4 subnet ID** of the subnet where the load balancer works.
+  Changing this creates a new loadbalancer.
 
 * `vip_address` - (Optional, String, ForceNew) The ip address of the load balancer. Changing this creates a new
   loadbalancer.

--- a/docs/resources/lb_member.md
+++ b/docs/resources/lb_member.md
@@ -9,11 +9,14 @@ Manages an ELB member resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
+variable "lb_pool_id" {}
+variable "ipv4_subnet_id" {}
+
 resource "huaweicloud_lb_member" "member_1" {
   address       = "192.168.199.23"
   protocol_port = 8080
-  pool_id       = var.pool_id
-  subnet_id     = var.subnet_id
+  pool_id       = var.lb_pool_id
+  subnet_id     = var.ipv4_subnet_id
 }
 ```
 
@@ -26,7 +29,7 @@ The following arguments are supported:
 
 * `pool_id` - (Required, String, ForceNew) The id of the pool that this member will be assigned to.
 
-* `subnet_id` - (Required, String, ForceNew) The subnet in which to access the member
+* `subnet_id` - (Required, String, ForceNew) The **IPv4 subnet ID** of the subnet in which to access the member.
 
 * `name` - (Optional, String) Human-readable name for the member.
 

--- a/examples/elb/basic/main.tf
+++ b/examples/elb/basic/main.tf
@@ -68,7 +68,7 @@ resource "huaweicloud_vpc_eip" "eip_1" {
 
 resource "huaweicloud_lb_loadbalancer" "elb_1" {
   name          = var.loadbalancer_name
-  vip_subnet_id = huaweicloud_vpc_subnet.subnet_1.subnet_id
+  vip_subnet_id = huaweicloud_vpc_subnet.subnet_1.ipv4_subnet_id
 }
 
 # associate eip with loadbalancer
@@ -107,7 +107,7 @@ resource "huaweicloud_lb_member" "member_1" {
   protocol_port = 80
   weight        = 1
   pool_id       = huaweicloud_lb_pool.group_1.id
-  subnet_id     = huaweicloud_vpc_subnet.subnet_1.subnet_id
+  subnet_id     = huaweicloud_vpc_subnet.subnet_1.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_member" "member_2" {
@@ -115,5 +115,5 @@ resource "huaweicloud_lb_member" "member_2" {
   protocol_port = 80
   weight        = 1
   pool_id       = huaweicloud_lb_pool.group_1.id
-  subnet_id     = huaweicloud_vpc_subnet.subnet_1.subnet_id
+  subnet_id     = huaweicloud_vpc_subnet.subnet_1.ipv4_subnet_id
 }

--- a/examples/elb/dedicated/main.tf
+++ b/examples/elb/dedicated/main.tf
@@ -143,7 +143,7 @@ resource "huaweicloud_elb_loadbalancer" "default" {
   name            = var.elb_loadbalancer_name
   description     = "Created by terraform"
   vpc_id          = huaweicloud_vpc.default.id
-  ipv4_subnet_id  = huaweicloud_vpc_subnet.default.subnet_id
+  ipv4_subnet_id  = huaweicloud_vpc_subnet.default.ipv4_subnet_id
   ipv6_network_id = huaweicloud_vpc_subnet.default.id
 
   availability_zone = [
@@ -195,5 +195,5 @@ resource "huaweicloud_elb_member" "default" {
   address       = huaweicloud_compute_instance.default.access_ip_v4
   protocol_port = 8080
   pool_id       = huaweicloud_elb_pool.default.id
-  subnet_id     = huaweicloud_vpc_subnet.default.subnet_id
+  subnet_id     = huaweicloud_vpc_subnet.default.ipv4_subnet_id
 }

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -204,7 +204,7 @@ resource "huaweicloud_compute_keypair" "acc_key" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_v3_test.go
@@ -452,7 +452,7 @@ resource "huaweicloud_cce_cluster" "test" {
   vpc_id                 = huaweicloud_vpc.test.id
   subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "eni"
-  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.subnet_id
+  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.ipv4_subnet_id
   eni_subnet_cidr        = huaweicloud_vpc_subnet.eni_test.cidr
 }
 

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7policy_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7policy_test.go
@@ -107,7 +107,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7rule_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7rule_test.go
@@ -159,7 +159,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_listener_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_listener_test.go
@@ -78,7 +78,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -124,7 +124,7 @@ data "huaweicloud_availability_zones" "test" {}
 resource "huaweicloud_elb_loadbalancer" "test" {
   name              = "%s"
   cross_vpc_backend = true
-  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id   = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
@@ -197,7 +197,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -223,7 +223,7 @@ data "huaweicloud_availability_zones" "test" {}
 resource "huaweicloud_elb_loadbalancer" "test" {
   name              = "%s"
   cross_vpc_backend = true
-  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id   = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -248,7 +248,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name                  = "%s"
-  ipv4_subnet_id        = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id        = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
@@ -272,7 +272,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name              = "%s"
-  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
 
   iptype                = "5_bgp"
@@ -293,7 +293,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   charging_mode = "prePaid"
@@ -337,7 +337,7 @@ data "huaweicloud_elb_flavors" "l7flavors" {
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
   description     = "update flavors"
   l4_flavor_id    = data.huaweicloud_elb_flavors.l4flavors.ids[0]

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_logtank_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_logtank_test.go
@@ -82,7 +82,7 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%[1]s"
-  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = huaweicloud_vpc_subnet.test.id
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
@@ -120,7 +120,7 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%[1]s"
-  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = huaweicloud_vpc_subnet.test.id
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_member_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_member_test.go
@@ -164,7 +164,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -179,10 +179,9 @@ resource "huaweicloud_elb_listener" "test" {
   protocol_port   = 8080
   loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
 
-  forward_eip = true
-
-  idle_timeout = 60
-  request_timeout = 60
+  forward_eip      = true
+  idle_timeout     = 60
+  request_timeout  = 60
   response_timeout = 60
 }
 
@@ -197,14 +196,14 @@ resource "huaweicloud_elb_member" "member_1" {
   address       = "192.168.0.10"
   protocol_port = 8080
   pool_id       = huaweicloud_elb_pool.test.id
-  subnet_id     = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id     = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_elb_member" "member_2" {
   address       = "192.168.0.11"
   protocol_port = 8080
   pool_id       = huaweicloud_elb_pool.test.id
-  subnet_id     = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id     = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 `, rName, rName, rName)
 }
@@ -219,7 +218,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -234,10 +233,9 @@ resource "huaweicloud_elb_listener" "test" {
   protocol_port   = 8080
   loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
 
-  forward_eip = true
-
-  idle_timeout = 60
-  request_timeout = 60
+  forward_eip      = true
+  idle_timeout     = 60
+  request_timeout  = 60
   response_timeout = 60
 }
 
@@ -253,7 +251,7 @@ resource "huaweicloud_elb_member" "member_1" {
   protocol_port  = 8080
   weight         = 10
   pool_id        = huaweicloud_elb_pool.test.id
-  subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_elb_member" "member_2" {
@@ -261,7 +259,7 @@ resource "huaweicloud_elb_member" "member_2" {
   protocol_port  = 8080
   weight         = 15
   pool_id        = huaweicloud_elb_pool.test.id
-  subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 `, rName, rName, rName)
 }
@@ -277,7 +275,7 @@ data "huaweicloud_availability_zones" "test" {}
 resource "huaweicloud_elb_loadbalancer" "test" {
   name              = "%s"
   cross_vpc_backend = true
-  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id   = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -292,10 +290,9 @@ resource "huaweicloud_elb_listener" "test" {
   protocol_port   = 8080
   loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
 
-  forward_eip = true
-
-  idle_timeout = 60
-  request_timeout = 60
+  forward_eip      = true
+  idle_timeout     = 60
+  request_timeout  = 60
   response_timeout = 60
 }
 
@@ -331,7 +328,7 @@ data "huaweicloud_availability_zones" "test" {}
 resource "huaweicloud_elb_loadbalancer" "test" {
   name              = "%s"
   cross_vpc_backend = true
-  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id    = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id   = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -346,10 +343,9 @@ resource "huaweicloud_elb_listener" "test" {
   protocol_port   = 8080
   loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
 
-  forward_eip = true
-
-  idle_timeout = 60
-  request_timeout = 60
+  forward_eip      = true
+  idle_timeout     = 60
+  request_timeout  = 60
   response_timeout = 60
 }
 

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
@@ -118,7 +118,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
@@ -112,7 +112,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -159,7 +159,7 @@ data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%s"
-  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = data.huaweicloud_vpc_subnet.test.id
 
   availability_zone = [

--- a/huaweicloud/services/acceptance/lb/data_source_huaweicloud_lb_listeners_test.go
+++ b/huaweicloud/services/acceptance/lb/data_source_huaweicloud_lb_listeners_test.go
@@ -78,7 +78,7 @@ resource "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "test" {
   name          = "%[1]s"
-  vip_subnet_id = huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "test" {

--- a/huaweicloud/services/acceptance/lb/data_source_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/lb/data_source_huaweicloud_lb_loadbalancer_test.go
@@ -52,7 +52,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "test" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   description   = "test for load balancer data source"
 }
 

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_l7policy_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_l7policy_test.go
@@ -71,7 +71,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_l7rule_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_l7rule_test.go
@@ -100,7 +100,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_listener_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_listener_test.go
@@ -79,7 +79,7 @@ data "huaweicloud_vpc_subnet" "test" {
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
   description   = "created by acceptance test"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {
@@ -106,7 +106,7 @@ data "huaweicloud_vpc_subnet" "test" {
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
   description   = "created by acceptance test"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
@@ -239,7 +239,7 @@ data "huaweicloud_vpc_subnet" "test" {
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
   description   = "created by acceptance test"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   tags = {
     key   = "value"
@@ -258,7 +258,7 @@ data "huaweicloud_vpc_subnet" "test" {
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name           = "%s"
   admin_state_up = "true"
-  vip_subnet_id  = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   tags = {
     key1  = "value1"
@@ -286,7 +286,7 @@ resource "huaweicloud_networking_secgroup" "secgroup_2" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name               = "%s"
-  vip_subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   security_group_ids = [
     huaweicloud_networking_secgroup.secgroup_1.id
   ]
@@ -312,7 +312,7 @@ resource "huaweicloud_networking_secgroup" "secgroup_2" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name               = "%s"
-  vip_subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   security_group_ids = [
     huaweicloud_networking_secgroup.secgroup_1.id,
     huaweicloud_networking_secgroup.secgroup_2.id
@@ -339,7 +339,7 @@ resource "huaweicloud_networking_secgroup" "secgroup_2" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name               = "%s"
-  vip_subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   security_group_ids = [
     huaweicloud_networking_secgroup.secgroup_2.id
   ]
@@ -355,7 +355,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name                  = "%s"
-  vip_subnet_id         = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id         = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
   enterprise_project_id = "%s"
 
   tags = {

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
@@ -121,7 +121,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
 }
 
@@ -143,7 +143,7 @@ resource "huaweicloud_lb_member" "member_1" {
   address       = "192.168.0.10"
   protocol_port = 8080
   pool_id       = huaweicloud_lb_pool.pool_1.id
-  subnet_id     = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id     = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   timeouts {
     create = "5m"
@@ -156,7 +156,7 @@ resource "huaweicloud_lb_member" "member_2" {
   address       = "192.168.0.11"
   protocol_port = 8080
   pool_id       = huaweicloud_lb_pool.pool_1.id
-  subnet_id     = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id     = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   timeouts {
     create = "5m"
@@ -175,7 +175,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {
@@ -198,7 +198,7 @@ resource "huaweicloud_lb_member" "member_1" {
   weight         = 10
   admin_state_up = "true"
   pool_id        = huaweicloud_lb_pool.pool_1.id
-  subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   timeouts {
     create = "5m"
@@ -213,7 +213,7 @@ resource "huaweicloud_lb_member" "member_2" {
   weight         = 15
   admin_state_up = "true"
   pool_id        = huaweicloud_lb_pool.pool_1.id
-  subnet_id      = data.huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   timeouts {
     create = "5m"

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_monitor_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_monitor_test.go
@@ -144,7 +144,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {
@@ -219,7 +219,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_pool_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_pool_test.go
@@ -73,7 +73,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {
@@ -106,7 +106,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_whitelist_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_whitelist_test.go
@@ -69,7 +69,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {
@@ -95,7 +95,7 @@ data "huaweicloud_vpc_subnet" "test" {
 
 resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
   name          = "%s"
-  vip_subnet_id = data.huaweicloud_vpc_subnet.test.subnet_id
+  vip_subnet_id = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_lb_listener" "listener_1" {

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_environment_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_environment_test.go
@@ -382,7 +382,7 @@ resource "huaweicloud_elb_loadbalancer" "test" {
   name            = "%[1]s_${count.index}"
   description     = "Created by terraform."
   vpc_id          = huaweicloud_vpc.test.id
-  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.subnet_id
+  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.ipv4_subnet_id
   ipv6_network_id = huaweicloud_vpc_subnet.test.id
 
   availability_zone = [
@@ -434,7 +434,7 @@ resource "huaweicloud_elb_member" "test" {
   address       = huaweicloud_compute_instance.test[count.index].access_ip_v4
   protocol_port = 8080
   pool_id       = huaweicloud_elb_pool.test[count.index].id
-  subnet_id     = huaweicloud_vpc_subnet.test.subnet_id
+  subnet_id     = huaweicloud_vpc_subnet.test.ipv4_subnet_id
 }
 
 resource "huaweicloud_vpc_eip" "test" {

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
@@ -75,7 +75,7 @@ resource "huaweicloud_elb_loadbalancer" "elb" {
   name              = "%s"
   vpc_id            = huaweicloud_vpc.vpc_1.id
   cross_vpc_backend = true
-  ipv4_subnet_id    = huaweicloud_vpc_subnet.vpc_subnet_1.subnet_id
+  ipv4_subnet_id    = huaweicloud_vpc_subnet.vpc_subnet_1.ipv4_subnet_id
 
   availability_zone = [
     data.huaweicloud_availability_zones.zones.names[0],

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_v3.go
@@ -129,6 +129,7 @@ func ResourceCCEClusterV3() *schema.Resource {
 				ForceNew:     true,
 				Computed:     true,
 				RequiredWith: []string{"eni_subnet_cidr"},
+				Description:  "the IPv4 subnet ID of the subnet where the ENI resides",
 			},
 			"eni_subnet_cidr": {
 				Type:         schema.TypeString,

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -70,13 +70,15 @@ func ResourceLoadBalancerV3() *schema.Resource {
 			},
 
 			"ipv4_subnet_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "the IPv4 subnet ID of the subnet where the load balancer resides",
 			},
 
 			"ipv6_network_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "the ID of the subnet where the load balancer resides",
 			},
 
 			"ipv6_bandwidth_id": {

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_member.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_member.go
@@ -72,9 +72,10 @@ func ResourceMemberV3() *schema.Resource {
 			},
 
 			"subnet_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The IPv4 or IPv6 subnet ID of the subnet in which to access the member",
 			},
 
 			"pool_id": {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -55,9 +55,10 @@ func ResourceLoadBalancerV2() *schema.Resource {
 			},
 
 			"vip_subnet_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "the IPv4 subnet ID of the subnet where the load balancer works",
 			},
 
 			"tenant_id": {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
@@ -81,9 +81,10 @@ func ResourceMemberV2() *schema.Resource {
 			},
 
 			"subnet_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "the IPv4 subnet ID of the subnet in which to access the member",
 			},
 
 			"admin_state_up": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 
this PR is following #2477 
the `subnet_id` has been deprecated, we should use **ipv4_subnet_id** instead

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccCCEClusterV3_turbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run=TestAccCCEClusterV3_turbo -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3_turbo
=== PAUSE TestAccCCEClusterV3_turbo
=== CONT  TestAccCCEClusterV3_turbo
--- PASS: TestAccCCEClusterV3_turbo (541.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       541.187s

$ make testacc TEST='./huaweicloud/services/acceptance/lb' TESTARGS='-run=TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run=TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (63.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        63.104s

$ make testacc TEST='./huaweicloud/services/acceptance/lb' TESTARGS='-run=TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run=TestAccLBV2Listener_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== CONT  TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (98.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        98.100s

$ make testacc TEST='./huaweicloud/services/acceptance/lb' TESTARGS='-run=TestAccLBV2Member_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run=TestAccLBV2Member_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (165.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        165.703s

$ make testacc TEST='./huaweicloud/services/acceptance/elb' TESTARGS='-run=TestAccElbV3LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run=TestAccElbV3LoadBalancer_basic -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_basic
--- PASS: TestAccElbV3LoadBalancer_basic (56.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       56.339s

$ make testacc TEST='./huaweicloud/services/acceptance/elb' TESTARGS='-run=TestAccElbV3L7Policy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run=TestAccElbV3L7Policy_basic -timeout 360m -parallel 4
=== RUN   TestAccElbV3L7Policy_basic
=== PAUSE TestAccElbV3L7Policy_basic
=== CONT  TestAccElbV3L7Policy_basic
--- PASS: TestAccElbV3L7Policy_basic (68.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       68.398s

$ make testacc TEST='./huaweicloud/services/acceptance/elb' TESTARGS='-run=TestAccElbV3Member_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run=TestAccElbV3Member_basic -timeout 360m -parallel 4
=== RUN   TestAccElbV3Member_basic
=== PAUSE TestAccElbV3Member_basic
=== CONT  TestAccElbV3Member_basic
--- PASS: TestAccElbV3Member_basic (82.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       82.344s

$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (171.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        171.171s

$ make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccEnvironment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccEnvironment_basic -timeout 360m -parallel 4
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccEnvironment_basic (916.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      916.994s
```
