### PR TITLE
fix(cc/network): Fix the problem for update method

### DIFF
--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go
@@ -70,6 +70,7 @@ func TestAccNetworkInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_vpc.test.0", "id"),
 					resource.TestCheckResourceAttrPair(rName, "region_id", "huaweicloud_vpc.test.0", "region"),
 					resource.TestCheckResourceAttrPair(rName, "cloud_connection_id", "huaweicloud_cc_connection.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "demo_description"),
 				),
 			},
 			{
@@ -77,7 +78,7 @@ func TestAccNetworkInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "type", "vpc"),
-					resource.TestCheckResourceAttr(rName, "description", "demo_description"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
 				),
 			},
 			{
@@ -170,6 +171,7 @@ resource "huaweicloud_cc_network_instance" "test" {
   instance_id         = try(huaweicloud_vpc.test[0].id, "")
   project_id          = "%[2]s"
   region_id           = try(huaweicloud_vpc.test[0].region, "")
+  description         = "demo_description"
 
   cidrs = [
     try(huaweicloud_vpc_subnet.test[0].cidr, ""),
@@ -188,7 +190,6 @@ resource "huaweicloud_cc_network_instance" "test" {
   instance_id         = try(huaweicloud_vpc.test[0].id, "")
   project_id          = "%[2]s"
   region_id           = try(huaweicloud_vpc.test[0].region, "")
-  description         = "demo_description"
 
   cidrs = [
     try(huaweicloud_vpc_subnet.test[0].cidr, ""),

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
@@ -92,7 +92,6 @@ func ResourceNetworkInstance() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: `The description about the network instance.`,
 				ValidateFunc: validation.All(
 					validation.StringMatch(regexp.MustCompile(`^[^<>]+$`),
@@ -136,7 +135,7 @@ func resourceNetworkInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	createNetworkInstancePath := createNetworkInstanceClient.Endpoint + createNetworkInstanceHttpUrl
-	createNetworkInstancePath = strings.Replace(createNetworkInstancePath, "{domain_id}", cfg.DomainID, -1)
+	createNetworkInstancePath = strings.ReplaceAll(createNetworkInstancePath, "{domain_id}", cfg.DomainID)
 
 	createNetworkInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -203,8 +202,8 @@ func resourceNetworkInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	getNetworkInstancePath := getNetworkInstanceClient.Endpoint + getNetworkInstanceHttpUrl
-	getNetworkInstancePath = strings.Replace(getNetworkInstancePath, "{domain_id}", config.DomainID, -1)
-	getNetworkInstancePath = strings.Replace(getNetworkInstancePath, "{id}", d.Id(), -1)
+	getNetworkInstancePath = strings.ReplaceAll(getNetworkInstancePath, "{domain_id}", config.DomainID)
+	getNetworkInstancePath = strings.ReplaceAll(getNetworkInstancePath, "{id}", d.Id())
 
 	getNetworkInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -266,8 +265,8 @@ func resourceNetworkInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		config.MutexKV.Lock(cfg.DomainID)
 		defer config.MutexKV.Unlock(cfg.DomainID)
 		updateNetworkInstancePath := updateNetworkInstanceClient.Endpoint + updateNetworkInstanceHttpUrl
-		updateNetworkInstancePath = strings.Replace(updateNetworkInstancePath, "{domain_id}", cfg.DomainID, -1)
-		updateNetworkInstancePath = strings.Replace(updateNetworkInstancePath, "{id}", d.Id(), -1)
+		updateNetworkInstancePath = strings.ReplaceAll(updateNetworkInstancePath, "{domain_id}", cfg.DomainID)
+		updateNetworkInstancePath = strings.ReplaceAll(updateNetworkInstancePath, "{id}", d.Id())
 
 		updateNetworkInstanceOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
@@ -294,7 +293,7 @@ func buildUpdateNetworkInstanceBodyParams(d *schema.ResourceData, config *config
 func buildUpdateNetworkInstanceNetworkInstanceChildBody(d *schema.ResourceData) map[string]interface{} {
 	params := map[string]interface{}{
 		"name":        utils.ValueIngoreEmpty(d.Get("name")),
-		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"description": d.Get("description"),
 		"cidrs":       utils.ValueIngoreEmpty(d.Get("cidrs")),
 	}
 	return params
@@ -315,8 +314,8 @@ func resourceNetworkInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	deleteNetworkInstancePath := deleteNetworkInstanceClient.Endpoint + deleteNetworkInstanceHttpUrl
-	deleteNetworkInstancePath = strings.Replace(deleteNetworkInstancePath, "{domain_id}", cfg.DomainID, -1)
-	deleteNetworkInstancePath = strings.Replace(deleteNetworkInstancePath, "{id}", d.Id(), -1)
+	deleteNetworkInstancePath = strings.ReplaceAll(deleteNetworkInstancePath, "{domain_id}", cfg.DomainID)
+	deleteNetworkInstancePath = strings.ReplaceAll(deleteNetworkInstancePath, "{id}", d.Id())
 
 	deleteNetworkInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
@@ -122,21 +122,21 @@ func ResourceNetworkInstance() *schema.Resource {
 }
 
 func resourceNetworkInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createNetworkInstance: create a Cloud Connect.
 	var (
 		createNetworkInstanceHttpUrl = "v3/{domain_id}/ccaas/network-instances"
 		createNetworkInstanceProduct = "cc"
 	)
-	createNetworkInstanceClient, err := config.NewServiceClient(createNetworkInstanceProduct, region)
+	createNetworkInstanceClient, err := cfg.NewServiceClient(createNetworkInstanceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating NetworkInstance Client: %s", err)
 	}
 
 	createNetworkInstancePath := createNetworkInstanceClient.Endpoint + createNetworkInstanceHttpUrl
-	createNetworkInstancePath = strings.Replace(createNetworkInstancePath, "{domain_id}", config.DomainID, -1)
+	createNetworkInstancePath = strings.Replace(createNetworkInstancePath, "{domain_id}", cfg.DomainID, -1)
 
 	createNetworkInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -144,7 +144,7 @@ func resourceNetworkInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 			201,
 		},
 	}
-	createNetworkInstanceOpt.JSONBody = utils.RemoveNil(buildCreateNetworkInstanceBodyParams(d, config))
+	createNetworkInstanceOpt.JSONBody = utils.RemoveNil(buildCreateNetworkInstanceBodyParams(d, cfg))
 	createNetworkInstanceResp, err := createNetworkInstanceClient.Request("POST", createNetworkInstancePath, &createNetworkInstanceOpt)
 	if err != nil {
 		return diag.Errorf("error creating NetworkInstance: %s", err)
@@ -243,8 +243,8 @@ func resourceNetworkInstanceRead(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceNetworkInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	updateNetworkInstancehasChanges := []string{
 		"name",
@@ -258,13 +258,15 @@ func resourceNetworkInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 			updateNetworkInstanceHttpUrl = "v3/{domain_id}/ccaas/network-instances/{id}"
 			updateNetworkInstanceProduct = "cc"
 		)
-		updateNetworkInstanceClient, err := config.NewServiceClient(updateNetworkInstanceProduct, region)
+		updateNetworkInstanceClient, err := cfg.NewServiceClient(updateNetworkInstanceProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating NetworkInstance Client: %s", err)
 		}
 
+		config.MutexKV.Lock(cfg.DomainID)
+		defer config.MutexKV.Unlock(cfg.DomainID)
 		updateNetworkInstancePath := updateNetworkInstanceClient.Endpoint + updateNetworkInstanceHttpUrl
-		updateNetworkInstancePath = strings.Replace(updateNetworkInstancePath, "{domain_id}", config.DomainID, -1)
+		updateNetworkInstancePath = strings.Replace(updateNetworkInstancePath, "{domain_id}", cfg.DomainID, -1)
 		updateNetworkInstancePath = strings.Replace(updateNetworkInstancePath, "{id}", d.Id(), -1)
 
 		updateNetworkInstanceOpt := golangsdk.RequestOpts{
@@ -273,7 +275,7 @@ func resourceNetworkInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 				200,
 			},
 		}
-		updateNetworkInstanceOpt.JSONBody = utils.RemoveNil(buildUpdateNetworkInstanceBodyParams(d, config))
+		updateNetworkInstanceOpt.JSONBody = utils.RemoveNil(buildUpdateNetworkInstanceBodyParams(d, cfg))
 		_, err = updateNetworkInstanceClient.Request("PUT", updateNetworkInstancePath, &updateNetworkInstanceOpt)
 		if err != nil {
 			return diag.Errorf("error updating NetworkInstance: %s", err)
@@ -299,21 +301,21 @@ func buildUpdateNetworkInstanceNetworkInstanceChildBody(d *schema.ResourceData) 
 }
 
 func resourceNetworkInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteNetworkInstance: missing operation notes
 	var (
 		deleteNetworkInstanceHttpUrl = "v3/{domain_id}/ccaas/network-instances/{id}"
 		deleteNetworkInstanceProduct = "cc"
 	)
-	deleteNetworkInstanceClient, err := config.NewServiceClient(deleteNetworkInstanceProduct, region)
+	deleteNetworkInstanceClient, err := cfg.NewServiceClient(deleteNetworkInstanceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating NetworkInstance Client: %s", err)
 	}
 
 	deleteNetworkInstancePath := deleteNetworkInstanceClient.Endpoint + deleteNetworkInstanceHttpUrl
-	deleteNetworkInstancePath = strings.Replace(deleteNetworkInstancePath, "{domain_id}", config.DomainID, -1)
+	deleteNetworkInstancePath = strings.Replace(deleteNetworkInstancePath, "{domain_id}", cfg.DomainID, -1)
 	deleteNetworkInstancePath = strings.Replace(deleteNetworkInstancePath, "{id}", d.Id(), -1)
 
 	deleteNetworkInstanceOpt := golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix the problem that resource description cannot be updated.
support a new acc test to test resource creation and deletion of the multiple networks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new acc test to test resource creation and deletion of the multiple networks.
2. fix the problem that description cannot be updated to empty.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cc' TESTARGS='-run=TestAccNetworkInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run=TestAccNetworkInstance_ -timeout 360m -parallel 4
=== RUN   TestAccNetworkInstance_basic
=== PAUSE TestAccNetworkInstance_basic
=== RUN   TestAccNetworkInstance_multiple
=== PAUSE TestAccNetworkInstance_multiple
=== CONT  TestAccNetworkInstance_basic
=== CONT  TestAccNetworkInstance_multiple
--- PASS: TestAccNetworkInstance_multiple (60.92s)
--- PASS: TestAccNetworkInstance_basic (64.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        64.313s
```
