### PR TITLE
refactor(apig): refactor group resource

### DIFF
--- a/docs/resources/apig_group.md
+++ b/docs/resources/apig_group.md
@@ -8,7 +8,7 @@ Manages an APIG (API) group resource within HuaweiCloud.
 
 ## Example Usage
 
-```hcl
+```HCL
 variable "instance_id" {}
 variable "group_name" {}
 variable "description" {}
@@ -33,39 +33,48 @@ resource "huaweicloud_apig_group" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API group resource. If omitted,
-  the provider-level region will be used. Changing this will create a new API group resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the APIG (API) group is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API group
-  belongs to. Changing this will create a new API group resource.
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the group belongs.  
+  Changing this will create a new resource.
 
-* `name` - (Required, String) Specifies the name of the API group. The API group name consists of 3 to 64 characters,
-  starting with a letter. Only letters, digits and underscores (_) are allowed. Chinese characters must be in UTF-8 or
-  Unicode format.
-
-* `description` - (Optional, String) Specifies the description about the API group. The description contain a maximum of
-  255 characters and the angle brackets (< and >) are not allowed. Chinese characters must be in UTF-8 or Unicode
+* `name` - (Required, String) Specifies the group name.  
+  The valid length is limited from `3` to `64`, only chinese and english letters, digits and hyphens (-) are
+  allowed.  
+  The name must start with a chinese or english letter, and the Chinese characters must be in **UTF-8** or **Unicode**
   format.
 
-* `environment` - (Optional, List) Specifies an array of one or more APIG environments of the associated APIG group. The
-  object structure is documented below.
+* `description` - (Optional, String) Specifies the group description.  
+  The description contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.  
+  Chinese characters must be in **UTF-8** or **Unicode** format.
 
+* `environment` - (Optional, List) Specifies an array of one or more environments of the associated group.  
+  The [object](#group_environment) structure is documented below.
+
+<a name="group_environment"></a>
 The `environment` block supports:
 
-* `variable` - (Required, List) Specifies an array of one or more APIG environment variables. The object structure is
-  documented below. The environment variables of different groups are isolated in the same environment.
+* `variable` - (Required, List) Specifies an array of one or more environment variables.  
+  The [object](#group_environment_variable) structure is documented below.
 
-* `environment_id` - (Required, String) Specifies the APIG environment ID of the associated APIG group.
+  -> The environment variables of different groups are isolated in the same environment.
 
+* `environment_id` - (Required, String) Specifies the environment ID of the associated group.
+
+<a name="group_environment_variable"></a>
 The `variable` block supports:
 
-* `name` - (Required, String) Specifies the variable name, which can contains of 3 to 32 characters, starting with a
-  letter. Only letters, digits, hyphens (-), and underscores (_) are allowed. In the definition of an API, `name` (
-  case-sensitive) indicates a variable, such as #Name#. It is replaced by the actual value when the API is published in
-  an environment. The variable names are not allowed to be repeated for an API group.
+* `name` - (Required, String) Specifies the variable name.  
+  The valid length is limited from `3` to `32` characters.  
+  Only letters, digits, hyphens (-), and underscores (_) are allowed, and must start with a letter.  
+  In the definition of an API, `name` (case-sensitive) indicates a variable, such as #Name#.
+  It is replaced by the actual value when the API is published in an environment.  
+  The variable names are not allowed to be repeated for an API group.
 
-* `value` - (Required, String) Specifies the environment ariable value, which can contains of 1 to 255 characters. Only
-  letters, digits and special characters (_-/.:) are allowed.
+* `value` - (Required, String) Specifies the variable value.  
+  The valid length is limited from `1` to `255` characters.  
+  Only letters, digits and special characters (_-/.:) are allowed.
 
   -> **NOTE:** The variable value will be displayed in plain text on the console.
 
@@ -73,16 +82,30 @@ The `variable` block supports:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the API group.
-* `registraion_time` - Registration time, in RFC-3339 format.
-* `update_time` - Time when the API group was last modified, in RFC-3339 format.
-* `environment/variable/variable_id` - ID of the environment variable.
+* `id` - The group ID.
+
+* `registration_time` - The registration time, in RFC-3339 format.
+
+* `updated_at` - The time when the API group was last modified, in RFC-3339 format.
+
+* `environment` - The array of one or more environments of the associated group.  
+  The [object](#group_environment_attr) structure is documented below.
+
+<a name="group_environment_attr"></a>
+The `environment` block supports:
+
+* `variable` - The array of one or more environment variables.  
+  The [object](#group_environment_variable_attr) structure is documented below.
+
+<a name="group_environment_variable_attr"></a>
+The `variable` block supports:
+
+* `id` - The variable ID.
 
 ## Import
 
-API groups of the APIG can be imported using their `id` and the ID of the APIG instance to which the group belongs,
-separated by a slash, e.g.
+API groups can be imported using their `id` and the ID of the related dedicated instance, separated by a slash, e.g.
 
-```
-$ terraform import huaweicloud_apig_group.test <instance id>/<id>
+```shell
+$ terraform import huaweicloud_apig_group.test <instance_id>/<id>
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refactor API group resource.
- rewrite methods.
- deprecated 'update_time' parameter.
- rename the 'registraion_time' parameter.

The description cannot be updated, even pointer type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor API group resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== CONT  TestAccGroup_basic
--- PASS: TestAccGroup_basic (494.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      494.556s
```
