### PR TITLE
refactor(vpc): refactor for vpc resources.

### DIFF
--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
@@ -149,25 +149,25 @@ func dataSourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData,
 	config := meta.(*config.Config)
 	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud networking client: %s", err)
+		return diag.Errorf("error creating networking client: %s", err)
 	}
 
 	listOpts := getNetworkingPortOpts(d)
 
 	allPages, err := ports.List(networkingClient, listOpts).AllPages()
 	if err != nil {
-		return diag.Errorf("Unable to list huaweicloud_networking_ports_v2: %s", err)
+		return diag.Errorf("unable to list networking ports v2: %s", err)
 	}
 
 	var allPorts []ports.Port
 
 	err = ports.ExtractPortsInto(allPages, &allPorts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve huaweicloud_networking_ports_v2: %s", err)
+		return diag.Errorf("unable to retrieve networking ports v2: %s", err)
 	}
 
 	if len(allPorts) == 0 {
-		return diag.Errorf("No huaweicloud_networking_port found")
+		return diag.Errorf("no networking port found")
 	}
 
 	var portsList []ports.Port
@@ -182,8 +182,8 @@ func dataSourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData,
 			}
 		}
 		if len(portsList) == 0 {
-			log.Printf("No huaweicloud_networking_port found after the 'fixed_ip' filter")
-			return diag.Errorf("No huaweicloud_networking_port found")
+			log.Printf("No networking port found after the 'fixed_ip' filter")
+			return diag.Errorf("no networking port found")
 		}
 	} else {
 		portsList = allPorts
@@ -201,19 +201,19 @@ func dataSourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData,
 			}
 		}
 		if len(sgPorts) == 0 {
-			log.Printf("[DEBUG] No huaweicloud_networking_port found after the 'security_group_ids' filter")
-			return diag.Errorf("No huaweicloud_networking_port found")
+			log.Printf("[DEBUG] No networking port found after the 'security_group_ids' filter")
+			return diag.Errorf("no networking port found")
 		}
 		portsList = sgPorts
 	}
 
 	if len(portsList) > 1 {
-		return diag.Errorf("More than one huaweicloud_networking_port found (%d)", len(portsList))
+		return diag.Errorf("more than one networking port found (%d)", len(portsList))
 	}
 
 	port := portsList[0]
 
-	log.Printf("[DEBUG] Retrieved huaweicloud_networking_port %s: %+v", port.ID, port)
+	log.Printf("[DEBUG] Retrieved networking port %s: %+v", port.ID, port)
 	d.SetId(port.ID)
 
 	d.Set("port_id", port.ID)

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
@@ -166,7 +166,7 @@ func dataSourceNetworkingSecGroupsRead(ctx context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	v3Client, err := config.NetworkingV3Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud networking v3 client: %s", err)
+		return diag.Errorf("error creating networking v3 client: %s", err)
 	}
 
 	// The List method currently does not support filtering by keyword in the description. Therefore, keyword filtering
@@ -184,7 +184,7 @@ func dataSourceNetworkingSecGroupsRead(ctx context.Context, d *schema.ResourceDa
 			// If the v3 API does not exist or has not been published in the specified region, set again using v1 API.
 			return dataSourceNetworkingSecGroupsReadV1(ctx, d, meta)
 		} else {
-			return diag.Errorf("Error getting security groups list: %s", err)
+			return diag.Errorf("error getting security groups list: %s", err)
 		}
 	} else {
 		groupList, ids = filterAvailableSecGroupsV3(allSecGroups, d.Get("description").(string))
@@ -204,7 +204,7 @@ func dataSourceNetworkingSecGroupsReadV1(_ context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	v1Client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud networking v1 client: %s", err)
+		return diag.Errorf("error creating networking v1 client: %s", err)
 	}
 
 	listOpts := v1groups.ListOpts{
@@ -212,11 +212,11 @@ func dataSourceNetworkingSecGroupsReadV1(_ context.Context, d *schema.ResourceDa
 	}
 	pages, err := v1groups.List(v1Client, listOpts).AllPages()
 	if err != nil {
-		return diag.Errorf("Error getting security groups: %s", err)
+		return diag.Errorf("error getting security groups: %s", err)
 	}
 	allSecGroups, err := v1groups.ExtractSecurityGroups(pages)
 	if err != nil {
-		return diag.Errorf("Error retrieving security groups list: %s", err)
+		return diag.Errorf("error retrieving security groups list: %s", err)
 	}
 	log.Printf("[DEBUG] Retrieved Security Groups: %+v", allSecGroups)
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -13,8 +14,6 @@ import (
 	v3groups "github.com/chnsz/golangsdk/openstack/networking/v3/security/groups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 type v1Group = v1groups.SecurityGroup
@@ -167,7 +166,7 @@ func dataSourceNetworkingSecGroupsRead(ctx context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	v3Client, err := config.NetworkingV3Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud networking v3 client: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud networking v3 client: %s", err)
 	}
 
 	// The List method currently does not support filtering by keyword in the description. Therefore, keyword filtering
@@ -185,7 +184,7 @@ func dataSourceNetworkingSecGroupsRead(ctx context.Context, d *schema.ResourceDa
 			// If the v3 API does not exist or has not been published in the specified region, set again using v1 API.
 			return dataSourceNetworkingSecGroupsReadV1(ctx, d, meta)
 		} else {
-			return fmtp.DiagErrorf("Error getting security groups list: %s", err)
+			return diag.Errorf("Error getting security groups list: %s", err)
 		}
 	} else {
 		groupList, ids = filterAvailableSecGroupsV3(allSecGroups, d.Get("description").(string))
@@ -205,7 +204,7 @@ func dataSourceNetworkingSecGroupsReadV1(_ context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	v1Client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud networking v1 client: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud networking v1 client: %s", err)
 	}
 
 	listOpts := v1groups.ListOpts{
@@ -213,13 +212,13 @@ func dataSourceNetworkingSecGroupsReadV1(_ context.Context, d *schema.ResourceDa
 	}
 	pages, err := v1groups.List(v1Client, listOpts).AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("Error getting security groups: %s", err)
+		return diag.Errorf("Error getting security groups: %s", err)
 	}
 	allSecGroups, err := v1groups.ExtractSecurityGroups(pages)
 	if err != nil {
-		return fmtp.DiagErrorf("Error retrieving security groups list: %s", err)
+		return diag.Errorf("Error retrieving security groups list: %s", err)
 	}
-	logp.Printf("[DEBUG] Retrieved Security Groups: %+v", allSecGroups)
+	log.Printf("[DEBUG] Retrieved Security Groups: %+v", allSecGroups)
 
 	groupList, ids := filterAvailableSecGroupsV1(allSecGroups, d.Get("name").(string), d.Get("description").(string))
 	d.SetId(hashcode.Strings(ids))

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"log"
 
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
@@ -9,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceVpcV1() *schema.Resource {
@@ -82,7 +81,7 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{
@@ -95,22 +94,22 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 
 	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve vpcs: %s", err)
+		return diag.Errorf("Unable to retrieve vpcs: %s", err)
 	}
 
 	if len(refinedVpcs) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(refinedVpcs) > 1 {
-		return fmtp.DiagErrorf("Your query returned more than one result." +
+		return diag.Errorf("Your query returned more than one result." +
 			" Please try a more specific search criteria")
 	}
 
 	Vpc := refinedVpcs[0]
 
-	logp.Printf("[INFO] Retrieved Vpc using given filter %s: %+v", Vpc.ID, Vpc)
+	log.Printf("[INFO] Retrieved Vpc using given filter %s: %+v", Vpc.ID, Vpc)
 	d.SetId(Vpc.ID)
 
 	d.Set("region", config.GetRegion(d))
@@ -135,10 +134,10 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
 			if err := d.Set("tags", tagmap); err != nil {
-				return fmtp.DiagErrorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+				return diag.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
 			}
 		} else {
-			logp.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
+			log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc.go
@@ -81,7 +81,7 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{
@@ -94,16 +94,16 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 
 	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve vpcs: %s", err)
+		return diag.Errorf("unable to retrieve vpcs: %s", err)
 	}
 
 	if len(refinedVpcs) < 1 {
-		return diag.Errorf("Your query returned no results. " +
+		return diag.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(refinedVpcs) > 1 {
-		return diag.Errorf("Your query returned more than one result." +
+		return diag.Errorf("your query returned more than one result." +
 			" Please try a more specific search criteria")
 	}
 
@@ -134,7 +134,7 @@ func dataSourceVpcV1Read(_ context.Context, d *schema.ResourceData, meta interfa
 		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
 			if err := d.Set("tags", tagmap); err != nil {
-				return diag.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+				return diag.Errorf("error saving tags to state for VPC (%s): %s", d.Id(), err)
 			}
 		} else {
 			log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
@@ -32,17 +32,17 @@ func dataSourceVpcIdsV1Read(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("error creating Vpc client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{}
 	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve vpcs: %s", err)
+		return diag.Errorf("unable to retrieve vpcs: %s", err)
 	}
 
 	if len(refinedVpcs) < 1 {
-		return diag.Errorf("Your query returned no results. " +
+		return diag.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
@@ -1,15 +1,17 @@
 package vpc
 
 import (
+	"context"
+
 	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceVpcIdsV1() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceVpcIdsV1Read,
+		ReadContext: dataSourceVpcIdsV1Read,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -26,21 +28,21 @@ func DataSourceVpcIdsV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcIdsV1Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceVpcIdsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{}
 	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve vpcs: %s", err)
+		return diag.Errorf("Unable to retrieve vpcs: %s", err)
 	}
 
 	if len(refinedVpcs) < 1 {
-		return fmtp.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
@@ -28,7 +28,7 @@ func DataSourceVpcIdsV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcIdsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVpcIdsV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
@@ -3,9 +3,10 @@ package vpc
 import (
 	"context"
 
-	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
@@ -1,17 +1,19 @@
 package vpc
 
 import (
+	"context"
+	"log"
+
 	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceVpcPeeringConnectionV2Read,
+		ReadContext: dataSourceVpcPeeringConnectionV2Read,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -54,11 +56,11 @@ func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 	}
 }
 
-func dataSourceVpcPeeringConnectionV2Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceVpcPeeringConnectionV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
 	}
 
 	listOpts := peerings.ListOpts{
@@ -72,22 +74,22 @@ func dataSourceVpcPeeringConnectionV2Read(d *schema.ResourceData, meta interface
 
 	refinedPeering, err := peerings.List(peeringClient, listOpts)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve vpc peering connections: %s", err)
+		return diag.Errorf("Unable to retrieve vpc peering connections: %s", err)
 	}
 
 	if len(refinedPeering) < 1 {
-		return fmtp.Errorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(refinedPeering) > 1 {
-		return fmtp.Errorf("Multiple VPC peering connections matched." +
+		return diag.Errorf("Multiple VPC peering connections matched." +
 			" Use additional constraints to reduce matches to a single VPC peering connection")
 	}
 
 	Peering := refinedPeering[0]
 
-	logp.Printf("[INFO] Retrieved Vpc peering Connections using given filter %s: %+v", Peering.ID, Peering)
+	log.Printf("[INFO] Retrieved Vpc peering Connections using given filter %s: %+v", Peering.ID, Peering)
 	d.SetId(Peering.ID)
 
 	d.Set("id", Peering.ID)

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
@@ -60,7 +60,7 @@ func dataSourceVpcPeeringConnectionV2Read(ctx context.Context, d *schema.Resourc
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("error creating Vpc client: %s", err)
 	}
 
 	listOpts := peerings.ListOpts{
@@ -74,16 +74,16 @@ func dataSourceVpcPeeringConnectionV2Read(ctx context.Context, d *schema.Resourc
 
 	refinedPeering, err := peerings.List(peeringClient, listOpts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve vpc peering connections: %s", err)
+		return diag.Errorf("unable to retrieve vpc peering connections: %s", err)
 	}
 
 	if len(refinedPeering) < 1 {
-		return diag.Errorf("Your query returned no results. " +
+		return diag.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(refinedPeering) > 1 {
-		return diag.Errorf("Multiple VPC peering connections matched." +
+		return diag.Errorf("multiple VPC peering connections matched." +
 			" Use additional constraints to reduce matches to a single VPC peering connection")
 	}
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
@@ -56,7 +56,7 @@ func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 	}
 }
 
-func dataSourceVpcPeeringConnectionV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet.go
@@ -1,16 +1,18 @@
 package vpc
 
 import (
+	"context"
+	"log"
+
 	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceVpcSubnetV1() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceVpcSubnetV1Read,
+		ReadContext: dataSourceVpcSubnetV1Read,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -106,11 +108,11 @@ func DataSourceVpcSubnetV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -127,21 +129,21 @@ func dataSourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	refinedSubnets, err := subnets.List(subnetClient, listOpts)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve subnets: %s", err)
+		return diag.Errorf("Unable to retrieve subnets: %s", err)
 	}
 
 	if len(refinedSubnets) == 0 {
-		return fmtp.Errorf("No matching subnet found. " +
+		return diag.Errorf("No matching subnet found. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(refinedSubnets) > 1 {
-		return fmtp.Errorf("multiple subnets matched; use additional constraints to reduce matches to a single subnet")
+		return diag.Errorf("multiple subnets matched; use additional constraints to reduce matches to a single subnet")
 	}
 
 	Subnets := refinedSubnets[0]
 
-	logp.Printf("[INFO] Retrieved Subnet using given filter %s: %+v", Subnets.ID, Subnets)
+	log.Printf("[INFO] Retrieved Subnet using given filter %s: %+v", Subnets.ID, Subnets)
 	d.SetId(Subnets.ID)
 
 	d.Set("name", Subnets.Name)

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet.go
@@ -112,7 +112,7 @@ func dataSourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("error creating Vpc client: %s", err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -129,11 +129,11 @@ func dataSourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta
 
 	refinedSubnets, err := subnets.List(subnetClient, listOpts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve subnets: %s", err)
+		return diag.Errorf("unable to retrieve subnets: %s", err)
 	}
 
 	if len(refinedSubnets) == 0 {
-		return diag.Errorf("No matching subnet found. " +
+		return diag.Errorf("no matching subnet found. " +
 			"Please change your search criteria and try again.")
 	}
 

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet.go
@@ -108,7 +108,7 @@ func DataSourceVpcSubnetV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_ids.go
@@ -1,15 +1,17 @@
 package vpc
 
 import (
+	"context"
+
 	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceVpcSubnetIdsV1() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceVpcSubnetIdsV1Read,
+		ReadContext: dataSourceVpcSubnetIdsV1Read,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -30,11 +32,11 @@ func DataSourceVpcSubnetIdsV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcSubnetIdsV1Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceVpcSubnetIdsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -43,11 +45,11 @@ func dataSourceVpcSubnetIdsV1Read(d *schema.ResourceData, meta interface{}) erro
 
 	refinedSubnets, err := subnets.List(subnetClient, listOpts)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve subnets: %s", err)
+		return diag.Errorf("Unable to retrieve subnets: %s", err)
 	}
 
 	if len(refinedSubnets) == 0 {
-		return fmtp.Errorf("no matching subnet found for vpc with id %s", d.Get("vpc_id").(string))
+		return diag.Errorf("no matching subnet found for vpc with id %s", d.Get("vpc_id").(string))
 	}
 
 	Subnets := make([]string, 0)

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_ids.go
@@ -32,7 +32,7 @@ func DataSourceVpcSubnetIdsV1() *schema.Resource {
 	}
 }
 
-func dataSourceVpcSubnetIdsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVpcSubnetIdsV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_ids.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnet_ids.go
@@ -36,7 +36,7 @@ func dataSourceVpcSubnetIdsV1Read(ctx context.Context, d *schema.ResourceData, m
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc client: %s", err)
+		return diag.Errorf("error creating Vpc client: %s", err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -45,7 +45,7 @@ func dataSourceVpcSubnetIdsV1Read(ctx context.Context, d *schema.ResourceData, m
 
 	refinedSubnets, err := subnets.List(subnetClient, listOpts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve subnets: %s", err)
+		return diag.Errorf("unable to retrieve subnets: %s", err)
 	}
 
 	if len(refinedSubnets) == 0 {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"log"
 
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
@@ -10,8 +11,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceVpcSubnets() *schema.Resource {
@@ -163,12 +162,12 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 	region := config.GetRegion(d)
 	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	clientV2, err := config.NetworkingV2Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC V2 client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC V2 client: %s", err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -185,10 +184,10 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	subnetList, err := subnets.List(client, listOpts)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve subnets: %s", err)
+		return diag.Errorf("Unable to retrieve subnets: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Retrieved subnets using given filter: %+v", subnetList)
+	log.Printf("[DEBUG] Retrieved subnets using given filter: %+v", subnetList)
 
 	var subnets []map[string]interface{}
 	tagFilter := d.Get("tags").(map[string]interface{})
@@ -223,17 +222,17 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 			}
 			subnet["tags"] = tagmap
 		} else {
-			return fmtp.DiagErrorf("Error query tags of subnets (%s): %s", item.ID, err)
+			return diag.Errorf("Error query tags of subnets (%s): %s", item.ID, err)
 		}
 
 		subnets = append(subnets, subnet)
 		ids = append(ids, item.ID)
 	}
-	logp.Printf("[DEBUG]subnets List after filter, count=%d :%+v", len(subnets), subnets)
+	log.Printf("[DEBUG]subnets List after filter, count=%d :%+v", len(subnets), subnets)
 
 	mErr := d.Set("subnets", subnets)
 	if mErr != nil {
-		return fmtp.DiagErrorf("set subnets err:%s", mErr)
+		return diag.Errorf("set subnets err:%s", mErr)
 	}
 
 	d.SetId(hashcode.Strings(ids))

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_subnets.go
@@ -162,12 +162,12 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 	region := config.GetRegion(d)
 	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	clientV2, err := config.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC V2 client: %s", err)
+		return diag.Errorf("error creating VPC V2 client: %s", err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -184,7 +184,7 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	subnetList, err := subnets.List(client, listOpts)
 	if err != nil {
-		return diag.Errorf("Unable to retrieve subnets: %s", err)
+		return diag.Errorf("unable to retrieve subnets: %s", err)
 	}
 
 	log.Printf("[DEBUG] Retrieved subnets using given filter: %+v", subnetList)
@@ -222,13 +222,13 @@ func dataSourceVpcSubnetsRead(_ context.Context, d *schema.ResourceData, meta in
 			}
 			subnet["tags"] = tagmap
 		} else {
-			return diag.Errorf("Error query tags of subnets (%s): %s", item.ID, err)
+			return diag.Errorf("error query tags of subnets (%s): %s", item.ID, err)
 		}
 
 		subnets = append(subnets, subnet)
 		ids = append(ids, item.ID)
 	}
-	log.Printf("[DEBUG]subnets List after filter, count=%d :%+v", len(subnets), subnets)
+	log.Printf("[DEBUG] Subnets List after filter, count=%d :%+v", len(subnets), subnets)
 
 	mErr := d.Set("subnets", subnets)
 	if mErr != nil {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -97,12 +97,12 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 	region := config.GetRegion(d)
 	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return fmtp.DiagErrorf("error creating VPC client: %s", err)
 	}
 
 	vpcV2Client, err := config.NetworkingV2Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC V2 client: %s", err)
+		return fmtp.DiagErrorf("error creating VPC V2 client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{
@@ -115,7 +115,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 
 	vpcList, err := vpcs.List(client, listOpts)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve vpcs: %s", err)
+		return fmtp.DiagErrorf("unable to retrieve vpcs: %s", err)
 	}
 
 	logp.Printf("[DEBUG] Retrieved Vpc using given filter: %+v", vpcList)
@@ -145,7 +145,7 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 			if _, ok := err.(golangsdk.ErrDefault403); ok {
 				logp.Printf("[WARN] Error query tags of VPC (%s): %s", vpcResource.ID, err)
 			} else {
-				return fmtp.DiagErrorf("Error query tags of VPC (%s): %s", vpcResource.ID, err)
+				return fmtp.DiagErrorf("error query tags of VPC (%s): %s", vpcResource.ID, err)
 			}
 		}
 

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_vip.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_vip.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -15,8 +16,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceNetworkingVip() *schema.Resource {
@@ -97,26 +96,26 @@ func resourceNetworkingVipCreate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
 	}
 
 	networkId := d.Get("network_id").(string)
 	n, err := subnets.Get(client, networkId).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Error retrieving HuaweiCloud subnet by network ID (%s): %s", networkId, err)
+		return diag.Errorf("Error retrieving HuaweiCloud subnet by network ID (%s): %s", networkId, err)
 	}
 
 	// Check whether the subnet ID entered by the user belongs to the same subnet as the network ID.
 	subnetId := d.Get("subnet_id").(string)
 	if subnetId != "" && subnetId != n.SubnetId && subnetId != n.IPv6SubnetId {
-		return fmtp.DiagErrorf("The subnet ID does not belong to the subnet where the network ID is located.")
+		return diag.Errorf("The subnet ID does not belong to the subnet where the network ID is located.")
 	}
 
 	// Pre-check for subnet network, the virtual IP of IPv6 must be established on the basis that the subnet supports
 	// IPv6.
 	if d.Get("ip_version").(int) == 6 {
 		if n.IPv6SubnetId == "" {
-			return fmtp.DiagErrorf("The subnet does not support IPv6, please enable IPv6 first.")
+			return diag.Errorf("The subnet does not support IPv6, please enable IPv6 first.")
 		}
 		subnetId = n.IPv6SubnetId
 	} else {
@@ -135,12 +134,12 @@ func resourceNetworkingVipCreate(ctx context.Context, d *schema.ResourceData, me
 		},
 	}
 
-	logp.Printf("[DEBUG] Updating network VIP (%s) with options: %#v", d.Id(), opts)
+	log.Printf("[DEBUG] Updating network VIP (%s) with options: %#v", d.Id(), opts)
 	vip, err := ports.Create(client, opts)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud network VIP: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud network VIP: %s", err)
 	}
-	logp.Printf("[DEBUG] Waiting for HuaweiCloud network VIP (%s) to become available.", vip.ID)
+	log.Printf("[DEBUG] Waiting for HuaweiCloud network VIP (%s) to become available.", vip.ID)
 	d.SetId(vip.ID)
 
 	stateConf := &resource.StateChangeConf{
@@ -192,7 +191,7 @@ func resourceNetworkingVipRead(_ context.Context, d *schema.ResourceData, meta i
 	region := config.GetRegion(d)
 	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
 	}
 
 	vip, err := ports.Get(client, d.Id())
@@ -200,7 +199,7 @@ func resourceNetworkingVipRead(_ context.Context, d *schema.ResourceData, meta i
 		return common.CheckDeletedDiag(d, err, "VPC network VIP")
 	}
 
-	logp.Printf("[DEBUG] Retrieved VIP %s: %+v", d.Id(), vip)
+	log.Printf("[DEBUG] Retrieved VIP %s: %+v", d.Id(), vip)
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
@@ -219,17 +218,17 @@ func resourceNetworkingVipUpdate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
 	}
 
 	opts := ports.UpdateOpts{
 		Name: d.Get("name").(string),
 	}
-	logp.Printf("[DEBUG] Updating network VIP (%s) with options: %#v", d.Id(), opts)
+	log.Printf("[DEBUG] Updating network VIP (%s) with options: %#v", d.Id(), opts)
 
 	_, err = ports.Update(client, d.Id(), opts)
 	if err != nil {
-		return fmtp.DiagErrorf("Error updating HuaweiCloud networking VIP: %s", err)
+		return diag.Errorf("Error updating HuaweiCloud networking VIP: %s", err)
 	}
 
 	return resourceNetworkingVipRead(ctx, d, meta)
@@ -239,12 +238,12 @@ func resourceNetworkingVipDelete(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
 	}
 
 	err = ports.Delete(client, d.Id()).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting HuaweiCloud Network VIP: %s", err)
+		return diag.Errorf("Error deleting HuaweiCloud Network VIP: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -258,7 +257,7 @@ func resourceNetworkingVipDelete(ctx context.Context, d *schema.ResourceData, me
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting HuaweiCloud Network VIP: %s", err)
+		return diag.Errorf("Error deleting HuaweiCloud Network VIP: %s", err)
 	}
 
 	d.SetId("")
@@ -271,12 +270,12 @@ func waitForNetworkVipStateRefresh(networkingClient *golangsdk.ServiceClient, vi
 		resp, err := ports.Get(networkingClient, vipId)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[DEBUG] The network VIP (%s) has been deleted.", vipId)
+				log.Printf("[DEBUG] The network VIP (%s) has been deleted.", vipId)
 				return resp, "DELETED", nil
 			}
 			return nil, "ERROR", err
 		}
-		logp.Printf("[DEBUG] The status of the network VIP is: %s", resp.Status)
+		log.Printf("[DEBUG] The status of the network VIP is: %s", resp.Status)
 		return resp, resp.Status, nil
 	}
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_vip.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_vip.go
@@ -96,26 +96,26 @@ func resourceNetworkingVipCreate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("error creating VPC network v1 client: %s", err)
 	}
 
 	networkId := d.Get("network_id").(string)
 	n, err := subnets.Get(client, networkId).Extract()
 	if err != nil {
-		return diag.Errorf("Error retrieving HuaweiCloud subnet by network ID (%s): %s", networkId, err)
+		return diag.Errorf("error retrieving subnet by network ID (%s): %s", networkId, err)
 	}
 
 	// Check whether the subnet ID entered by the user belongs to the same subnet as the network ID.
 	subnetId := d.Get("subnet_id").(string)
 	if subnetId != "" && subnetId != n.SubnetId && subnetId != n.IPv6SubnetId {
-		return diag.Errorf("The subnet ID does not belong to the subnet where the network ID is located.")
+		return diag.Errorf("the subnet ID does not belong to the subnet where the network ID is located.")
 	}
 
 	// Pre-check for subnet network, the virtual IP of IPv6 must be established on the basis that the subnet supports
 	// IPv6.
 	if d.Get("ip_version").(int) == 6 {
 		if n.IPv6SubnetId == "" {
-			return diag.Errorf("The subnet does not support IPv6, please enable IPv6 first.")
+			return diag.Errorf("the subnet does not support IPv6, please enable IPv6 first.")
 		}
 		subnetId = n.IPv6SubnetId
 	} else {
@@ -137,9 +137,9 @@ func resourceNetworkingVipCreate(ctx context.Context, d *schema.ResourceData, me
 	log.Printf("[DEBUG] Updating network VIP (%s) with options: %#v", d.Id(), opts)
 	vip, err := ports.Create(client, opts)
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud network VIP: %s", err)
+		return diag.Errorf("error creating network VIP: %s", err)
 	}
-	log.Printf("[DEBUG] Waiting for HuaweiCloud network VIP (%s) to become available.", vip.ID)
+	log.Printf("[DEBUG] Waiting for network VIP (%s) to become available.", vip.ID)
 	d.SetId(vip.ID)
 
 	stateConf := &resource.StateChangeConf{
@@ -191,7 +191,7 @@ func resourceNetworkingVipRead(_ context.Context, d *schema.ResourceData, meta i
 	region := config.GetRegion(d)
 	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("error creating VPC network v1 client: %s", err)
 	}
 
 	vip, err := ports.Get(client, d.Id())
@@ -218,7 +218,7 @@ func resourceNetworkingVipUpdate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("error creating VPC network v1 client: %s", err)
 	}
 
 	opts := ports.UpdateOpts{
@@ -228,7 +228,7 @@ func resourceNetworkingVipUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	_, err = ports.Update(client, d.Id(), opts)
 	if err != nil {
-		return diag.Errorf("Error updating HuaweiCloud networking VIP: %s", err)
+		return diag.Errorf("error updating networking VIP: %s", err)
 	}
 
 	return resourceNetworkingVipRead(ctx, d, meta)
@@ -238,12 +238,12 @@ func resourceNetworkingVipDelete(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+		return diag.Errorf("error creating VPC network v1 client: %s", err)
 	}
 
 	err = ports.Delete(client, d.Id()).ExtractErr()
 	if err != nil {
-		return diag.Errorf("Error deleting HuaweiCloud Network VIP: %s", err)
+		return diag.Errorf("error deleting Network VIP: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -257,7 +257,7 @@ func resourceNetworkingVipDelete(ctx context.Context, d *schema.ResourceData, me
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting HuaweiCloud Network VIP: %s", err)
+		return diag.Errorf("error deleting Network VIP: %s", err)
 	}
 
 	d.SetId("")

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
@@ -222,7 +222,7 @@ func resourceNetworkingVIPAssociateV2Read(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceNetworkingVIPAssociateV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkingVIPAssociateV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -98,7 +98,7 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	createOpts := vpcs.CreateOpts{
@@ -114,7 +114,7 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 
 	n, err := vpcs.Create(vpcClient, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC: %s", err)
+		return diag.Errorf("error creating VPC: %s", err)
 	}
 
 	d.SetId(n.ID)
@@ -132,7 +132,7 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 	_, stateErr := stateConf.WaitForStateContext(ctx)
 	if stateErr != nil {
 		return diag.Errorf(
-			"Error waiting for Vpc (%s) to become ACTIVE: %s",
+			"error waiting for Vpc (%s) to become ACTIVE: %s",
 			n.ID, stateErr)
 	}
 
@@ -141,11 +141,11 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 	if len(tagRaw) > 0 {
 		vpcV2Client, err := config.NetworkingV2Client(region)
 		if err != nil {
-			return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+			return diag.Errorf("error creating VPC client: %s", err)
 		}
 		taglist := utils.ExpandResourceTags(tagRaw)
 		if tagErr := tags.Create(vpcV2Client, "vpcs", n.ID, taglist).ExtractErr(); tagErr != nil {
-			return diag.Errorf("Error setting tags of VPC %q: %s", n.ID, tagErr)
+			return diag.Errorf("error setting tags of VPC %q: %s", n.ID, tagErr)
 		}
 	}
 
@@ -204,13 +204,13 @@ func resourceVirtualPrivateCloudRead(_ context.Context, d *schema.ResourceData, 
 		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
 			if err := d.Set("tags", tagmap); err != nil {
-				return diag.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+				return diag.Errorf("error saving tags to state for VPC (%s): %s", d.Id(), err)
 			}
 		} else {
 			log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
 		}
 	} else {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	return nil
@@ -221,7 +221,7 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	vpcID := d.Id()
@@ -237,7 +237,7 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 
 		_, err = vpcs.Update(vpcClient, vpcID, updateOpts).Extract()
 		if err != nil {
-			return diag.Errorf("Error updating Huaweicloud VPC: %s", err)
+			return diag.Errorf("error updating VPC: %s", err)
 		}
 	}
 
@@ -245,12 +245,12 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 	if d.HasChange("tags") {
 		vpcV2Client, err := config.NetworkingV2Client(region)
 		if err != nil {
-			return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+			return diag.Errorf("error creating VPC client: %s", err)
 		}
 
 		tagErr := utils.UpdateResourceTags(vpcV2Client, d, "vpcs", vpcID)
 		if tagErr != nil {
-			return diag.Errorf("Error updating tags of VPC %s: %s", vpcID, tagErr)
+			return diag.Errorf("error updating tags of VPC %s: %s", vpcID, tagErr)
 		}
 	}
 
@@ -284,7 +284,7 @@ func resourceVirtualPrivateCloudDelete(ctx context.Context, d *schema.ResourceDa
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -298,7 +298,7 @@ func resourceVirtualPrivateCloudDelete(ctx context.Context, d *schema.ResourceDa
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting Huaweicloud VPC %s: %s", d.Id(), err)
+		return diag.Errorf("error deleting VPC %s: %s", d.Id(), err)
 	}
 
 	d.SetId("")
@@ -318,7 +318,7 @@ func waitForVpcActive(vpcClient *golangsdk.ServiceClient, vpcId string) resource
 
 		// If vpc status is other than Ok, send error
 		if n.Status == "DOWN" {
-			return nil, "", fmt.Errorf("Vpc status: '%s'", n.Status)
+			return nil, "", fmt.Errorf("VPC status: '%s'", n.Status)
 		}
 
 		return n, n.Status, nil
@@ -382,7 +382,7 @@ func removeSecondaryCIDR(client *client.VpcClient, vpcID, preCidr string) error 
 		Body:  &reqBody,
 	}
 
-	log.Printf("[DEBUG] remove secondary CIDR %s from VPC %s", preCidr, vpcID)
+	log.Printf("[DEBUG] Remove secondary CIDR %s from VPC %s", preCidr, vpcID)
 	_, err := client.RemoveVpcExtendCidr(&reqOpts)
 	return err
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func ResourceVirtualPrivateCloudV1() *schema.Resource {
@@ -35,7 +35,7 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{ //request and response parameters
+		Schema: map[string]*schema.Schema{ // request and response parameters
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -98,7 +98,7 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	createOpts := vpcs.CreateOpts{
@@ -114,7 +114,7 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 
 	n, err := vpcs.Create(vpcClient, createOpts).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC: %s", err)
 	}
 
 	d.SetId(n.ID)
@@ -131,21 +131,21 @@ func resourceVirtualPrivateCloudCreate(ctx context.Context, d *schema.ResourceDa
 
 	_, stateErr := stateConf.WaitForStateContext(ctx)
 	if stateErr != nil {
-		return fmtp.DiagErrorf(
+		return diag.Errorf(
 			"Error waiting for Vpc (%s) to become ACTIVE: %s",
 			n.ID, stateErr)
 	}
 
-	//set tags
+	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
 		vpcV2Client, err := config.NetworkingV2Client(region)
 		if err != nil {
-			return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+			return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 		}
 		taglist := utils.ExpandResourceTags(tagRaw)
 		if tagErr := tags.Create(vpcV2Client, "vpcs", n.ID, taglist).ExtractErr(); tagErr != nil {
-			return fmtp.DiagErrorf("Error setting tags of VPC %q: %s", n.ID, tagErr)
+			return diag.Errorf("Error setting tags of VPC %q: %s", n.ID, tagErr)
 		}
 	}
 
@@ -204,13 +204,13 @@ func resourceVirtualPrivateCloudRead(_ context.Context, d *schema.ResourceData, 
 		if resourceTags, err := tags.Get(vpcV2Client, "vpcs", d.Id()).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
 			if err := d.Set("tags", tagmap); err != nil {
-				return fmtp.DiagErrorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
+				return diag.Errorf("Error saving tags to state for VPC (%s): %s", d.Id(), err)
 			}
 		} else {
 			log.Printf("[WARN] Error fetching tags of VPC (%s): %s", d.Id(), err)
 		}
 	} else {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	return nil
@@ -221,7 +221,7 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 	region := config.GetRegion(d)
 	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	vpcID := d.Id()
@@ -237,20 +237,20 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 
 		_, err = vpcs.Update(vpcClient, vpcID, updateOpts).Extract()
 		if err != nil {
-			return fmtp.DiagErrorf("Error updating Huaweicloud VPC: %s", err)
+			return diag.Errorf("Error updating Huaweicloud VPC: %s", err)
 		}
 	}
 
-	//update tags
+	// update tags
 	if d.HasChange("tags") {
 		vpcV2Client, err := config.NetworkingV2Client(region)
 		if err != nil {
-			return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+			return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 		}
 
 		tagErr := utils.UpdateResourceTags(vpcV2Client, d, "vpcs", vpcID)
 		if tagErr != nil {
-			return fmtp.DiagErrorf("Error updating tags of VPC %s: %s", vpcID, tagErr)
+			return diag.Errorf("Error updating tags of VPC %s: %s", vpcID, tagErr)
 		}
 	}
 
@@ -284,7 +284,7 @@ func resourceVirtualPrivateCloudDelete(ctx context.Context, d *schema.ResourceDa
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -298,7 +298,7 @@ func resourceVirtualPrivateCloudDelete(ctx context.Context, d *schema.ResourceDa
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting Huaweicloud VPC %s: %s", d.Id(), err)
+		return diag.Errorf("Error deleting Huaweicloud VPC %s: %s", d.Id(), err)
 	}
 
 	d.SetId("")
@@ -316,9 +316,9 @@ func waitForVpcActive(vpcClient *golangsdk.ServiceClient, vpcId string) resource
 			return n, "ACTIVE", nil
 		}
 
-		//If vpc status is other than Ok, send error
+		// If vpc status is other than Ok, send error
 		if n.Status == "DOWN" {
-			return nil, "", fmtp.Errorf("Vpc status: '%s'", n.Status)
+			return nil, "", fmt.Errorf("Vpc status: '%s'", n.Status)
 		}
 
 		return n, n.Status, nil

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -11,8 +12,6 @@ import (
 	vpc_model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceVpcAddressGroup() *schema.Resource {
@@ -69,7 +68,7 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	rawAddresses := d.Get("addresses").(*schema.Set).List()
@@ -94,10 +93,10 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 		},
 	}
 
-	logp.Printf("[DEBUG] Create VPC address group options: %#v", addressGroupBody)
+	log.Printf("[DEBUG] Create VPC address group options: %#v", addressGroupBody)
 	response, err := client.CreateAddressGroup(createOpts)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC address group: %s", err)
+		return diag.Errorf("Error creating VPC address group: %s", err)
 	}
 
 	d.SetId(response.AddressGroup.Id)
@@ -109,7 +108,7 @@ func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, me
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	request := &vpc_model.ShowAddressGroupRequest{
@@ -130,7 +129,7 @@ func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, me
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("Error saving VPC address group: %s", err)
+		return diag.Errorf("Error saving VPC address group: %s", err)
 	}
 
 	return nil
@@ -140,7 +139,7 @@ func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 	c := meta.(*config.Config)
 	client, err := c.HcVpcV3Client(c.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	addressGroupBody := &vpc_model.UpdateAddressGroupOption{}
@@ -170,10 +169,10 @@ func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 		},
 	}
 
-	logp.Printf("[DEBUG] Update VPC address group options: %#v", addressGroupBody)
+	log.Printf("[DEBUG] Update VPC address group options: %#v", addressGroupBody)
 	_, err = client.UpdateAddressGroup(updateOpts)
 	if err != nil {
-		return fmtp.DiagErrorf("Error updating VPC address group: %s", err)
+		return diag.Errorf("Error updating VPC address group: %s", err)
 	}
 
 	return resourceVpcAddressGroupRead(ctx, d, meta)
@@ -184,7 +183,7 @@ func resourceVpcAddressGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
 	}
 
 	request := &vpc_model.DeleteAddressGroupRequest{
@@ -193,7 +192,7 @@ func resourceVpcAddressGroupDelete(ctx context.Context, d *schema.ResourceData, 
 
 	_, err = client.DeleteAddressGroup(request)
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting VPC address group: %s", err)
+		return diag.Errorf("Error deleting VPC address group: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -103,7 +103,7 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	return resourceVpcAddressGroupRead(ctx, d, meta)
 }
 
-func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcAddressGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
@@ -178,7 +178,7 @@ func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 	return resourceVpcAddressGroupRead(ctx, d, meta)
 }
 
-func resourceVpcAddressGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcAddressGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -68,7 +68,7 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	rawAddresses := d.Get("addresses").(*schema.Set).List()
@@ -96,7 +96,7 @@ func resourceVpcAddressGroupCreate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] Create VPC address group options: %#v", addressGroupBody)
 	response, err := client.CreateAddressGroup(createOpts)
 	if err != nil {
-		return diag.Errorf("Error creating VPC address group: %s", err)
+		return diag.Errorf("error creating VPC address group: %s", err)
 	}
 
 	d.SetId(response.AddressGroup.Id)
@@ -108,7 +108,7 @@ func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, me
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	request := &vpc_model.ShowAddressGroupRequest{
@@ -117,7 +117,7 @@ func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, me
 
 	response, err := client.ShowAddressGroup(request)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error fetching VPC address group")
+		return common.CheckDeletedDiag(d, err, "error fetching VPC address group")
 	}
 
 	mErr := multierror.Append(nil,
@@ -129,7 +129,7 @@ func resourceVpcAddressGroupRead(ctx context.Context, d *schema.ResourceData, me
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("Error saving VPC address group: %s", err)
+		return diag.Errorf("error saving VPC address group: %s", err)
 	}
 
 	return nil
@@ -139,7 +139,7 @@ func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 	c := meta.(*config.Config)
 	client, err := c.HcVpcV3Client(c.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	addressGroupBody := &vpc_model.UpdateAddressGroupOption{}
@@ -172,7 +172,7 @@ func resourceVpcAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] Update VPC address group options: %#v", addressGroupBody)
 	_, err = client.UpdateAddressGroup(updateOpts)
 	if err != nil {
-		return diag.Errorf("Error updating VPC address group: %s", err)
+		return diag.Errorf("error updating VPC address group: %s", err)
 	}
 
 	return resourceVpcAddressGroupRead(ctx, d, meta)
@@ -183,7 +183,7 @@ func resourceVpcAddressGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	region := c.GetRegion(d)
 	client, err := c.HcVpcV3Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	request := &vpc_model.DeleteAddressGroupRequest{
@@ -192,7 +192,7 @@ func resourceVpcAddressGroupDelete(ctx context.Context, d *schema.ResourceData, 
 
 	_, err = client.DeleteAddressGroup(request)
 	if err != nil {
-		return diag.Errorf("Error deleting VPC address group: %s", err)
+		return diag.Errorf("error deleting VPC address group: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -70,7 +70,7 @@ func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, met
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
 	}
 
 	requestvpcinfo := peerings.VpcInfo{
@@ -91,12 +91,12 @@ func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, met
 	n, err := peerings.Create(peeringClient, createOpts).Extract()
 
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("error creating Vpc Peering Connection: %s", err)
 	}
 
 	log.Printf("[INFO] Vpc Peering Connection ID: %s", n.ID)
 
-	log.Printf("[INFO] Waiting for Huaweicloud Vpc Peering Connection(%s) to become available", n.ID)
+	log.Printf("[INFO] Waiting for Vpc Peering Connection(%s) to become available", n.ID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"CREATING"},
@@ -109,7 +109,7 @@ func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, met
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		log.Printf("Error creating Huaweicloud Vpc Peering Connection: %s", err)
+		log.Printf("Error creating Vpc Peering Connection: %s", err)
 	}
 	d.SetId(n.ID)
 
@@ -121,7 +121,7 @@ func resourceVPCPeeringV2Read(_ context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud   Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating   Vpc Peering Connection Client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringClient, d.Id()).Extract()
@@ -131,7 +131,7 @@ func resourceVPCPeeringV2Read(_ context.Context, d *schema.ResourceData, meta in
 			return nil
 		}
 
-		return diag.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("error retrieving Vpc Peering Connection: %s", err)
 	}
 
 	d.Set("name", n.Name)
@@ -148,7 +148,7 @@ func resourceVPCPeeringV2Update(ctx context.Context, d *schema.ResourceData, met
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating  Vpc Peering Connection Client: %s", err)
 	}
 
 	var updateOpts peerings.UpdateOpts
@@ -157,7 +157,7 @@ func resourceVPCPeeringV2Update(ctx context.Context, d *schema.ResourceData, met
 
 	_, err = peerings.Update(peeringClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error updating Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("error updating Vpc Peering Connection: %s", err)
 	}
 
 	return resourceVPCPeeringV2Read(ctx, d, meta)
@@ -168,7 +168,7 @@ func resourceVPCPeeringV2Delete(ctx context.Context, d *schema.ResourceData, met
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating  Vpc Peering Connection Client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -182,7 +182,7 @@ func resourceVPCPeeringV2Delete(ctx context.Context, d *schema.ResourceData, met
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("error deleting Vpc Peering Connection: %s", err)
 	}
 
 	d.SetId("")
@@ -211,7 +211,7 @@ func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId s
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud vpc peering connection %s", peeringId)
+				log.Printf("[INFO] Successfully deleted vpc peering connection %s", peeringId)
 				return r, "DELETED", nil
 			}
 			return r, "ACTIVE", err
@@ -221,7 +221,7 @@ func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId s
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud vpc peering connection %s", peeringId)
+				log.Printf("[INFO] Successfully deleted vpc peering connection %s", peeringId)
 				return r, "DELETED", nil
 			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -1,33 +1,35 @@
 package vpc
 
 import (
+	"context"
+	"log"
 	"time"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceVpcPeeringConnectionV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVPCPeeringV2Create,
-		Read:   resourceVPCPeeringV2Read,
-		Update: resourceVPCPeeringV2Update,
-		Delete: resourceVPCPeeringV2Delete,
+		CreateContext: resourceVPCPeeringV2Create,
+		ReadContext:   resourceVPCPeeringV2Read,
+		UpdateContext: resourceVPCPeeringV2Update,
+		DeleteContext: resourceVPCPeeringV2Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{ //request and response parameters
+		Schema: map[string]*schema.Schema{ // request and response parameters
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -63,12 +65,12 @@ func ResourceVpcPeeringConnectionV2() *schema.Resource {
 	}
 }
 
-func resourceVPCPeeringV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc Peering Connection Client: %s", err)
 	}
 
 	requestvpcinfo := peerings.VpcInfo{
@@ -89,12 +91,12 @@ func resourceVPCPeeringV2Create(d *schema.ResourceData, meta interface{}) error 
 	n, err := peerings.Create(peeringClient, createOpts).Extract()
 
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc Peering Connection: %s", err)
 	}
 
-	logp.Printf("[INFO] Vpc Peering Connection ID: %s", n.ID)
+	log.Printf("[INFO] Vpc Peering Connection ID: %s", n.ID)
 
-	logp.Printf("[INFO] Waiting for Huaweicloud Vpc Peering Connection(%s) to become available", n.ID)
+	log.Printf("[INFO] Waiting for Huaweicloud Vpc Peering Connection(%s) to become available", n.ID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"CREATING"},
@@ -105,18 +107,21 @@ func resourceVPCPeeringV2Create(d *schema.ResourceData, meta interface{}) error 
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		log.Printf("Error creating Huaweicloud Vpc Peering Connection: %s", err)
+	}
 	d.SetId(n.ID)
 
-	return resourceVPCPeeringV2Read(d, meta)
+	return resourceVPCPeeringV2Read(ctx, d, meta)
 
 }
 
-func resourceVPCPeeringV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCPeeringV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud   Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud   Vpc Peering Connection Client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringClient, d.Id()).Extract()
@@ -126,7 +131,7 @@ func resourceVPCPeeringV2Read(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		return fmtp.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
 	}
 
 	d.Set("name", n.Name)
@@ -139,11 +144,11 @@ func resourceVPCPeeringV2Read(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceVPCPeeringV2Update(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCPeeringV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud  Vpc Peering Connection Client: %s", err)
 	}
 
 	var updateOpts peerings.UpdateOpts
@@ -152,18 +157,18 @@ func resourceVPCPeeringV2Update(d *schema.ResourceData, meta interface{}) error 
 
 	_, err = peerings.Update(peeringClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error updating Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("Error updating Huaweicloud Vpc Peering Connection: %s", err)
 	}
 
-	return resourceVPCPeeringV2Read(d, meta)
+	return resourceVPCPeeringV2Read(ctx, d, meta)
 }
 
-func resourceVPCPeeringV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCPeeringV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud  Vpc Peering Connection Client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -175,9 +180,9 @@ func resourceVPCPeeringV2Delete(d *schema.ResourceData, meta interface{}) error 
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf("Error deleting Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("Error deleting Huaweicloud Vpc Peering Connection: %s", err)
 	}
 
 	d.SetId("")
@@ -206,7 +211,7 @@ func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId s
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[INFO] Successfully deleted Huaweicloud vpc peering connection %s", peeringId)
+				log.Printf("[INFO] Successfully deleted Huaweicloud vpc peering connection %s", peeringId)
 				return r, "DELETED", nil
 			}
 			return r, "ACTIVE", err
@@ -216,7 +221,7 @@ func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId s
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[INFO] Successfully deleted Huaweicloud vpc peering connection %s", peeringId)
+				log.Printf("[INFO] Successfully deleted Huaweicloud vpc peering connection %s", peeringId)
 				return r, "DELETED", nil
 			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
@@ -128,7 +128,7 @@ func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceD
 
 }
 
-func resourceVpcPeeringAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcPeeringAccepterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringclient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
@@ -164,7 +164,7 @@ func resourceVPCPeeringAccepterUpdate(ctx context.Context, d *schema.ResourceDat
 	return resourceVpcPeeringAccepterRead(ctx, d, meta)
 }
 
-func resourceVPCPeeringAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringAccepterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[WARN] Will not delete VPC peering connection. Terraform will remove this resource from the state file, however resources may remain.")
 	d.SetId("")
 	return nil

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
@@ -1,25 +1,26 @@
 package vpc
 
 import (
+	"context"
+	"log"
 	"time"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVPCPeeringAccepterV2Create,
-		Read:   resourceVpcPeeringAccepterRead,
-		Update: resourceVPCPeeringAccepterUpdate,
-		Delete: resourceVPCPeeringAccepterDelete,
+		CreateContext: resourceVPCPeeringAccepterV2Create,
+		ReadContext:   resourceVpcPeeringAccepterRead,
+		UpdateContext: resourceVPCPeeringAccepterUpdate,
+		DeleteContext: resourceVPCPeeringAccepterDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -67,23 +68,23 @@ func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 	}
 }
 
-func resourceVPCPeeringAccepterV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Peering client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Peering client: %s", err)
 	}
 
 	id := d.Get("vpc_peering_connection_id").(string)
 
 	n, err := peerings.Get(peeringClient, id).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
 	}
 
 	if n.Status != "PENDING_ACCEPTANCE" {
-		return fmtp.Errorf("VPC peering action not permitted: Can not accept/reject peering request not in PENDING_ACCEPTANCE state.")
+		return diag.Errorf("VPC peering action not permitted: Can not accept/reject peering request not in PENDING_ACCEPTANCE state.")
 	}
 
 	var expectedStatus string
@@ -94,7 +95,7 @@ func resourceVPCPeeringAccepterV2Create(d *schema.ResourceData, meta interface{}
 		_, err := peerings.Accept(peeringClient, id).ExtractResult()
 
 		if err != nil {
-			return fmtp.Errorf("Unable to accept VPC Peering Connection: {{err}}", err)
+			return diag.Errorf("Unable to accept VPC Peering Connection: %s", err)
 		}
 
 	} else {
@@ -103,7 +104,7 @@ func resourceVPCPeeringAccepterV2Create(d *schema.ResourceData, meta interface{}
 		_, err := peerings.Reject(peeringClient, id).ExtractResult()
 
 		if err != nil {
-			return fmtp.Errorf("Unable to reject VPC Peering Connection: {{err}}", err)
+			return diag.Errorf("Unable to reject VPC Peering Connection: %s", err)
 		}
 	}
 
@@ -116,19 +117,22 @@ func resourceVPCPeeringAccepterV2Create(d *schema.ResourceData, meta interface{}
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		log.Printf("[ERROR] Error deleting VPC Peering Connection: %s", err)
+	}
 	d.SetId(n.ID)
-	logp.Printf("[INFO] VPC Peering Connection status: %s", expectedStatus)
+	log.Printf("[INFO] VPC Peering Connection status: %s", expectedStatus)
 
-	return resourceVpcPeeringAccepterRead(d, meta)
+	return resourceVpcPeeringAccepterRead(ctx, d, meta)
 
 }
 
-func resourceVpcPeeringAccepterRead(d *schema.ResourceData, meta interface{}) error {
+func resourceVpcPeeringAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	peeringclient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud peering client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud peering client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringclient, d.Id()).Extract()
@@ -138,7 +142,7 @@ func resourceVpcPeeringAccepterRead(d *schema.ResourceData, meta interface{}) er
 			return nil
 		}
 
-		return fmtp.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
 	}
 
 	d.Set("name", n.Name)
@@ -151,17 +155,17 @@ func resourceVpcPeeringAccepterRead(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceVPCPeeringAccepterUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCPeeringAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	if d.HasChange("accept") {
-		return fmtp.Errorf("VPC peering action not permitted: Can not accept/reject peering request not in pending_acceptance state.'")
+		return diag.Errorf("VPC peering action not permitted: Can not accept/reject peering request not in pending_acceptance state.'")
 	}
 
-	return resourceVpcPeeringAccepterRead(d, meta)
+	return resourceVpcPeeringAccepterRead(ctx, d, meta)
 }
 
-func resourceVPCPeeringAccepterDelete(d *schema.ResourceData, meta interface{}) error {
-	logp.Printf("[WARN] Will not delete VPC peering connection. Terraform will remove this resource from the state file, however resources may remain.")
+func resourceVPCPeeringAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[WARN] Will not delete VPC peering connection. Terraform will remove this resource from the state file, however resources may remain.")
 	d.SetId("")
 	return nil
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
@@ -73,14 +73,14 @@ func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceD
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Peering client: %s", err)
+		return diag.Errorf("error creating Peering client: %s", err)
 	}
 
 	id := d.Get("vpc_peering_connection_id").(string)
 
 	n, err := peerings.Get(peeringClient, id).Extract()
 	if err != nil {
-		return diag.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("error retrieving Vpc Peering Connection: %s", err)
 	}
 
 	if n.Status != "PENDING_ACCEPTANCE" {
@@ -95,7 +95,7 @@ func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceD
 		_, err := peerings.Accept(peeringClient, id).ExtractResult()
 
 		if err != nil {
-			return diag.Errorf("Unable to accept VPC Peering Connection: %s", err)
+			return diag.Errorf("unable to accept VPC Peering Connection: %s", err)
 		}
 
 	} else {
@@ -104,7 +104,7 @@ func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceD
 		_, err := peerings.Reject(peeringClient, id).ExtractResult()
 
 		if err != nil {
-			return diag.Errorf("Unable to reject VPC Peering Connection: %s", err)
+			return diag.Errorf("unable to reject VPC Peering Connection: %s", err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func resourceVpcPeeringAccepterRead(ctx context.Context, d *schema.ResourceData,
 	config := meta.(*config.Config)
 	peeringclient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud peering client: %s", err)
+		return diag.Errorf("error creating peering client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringclient, d.Id()).Extract()
@@ -142,7 +142,7 @@ func resourceVpcPeeringAccepterRead(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 
-		return diag.Errorf("Error retrieving Huaweicloud Vpc Peering Connection: %s", err)
+		return diag.Errorf("error retrieving Vpc Peering Connection: %s", err)
 	}
 
 	d.Set("name", n.Name)

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route.go
@@ -65,7 +65,7 @@ func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta 
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud vpc route client: %s", err)
+		return diag.Errorf("error creating vpc route client: %s", err)
 	}
 
 	createOpts := routes.CreateOpts{
@@ -78,7 +78,7 @@ func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta 
 	n, err := routes.Create(vpcRouteClient, createOpts).Extract()
 
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC route: %s", err)
+		return diag.Errorf("error creating VPC route: %s", err)
 	}
 	d.SetId(n.RouteID)
 
@@ -94,7 +94,7 @@ func resourceVpcRouteV2Read(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud Vpc route client: %s", err)
+		return diag.Errorf("error creating Vpc route client: %s", err)
 	}
 
 	n, err := routes.Get(vpcRouteClient, d.Id()).Extract()
@@ -104,7 +104,7 @@ func resourceVpcRouteV2Read(ctx context.Context, d *schema.ResourceData, meta in
 			return nil
 		}
 
-		return diag.Errorf("Error retrieving Huaweicloud Vpc route: %s", err)
+		return diag.Errorf("error retrieving Vpc route: %s", err)
 	}
 
 	d.Set("type", n.Type)
@@ -121,7 +121,7 @@ func resourceVpcRouteV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud vpc route: %s", err)
+		return diag.Errorf("error creating vpc route: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -135,7 +135,7 @@ func resourceVpcRouteV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting Huaweicloud Vpc route: %s", err)
+		return diag.Errorf("error deleting Vpc route: %s", err)
 	}
 
 	d.SetId("")
@@ -149,7 +149,7 @@ func waitForVpcRouteDelete(vpcRouteClient *golangsdk.ServiceClient, routeId stri
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud vpc route %s", routeId)
+				log.Printf("[INFO] Successfully deleted vpc route %s", routeId)
 				return r, "DELETED", nil
 			}
 			return r, "ACTIVE", err
@@ -160,7 +160,7 @@ func waitForVpcRouteDelete(vpcRouteClient *golangsdk.ServiceClient, routeId stri
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud vpc route %s", routeId)
+				log.Printf("[INFO] Successfully deleted vpc route %s", routeId)
 				return r, "DELETED", nil
 			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route.go
@@ -1,25 +1,26 @@
 package vpc
 
 import (
+	"context"
+	"log"
 	"time"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/routes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceVPCRouteV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVpcRouteV2Create,
-		Read:   resourceVpcRouteV2Read,
-		Delete: resourceVpcRouteV2Delete,
+		CreateContext: resourceVpcRouteV2Create,
+		ReadContext:   resourceVpcRouteV2Read,
+		DeleteContext: resourceVpcRouteV2Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -27,7 +28,7 @@ func ResourceVPCRouteV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{ //request and response parameters
+		Schema: map[string]*schema.Schema{ // request and response parameters
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -59,12 +60,12 @@ func ResourceVPCRouteV2() *schema.Resource {
 	}
 }
 
-func resourceVpcRouteV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud vpc route client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud vpc route client: %s", err)
 	}
 
 	createOpts := routes.CreateOpts{
@@ -77,23 +78,23 @@ func resourceVpcRouteV2Create(d *schema.ResourceData, meta interface{}) error {
 	n, err := routes.Create(vpcRouteClient, createOpts).Extract()
 
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud VPC route: %s", err)
+		return diag.Errorf("Error creating Huaweicloud VPC route: %s", err)
 	}
 	d.SetId(n.RouteID)
 
-	logp.Printf("[INFO] Vpc Route ID: %s", n.RouteID)
+	log.Printf("[INFO] Vpc Route ID: %s", n.RouteID)
 
 	d.SetId(n.RouteID)
 
-	return resourceVpcRouteV2Read(d, meta)
+	return resourceVpcRouteV2Read(ctx, d, meta)
 
 }
 
-func resourceVpcRouteV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceVpcRouteV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud Vpc route client: %s", err)
+		return diag.Errorf("Error creating Huaweicloud Vpc route client: %s", err)
 	}
 
 	n, err := routes.Get(vpcRouteClient, d.Id()).Extract()
@@ -103,7 +104,7 @@ func resourceVpcRouteV2Read(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		return fmtp.Errorf("Error retrieving Huaweicloud Vpc route: %s", err)
+		return diag.Errorf("Error retrieving Huaweicloud Vpc route: %s", err)
 	}
 
 	d.Set("type", n.Type)
@@ -115,12 +116,12 @@ func resourceVpcRouteV2Read(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceVpcRouteV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceVpcRouteV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	config := meta.(*config.Config)
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud vpc route: %s", err)
+		return diag.Errorf("Error creating Huaweicloud vpc route: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -132,9 +133,9 @@ func resourceVpcRouteV2Delete(d *schema.ResourceData, meta interface{}) error {
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf("Error deleting Huaweicloud Vpc route: %s", err)
+		return diag.Errorf("Error deleting Huaweicloud Vpc route: %s", err)
 	}
 
 	d.SetId("")
@@ -148,18 +149,18 @@ func waitForVpcRouteDelete(vpcRouteClient *golangsdk.ServiceClient, routeId stri
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[INFO] Successfully deleted Huaweicloud vpc route %s", routeId)
+				log.Printf("[INFO] Successfully deleted Huaweicloud vpc route %s", routeId)
 				return r, "DELETED", nil
 			}
 			return r, "ACTIVE", err
 		}
 
 		err = routes.Delete(vpcRouteClient, routeId).ExtractErr()
-		logp.Printf("[DEBUG] Value if error: %#v", err)
+		log.Printf("[DEBUG] Value if error: %#v", err)
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[INFO] Successfully deleted Huaweicloud vpc route %s", routeId)
+				log.Printf("[INFO] Successfully deleted Huaweicloud vpc route %s", routeId)
 				return r, "DELETED", nil
 			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route.go
@@ -90,7 +90,7 @@ func resourceVpcRouteV2Create(ctx context.Context, d *schema.ResourceData, meta 
 
 }
 
-func resourceVpcRouteV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	vpcRouteClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
@@ -95,7 +95,7 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	createOpts := routetables.CreateOpts{
@@ -112,7 +112,7 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 	log.Printf("[DEBUG] VPC route table create options: %#v", createOpts)
 	routeTable, err := routetables.Create(vpcClient, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error creating VPC route table: %s", err)
+		return diag.Errorf("error creating VPC route table: %s", err)
 	}
 
 	d.SetId(routeTable.ID)
@@ -121,7 +121,7 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 		subnets := utils.ExpandToStringList(v.(*schema.Set).List())
 		err = associateRouteTableSubnets(vpcClient, d.Id(), subnets)
 		if err != nil {
-			return diag.Errorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
+			return diag.Errorf("error associating subnets with VPC route table %s: %s", d.Id(), err)
 		}
 	}
 
@@ -135,7 +135,7 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 		log.Printf("[DEBUG] add routes to VPC route table %s: %#v", d.Id(), updateOpts)
 		_, err = routetables.Update(vpcClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return diag.Errorf("Error creating VPC route: %s", err)
+			return diag.Errorf("error creating VPC route: %s", err)
 		}
 	}
 
@@ -147,7 +147,7 @@ func resourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	routeTable, err := routetables.Get(vpcClient, d.Id()).Extract()
@@ -165,7 +165,7 @@ func resourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta i
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("Error saving VPC route table: %s", err)
+		return diag.Errorf("error saving VPC route table: %s", err)
 	}
 
 	return nil
@@ -175,7 +175,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	var changed bool
@@ -228,7 +228,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 	if changed {
 		log.Printf("[DEBUG] VPC route table update options: %#v", updateOpts)
 		if _, err := routetables.Update(vpcClient, d.Id(), updateOpts).Extract(); err != nil {
-			return diag.Errorf("Error updating VPC route table: %s", err)
+			return diag.Errorf("error updating VPC route table: %s", err)
 		}
 	}
 
@@ -241,7 +241,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 		if len(disassociateSubnets) > 0 {
 			err = disassociateRouteTableSubnets(vpcClient, d.Id(), disassociateSubnets)
 			if err != nil {
-				return diag.Errorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
+				return diag.Errorf("error disassociating subnets with VPC route table %s: %s", d.Id(), err)
 			}
 		}
 
@@ -249,7 +249,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 		if len(associateSubnets) > 0 {
 			err = associateRouteTableSubnets(vpcClient, d.Id(), associateSubnets)
 			if err != nil {
-				return diag.Errorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
+				return diag.Errorf("error associating subnets with VPC route table %s: %s", d.Id(), err)
 			}
 		}
 	}
@@ -261,20 +261,20 @@ func resourceVpcRouteTableDelete(_ context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	if v, ok := d.GetOk("subnets"); ok {
 		subnets := utils.ExpandToStringList(v.(*schema.Set).List())
 		err = disassociateRouteTableSubnets(vpcClient, d.Id(), subnets)
 		if err != nil {
-			return diag.Errorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
+			return diag.Errorf("error disassociating subnets with VPC route table %s: %s", d.Id(), err)
 		}
 	}
 
 	err = routetables.Delete(vpcClient, d.Id()).ExtractErr()
 	if err != nil {
-		return diag.Errorf("Error deleting VPC route table: %s", err)
+		return diag.Errorf("error deleting VPC route table: %s", err)
 	}
 
 	d.SetId("")

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
@@ -2,6 +2,8 @@ package vpc
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -13,8 +15,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceVPCRouteTable() *schema.Resource {
@@ -24,7 +24,7 @@ func ResourceVPCRouteTable() *schema.Resource {
 		UpdateContext: resourceVpcRouteTableUpdate,
 		DeleteContext: resourceVpcRouteTableDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -32,7 +32,7 @@ func ResourceVPCRouteTable() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{ //request and response parameters
+		Schema: map[string]*schema.Schema{ // request and response parameters
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -95,7 +95,7 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	createOpts := routetables.CreateOpts{
@@ -109,10 +109,10 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 		createOpts.Routes = allRouteOpts
 	}
 
-	logp.Printf("[DEBUG] VPC route table create options: %#v", createOpts)
+	log.Printf("[DEBUG] VPC route table create options: %#v", createOpts)
 	routeTable, err := routetables.Create(vpcClient, createOpts).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC route table: %s", err)
+		return diag.Errorf("Error creating VPC route table: %s", err)
 	}
 
 	d.SetId(routeTable.ID)
@@ -121,7 +121,7 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 		subnets := utils.ExpandToStringList(v.(*schema.Set).List())
 		err = associateRouteTableSubnets(vpcClient, d.Id(), subnets)
 		if err != nil {
-			return fmtp.DiagErrorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
+			return diag.Errorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
 		}
 	}
 
@@ -132,10 +132,10 @@ func resourceVpcRouteTableCreate(ctx context.Context, d *schema.ResourceData, me
 			},
 		}
 
-		logp.Printf("[DEBUG] add routes to VPC route table %s: %#v", d.Id(), updateOpts)
+		log.Printf("[DEBUG] add routes to VPC route table %s: %#v", d.Id(), updateOpts)
 		_, err = routetables.Update(vpcClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmtp.DiagErrorf("Error creating VPC route: %s", err)
+			return diag.Errorf("Error creating VPC route: %s", err)
 		}
 	}
 
@@ -147,7 +147,7 @@ func resourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	routeTable, err := routetables.Get(vpcClient, d.Id()).Extract()
@@ -165,7 +165,7 @@ func resourceVpcRouteTableRead(_ context.Context, d *schema.ResourceData, meta i
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("Error saving VPC route table: %s", err)
+		return diag.Errorf("Error saving VPC route table: %s", err)
 	}
 
 	return nil
@@ -175,7 +175,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	var changed bool
@@ -226,9 +226,9 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if changed {
-		logp.Printf("[DEBUG] VPC route table update options: %#v", updateOpts)
+		log.Printf("[DEBUG] VPC route table update options: %#v", updateOpts)
 		if _, err := routetables.Update(vpcClient, d.Id(), updateOpts).Extract(); err != nil {
-			return fmtp.DiagErrorf("Error updating VPC route table: %s", err)
+			return diag.Errorf("Error updating VPC route table: %s", err)
 		}
 	}
 
@@ -241,7 +241,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 		if len(disassociateSubnets) > 0 {
 			err = disassociateRouteTableSubnets(vpcClient, d.Id(), disassociateSubnets)
 			if err != nil {
-				return fmtp.DiagErrorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
+				return diag.Errorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
 			}
 		}
 
@@ -249,7 +249,7 @@ func resourceVpcRouteTableUpdate(ctx context.Context, d *schema.ResourceData, me
 		if len(associateSubnets) > 0 {
 			err = associateRouteTableSubnets(vpcClient, d.Id(), associateSubnets)
 			if err != nil {
-				return fmtp.DiagErrorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
+				return diag.Errorf("Error associating subnets with VPC route table %s: %s", d.Id(), err)
 			}
 		}
 	}
@@ -261,20 +261,20 @@ func resourceVpcRouteTableDelete(_ context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	if v, ok := d.GetOk("subnets"); ok {
 		subnets := utils.ExpandToStringList(v.(*schema.Set).List())
 		err = disassociateRouteTableSubnets(vpcClient, d.Id(), subnets)
 		if err != nil {
-			return fmtp.DiagErrorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
+			return diag.Errorf("Error disassociating subnets with VPC route table %s: %s", d.Id(), err)
 		}
 	}
 
 	err = routetables.Delete(vpcClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting VPC route table: %s", err)
+		return diag.Errorf("Error deleting VPC route table: %s", err)
 	}
 
 	d.SetId("")
@@ -297,14 +297,14 @@ func ipmlVpcRTSubnetsAction(client *golangsdk.ServiceClient, id, action string, 
 	case "disassociate":
 		opts.Disassociate = subnets
 	default:
-		return fmtp.Errorf("action should be associate or disassociate, but got %s", action)
+		return fmt.Errorf("action should be associate or disassociate, but got %s", action)
 	}
 
 	actionOpts := routetables.ActionOpts{
 		Subnets: opts,
 	}
 
-	logp.Printf("[DEBUG] %s subnets %v with VPC route table %s", action, subnets, id)
+	log.Printf("[DEBUG] %s subnets %v with VPC route table %s", action, subnets, id)
 	_, err := routetables.Action(client, id, actionOpts).Extract()
 	return err
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table_route.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table_route.go
@@ -3,6 +3,7 @@ package vpc
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -17,8 +18,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceVPCRouteTableRoute() *schema.Resource {
@@ -85,7 +84,7 @@ func resourceVpcRTBRouteCreate(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	var routeTableID string
@@ -114,10 +113,10 @@ func resourceVpcRTBRouteCreate(ctx context.Context, d *schema.ResourceData, meta
 		},
 	}
 
-	logp.Printf("[DEBUG] add route in VPC route table[%s]: %#v", routeTableID, updateOpts)
+	log.Printf("[DEBUG] add route in VPC route table[%s]: %#v", routeTableID, updateOpts)
 	_, err = routetables.Update(vpcClient, routeTableID, updateOpts).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC route: %s", err)
+		return diag.Errorf("Error creating VPC route: %s", err)
 	}
 
 	routeID := fmt.Sprintf("%s/%s", routeTableID, destination)
@@ -131,7 +130,7 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 	region := config.GetRegion(d)
 	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	var diags diag.Diagnostics
@@ -140,7 +139,7 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 	// Compatible with previous versions: conver ID to new format
 	if routeTableID == "" {
 		oldID := d.Id()
-		logp.Printf("[WARN] The resource ID %s is in the old format, try to upgrade it to the new format", oldID)
+		log.Printf("[WARN] The resource ID %s is in the old format, try to upgrade it to the new format", oldID)
 
 		newID, subDiags := convertRouteIDtoNewFormat(d, config, oldID)
 		if subDiags.HasError() {
@@ -149,7 +148,7 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 
 		diags = subDiags
 		d.SetId(newID)
-		logp.Printf("[DEBUG] The resource ID %s has upgraded to %s", oldID, d.Id())
+		log.Printf("[DEBUG] The resource ID %s has upgraded to %s", oldID, d.Id())
 		routeTableID, destination = parseResourceID(newID)
 	}
 
@@ -159,15 +158,15 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	var route *routetables.Route
-	for _, item := range routeTable.Routes {
-		if item.DestinationCIDR == destination {
-			route = &item
+	for index := range routeTable.Routes {
+		if routeTable.Routes[index].DestinationCIDR == destination {
+			route = &routeTable.Routes[index]
 			break
 		}
 	}
 
 	if route == nil {
-		logp.Printf("[INFO] Since can not find destination %s in the vpc route %s, remove %s from state",
+		log.Printf("[INFO] Since can not find destination %s in the vpc route %s, remove %s from state",
 			routeTableID, destination, d.Id())
 		d.SetId("")
 		return nil
@@ -185,7 +184,7 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		diags = append(diags, fmtp.DiagErrorf("Error saving VPC route: %s", err)[0])
+		diags = append(diags, diag.Errorf("Error saving VPC route: %s", err)[0])
 	}
 
 	return diags
@@ -195,7 +194,7 @@ func resourceVpcRTBRouteUpdate(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	routeTableID, _ := parseResourceID(d.Id())
@@ -213,9 +212,9 @@ func resourceVpcRTBRouteUpdate(ctx context.Context, d *schema.ResourceData, meta
 		},
 	}
 
-	logp.Printf("[DEBUG] update route in vpc route table[%s]: %#v", routeTableID, updateOpts)
+	log.Printf("[DEBUG] update route in vpc route table[%s]: %#v", routeTableID, updateOpts)
 	if _, err := routetables.Update(vpcClient, routeTableID, updateOpts).Extract(); err != nil {
-		return fmtp.DiagErrorf("Error updating VPC route: %s", err)
+		return diag.Errorf("Error updating VPC route: %s", err)
 	}
 
 	return resourceVpcRTBRouteRead(ctx, d, meta)
@@ -225,7 +224,7 @@ func resourceVpcRTBRouteDelete(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating VPC client: %s", err)
+		return diag.Errorf("Error creating VPC client: %s", err)
 	}
 
 	routeTableID, _ := parseResourceID(d.Id())
@@ -241,9 +240,9 @@ func resourceVpcRTBRouteDelete(_ context.Context, d *schema.ResourceData, meta i
 		},
 	}
 
-	logp.Printf("[DEBUG] delete route in vpc route table[%s]: %#v", routeTableID, updateOpts)
+	log.Printf("[DEBUG] delete route in vpc route table[%s]: %#v", routeTableID, updateOpts)
 	if _, err := routetables.Update(vpcClient, routeTableID, updateOpts).Extract(); err != nil {
-		return fmtp.DiagErrorf("Error deleting VPC route: %s", err)
+		return diag.Errorf("Error deleting VPC route: %s", err)
 	}
 
 	d.SetId("")

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table_route.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table_route.go
@@ -84,7 +84,7 @@ func resourceVpcRTBRouteCreate(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	var routeTableID string
@@ -113,10 +113,10 @@ func resourceVpcRTBRouteCreate(ctx context.Context, d *schema.ResourceData, meta
 		},
 	}
 
-	log.Printf("[DEBUG] add route in VPC route table[%s]: %#v", routeTableID, updateOpts)
+	log.Printf("[DEBUG] Add route in VPC route table[%s]: %#v", routeTableID, updateOpts)
 	_, err = routetables.Update(vpcClient, routeTableID, updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error creating VPC route: %s", err)
+		return diag.Errorf("error creating VPC route: %s", err)
 	}
 
 	routeID := fmt.Sprintf("%s/%s", routeTableID, destination)
@@ -130,7 +130,7 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 	region := config.GetRegion(d)
 	vpcClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	var diags diag.Diagnostics
@@ -184,7 +184,7 @@ func resourceVpcRTBRouteRead(_ context.Context, d *schema.ResourceData, meta int
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		diags = append(diags, diag.Errorf("Error saving VPC route: %s", err)[0])
+		diags = append(diags, diag.Errorf("error saving VPC route: %s", err)[0])
 	}
 
 	return diags
@@ -194,7 +194,7 @@ func resourceVpcRTBRouteUpdate(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	routeTableID, _ := parseResourceID(d.Id())
@@ -214,7 +214,7 @@ func resourceVpcRTBRouteUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	log.Printf("[DEBUG] update route in vpc route table[%s]: %#v", routeTableID, updateOpts)
 	if _, err := routetables.Update(vpcClient, routeTableID, updateOpts).Extract(); err != nil {
-		return diag.Errorf("Error updating VPC route: %s", err)
+		return diag.Errorf("error updating VPC route: %s", err)
 	}
 
 	return resourceVpcRTBRouteRead(ctx, d, meta)
@@ -224,7 +224,7 @@ func resourceVpcRTBRouteDelete(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	routeTableID, _ := parseResourceID(d.Id())
@@ -242,7 +242,7 @@ func resourceVpcRTBRouteDelete(_ context.Context, d *schema.ResourceData, meta i
 
 	log.Printf("[DEBUG] delete route in vpc route table[%s]: %#v", routeTableID, updateOpts)
 	if _, err := routetables.Update(vpcClient, routeTableID, updateOpts).Extract(); err != nil {
-		return diag.Errorf("Error deleting VPC route: %s", err)
+		return diag.Errorf("error deleting VPC route: %s", err)
 	}
 
 	d.SetId("")
@@ -291,7 +291,7 @@ func resourceVpcRTBRouteImportState(_ context.Context, d *schema.ResourceData,
 
 	routeID, _ := parseResourceID(d.Id())
 	if routeID == "" {
-		return nil, fmt.Errorf("Invalid format specified for import id, must be <route_table_id>/<destination>")
+		return nil, fmt.Errorf("invalid format specified for import id, must be <route_table_id>/<destination>")
 	}
 
 	return []*schema.ResourceData{d}, nil
@@ -302,7 +302,7 @@ func convertRouteIDtoNewFormat(d *schema.ResourceData, conf *config.Config, oldI
 		diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  "Deprecated ID format",
-			Detail:   fmt.Sprintf("The resource ID %s is in the old format, try to upgrade it to the new format", oldID),
+			Detail:   fmt.Sprintf("the resource ID %s is in the old format, try to upgrade it to the new format", oldID),
 		},
 	}
 
@@ -330,7 +330,7 @@ func convertRouteIDtoNewFormat(d *schema.ResourceData, conf *config.Config, oldI
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  fmt.Sprintf("The resource %s does not exist", oldID),
+				Summary:  fmt.Sprintf("the resource %s does not exist", oldID),
 			})
 			d.SetId("")
 		} else {
@@ -368,7 +368,7 @@ func convertRouteIDtoNewFormat(d *schema.ResourceData, conf *config.Config, oldI
 	newRouteID := fmt.Sprintf("%s/%s", routeTableID, destination)
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Warning,
-		Summary:  fmt.Sprintf("The resource ID is upgraded to %s", newRouteID),
+		Summary:  fmt.Sprintf("the resource ID is upgraded to %s", newRouteID),
 	})
 	return newRouteID, diags
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -170,7 +170,7 @@ func resourceVpcSubnetCreate(ctx context.Context, d *schema.ResourceData, meta i
 	region := config.GetRegion(d)
 	subnetClient, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud networking client: %s", err)
+		return diag.Errorf("error creating networking client: %s", err)
 	}
 
 	enable := d.Get("ipv6_enable").(bool)
@@ -191,7 +191,7 @@ func resourceVpcSubnetCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	n, err := subnets.Create(subnetClient, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud VPC subnet: %s", err)
+		return diag.Errorf("error creating VPC subnet: %s", err)
 	}
 
 	d.SetId(n.ID)
@@ -218,11 +218,11 @@ func resourceVpcSubnetCreate(ctx context.Context, d *schema.ResourceData, meta i
 	if len(tagRaw) > 0 {
 		vpcSubnetV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
 		if err != nil {
-			return diag.Errorf("Error creating Huaweicloud VpcSubnet client: %s", err)
+			return diag.Errorf("error creating VpcSubnet client: %s", err)
 		}
 		taglist := utils.ExpandResourceTags(tagRaw)
 		if tagErr := tags.Create(vpcSubnetV2Client, "subnets", n.ID, taglist).ExtractErr(); tagErr != nil {
-			return diag.Errorf("Error setting tags of VpcSubnet %q: %s", n.ID, tagErr)
+			return diag.Errorf("error setting tags of VpcSubnet %q: %s", n.ID, tagErr)
 		}
 	}
 
@@ -278,11 +278,11 @@ func resourceVpcSubnetRead(_ context.Context, d *schema.ResourceData, meta inter
 			log.Printf("[WARN] Error fetching tags of Subnet (%s): %s", d.Id(), err)
 		}
 	} else {
-		return diag.Errorf("Error creating Huaweicloud VpcSubnet client: %s", err)
+		return diag.Errorf("error creating VpcSubnet client: %s", err)
 	}
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting HuaweiCloud VPC subnet fields: %s", err)
+		return diag.Errorf("error setting VPC subnet fields: %s", err)
 	}
 
 	return nil
@@ -292,7 +292,7 @@ func resourceVpcSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud networking client: %s", err)
+		return diag.Errorf("error creating networking client: %s", err)
 	}
 
 	if d.HasChanges("name", "description", "dhcp_enable", "primary_dns", "secondary_dns", "dns_list", "ipv6_enable") {
@@ -308,7 +308,7 @@ func resourceVpcSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta i
 				enable := d.Get("ipv6_enable").(bool)
 				updateOpts.EnableIPv6 = &enable
 			} else {
-				return diag.Errorf("Parameter cannot be disabled after IPv6 enable")
+				return diag.Errorf("parameter cannot be disabled after IPv6 enable")
 			}
 		}
 		if d.HasChange("description") {
@@ -330,7 +330,7 @@ func resourceVpcSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		vpcID := d.Get("vpc_id").(string)
 		_, err = subnets.Update(subnetClient, vpcID, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return diag.Errorf("Error updating VPC Subnet: %s", err)
+			return diag.Errorf("error updating VPC Subnet: %s", err)
 		}
 	}
 
@@ -338,12 +338,12 @@ func resourceVpcSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	if d.HasChange("tags") {
 		vpcSubnetV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
 		if err != nil {
-			return diag.Errorf("Error creating Huaweicloud VpcSubnet client: %s", err)
+			return diag.Errorf("error creating VpcSubnet client: %s", err)
 		}
 
 		tagErr := utils.UpdateResourceTags(vpcSubnetV2Client, d, "subnets", d.Id())
 		if tagErr != nil {
-			return diag.Errorf("Error updating tags of VPC subnet %s: %s", d.Id(), tagErr)
+			return diag.Errorf("error updating tags of VPC subnet %s: %s", d.Id(), tagErr)
 		}
 	}
 
@@ -355,7 +355,7 @@ func resourceVpcSubnetDelete(ctx context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huaweicloud networking client: %s", err)
+		return diag.Errorf("error creating networking client: %s", err)
 	}
 
 	vpcID := d.Get("vpc_id").(string)
@@ -370,7 +370,7 @@ func resourceVpcSubnetDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting Huaweicloud Subnet: %s", err)
+		return diag.Errorf("error deleting Subnet: %s", err)
 	}
 
 	d.SetId("")
@@ -390,7 +390,7 @@ func waitForVpcSubnetActive(subnetClient *golangsdk.ServiceClient, vpcId string)
 
 		// If subnet status is other than Active, send error
 		if n.Status == "DOWN" || n.Status == "ERROR" {
-			return nil, "", fmt.Errorf("Subnet status: '%s'", n.Status)
+			return nil, "", fmt.Errorf("subnet status: '%s'", n.Status)
 		}
 
 		return n, "UNKNOWN", nil
@@ -404,11 +404,11 @@ func waitForVpcSubnetDelete(subnetClient *golangsdk.ServiceClient, vpcId string,
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud subnet %s", subnetId)
+				log.Printf("[INFO] Successfully deleted subnet %s", subnetId)
 				return r, "DELETED", nil
 			}
 			if _, ok := err.(golangsdk.ErrDefault500); ok {
-				log.Printf("[DEBUG] Got 500 error when delting HuaweiCloud subnet %s, it should be stream control on API server, try again later", subnetId)
+				log.Printf("[DEBUG] Got 500 error when delting subnet %s, it should be stream control on API server, try again later", subnetId)
 				return r, "ACTIVE", nil
 			}
 
@@ -417,7 +417,7 @@ func waitForVpcSubnetDelete(subnetClient *golangsdk.ServiceClient, vpcId string,
 			// add this in retry can avoid temporary 403 error
 			// but the real 403 error can only be returned after the timeout period is reached
 			if _, ok := err.(golangsdk.ErrDefault403); ok {
-				log.Printf("[DEBUG] Got 403 error when delting HuaweiCloud subnet %s, it should be temporary permission error, try again later", subnetId)
+				log.Printf("[DEBUG] Got 403 error when delting subnet %s, it should be temporary permission error, try again later", subnetId)
 				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
@@ -426,15 +426,15 @@ func waitForVpcSubnetDelete(subnetClient *golangsdk.ServiceClient, vpcId string,
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud subnet %s", subnetId)
+				log.Printf("[INFO] Successfully deleted subnet %s", subnetId)
 				return r, "DELETED", nil
 			}
 			if _, ok := err.(golangsdk.ErrDefault400); ok {
-				log.Printf("[INFO] Successfully deleted Huaweicloud subnet %s", subnetId)
+				log.Printf("[INFO] Successfully deleted subnet %s", subnetId)
 				return r, "DELETED", nil
 			}
 			if _, ok := err.(golangsdk.ErrDefault500); ok {
-				log.Printf("[DEBUG] Got 500 error when delting HuaweiCloud subnet %s, it should be stream control on API server, try again later", subnetId)
+				log.Printf("[DEBUG] Got 500 error when delting subnet %s, it should be stream control on API server, try again later", subnetId)
 				return r, "ACTIVE", nil
 			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- refactor for vpc resources.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
#
For: huaweicloud/services/vpc/data_source_huaweicloud_vpc_ids.go
RUN: huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_ids_test.go

$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcIdsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcIdsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcIdsDataSource_basic
=== PAUSE TestAccVpcIdsDataSource_basic
=== CONT  TestAccVpcIdsDataSource_basic
--- PASS: TestAccVpcIdsDataSource_basic (25.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       25.786s
$ make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run testAccDataSourceVpcIds_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run testAccDataSourceVpcIds_basic -timeout 360m -parallel 4
testing: warning: no tests to run
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       0.042s [no tests to run]


# For: huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connection_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connection_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnectionDataSource_basic
=== PAUSE TestAccVpcPeeringConnectionDataSource_basic
=== RUN   TestAccVpcPeeringConnectionDataSource_byVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byVpcId
=== RUN   TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== RUN   TestAccVpcPeeringConnectionDataSource_byVpcIds
=== PAUSE TestAccVpcPeeringConnectionDataSource_byVpcIds
=== CONT  TestAccVpcPeeringConnectionDataSource_basic
=== CONT  TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== CONT  TestAccVpcPeeringConnectionDataSource_byVpcIds
=== CONT  TestAccVpcPeeringConnectionDataSource_byVpcId
--- PASS: TestAccVpcPeeringConnectionDataSource_basic (41.10s)
--- PASS: TestAccVpcPeeringConnectionDataSource_byPeerVpcId (44.30s)
--- PASS: TestAccVpcPeeringConnectionDataSource_byVpcId (46.23s)
--- PASS: TestAccVpcPeeringConnectionDataSource_byVpcIds (47.29s)
PASS
ok      command-line-arguments  47.337s

# For: 

make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test*'


# For:

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetIdsDataSource_basic
=== PAUSE TestAccVpcSubnetIdsDataSource_basic
=== RUN   TestAccVpcSubnetDataSource_ipv4Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv4Basic
=== RUN   TestAccVpcSubnetDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetIdsDataSource_basic
=== CONT  TestAccVpcSubnetDataSource_ipv4ByName
=== CONT  TestAccVpcSubnetDataSource_ipv4ByCidr
=== CONT  TestAccVpcSubnetDataSource_ipv4Basic
--- PASS: TestAccVpcSubnetDataSource_ipv4Basic (45.64s)
=== CONT  TestAccVpcSubnetDataSource_ipv6Basic
--- PASS: TestAccVpcSubnetDataSource_ipv4ByCidr (48.12s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByVpcId
--- PASS: TestAccVpcSubnetDataSource_ipv4ByName (51.07s)
--- PASS: TestAccVpcSubnetIdsDataSource_basic (61.65s)
--- PASS: TestAccVpcSubnetDataSource_ipv6Basic (46.89s)
--- PASS: TestAccVpcSubnetDataSource_ipv4ByVpcId (47.30s)
PASS
ok      command-line-arguments  95.471s
$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnets*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnets* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetsDataSource_basic
=== PAUSE TestAccVpcSubnetsDataSource_basic
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetsDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetsDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetsDataSource_basic
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== CONT  TestAccVpcSubnetsDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByVpcId (46.99s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByCidr
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByName (49.18s)
--- PASS: TestAccVpcSubnetsDataSource_ipv6Basic (55.20s)
--- PASS: TestAccVpcSubnetsDataSource_basic (57.10s)
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByCidr (47.79s)
PASS
ok      command-line-arguments  94.827s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetIdsDataSource_basic
=== PAUSE TestAccVpcSubnetIdsDataSource_basic
=== RUN   TestAccVpcSubnetDataSource_ipv4Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv4Basic
=== RUN   TestAccVpcSubnetDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv6Basic
=== RUN   TestAccVpcSubnetsDataSource_basic
=== PAUSE TestAccVpcSubnetsDataSource_basic
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetsDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetsDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetIdsDataSource_basic
=== CONT  TestAccVpcSubnetsDataSource_basic
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== CONT  TestAccVpcSubnetDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetDataSource_ipv4ByName (46.68s)
=== CONT  TestAccVpcSubnetDataSource_ipv6Basic
--- PASS: TestAccVpcSubnetsDataSource_basic (50.27s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByVpcId
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByVpcId (57.70s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByCidr
--- PASS: TestAccVpcSubnetIdsDataSource_basic (63.17s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetDataSource_ipv6Basic (47.92s)
=== CONT  TestAccVpcSubnetsDataSource_ipv6Basic
--- PASS: TestAccVpcSubnetDataSource_ipv4ByVpcId (46.67s)
=== CONT  TestAccVpcSubnetDataSource_ipv4Basic
--- PASS: TestAccVpcSubnetDataSource_ipv4ByCidr (44.75s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByCidr
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByName (46.98s)
--- PASS: TestAccVpcSubnetDataSource_ipv4Basic (47.51s)
--- PASS: TestAccVpcSubnetsDataSource_ipv6Basic (52.00s)
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByCidr (47.72s)
PASS
ok      command-line-arguments  150.220s



# For huaweicloud/services/vpc/data_source_huaweicloud_vpc.go

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== RUN   TestAccVpcDataSource_byCidr
=== PAUSE TestAccVpcDataSource_byCidr
=== RUN   TestAccVpcDataSource_byName
=== PAUSE TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_basic
=== CONT  TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_byCidr
--- PASS: TestAccVpcDataSource_byName (26.16s)
--- PASS: TestAccVpcDataSource_basic (27.14s)
--- PASS: TestAccVpcDataSource_byCidr (29.14s)
PASS
ok      command-line-arguments  29.188s


# For huaweicloud/services/vpc/resource_huaweicloud_vpc.go

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_secondaryCIDR
--- PASS: TestAccVpcV1_WithCustomRegion (27.61s)
--- PASS: TestAccVpcV1_WithEpsId (29.29s)
--- PASS: TestAccVpcV1_secondaryCIDR (37.35s)
--- PASS: TestAccVpcV1_basic (41.48s)
PASS
ok      command-line-arguments  41.524s


# For huaweicloud/services/vpc/resource_huaweicloud_networking_vip_associate.go
$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_associate_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_associate_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2VIPAssociate_basic
=== PAUSE TestAccNetworkingV2VIPAssociate_basic
=== CONT  TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (190.18s)
PASS
ok      command-line-arguments  190.219s


# For huaweicloud/services/vpc/resource_huaweicloud_networking_vip.go
$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_vip_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccNetworkingVip_basic
=== PAUSE TestAccNetworkingVip_basic
=== RUN   TestAccNetworkingVip_ipv6
=== PAUSE TestAccNetworkingVip_ipv6
=== CONT  TestAccNetworkingVip_basic
=== CONT  TestAccNetworkingVip_ipv6
--- PASS: TestAccNetworkingVip_ipv6 (57.41s)
--- PASS: TestAccNetworkingVip_basic (72.00s)
PASS
ok      command-line-arguments  72.041s


$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_address_group_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_address_group_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcAddressGroup_basic
=== PAUSE TestAccVpcAddressGroup_basic
=== RUN   TestAccVpcAddressGroup_ipv6
=== PAUSE TestAccVpcAddressGroup_ipv6
=== CONT  TestAccVpcAddressGroup_basic
=== CONT  TestAccVpcAddressGroup_ipv6
--- PASS: TestAccVpcAddressGroup_basic (15.36s)
--- PASS: TestAccVpcAddressGroup_ipv6 (15.38s)
PASS
ok      command-line-arguments  15.433s


$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnectionAccepter_basic
=== PAUSE TestAccVpcPeeringConnectionAccepter_basic
=== RUN   TestAccVpcPeeringConnection_basic
=== PAUSE TestAccVpcPeeringConnection_basic
=== CONT  TestAccVpcPeeringConnectionAccepter_basic
=== CONT  TestAccVpcPeeringConnection_basic
--- PASS: TestAccVpcPeeringConnectionAccepter_basic (37.46s)
--- PASS: TestAccVpcPeeringConnection_basic (53.42s)
PASS
ok      command-line-arguments  53.461s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_route_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_route_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcRTBRoute_basic
=== PAUSE TestAccVpcRTBRoute_basic
=== RUN   TestAccVpcRTBRoute_vip
=== PAUSE TestAccVpcRTBRoute_vip
=== CONT  TestAccVpcRTBRoute_basic
=== CONT  TestAccVpcRTBRoute_vip
--- PASS: TestAccVpcRTBRoute_basic (46.10s)
--- PASS: TestAccVpcRTBRoute_vip (59.87s)
PASS
ok      command-line-arguments  59.910s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_table_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTable_basic
=== PAUSE TestAccVpcRouteTable_basic
=== RUN   TestAccVpcRouteTable_multiRoutes
=== PAUSE TestAccVpcRouteTable_multiRoutes
=== CONT  TestAccVpcRouteTable_basic
=== CONT  TestAccVpcRouteTable_multiRoutes
--- PASS: TestAccVpcRouteTable_multiRoutes (56.63s)
--- PASS: TestAccVpcRouteTable_basic (87.40s)
PASS
ok      command-line-arguments  87.461s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== CONT  TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_ipv6 (63.00s)
--- PASS: TestAccVpcSubnetV1_basic (63.49s)
PASS
ok      command-line-arguments  63.529s


$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_port_v2_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_port_v2_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (8.05s)
PASS
ok      command-line-arguments  8.094s


$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupsDataSource_basic
=== PAUSE TestAccNetworkingSecGroupsDataSource_basic
=== RUN   TestAccNetworkingSecGroupsDataSource_description
=== PAUSE TestAccNetworkingSecGroupsDataSource_description
=== CONT  TestAccNetworkingSecGroupsDataSource_basic
=== CONT  TestAccNetworkingSecGroupsDataSource_description
--- PASS: TestAccNetworkingSecGroupsDataSource_description (19.17s)
--- PASS: TestAccNetworkingSecGroupsDataSource_basic (19.50s)
PASS
ok      command-line-arguments  19.553s

```
