### PR TITLE
refactor(apig): refactor vpc channel resource

### DIFF
--- a/docs/resources/apig_vpc_channel.md
+++ b/docs/resources/apig_vpc_channel.md
@@ -38,79 +38,88 @@ resource "huaweicloud_apig_vpc_channel" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC channel resource.
-  If omitted, the provider-level region will be used.
-  Changing this will create a new VPC channel resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the VPC channel is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the APIG
-  vpc channel belongs to.
-  Changing this will create a new VPC channel resource.
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the VPC channel
+  belongs.  
+  Changing this will create a new resource.
 
-* `name` - (Required, String) Specifies the name of the VPC channel.
-  The channel name consists of 3 to 64 characters, starting with a letter.
-  Only letters, digits and underscores (_) are allowed.
-  Chinese characters must be in UTF-8 or Unicode format.
+* `name` - (Required, String) Specifies the name of the VPC channel.  
+  The valid length is limited from `3` to `64`, only chinese and english letters, digits, hyphens (-), underscores (_)
+  and dots (.) are allowed.  
+  The name must start with a chinese or english letter, and the Chinese characters must be in **UTF-8** or **Unicode**
+  format.
 
-* `port` - (Optional, Int) Specifies the host port of the VPC channel.
-  The valid value is range from 1 to 65535.
+* `port` - (Required, Int) Specifies the host port of the VPC channel.  
+  The valid value ranges from `1` to `65,535`.
 
-* `member_type` - (Optional, String) Specifies the type of the backend service.
-  The valid types are *ECS* and *EIP*, default to *ECS*.
+* `members` - (Required, List) Specifies the configuration of the backend servers that bind the VPC channel.  
+  The [object](#vpc_channel_members) structure is documented below.
 
-* `algorithm` - (Optional, String) Specifies the type of the backend service.
-  The valid types are *WRR*, *WLC*, *SH* and *URI hashing*, default to *WRR*.
+* `member_type` - (Optional, String) Specifies the member type of the VPC channel.  
+  The valid types are **ECS** and **EIP**, defaults to **ECS**.
+
+* `algorithm` - (Optional, String) Specifies the distribution algorithm.  
+  The valid types are **WRR**, **WLC**, **SH** and **URI hashing**, defaults to **WRR**.
 
 * `protocol` - (Optional, String) Specifies the protocol for performing health checks on backend servers in the VPC
-  channel.
-  The valid values are *TCP*, *HTTP* and *HTTPS*, default to *TCP*.
+  channel.  
+  The valid values are **TCP**, **HTTP** and **HTTPS**, defaults to **TCP**.
 
-* `path` - (Optional, String) Specifies the destination path for health checks.
-  Required if `protocol` is *HTTP* or *HTTPS*.
+* `path` - (Optional, String) Specifies the destination path for health checks.  
+  Required if the `protocol` is **HTTP** or **HTTPS**.
 
 * `healthy_threshold` - (Optional, Int) Specifies the healthy threshold, which refers to the number of consecutive
-  successful checks required for a backend server to be considered healthy.
-  The valid value is range from 2 to 10, default to 2.
+  successful checks required for a backend server to be considered healthy.  
+  The valid value ranges from `2` to `10`, defaults to `2`.
 
 * `unhealthy_threshold` - (Optional, Int) Specifies the unhealthy threshold, which refers to the number of consecutive
-  failed checks required for a backend server to be considered unhealthy.
-  The valid value is range from 2 to 10, default to 5.
+  failed checks required for a backend server to be considered unhealthy.  
+  The valid value ranges from `2` to `10`, defaults to `5`.
 
-* `timeout` - (Optional, Int) Specifies the timeout for determining whether a health check fails, in second.
-  The value must be less than the value of time_interval.
-  The valid value is range from 2 to 30, default to 5.
+* `timeout` - (Optional, Int) Specifies the timeout for determining whether a health check fails, in second.  
+  The value must be less than the value of the time `interval`.
+  The valid value ranges from `2` to `30`, defaults to `5`.
 
-* `interval` - (Optional, Int) Specifies the interval between consecutive checks, in second.
-  The valid value is range from 5 to 300, default to 10.
+* `interval` - (Optional, Int) Specifies the interval between consecutive checks, in second.  
+  The valid value ranges from `5` to `300`, defaults to `10`.
 
-* `members` - (Optional, List) Specifies an array of one or more backend server IDs or IP addresses that bind the VPC
-  channel.
-  The object structure is documented below.
+* `http_code` - (Optional, String) Specifies the response codes for determining a successful HTTP response.  
+  The valid value ranges from `100` to `599` and the valid formats are as follows:
+  + The multiple values, for example, **200,201,202**.
+  + The range, for example, **200-299**.
+  + Both multiple values and ranges, for example, **201,202,210-299**.
 
+  Required if the `protocol` is **HTTP**.
+
+<a name="vpc_channel_members"></a>
 The `members` block supports:
 
 * `id` - (Optional, String) Specifies the ECS ID for each backend servers.
-  Required if `member_type` is *ECS*.
+  Required if the `member_type` is **ECS**.
   This parameter and `ip_address` are alternative.
 
 * `ip_address` - (Optional, String) Specifies the IP address each backend servers.
-  Required if `member_type` is *EIP*.
+  Required if the `member_type` is **EIP**.
 
 * `weight` - (Optional, Int) Specifies the backend server weight.
-  The valid values are range from 1 to 100, default to 1.
+  The valid value ranges from `1` to `100`, defaults to `1`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the VPC channel.
-* `create_time` - Time when the channel created, in UTC format.
-* `status` - The status of VPC channel, supports *Normal* and *Abnormal*.
+* `id` - The ID of the VPC channel.
+
+* `created_at` - The time when the VPC channel was created.
+
+* `status` - The current status of the VPC channel, supports **Normal** and **Abnormal**.
 
 ## Import
 
-VPC Channels can be imported using their `name` and ID of the APIG dedicated instance to which the channel
-belongs, separated by a slash, e.g.
+VPC Channels can be imported using their `name` and the ID of the related dedicated instance, separated by a slash, e.g.
 
-```
-$ terraform import huaweicloud_apig_vpc_channel.test <instance id>/<channel name>
+```shell
+$ terraform import huaweicloud_apig_vpc_channel.test <instance_id>/<name>
 ```

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -172,7 +172,7 @@ resource "huaweicloud_apig_vpc_channel" "test" {
     id = huaweicloud_compute_instance.test.id
   }
 }
-`, testAccApigVpcChannel_base(rName), rName, rName)
+`, testAccVpcChannel_base(rName), rName, rName)
 }
 
 func testAccApigAPI_basic(rName string) string {

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -55,7 +55,7 @@ func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccCustomAuthorizerImportStateFunc(),
 			},
 		},
 	})
@@ -101,7 +101,7 @@ func TestAccApigCustomAuthorizerV2_backend(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccCustomAuthorizerImportStateFunc(),
 			},
 		},
 	})
@@ -146,6 +146,21 @@ func testAccCheckApigCustomAuthorizerExists(name string, env *authorizers.Custom
 		}
 		*env = *found
 		return nil
+	}
+}
+
+func testAccCustomAuthorizerImportStateFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rName := "huaweicloud_apig_custom_authorizer.test"
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", rName, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["name"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["name"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
 	}
 }
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
@@ -64,7 +64,7 @@ func TestAccApigThrottlingPolicyV2_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccThrottlingPolicyImportStateFunc(),
 			},
 		},
 	})
@@ -132,7 +132,7 @@ func TestAccApigThrottlingPolicyV2_spec(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+				ImportStateIdFunc: testAccThrottlingPolicyImportStateFunc(),
 			},
 		},
 	})
@@ -177,6 +177,21 @@ func testAccCheckApigThrottlingPolicyExists(n string, app *throttles.ThrottlingP
 		}
 		*app = *found
 		return nil
+	}
+}
+
+func testAccThrottlingPolicyImportStateFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rName := "huaweicloud_apig_throttling_policy.test"
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", rName, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["name"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["name"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
 	}
 }
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_vpc_channel_test.go
@@ -4,163 +4,143 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccApigVpcChannelV2_basic(t *testing.T) {
-	var (
-		// The dedicated instance name only allow letters, digits and underscores (_).
-		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
-		resourceName = "huaweicloud_apig_vpc_channel.test"
-		channel      channels.VpcChannel
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckApigVpcChannelDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccApigVpcChannel_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApigVpcChannelExists(resourceName, &channel),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "member_type", "ECS"),
-					resource.TestCheckResourceAttr(resourceName, "algorithm", "WRR"),
-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/"),
-					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
-				),
-			},
-			{
-				Config: testAccApigVpcChannel_update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApigVpcChannelExists(resourceName, &channel),
-					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
-					resource.TestCheckResourceAttr(resourceName, "port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "member_type", "ECS"),
-					resource.TestCheckResourceAttr(resourceName, "algorithm", "WLC"),
-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/terraform/"),
-					resource.TestCheckResourceAttr(resourceName, "members.#", "2"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
-			},
-		},
-	})
-}
-
-func TestAccApigVpcChannelV2_withEipMembers(t *testing.T) {
-	var (
-		// The dedicated instance name only allow letters, digits and underscores (_).
-		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
-		resourceName = "huaweicloud_apig_vpc_channel.test"
-		channel      channels.VpcChannel
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckApigVpcChannelDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccApigVpcChannel_withEipMembers(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApigVpcChannelExists(resourceName, &channel),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "member_type", "EIP"),
-					resource.TestCheckResourceAttr(resourceName, "algorithm", "WRR"),
-					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/"),
-					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
-				),
-			},
-			{
-				Config: testAccApigVpcChannel_withEipMembersUpdate(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckApigVpcChannelExists(resourceName, &channel),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "members.#", "2"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
-			},
-		},
-	})
-}
-
-func testAccCheckApigVpcChannelDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
+func getVpcChannelFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_apig_vpc_channel" {
-			continue
-		}
-		_, err := channels.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
-		if err == nil {
-			return fmt.Errorf("APIG v2 Vpc Channel (%s) is still exists", rs.Primary.ID)
-		}
-	}
-	return nil
+	return channels.Get(client, state.Primary.Attributes["instance_id"], state.Primary.ID).Extract()
 }
 
-func testAccCheckApigVpcChannelExists(n string, app *channels.VpcChannel) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("resource %s not found", n)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no vpc channel id")
-		}
+func TestAccVpcChannel_basic(t *testing.T) {
+	var (
+		channel channels.VpcChannel
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud APIG v2 client: %s", err)
-		}
-		found, err := channels.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-		*app = *found
-		return nil
-	}
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName      = "huaweicloud_apig_vpc_channel.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&channel,
+		getVpcChannelFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcChannel_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "port", "80"),
+					resource.TestCheckResourceAttr(rName, "member_type", "ECS"),
+					resource.TestCheckResourceAttr(rName, "algorithm", "WRR"),
+					resource.TestCheckResourceAttr(rName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(rName, "path", "/"),
+					resource.TestCheckResourceAttr(rName, "members.#", "1"),
+				),
+			},
+			{
+				Config: testAccVpcChannel_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "port", "8080"),
+					resource.TestCheckResourceAttr(rName, "member_type", "ECS"),
+					resource.TestCheckResourceAttr(rName, "algorithm", "WLC"),
+					resource.TestCheckResourceAttr(rName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(rName, "path", "/terraform/"),
+					resource.TestCheckResourceAttr(rName, "members.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcChannelImportStateFunc(),
+			},
+		},
+	})
 }
 
-func testAccApigSubResNameImportStateFunc(name string) resource.ImportStateIdFunc {
+func TestAccVpcChannel_withEipMembers(t *testing.T) {
+	var (
+		channel channels.VpcChannel
+
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName = "huaweicloud_apig_vpc_channel.test"
+		name  = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&channel,
+		getVpcChannelFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcChannel_withEipMembers(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "port", "80"),
+					resource.TestCheckResourceAttr(rName, "member_type", "EIP"),
+					resource.TestCheckResourceAttr(rName, "algorithm", "WRR"),
+					resource.TestCheckResourceAttr(rName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(rName, "path", "/"),
+					resource.TestCheckResourceAttr(rName, "members.#", "1"),
+				),
+			},
+			{
+				Config: testAccVpcChannel_withEipMembersUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "members.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcChannelImportStateFunc(),
+			},
+		},
+	})
+}
+
+func testAccVpcChannelImportStateFunc() resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[name]
+		rName := "huaweicloud_apig_vpc_channel.test"
+		rs, ok := s.RootModule().Resources[rName]
 		if !ok {
-			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+			return "", fmt.Errorf("Resource (%s) not found: %s", rName, rs)
 		}
-		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["name"] == "" {
 			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
 				rs.Primary.Attributes["name"])
 		}
@@ -168,9 +148,36 @@ func testAccApigSubResNameImportStateFunc(name string) resource.ImportStateIdFun
 	}
 }
 
-func testAccApigVpcChannel_base(rName string) string {
+func testAccVpcChannel_base(name string) string {
 	return fmt.Sprintf(`
-%s
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[1]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
 
 data "huaweicloud_images_image" "test" {
   name        = "Ubuntu 18.04 server 64bit"
@@ -185,7 +192,7 @@ data "huaweicloud_compute_flavors" "test" {
 }
 
 resource "huaweicloud_compute_instance" "test" {
-  name               = "%s"
+  name               = "%[1]s"
   image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
@@ -196,15 +203,15 @@ resource "huaweicloud_compute_instance" "test" {
     uuid = huaweicloud_vpc_subnet.test.id
   }
 }
-`, testAccApigApplication_base(rName), rName)
+`, name)
 }
 
-func testAccApigVpcChannel_basic(rName string) string {
+func testAccVpcChannel_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_apig_vpc_channel" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   instance_id = huaweicloud_apig_instance.test.id
   port        = 80
   algorithm   = "WRR"
@@ -216,15 +223,15 @@ resource "huaweicloud_apig_vpc_channel" "test" {
     id = huaweicloud_compute_instance.test.id
   }
 }
-`, testAccApigVpcChannel_base(rName), rName)
+`, testAccVpcChannel_base(name), name)
 }
 
-func testAccApigVpcChannel_update(rName string) string {
+func testAccVpcChannel_update(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_compute_instance" "newone" {
-  name               = "%s"
+  name               = "%[2]s"
   image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
@@ -237,7 +244,7 @@ resource "huaweicloud_compute_instance" "newone" {
 }
 
 resource "huaweicloud_apig_vpc_channel" "test" {
-  name        = "%s_update"
+  name        = "%[2]s"
   instance_id = huaweicloud_apig_instance.test.id
   port        = 8080
   algorithm   = "WLC"
@@ -254,34 +261,74 @@ resource "huaweicloud_apig_vpc_channel" "test" {
     weight = 70
   }
 }
-`, testAccApigVpcChannel_base(rName), rName, rName)
+`, testAccVpcChannel_base(name), name)
 }
 
-func testAccApigVpcChannel_eipBase(rName string) string {
+func testAccVpcChannel_eipBase(name string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[1]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
 resource "huaweicloud_vpc_eip" "test" {
   publicip {
     type = "5_bgp"
   }
 
   bandwidth {
-    name        = "%s"
+    name        = "%[1]s"
     size        = 5
     share_type  = "PER"
     charge_mode = "traffic"
   }
 }
-`, rName)
+
+resource "huaweicloud_vpc_eip" "newone" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[1]s_newone"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+`, name)
 }
 
-func testAccApigVpcChannel_withEipMembers(rName string) string {
+func testAccVpcChannel_withEipMembers(rName string) string {
 	return fmt.Sprintf(`
-%s
-
-%s
+%[1]s
 
 resource "huaweicloud_apig_vpc_channel" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   instance_id = huaweicloud_apig_instance.test.id
   port        = 80
   member_type = "EIP"
@@ -294,30 +341,15 @@ resource "huaweicloud_apig_vpc_channel" "test" {
     ip_address = huaweicloud_vpc_eip.test.address
   }
 }
-`, testAccApigApplication_base(rName), testAccApigVpcChannel_eipBase(rName), rName)
+`, testAccVpcChannel_eipBase(rName), rName)
 }
 
-func testAccApigVpcChannel_withEipMembersUpdate(rName string) string {
+func testAccVpcChannel_withEipMembersUpdate(rName string) string {
 	return fmt.Sprintf(`
-%s
-
-%s
-
-resource "huaweicloud_vpc_eip" "newone" {
-  publicip {
-    type = "5_bgp"
-  }
-
-  bandwidth {
-    name        = "%s_newone"
-    size        = 5
-    share_type  = "PER"
-    charge_mode = "traffic"
-  }
-}
+%[1]s
 
 resource "huaweicloud_apig_vpc_channel" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   instance_id = huaweicloud_apig_instance.test.id
   port        = 80
   member_type = "EIP"
@@ -335,5 +367,5 @@ resource "huaweicloud_apig_vpc_channel" "test" {
     weight     = 70
   }
 }
-`, testAccApigApplication_base(rName), testAccApigVpcChannel_eipBase(rName), rName, rName)
+`, testAccVpcChannel_eipBase(rName), rName, rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
refactor vpc channel resource:
- update functions
- adjust structure
- rename variables
- deprecated parameter "create_time" and add a new parameter "created_at"

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor vpc channel resource and acc test
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccVpcChannel_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccVpcChannel_ -timeout 360m -parallel 4
=== RUN   TestAccVpcChannel_basic
=== PAUSE TestAccVpcChannel_basic
=== RUN   TestAccVpcChannel_withEipMembers
=== PAUSE TestAccVpcChannel_withEipMembers
=== CONT  TestAccVpcChannel_basic
=== CONT  TestAccVpcChannel_withEipMembers
--- PASS: TestAccVpcChannel_withEipMembers (507.93s)
--- PASS: TestAccVpcChannel_basic (611.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      611.622s
```
