### PR TITLE
feat: add dms rocketmq consumer group resource

### DIFF
--- a/docs/resources/dms_rocketmq_consumer_group.md
+++ b/docs/resources/dms_rocketmq_consumer_group.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_rocketmq_consumer_group
+
+Manages DMS RocketMQ consumer group resources within HuaweiCloud.
+
+## Example Usage
+
+```HCL
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  instance_id     = var.instance_id
+  name            = "consumer_group_test"
+  enabled         = true
+  broadcast       = true
+  brokers         = ["broker-0","broker-1"]
+  retry_max_times = 3
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the rocketMQ instance.
+
+  Changing this parameter will create a new resource.
+
+* `brokers` - (Required, List, ForceNew) Specifies the list of associated brokers of the consumer group.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the consumer group.
+
+  Changing this parameter will create a new resource.
+
+* `retry_max_times` - (Required, Int) Specifies the maximum number of retry times.
+
+* `enabled` - (Optional, Bool) Specifies the consumer group is enabled or not. Default to true.
+
+* `broadcast` - (Optional, Bool) Specifies whether to broadcast of the consumer group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The rocketmq consumer group can be imported using the rocketMQ instance ID and topic name separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_dms_rocketmq_consumer_group.test 8d3c7938-dc47-4937-a30f-c80de381c5e3/group_1
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -679,7 +679,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_topic":       dms.ResourceDmsKafkaTopic(),
 			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),
 
-			"huaweicloud_dms_rocketmq_instance": dms.ResourceDmsRocketMQInstance(),
+			"huaweicloud_dms_rocketmq_instance":       dms.ResourceDmsRocketMQInstance(),
+			"huaweicloud_dms_rocketmq_consumer_group": dms.ResourceDmsRocketMQConsumerGroup(),
 
 			"huaweicloud_dns_ptrrecord": ResourceDNSPtrRecordV2(),
 			"huaweicloud_dns_recordset": ResourceDNSRecordSetV2(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
@@ -1,0 +1,169 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDmsRocketMQConsumerGroupResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getRocketmqConsumerGroup: query DMS rocketmq consumer group
+	var (
+		getRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
+		getRocketmqConsumerGroupProduct = "dms"
+	)
+	getRocketmqConsumerGroupClient, err := config.NewServiceClient(getRocketmqConsumerGroupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+	}
+
+	// Split instance_id and group from resource id
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+	}
+	instanceID := parts[0]
+	name := parts[1]
+	getRocketmqConsumerGroupPath := getRocketmqConsumerGroupClient.Endpoint + getRocketmqConsumerGroupHttpUrl
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{project_id}", getRocketmqConsumerGroupClient.ProjectID)
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{instance_id}", instanceID)
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{group}", name)
+
+	getRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath, &getRocketmqConsumerGroupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DmsRocketMQConsumerGroup: %s", err)
+	}
+	return utils.FlattenResponse(getRocketmqConsumerGroupResp)
+}
+
+func TestAccDmsRocketMQConsumerGroup_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_rocketmq_consumer_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsRocketMQConsumerGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsRocketMQConsumerGroup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "broadcast", "true"),
+					resource.TestCheckResourceAttr(resourceName, "retry_max_times", "3"),
+				),
+			},
+			{
+				Config: testDmsRocketMQConsumerGroup_basic_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "broadcast", "false"),
+					resource.TestCheckResourceAttr(resourceName, "retry_max_times", "5"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDmsRocketmqConsumerGroup_Base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  description = "Test for DMS RocketMQ"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%[1]s"
+  description = "secgroup for rocketmq"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name                = "%[1]s"
+  engine_version      = "4.8.0"
+  storage_space       = 600
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zones  = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+  flavor_id           = "c6.4u8g.cluster"
+  storage_spec_code   = "dms.physical.storage.high.v2"
+  broker_num          = 1
+}
+`, rName)
+}
+
+func testDmsRocketMQConsumerGroup_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  instance_id    = huaweicloud_dms_rocketmq_instance.test.id
+  broadcast      = true
+  brokers        = [
+    "broker-0"
+  ]
+  name            = "%s"
+  retry_max_times = "3"
+}
+`, testAccDmsRocketmqConsumerGroup_Base(name), name)
+}
+
+func testDmsRocketMQConsumerGroup_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  instance_id    = huaweicloud_dms_rocketmq_instance.test.id
+  broadcast      = false
+  brokers        = [
+    "broker-0"
+  ]
+  name            = "%s"
+  retry_max_times = "5"
+  enabled         = false
+}
+`, testAccDmsRocketmqConsumerGroup_Base(name), name)
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
@@ -1,0 +1,302 @@
+package dms
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/jmespath/go-jmespath"
+)
+
+func ResourceDmsRocketMQConsumerGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsRocketMQConsumerGroupCreate,
+		UpdateContext: resourceDmsRocketMQConsumerGroupUpdate,
+		ReadContext:   resourceDmsRocketMQConsumerGroupRead,
+		DeleteContext: resourceDmsRocketMQConsumerGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the rocketMQ instance.`,
+			},
+			"brokers": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the list of associated brokers of the consumer group.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of the consumer group.`,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z|%-_0-9]*$`),
+						"An instance name starts with a letter and can contain only letters, digits,"+
+							"vertical lines(|), percent sign(%), underscores (_), and hyphens (-)"),
+					validation.StringLenBetween(3, 64),
+				),
+			},
+			"retry_max_times": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				Description:  `Specifies the maximum number of retry times.`,
+				ValidateFunc: validation.IntBetween(1, 16),
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the consumer group is enabled or not. Default to true.`,
+			},
+			"broadcast": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies whether to broadcast of the consumer group.`,
+			},
+		},
+	}
+}
+
+func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	// createRocketmqConsumerGroup: create DMS rocketmq consumer group
+	var (
+		createRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups"
+		createRocketmqConsumerGroupProduct = "dms"
+	)
+	createRocketmqConsumerGroupClient, err := config.NewServiceClient(createRocketmqConsumerGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	createRocketmqConsumerGroupPath := createRocketmqConsumerGroupClient.Endpoint + createRocketmqConsumerGroupHttpUrl
+	createRocketmqConsumerGroupPath = strings.ReplaceAll(createRocketmqConsumerGroupPath, "{project_id}", createRocketmqConsumerGroupClient.ProjectID)
+	createRocketmqConsumerGroupPath = strings.ReplaceAll(createRocketmqConsumerGroupPath, "{instance_id}", instanceID)
+
+	createRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqConsumerGroupBodyParams(d, config))
+	createRocketmqConsumerGroupResp, err := createRocketmqConsumerGroupClient.Request("POST", createRocketmqConsumerGroupPath, &createRocketmqConsumerGroupOpt)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQConsumerGroup: %s", err)
+	}
+
+	createRocketmqConsumerGroupRespBody, err := utils.FlattenResponse(createRocketmqConsumerGroupResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("name", createRocketmqConsumerGroupRespBody)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQConsumerGroup: ID is not found in API response")
+	}
+
+	d.SetId(instanceID + "/" + id.(string))
+
+	return resourceDmsRocketMQConsumerGroupRead(ctx, d, meta)
+}
+
+func buildCreateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+	var enabled interface{} = true
+	if v, ok := d.GetOk("enabled"); ok {
+		enabled = v
+	}
+	bodyParams := map[string]interface{}{
+		"enabled":        enabled,
+		"broadcast":      utils.ValueIngoreEmpty(d.Get("broadcast")),
+		"brokers":        utils.ValueIngoreEmpty(d.Get("brokers")),
+		"name":           utils.ValueIngoreEmpty(d.Get("name")),
+		"retry_max_time": utils.ValueIngoreEmpty(d.Get("retry_max_times")),
+	}
+	return bodyParams
+}
+
+func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	updateRocketmqConsumerGrouphasChanges := []string{
+		"enabled",
+		"broadcast",
+		"retry_max_times",
+	}
+
+	if d.HasChanges(updateRocketmqConsumerGrouphasChanges...) {
+		// updateRocketmqConsumerGroup: update DMS rocketmq consumer group
+		var (
+			updateRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
+			updateRocketmqConsumerGroupProduct = "dms"
+		)
+		updateRocketmqConsumerGroupClient, err := config.NewServiceClient(updateRocketmqConsumerGroupProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+		}
+
+		parts := strings.SplitN(d.Id(), "/", 2)
+		if len(parts) != 2 {
+			return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+		}
+		instanceID := parts[0]
+		name := parts[1]
+		updateRocketmqConsumerGroupPath := updateRocketmqConsumerGroupClient.Endpoint + updateRocketmqConsumerGroupHttpUrl
+		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{project_id}", updateRocketmqConsumerGroupClient.ProjectID)
+		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{instance_id}", instanceID)
+		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{group}", name)
+
+		updateRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				204,
+			},
+		}
+		updateRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildUpdateRocketmqConsumerGroupBodyParams(d, config))
+		_, err = updateRocketmqConsumerGroupClient.Request("PUT", updateRocketmqConsumerGroupPath, &updateRocketmqConsumerGroupOpt)
+		if err != nil {
+			return diag.Errorf("error updating DmsRocketMQConsumerGroup: %s", err)
+		}
+	}
+
+	return resourceDmsRocketMQConsumerGroupRead(ctx, d, meta)
+}
+
+func buildUpdateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"broadcast":      utils.ValueIngoreEmpty(d.Get("broadcast")),
+		"retry_max_time": utils.ValueIngoreEmpty(d.Get("retry_max_times")),
+	}
+	enabled := utils.ValueIngoreEmpty(d.Get("enabled"))
+	if enabled != nil {
+		bodyParams["enabled"] = enabled
+	}
+	return bodyParams
+}
+
+func resourceDmsRocketMQConsumerGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getRocketmqConsumerGroup: query DMS rocketmq consumer group
+	var (
+		getRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
+		getRocketmqConsumerGroupProduct = "dms"
+	)
+	getRocketmqConsumerGroupClient, err := config.NewServiceClient(getRocketmqConsumerGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+	}
+	instanceID := parts[0]
+	name := parts[1]
+	getRocketmqConsumerGroupPath := getRocketmqConsumerGroupClient.Endpoint + getRocketmqConsumerGroupHttpUrl
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{project_id}", getRocketmqConsumerGroupClient.ProjectID)
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{instance_id}", instanceID)
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{group}", name)
+
+	getRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath, &getRocketmqConsumerGroupOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DmsRocketMQConsumerGroup")
+	}
+
+	getRocketmqConsumerGroupRespBody, err := utils.FlattenResponse(getRocketmqConsumerGroupResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+		d.Set("enabled", utils.PathSearch("enabled", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("broadcast", utils.PathSearch("broadcast", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("brokers", utils.PathSearch("brokers", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("name", utils.PathSearch("name", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("retry_max_times", utils.PathSearch("retry_max_time", getRocketmqConsumerGroupRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDmsRocketMQConsumerGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	// deleteRocketmqConsumerGroup: delete DMS rocketmq consumer group
+	var (
+		deleteRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
+		deleteRocketmqConsumerGroupProduct = "dms"
+	)
+	deleteRocketmqConsumerGroupClient, err := config.NewServiceClient(deleteRocketmqConsumerGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+	}
+	instanceID := parts[0]
+	name := parts[1]
+	deleteRocketmqConsumerGroupPath := deleteRocketmqConsumerGroupClient.Endpoint + deleteRocketmqConsumerGroupHttpUrl
+	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{project_id}", deleteRocketmqConsumerGroupClient.ProjectID)
+	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{instance_id}", instanceID)
+	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{group}", name)
+
+	deleteRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	_, err = deleteRocketmqConsumerGroupClient.Request("DELETE", deleteRocketmqConsumerGroupPath, &deleteRocketmqConsumerGroupOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DmsRocketMQConsumerGroup: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dms rocketMQ consumer group resource,  this resouce can be user to manage the consumer group of rocketMQ
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   add dms rocketMQ consumer group resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=
'./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRocketMQConsumerGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQConsumerGroup_basic -timeout 360m -parallel
 4
=== RUN   TestAccDmsRocketMQConsumerGroup_basic
=== PAUSE TestAccDmsRocketMQConsumerGroup_basic
=== CONT  TestAccDmsRocketMQConsumerGroup_basic
--- PASS: TestAccDmsRocketMQConsumerGroup_basic (717.32s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       717.375s
```
