### PR TITLE
feat: add dms rocketmq user resource

### DIFF
--- a/docs/resources/dms_rocketmq_user.md
+++ b/docs/resources/dms_rocketmq_user.md
@@ -8,7 +8,7 @@ Manages DMS RocketMQ user resources within HuaweiCloud.
 
 ## Example Usage
 
-```HCL
+```hcl
 variable "instance_id" {}
 
 resource "huaweicloud_dms_rocketmq_user" "test" {
@@ -19,8 +19,16 @@ resource "huaweicloud_dms_rocketmq_user" "test" {
   admin                = false
   default_topic_perm   = "PUB"
   default_group_perm   = "PUB"
-  topic_perms          = [{name = "topic_name", perm = "PUB"}]
-  group_perms          = [{name = "group_name", perm = "PUB"}]
+  
+  topic_perms {
+    name = "topic_name"
+    perm = "PUB"
+  }
+  
+  group_perms {
+    name = "group_name"
+    perm = "PUB"
+  }
 }
 ```
 
@@ -75,5 +83,5 @@ In addition to all arguments above, the following attributes are exported:
 The rocketmq user can be imported using the rocketMQ instance ID and user access key separated by a slash, e.g.
 
 ```
-$ terraform import huaweicloud_dms_rocketmq_user.test c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/user_serurity_key
+$ terraform import huaweicloud_dms_rocketmq_user.test c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/access_key
 ```

--- a/docs/resources/dms_rocketmq_user.md
+++ b/docs/resources/dms_rocketmq_user.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_rocketmq_user
+
+Manages DMS RocketMQ user resources within HuaweiCloud.
+
+## Example Usage
+
+```HCL
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rocketmq_user" "test" {
+  instance_id          = var.instance_id
+  access_key           = "user_test"
+  secret_key           = "abcdefg"
+  white_remote_address = "10.10.10.10"
+  admin                = false
+  default_topic_perm   = "PUB"
+  default_group_perm   = "PUB"
+  topic_perms          = [{name = "topic_name", perm = "PUB"}]
+  group_perms          = [{name = "group_name", perm = "PUB"}]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the rocketMQ instance.
+  Changing this parameter will create a new resource.
+
+* `access_key` - (Required, String, ForceNew) Specifies the access key of the user.
+  Changing this parameter will create a new resource.
+
+* `secret_key` - (Required, String, ForceNew) Specifies the secret key of the user.
+  Changing this parameter will create a new resource.
+
+* `white_remote_address` - (Optional, String) Specifies the IP address whitelist.
+
+* `admin` - (Optional, Bool) Specifies whether the user is an administrator.
+
+* `default_topic_perm` - (Optional, String) Specifies the default topic permissions.
+  Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.
+
+* `default_group_perm` - (Optional, String) Specifies the default consumer group permissions.
+  Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.
+
+* `topic_perms` - (Optional, List) Specifies the special topic permissions.
+  The [permission](#DmsRocketMQUser_PermsRef) structure is documented below.
+
+* `group_perms` - (Optional, List) Specifies the special consumer group permissions.
+  The [permission](#DmsRocketMQUser_PermsRef) structure is documented below.
+
+<a name="DmsRocketMQUser_PermsRef"></a>
+The `topic_perms` and `group_perms` block supports:
+
+* `name` - (Optional, String) Indicates the name of a topic or consumer group.
+
+* `perm` - (Optional, String) Indicates the permissions of the topic or consumer group.
+  Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The rocketmq user can be imported using the rocketMQ instance ID and user access key separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_dms_rocketmq_user.test c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/user_serurity_key
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -695,6 +695,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_instance":       dms.ResourceDmsRocketMQInstance(),
 			"huaweicloud_dms_rocketmq_consumer_group": dms.ResourceDmsRocketMQConsumerGroup(),
 			"huaweicloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
+			"huaweicloud_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),
 
 			"huaweicloud_dns_ptrrecord": ResourceDNSPtrRecordV2(),
 			"huaweicloud_dns_recordset": ResourceDNSRecordSetV2(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
@@ -28,7 +28,7 @@ func getDmsRocketMQUserResourceFunc(config *config.Config, state *terraform.Reso
 
 	parts := strings.SplitN(state.Primary.ID, "/", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<user>")
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<access_key>")
 	}
 	instanceID := parts[0]
 	user := parts[1]
@@ -68,25 +68,19 @@ func TestAccDmsRocketMQUser_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDmsRocketmqUser_base(name),
-			},
-			{
-				Config: testAccDmsRocketmqUser_update_base(name),
-			},
-			{
 				Config: testDmsRocketMQUser_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "access_key", acceptance.HW_ACCESS_KEY),
-					resource.TestCheckResourceAttr(resourceName, "secret_key", acceptance.HW_SECRET_KEY),
+					resource.TestCheckResourceAttr(resourceName, "access_key", "testRocketmqAK"),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", "testRocketmqSK123"),
 				),
 			},
 			{
 				Config: testDmsRocketMQUser_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "access_key", acceptance.HW_ACCESS_KEY),
-					resource.TestCheckResourceAttr(resourceName, "secret_key", acceptance.HW_SECRET_KEY),
+					resource.TestCheckResourceAttr(resourceName, "access_key", "testRocketmqAK"),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", "testRocketmqSK123"),
 					resource.TestCheckResourceAttr(resourceName, "white_remote_address", "10.10.10.10"),
 					resource.TestCheckResourceAttr(resourceName, "admin", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_topic_perm", "PUB"),
@@ -97,7 +91,7 @@ func TestAccDmsRocketMQUser_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_id", "access_key", "secret_key"},
+				ImportStateVerifyIgnore: []string{"access_key", "secret_key"},
 			},
 		},
 	})
@@ -140,48 +134,7 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   flavor_id         = "c6.4u8g.cluster"
   storage_spec_code = "dms.physical.storage.high.v2"
   broker_num        = 1
-}
-`, rName)
-}
-
-func testAccDmsRocketmqUser_update_base(rName string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_vpc" "test" {
-  name        = "%[1]s"
-  cidr        = "192.168.0.0/24"
-  description = "Test for DMS RocketMQ"
-}
-
-resource "huaweicloud_vpc_subnet" "test" {
-  name       = "%[1]s"
-  cidr       = "192.168.0.0/24"
-  gateway_ip = "192.168.0.1"
-  vpc_id     = huaweicloud_vpc.test.id
-}
-
-resource "huaweicloud_networking_secgroup" "test" {
-  name        = "%[1]s"
-  description = "secgroup for rocketmq"
-}
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_dms_rocketmq_instance" "test" {
-  name              = "%[1]s"
-  engine_version    = "4.8.0"
-  storage_space     = 600
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-
-  availability_zones = [
-    data.huaweicloud_availability_zones.test.names[0]
-  ]
-
-  flavor_id         = "c6.4u8g.cluster"
-  storage_spec_code = "dms.physical.storage.high.v2"
-  broker_num        = 1
-  retention_policy  = true
+  enable_acl        = true
 }
 `, rName)
 }
@@ -192,10 +145,10 @@ func testDmsRocketMQUser_basic(name string) string {
 
 resource "huaweicloud_dms_rocketmq_user" "test" {
   instance_id = huaweicloud_dms_rocketmq_instance.test.id
-  access_key  = "%s"
-  secret_key  = "%s"
+  access_key  = "testRocketmqAK"
+  secret_key  = "testRocketmqSK123"
 }
-`, testAccDmsRocketmqUser_update_base(name), acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+`, testAccDmsRocketmqUser_base(name))
 }
 
 func testDmsRocketMQUser_basic_update(name string) string {
@@ -204,12 +157,12 @@ func testDmsRocketMQUser_basic_update(name string) string {
 
 resource "huaweicloud_dms_rocketmq_user" "test" {
   instance_id          = huaweicloud_dms_rocketmq_instance.test.id
-  access_key           = "%s"
-  secret_key           = "%s"
+  access_key           = "testRocketmqAK"
+  secret_key           = "testRocketmqSK123"
   white_remote_address = "10.10.10.10"
   admin                = "false"
   default_topic_perm   = "PUB"
   default_group_perm   = "SUB"
 }
-`, testAccDmsRocketmqUser_update_base(name), acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+`, testAccDmsRocketmqUser_base(name))
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
@@ -1,0 +1,215 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDmsRocketMQUserResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getRocketmqUser: query DMS rocketmq user
+	var (
+		getRocketmqUserHttpUrl = "v2/{project_id}/instances/{instance_id}/users/{user_name}"
+		getRocketmqUserProduct = "dms"
+	)
+	getRocketmqUserClient, err := config.NewServiceClient(getRocketmqUserProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DmsRocketMQUser Client: %s", err)
+	}
+
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<topic>")
+	}
+	instanceID := parts[0]
+	user := parts[1]
+	getRocketmqUserPath := getRocketmqUserClient.Endpoint + getRocketmqUserHttpUrl
+	getRocketmqUserPath = strings.ReplaceAll(getRocketmqUserPath, "{project_id}", getRocketmqUserClient.ProjectID)
+	getRocketmqUserPath = strings.ReplaceAll(getRocketmqUserPath, "{instance_id}", instanceID)
+	getRocketmqUserPath = strings.ReplaceAll(getRocketmqUserPath, "{user_name}", user)
+
+	getRocketmqUserOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getRocketmqUserResp, err := getRocketmqUserClient.Request("GET", getRocketmqUserPath, &getRocketmqUserOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DmsRocketMQUser: %s", err)
+	}
+	return utils.FlattenResponse(getRocketmqUserResp)
+}
+
+func TestAccDmsRocketMQUser_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_dms_rocketmq_user.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsRocketMQUserResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsRocketmqUser_base(name),
+			},
+			{
+				Config: testAccDmsRocketmqUser_update_base(name),
+			},
+			{
+				Config: testDmsRocketMQUser_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "access_key", acceptance.HW_ACCESS_KEY),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", acceptance.HW_SECRET_KEY),
+				),
+			},
+			{
+				Config: testDmsRocketMQUser_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "access_key", acceptance.HW_ACCESS_KEY),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", acceptance.HW_SECRET_KEY),
+					resource.TestCheckResourceAttr(resourceName, "white_remote_address", "10.10.10.10"),
+					resource.TestCheckResourceAttr(resourceName, "admin", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_topic_perm", "PUB"),
+					resource.TestCheckResourceAttr(resourceName, "default_group_perm", "SUB"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_id", "access_key", "secret_key"},
+			},
+		},
+	})
+}
+
+func testAccDmsRocketmqUser_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  description = "Test for DMS RocketMQ"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%[1]s"
+  description = "secgroup for rocketmq"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+}
+`, rName)
+}
+
+func testAccDmsRocketmqUser_update_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  description = "Test for DMS RocketMQ"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%[1]s"
+  description = "secgroup for rocketmq"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+  retention_policy  = true
+}
+`, rName)
+}
+
+func testDmsRocketMQUser_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_user" "test" {
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  access_key  = "%s"
+  secret_key  = "%s"
+}
+`, testAccDmsRocketmqUser_update_base(name), acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}
+
+func testDmsRocketMQUser_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_user" "test" {
+  instance_id          = huaweicloud_dms_rocketmq_instance.test.id
+  access_key           = "%s"
+  secret_key           = "%s"
+  white_remote_address = "10.10.10.10"
+  admin                = "false"
+  default_topic_perm   = "PUB"
+  default_group_perm   = "SUB"
+}
+`, testAccDmsRocketmqUser_update_base(name), acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
@@ -28,7 +28,7 @@ func getDmsRocketMQUserResourceFunc(config *config.Config, state *terraform.Reso
 
 	parts := strings.SplitN(state.Primary.ID, "/", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<topic>")
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<user>")
 	}
 	instanceID := parts[0]
 	user := parts[1]

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
@@ -1,0 +1,369 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/jmespath/go-jmespath"
+)
+
+func ResourceDmsRocketMQUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsRocketMQUserCreate,
+		UpdateContext: resourceDmsRocketMQUserUpdate,
+		ReadContext:   resourceDmsRocketMQUserRead,
+		DeleteContext: resourceDmsRocketMQUserDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the rocketMQ instance.`,
+			},
+			"access_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the access key of the user.`,
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the secret key of the user.`,
+			},
+			"white_remote_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the IP address whitelist.`,
+			},
+			"admin": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies whether the user is an administrator.`,
+			},
+			"default_topic_perm": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the default topic permissions. Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
+			},
+			"default_group_perm": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the default consumer group permissions. Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
+			},
+			"topic_perms": {
+				Type:        schema.TypeList,
+				Elem:        DmsRocketMQUserPermsRefSchema(),
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the special topic permissions.`,
+			},
+			"group_perms": {
+				Type:        schema.TypeList,
+				Elem:        DmsRocketMQUserPermsRefSchema(),
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the special consumer group permissions.`,
+			},
+		},
+	}
+}
+
+func DmsRocketMQUserPermsRefSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Indicates the name of a topic or consumer group.`,
+			},
+			"perm": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: `Indicates the permissions of the topic or consumer group.
+Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDmsRocketMQUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	// createRocketmqUser: create DMS rocketmq user
+	var (
+		createRocketmqUserHttpUrl = "v2/{project_id}/instances/{instance_id}/users"
+		createRocketmqUserProduct = "dms"
+	)
+	createRocketmqUserClient, err := config.NewServiceClient(createRocketmqUserProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQUser Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	createRocketmqUserPath := createRocketmqUserClient.Endpoint + createRocketmqUserHttpUrl
+	createRocketmqUserPath = strings.ReplaceAll(createRocketmqUserPath, "{project_id}", createRocketmqUserClient.ProjectID)
+	createRocketmqUserPath = strings.ReplaceAll(createRocketmqUserPath, "{instance_id}", fmt.Sprintf("%v", d.Get("instance_id")))
+
+	createRocketmqUserOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createRocketmqUserOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqUserBodyParams(d, config))
+	createRocketmqUserResp, err := createRocketmqUserClient.Request("POST", createRocketmqUserPath, &createRocketmqUserOpt)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQUser: %s", err)
+	}
+
+	createRocketmqUserRespBody, err := utils.FlattenResponse(createRocketmqUserResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("access_key", createRocketmqUserRespBody)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQUser: ID is not found in API response")
+	}
+	d.SetId(instanceID + "/" + id.(string))
+
+	return resourceDmsRocketMQUserRead(ctx, d, meta)
+}
+
+func buildCreateRocketmqUserBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"access_key":           utils.ValueIngoreEmpty(d.Get("access_key")),
+		"secret_key":           utils.ValueIngoreEmpty(d.Get("secret_key")),
+		"white_remote_address": utils.ValueIngoreEmpty(d.Get("white_remote_address")),
+		"admin":                utils.ValueIngoreEmpty(d.Get("admin")),
+		"default_topic_perm":   utils.ValueIngoreEmpty(d.Get("default_topic_perm")),
+		"default_group_perm":   utils.ValueIngoreEmpty(d.Get("default_group_perm")),
+		"topic_perms":          buildRocketmqUserPermsChildBody(d, "topic_perms"),
+		"group_perms":          buildRocketmqUserPermsChildBody(d, "group_perms"),
+	}
+	return bodyParams
+}
+
+func resourceDmsRocketMQUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	updateRocketmqUserhasChanges := []string{
+		"white_remote_address",
+		"admin",
+		"default_topic_perm",
+		"default_group_perm",
+		"topic_perms",
+		"group_perms",
+	}
+
+	if d.HasChanges(updateRocketmqUserhasChanges...) {
+		// updateRocketmqUser: update DMS rocketmq user
+		var (
+			updateRocketmqUserHttpUrl = "v2/{project_id}/instances/{instance_id}/users/{user_name}"
+			updateRocketmqUserProduct = "dms"
+		)
+		updateRocketmqUserClient, err := config.NewServiceClient(updateRocketmqUserProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating DmsRocketMQUser Client: %s", err)
+		}
+
+		parts := strings.SplitN(d.Id(), "/", 2)
+		if len(parts) != 2 {
+			return diag.Errorf("invalid id format, must be <instance_id>/<topic>")
+		}
+		instanceID := parts[0]
+		user := parts[1]
+		updateRocketmqUserPath := updateRocketmqUserClient.Endpoint + updateRocketmqUserHttpUrl
+		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{project_id}", updateRocketmqUserClient.ProjectID)
+		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{instance_id}", instanceID)
+		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{user_name}", user)
+
+		updateRocketmqUserOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateRocketmqUserOpt.JSONBody = utils.RemoveNil(buildUpdateRocketmqUserBodyParams(d, config))
+		_, err = updateRocketmqUserClient.Request("PUT", updateRocketmqUserPath, &updateRocketmqUserOpt)
+		if err != nil {
+			return diag.Errorf("error updating DmsRocketMQUser: %s", err)
+		}
+	}
+	return resourceDmsRocketMQUserRead(ctx, d, meta)
+}
+
+func buildUpdateRocketmqUserBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"access_key":           fmt.Sprintf("%v", d.Get("access_key")),
+		"secret_key":           fmt.Sprintf("%v", d.Get("secret_key")),
+		"white_remote_address": utils.ValueIngoreEmpty(d.Get("white_remote_address")),
+		"admin":                utils.ValueIngoreEmpty(d.Get("admin")),
+		"default_topic_perm":   utils.ValueIngoreEmpty(d.Get("default_topic_perm")),
+		"default_group_perm":   utils.ValueIngoreEmpty(d.Get("default_group_perm")),
+		"topic_perms":          buildRocketmqUserPermsChildBody(d, "topic_perms"),
+		"group_perms":          buildRocketmqUserPermsChildBody(d, "group_perms"),
+	}
+	return bodyParams
+}
+
+func buildRocketmqUserPermsChildBody(d *schema.ResourceData, key string) []map[string]interface{} {
+	rawParams := d.Get(key).([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+	params := make([]map[string]interface{}, 0)
+	for _, param := range rawParams {
+		perm := make(map[string]interface{})
+		perm["name"] = utils.PathSearch("name", param, nil)
+		perm["perm"] = utils.PathSearch("perm", param, nil)
+		params = append(params, perm)
+	}
+	return params
+}
+
+func resourceDmsRocketMQUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getRocketmqUser: query DMS rocketmq user
+	var (
+		getRocketmqUserHttpUrl = "v2/{project_id}/instances/{instance_id}/users/{user_name}"
+		getRocketmqUserProduct = "dms"
+	)
+	getRocketmqUserClient, err := config.NewServiceClient(getRocketmqUserProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQUser Client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<topic>")
+	}
+	instanceID := parts[0]
+	user := parts[1]
+	getRocketmqUserPath := getRocketmqUserClient.Endpoint + getRocketmqUserHttpUrl
+	getRocketmqUserPath = strings.ReplaceAll(getRocketmqUserPath, "{project_id}", getRocketmqUserClient.ProjectID)
+	getRocketmqUserPath = strings.ReplaceAll(getRocketmqUserPath, "{instance_id}", instanceID)
+	getRocketmqUserPath = strings.ReplaceAll(getRocketmqUserPath, "{user_name}", user)
+
+	getRocketmqUserOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getRocketmqUserResp, err := getRocketmqUserClient.Request("GET", getRocketmqUserPath, &getRocketmqUserOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DmsRocketMQUser")
+	}
+
+	getRocketmqUserRespBody, err := utils.FlattenResponse(getRocketmqUserResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+		d.Set("access_key", utils.PathSearch("access_key", getRocketmqUserRespBody, nil)),
+		d.Set("secret_key", utils.PathSearch("secret_key", getRocketmqUserRespBody, nil)),
+		d.Set("white_remote_address", utils.PathSearch("white_remote_address", getRocketmqUserRespBody, nil)),
+		d.Set("admin", utils.PathSearch("admin", getRocketmqUserRespBody, nil)),
+		d.Set("default_topic_perm", utils.PathSearch("default_topic_perm", getRocketmqUserRespBody, nil)),
+		d.Set("default_group_perm", utils.PathSearch("default_group_perm", getRocketmqUserRespBody, nil)),
+		d.Set("topic_perms", flattenGetRocketmqUserResponseBodyPermsRef(getRocketmqUserRespBody, "topic_perms")),
+		d.Set("group_perms", flattenGetRocketmqUserResponseBodyPermsRef(getRocketmqUserRespBody, "group_perms")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetRocketmqUserResponseBodyPermsRef(resp interface{}, expression string) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch(expression, resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"name": utils.PathSearch("name", v, nil),
+			"perm": utils.PathSearch("perm", v, nil),
+		})
+	}
+	return rst
+}
+
+func resourceDmsRocketMQUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	// deleteRocketmqUser: delete DMS rocketmq user
+	var (
+		deleteRocketmqUserHttpUrl = "v2/{project_id}/instances/{instance_id}/users/{user_name}"
+		deleteRocketmqUserProduct = "dms"
+	)
+	deleteRocketmqUserClient, err := config.NewServiceClient(deleteRocketmqUserProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQUser Client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<user>")
+	}
+	instanceID := parts[0]
+	user := parts[1]
+	deleteRocketmqUserPath := deleteRocketmqUserClient.Endpoint + deleteRocketmqUserHttpUrl
+	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{project_id}", deleteRocketmqUserClient.ProjectID)
+	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{instance_id}", instanceID)
+	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{user_name}", user)
+
+	deleteRocketmqUserOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	_, err = deleteRocketmqUserClient.Request("DELETE", deleteRocketmqUserPath, &deleteRocketmqUserOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DmsRocketMQUser: %s", err)
+	}
+
+	return nil
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
@@ -3,11 +3,13 @@ package dms
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -44,12 +46,18 @@ func ResourceDmsRocketMQUser() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `Specifies the access key of the user.`,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z]*$`),
+						"Only support letters"),
+					validation.StringLenBetween(7, 64),
+				),
 			},
 			"secret_key": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `Specifies the secret key of the user.`,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  `Specifies the secret key of the user.`,
+				ValidateFunc: validation.StringLenBetween(8, 32),
 			},
 			"white_remote_address": {
 				Type:        schema.TypeString,
@@ -204,7 +212,7 @@ func resourceDmsRocketMQUserUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		parts := strings.SplitN(d.Id(), "/", 2)
 		if len(parts) != 2 {
-			return diag.Errorf("invalid id format, must be <instance_id>/<user>")
+			return diag.Errorf("invalid id format, must be <instance_id>/<access_key>")
 		}
 		instanceID := parts[0]
 		user := parts[1]
@@ -276,7 +284,7 @@ func resourceDmsRocketMQUserRead(ctx context.Context, d *schema.ResourceData, me
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<user>")
+		return diag.Errorf("invalid id format, must be <instance_id>/<access_key>")
 	}
 	instanceID := parts[0]
 	user := parts[1]
@@ -356,7 +364,7 @@ func resourceDmsRocketMQUserDelete(ctx context.Context, d *schema.ResourceData, 
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<user>")
+		return diag.Errorf("invalid id format, must be <instance_id>/<access_key>")
 	}
 	instanceID := parts[0]
 	user := parts[1]

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
@@ -64,16 +64,18 @@ func ResourceDmsRocketMQUser() *schema.Resource {
 				Description: `Specifies whether the user is an administrator.`,
 			},
 			"default_topic_perm": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `Specifies the default topic permissions. Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the default topic permissions.
+Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
 			},
 			"default_group_perm": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `Specifies the default consumer group permissions. Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the default consumer group permissions.
+Value options: **PUB|SUB**, **PUB**, **SUB**, **DENY**.`,
 			},
 			"topic_perms": {
 				Type:        schema.TypeList,
@@ -130,8 +132,10 @@ func resourceDmsRocketMQUserCreate(ctx context.Context, d *schema.ResourceData, 
 
 	instanceID := d.Get("instance_id").(string)
 	createRocketmqUserPath := createRocketmqUserClient.Endpoint + createRocketmqUserHttpUrl
-	createRocketmqUserPath = strings.ReplaceAll(createRocketmqUserPath, "{project_id}", createRocketmqUserClient.ProjectID)
-	createRocketmqUserPath = strings.ReplaceAll(createRocketmqUserPath, "{instance_id}", fmt.Sprintf("%v", d.Get("instance_id")))
+	createRocketmqUserPath = strings.ReplaceAll(createRocketmqUserPath, "{project_id}",
+		createRocketmqUserClient.ProjectID)
+	createRocketmqUserPath = strings.ReplaceAll(createRocketmqUserPath, "{instance_id}",
+		fmt.Sprintf("%v", d.Get("instance_id")))
 
 	createRocketmqUserOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -140,7 +144,8 @@ func resourceDmsRocketMQUserCreate(ctx context.Context, d *schema.ResourceData, 
 		},
 	}
 	createRocketmqUserOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqUserBodyParams(d, config))
-	createRocketmqUserResp, err := createRocketmqUserClient.Request("POST", createRocketmqUserPath, &createRocketmqUserOpt)
+	createRocketmqUserResp, err := createRocketmqUserClient.Request("POST", createRocketmqUserPath,
+		&createRocketmqUserOpt)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQUser: %s", err)
 	}
@@ -199,12 +204,13 @@ func resourceDmsRocketMQUserUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		parts := strings.SplitN(d.Id(), "/", 2)
 		if len(parts) != 2 {
-			return diag.Errorf("invalid id format, must be <instance_id>/<topic>")
+			return diag.Errorf("invalid id format, must be <instance_id>/<user>")
 		}
 		instanceID := parts[0]
 		user := parts[1]
 		updateRocketmqUserPath := updateRocketmqUserClient.Endpoint + updateRocketmqUserHttpUrl
-		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{project_id}", updateRocketmqUserClient.ProjectID)
+		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{project_id}",
+			updateRocketmqUserClient.ProjectID)
 		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{instance_id}", instanceID)
 		updateRocketmqUserPath = strings.ReplaceAll(updateRocketmqUserPath, "{user_name}", user)
 
@@ -270,7 +276,7 @@ func resourceDmsRocketMQUserRead(ctx context.Context, d *schema.ResourceData, me
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<topic>")
+		return diag.Errorf("invalid id format, must be <instance_id>/<user>")
 	}
 	instanceID := parts[0]
 	user := parts[1]
@@ -302,12 +308,17 @@ func resourceDmsRocketMQUserRead(ctx context.Context, d *schema.ResourceData, me
 		d.Set("instance_id", instanceID),
 		d.Set("access_key", utils.PathSearch("access_key", getRocketmqUserRespBody, nil)),
 		d.Set("secret_key", utils.PathSearch("secret_key", getRocketmqUserRespBody, nil)),
-		d.Set("white_remote_address", utils.PathSearch("white_remote_address", getRocketmqUserRespBody, nil)),
+		d.Set("white_remote_address", utils.PathSearch("white_remote_address",
+			getRocketmqUserRespBody, nil)),
 		d.Set("admin", utils.PathSearch("admin", getRocketmqUserRespBody, nil)),
-		d.Set("default_topic_perm", utils.PathSearch("default_topic_perm", getRocketmqUserRespBody, nil)),
-		d.Set("default_group_perm", utils.PathSearch("default_group_perm", getRocketmqUserRespBody, nil)),
-		d.Set("topic_perms", flattenGetRocketmqUserResponseBodyPermsRef(getRocketmqUserRespBody, "topic_perms")),
-		d.Set("group_perms", flattenGetRocketmqUserResponseBodyPermsRef(getRocketmqUserRespBody, "group_perms")),
+		d.Set("default_topic_perm", utils.PathSearch("default_topic_perm",
+			getRocketmqUserRespBody, nil)),
+		d.Set("default_group_perm", utils.PathSearch("default_group_perm",
+			getRocketmqUserRespBody, nil)),
+		d.Set("topic_perms", flattenGetRocketmqUserResponseBodyPermsRef(getRocketmqUserRespBody,
+			"topic_perms")),
+		d.Set("group_perms", flattenGetRocketmqUserResponseBodyPermsRef(getRocketmqUserRespBody,
+			"group_perms")),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -350,7 +361,8 @@ func resourceDmsRocketMQUserDelete(ctx context.Context, d *schema.ResourceData, 
 	instanceID := parts[0]
 	user := parts[1]
 	deleteRocketmqUserPath := deleteRocketmqUserClient.Endpoint + deleteRocketmqUserHttpUrl
-	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{project_id}", deleteRocketmqUserClient.ProjectID)
+	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{project_id}",
+		deleteRocketmqUserClient.ProjectID)
 	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{instance_id}", instanceID)
 	deleteRocketmqUserPath = strings.ReplaceAll(deleteRocketmqUserPath, "{user_name}", user)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dms rocketMQ user resource, this resouce can be user to manage the user of rocketMQ
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dms rocketMQ user resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRocketMQUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQUser_basic -timeout 360m -parallel 4       
=== RUN   TestAccDmsRocketMQUser_basic
=== PAUSE TestAccDmsRocketMQUser_basic
=== CONT  TestAccDmsRocketMQUser_basic
--- PASS: TestAccDmsRocketMQUser_basic (17.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       17.317s
```
