### PR TITLE
refactor(VPC): Fix some test case and add some validation for paramters.

### DIFF
--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test.go
@@ -35,7 +35,6 @@ func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "default", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "0"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test.go
@@ -149,14 +149,12 @@ func TestAccVpcsDataSource_byAll(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceVpcs_byAll(randName, randCidr, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccDataSourceVpcs_byAll(randName, randCidr),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
 					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.cidr", randCidr),
 					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.name", randName),
-					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(dataSourceName, "vpcs.0.status", "OK"),
 					acceptance.TestCheckResourceAttrWithVariable(dataSourceName, "vpcs.0.id",
 						"${huaweicloud_vpc.test.id}"),
@@ -166,7 +164,7 @@ func TestAccVpcsDataSource_byAll(t *testing.T) {
 	})
 }
 
-func testAccDataSourceVpcs_byAll(rName, cidr, enterpriseProjectID string) string {
+func testAccDataSourceVpcs_byAll(rName, cidr string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -174,14 +172,13 @@ data "huaweicloud_vpcs" "test" {
   id                    = huaweicloud_vpc.test.id
   name                  = huaweicloud_vpc.test.name
   cidr                  = huaweicloud_vpc.test.cidr
-  enterprise_project_id = "%s"
   status                = "OK"
 
   depends_on = [
     huaweicloud_vpc.test
   ]
 }
-`, testAccDataSourceVpcs_base(rName, cidr), enterpriseProjectID)
+`, testAccDataSourceVpcs_base(rName, cidr))
 }
 
 func TestAccVpcsDataSource_tags(t *testing.T) {

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -61,6 +61,7 @@ func TestAccVpcV1_secondaryCIDR(t *testing.T) {
 	var vpc vpcs.Vpc
 
 	rName := acceptance.RandomAccResourceName()
+	rNameUpdate := rName + "_updated"
 	resourceName := "huaweicloud_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -75,6 +76,17 @@ func TestAccVpcV1_secondaryCIDR(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "secondary_cidr", "168.10.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
+					resource.TestCheckResourceAttr(resourceName, "status", "OK"),
+				),
+			},
+			{
+				Config: testAccVpcV1_secondaryCIDR_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcV1Exists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_cidr", "168.20.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
 					resource.TestCheckResourceAttr(resourceName, "status", "OK"),
 				),
@@ -269,6 +281,22 @@ resource "huaweicloud_vpc" "test" {
   name           = "%s"
   cidr           = "192.168.0.0/16"
   secondary_cidr = "168.10.0.0/16"
+  description    = "created by acc test"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}
+
+func testAccVpcV1_secondaryCIDR_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name           = "%s"
+  cidr           = "192.168.0.0/16"
+  secondary_cidr = "168.20.0.0/16"
   description    = "created by acc test"
 
   tags = {

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpcs.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"log"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
@@ -11,8 +12,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceVpcs() *schema.Resource {
@@ -97,12 +96,12 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 	region := config.GetRegion(d)
 	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("error creating VPC client: %s", err)
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
 	vpcV2Client, err := config.NetworkingV2Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("error creating VPC V2 client: %s", err)
+		return diag.Errorf("error creating VPC V2 client: %s", err)
 	}
 
 	listOpts := vpcs.ListOpts{
@@ -115,10 +114,10 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 
 	vpcList, err := vpcs.List(client, listOpts)
 	if err != nil {
-		return fmtp.DiagErrorf("unable to retrieve vpcs: %s", err)
+		return diag.Errorf("unable to retrieve vpcs: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Retrieved Vpc using given filter: %+v", vpcList)
+	log.Printf("[DEBUG] Retrieved Vpc using given filter: %+v", vpcList)
 
 	var vpcs []map[string]interface{}
 	tagFilter := d.Get("tags").(map[string]interface{})
@@ -143,20 +142,20 @@ func dataSourceVpcsRead(_ context.Context, d *schema.ResourceData, meta interfac
 		} else {
 			// The tags api does not support eps authorization, so don't return 403 to avoid error
 			if _, ok := err.(golangsdk.ErrDefault403); ok {
-				logp.Printf("[WARN] Error query tags of VPC (%s): %s", vpcResource.ID, err)
+				log.Printf("[WARN] Error query tags of VPC (%s): %s", vpcResource.ID, err)
 			} else {
-				return fmtp.DiagErrorf("error query tags of VPC (%s): %s", vpcResource.ID, err)
+				return diag.Errorf("error query tags of VPC (%s): %s", vpcResource.ID, err)
 			}
 		}
 
 		vpcs = append(vpcs, vpc)
 		ids = append(ids, vpcResource.ID)
 	}
-	logp.Printf("[DEBUG]Vpc List after filter, count=%d :%+v", len(vpcs), vpcs)
+	log.Printf("[DEBUG] Vpc List after filter, count=%d :%+v", len(vpcs), vpcs)
 
 	mErr := d.Set("vpcs", vpcs)
 	if mErr != nil {
-		return fmtp.DiagErrorf("set vpcs err:%s", mErr)
+		return diag.Errorf("set vpcs err:%s", mErr)
 	}
 
 	d.SetId(hashcode.Strings(ids))

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	client "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3"
 	v3vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -43,9 +45,13 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: utils.ValidateString64WithChinese,
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa50-9a-zA-Z-_\\.]*$"),
+						"only letters, digits, underscores (_), hyphens (-), and dot (.) are allowed"),
+				),
 			},
 			"cidr": {
 				Type:         schema.TypeString,
@@ -55,6 +61,11 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"The angle brackets (< and >) are not allowed."),
+				),
 			},
 			"secondary_cidr": {
 				Type:         schema.TypeString,

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -3,6 +3,7 @@ package vpc
 import (
 	"context"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -40,6 +41,11 @@ func ResourceVpcAddressGroup() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa50-9a-zA-Z-_\\.]*$"),
+						"only letters, digits, underscores (_), hyphens (-), and dot (.) are allowed"),
+				),
 			},
 			"addresses": {
 				// the addresses will be sorted by cloud
@@ -58,6 +64,11 @@ func ResourceVpcAddressGroup() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"The angle brackets (< and >) are not allowed."),
+				),
 			},
 		},
 	}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -121,7 +121,7 @@ func resourceVPCPeeringV2Read(_ context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating   Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating  Vpc Peering Connection Client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringClient, d.Id()).Extract()
@@ -148,7 +148,7 @@ func resourceVPCPeeringV2Update(ctx context.Context, d *schema.ResourceData, met
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
 	}
 
 	var updateOpts peerings.UpdateOpts
@@ -168,7 +168,7 @@ func resourceVPCPeeringV2Delete(ctx context.Context, d *schema.ResourceData, met
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -121,7 +121,7 @@ func resourceVPCPeeringV2Read(_ context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating  Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringClient, d.Id()).Extract()

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -47,10 +49,20 @@ func ResourceVPCRouteTable() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa50-9a-zA-Z-_\\.]*$"),
+						"only letters, digits, underscores (_), hyphens (-), and dot (.) are allowed"),
+				),
 			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"The angle brackets (< and >) are not allowed."),
+				),
 			},
 			"subnets": {
 				Type:     schema.TypeSet,

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table_route.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_route_table_route.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -65,6 +67,11 @@ func ResourceVPCRouteTableRoute() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"The angle brackets (< and >) are not allowed."),
+				),
 			},
 			"route_table_id": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -77,9 +79,13 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				ForceNew: true,
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: utils.ValidateString64WithChinese,
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 64),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa50-9a-zA-Z-_\\.]*$"),
+						"only letters, digits, underscores (_), hyphens (-), and dot (.) are allowed"),
+				),
 			},
 			"cidr": {
 				Type:         schema.TypeString,
@@ -101,6 +107,11 @@ func ResourceVpcSubnetV1() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"The angle brackets (< and >) are not allowed."),
+				),
 			},
 			"ipv6_enable": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix some tests.
Do some refactor for vpc.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpcs_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== RUN   TestAccVpcsDataSource_byCidr
=== PAUSE TestAccVpcsDataSource_byCidr
=== RUN   TestAccVpcsDataSource_byName
=== PAUSE TestAccVpcsDataSource_byName
=== RUN   TestAccVpcsDataSource_byAll
=== PAUSE TestAccVpcsDataSource_byAll
=== RUN   TestAccVpcsDataSource_tags
=== PAUSE TestAccVpcsDataSource_tags
=== CONT  TestAccVpcsDataSource_basic
=== CONT  TestAccVpcsDataSource_byAll
=== CONT  TestAccVpcsDataSource_byName
=== CONT  TestAccVpcsDataSource_byCidr
--- PASS: TestAccVpcsDataSource_basic (27.83s)
=== CONT  TestAccVpcsDataSource_tags
--- PASS: TestAccVpcsDataSource_byCidr (28.70s)
--- PASS: TestAccVpcsDataSource_byAll (29.29s)
--- PASS: TestAccVpcsDataSource_byName (30.43s)
--- PASS: TestAccVpcsDataSource_tags (54.02s)
PASS
ok      command-line-arguments  81.901s


$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== RUN   TestAccVpcDataSource_byCidr
=== PAUSE TestAccVpcDataSource_byCidr
=== RUN   TestAccVpcDataSource_byName
=== PAUSE TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_basic
=== CONT  TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_byCidr
--- PASS: TestAccVpcDataSource_byName (26.45s)
--- PASS: TestAccVpcDataSource_basic (27.92s)
--- PASS: TestAccVpcDataSource_byCidr (29.21s)
PASS
ok      command-line-arguments  29.251s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_subnet_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetDataSource_ipv4Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv4Basic
=== RUN   TestAccVpcSubnetDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetDataSource_ipv4Basic
=== CONT  TestAccVpcSubnetDataSource_ipv4ByVpcId
=== CONT  TestAccVpcSubnetDataSource_ipv6Basic
=== CONT  TestAccVpcSubnetDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetDataSource_ipv4ByName (48.80s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByCidr
--- PASS: TestAccVpcSubnetDataSource_ipv4Basic (51.02s)
--- PASS: TestAccVpcSubnetDataSource_ipv4ByVpcId (53.05s)
--- PASS: TestAccVpcSubnetDataSource_ipv6Basic (59.16s)
--- PASS: TestAccVpcSubnetDataSource_ipv4ByCidr (45.77s)
PASS
ok      command-line-arguments  94.631s

$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_route_table_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcRouteTableDataSource_basic
=== PAUSE TestAccVpcRouteTableDataSource_basic
=== CONT  TestAccVpcRouteTableDataSource_basic
--- PASS: TestAccVpcRouteTableDataSource_basic (69.38s)
PASS
ok      command-line-arguments  69.427s


$ make testacc TEST='./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_test* -v  -timeout 360m -parallel 4
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== RUN   TestAccVpcDataSource_byCidr
=== PAUSE TestAccVpcDataSource_byCidr
=== RUN   TestAccVpcDataSource_byName
=== PAUSE TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_basic
=== CONT  TestAccVpcDataSource_byName
=== CONT  TestAccVpcDataSource_byCidr
--- PASS: TestAccVpcDataSource_byName (27.06s)
--- PASS: TestAccVpcDataSource_basic (28.77s)
--- PASS: TestAccVpcDataSource_byCidr (29.29s)
PASS
ok      command-line-arguments  29.345s


```
