### PR TITLE
fix(resource/obs_bucket): fix ci lint obs bucket and obs bucket object

### DIFF
--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -25,7 +25,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	// write some data to the tempfile
-	err = os.WriteFile(tmpFile.Name(), []byte("initial object state"), 0644)
+	err = os.WriteFile(tmpFile.Name(), []byte("initial object state"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -868,11 +868,11 @@ func resourceObsBucketWebsiteUpdate(obsClient *obs.ObsClient, d *schema.Resource
 			w = make(map[string]interface{})
 		}
 		return resourceObsBucketWebsitePut(obsClient, d, w)
-	} else if len(ws) == 0 {
-		return resourceObsBucketWebsiteDelete(obsClient, d)
-	} else {
-		return fmt.Errorf("cannot specify more than one website")
 	}
+	if len(ws) == 0 {
+		return resourceObsBucketWebsiteDelete(obsClient, d)
+	}
+	return fmt.Errorf("cannot specify more than one website")
 }
 
 func resourceObsBucketCorsUpdate(obsClient *obs.ObsClient, d *schema.ResourceData) error {

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -135,7 +135,7 @@ func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, met
 	content := d.Get("content").(string)
 	if source != "" {
 		// check source file whether exist
-		_, err := os.Stat(source)
+		_, err = os.Stat(source)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return diag.Errorf("source file %s is not exist", source)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix cli lint obs bucket and obs bucket object
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_website'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_website -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_website 
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (8.50s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       8.562s


make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObject_source -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketObject_source 
=== PAUSE TestAccObsBucketObject_source 
=== CONT  TestAccObsBucketObject_source 
--- PASS: TestAccObsBucketObject_source (17.35s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       17.400s
```
