### PR TITLE
fix: update obs sdk and obs sdk support roundTripper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20221209082629-c3b7ec06a8b1
+	github.com/chnsz/golangsdk v0.0.0-20221216030113-b948477d408a
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20221209082629-c3b7ec06a8b1 h1:AwklbEboW9dTAdFtxo0yMppFpaOm1aNqIIAkqdfcx7w=
-github.com/chnsz/golangsdk v0.0.0-20221209082629-c3b7ec06a8b1/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221216030113-b948477d408a h1:AdKbFE9NF8GlX3l61dTVxw+SpKknSMuAdw8PDPS6LUE=
+github.com/chnsz/golangsdk v0.0.0-20221216030113-b948477d408a/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -17,14 +17,10 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 const (
-	obsLogFile         string = "./.obs-sdk.log"
-	obsLogFileSize10MB int64  = 1024 * 1024 * 10
-	userAgent          string = "terraform-provider-iac"
+	userAgent string = "terraform-provider-iac"
 )
 
 // MutexKV is a global lock on all resources, it can lock the specified shared string (such as resource ID, resource
@@ -174,13 +170,6 @@ func (c *Config) ObjectStorageClientWithSignature(region string) (*obs.ObsClient
 		return nil, fmt.Errorf("missing credentials for OBS, need access_key and secret_key values for provider")
 	}
 
-	// init log
-	if utils.IsDebugOrHigher() {
-		if err := obs.InitLog(obsLogFile, obsLogFileSize10MB, 10, obs.LEVEL_DEBUG, false); err != nil {
-			log.Printf("[WARN] initial obs sdk log failed: %s", err)
-		}
-	}
-
 	var agent string = userAgent
 	if customUserAgent := os.Getenv("HW_TF_CUSTOM_UA"); len(customUserAgent) > 0 {
 		agent = fmt.Sprintf("%s %s", customUserAgent, userAgent)
@@ -199,13 +188,6 @@ func (c *Config) ObjectStorageClientWithSignature(region string) (*obs.ObsClient
 func (c *Config) ObjectStorageClient(region string) (*obs.ObsClient, error) {
 	if c.AccessKey == "" || c.SecretKey == "" {
 		return nil, fmt.Errorf("missing credentials for OBS, need access_key and secret_key values for provider")
-	}
-
-	// init log
-	if utils.IsDebugOrHigher() {
-		if err := obs.InitLog(obsLogFile, obsLogFileSize10MB, 10, obs.LEVEL_DEBUG, false); err != nil {
-			log.Printf("[WARN] initial obs sdk log failed: %s", err)
-		}
 	}
 
 	if !c.SecurityKeyExpiresAt.IsZero() {

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/README.MD
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/README.MD
@@ -2,11 +2,22 @@
 
 ## Version
 
-3.21.12
+3.22.11
 
-You can get the latest source code from [huaweicloud-sdk-go-obs](https://github.com/huaweicloud/huaweicloud-sdk-go-obs).
+## How to change local obs sdk
+- Try to submit pull request to the official repository：
+[OBS-Repository](https://github.com/huaweicloud/huaweicloud-sdk-go-obs), and waiting for the PR closing.
+- If you have to change local obs sdk, you need to record this change in the table below
 
-## Backporting
+| commit                                      | pull request                                          | description                 | date       |
+|---------------------------------------------|-------------------------------------------------------|-----------------------------|------------|
+| dab1291b283ee292638537274b9506de6eec5241    | [GH-11](https://github.com/chnsz/golangsdk/pull/11)   | get proxy URL from env      | 2021.09.10 |
+| 893f81801b653bada3a912b293a92bade2adb399    | [GH-109](https://github.com/chnsz/golangsdk/pull/109) | support bucket cross-region | 2022.01.29 |
 
-Please backport [GH-11](https://github.com/chnsz/golangsdk/pull/11) after updating the sdk from
-huaweicloud-sdk-go-obs.
+
+## How to update local obs sdk from official repository
+- Cover your local obs sdk package with the official repository and commit changes.
+
+- Cherry-pick local change commit records, and handling conflicts.
+
+- Update the Version

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/client_base.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/client_base.go
@@ -46,7 +46,7 @@ func New(ak, sk, endpoint string, configurers ...configurer) (*ObsClient, error)
 
 	if isWarnLogEnabled() {
 		info := make([]string, 3)
-		info[0] = fmt.Sprintf("[OBS SDK Version=%s", obsSdkVersion)
+		info[0] = fmt.Sprintf("[OBS SDK Version=%s", OBS_SDK_VERSION)
 		info[1] = fmt.Sprintf("Endpoint=%s", conf.endpoint)
 		accessMode := "Virtual Hosting"
 		if conf.pathStyle {
@@ -55,6 +55,13 @@ func New(ak, sk, endpoint string, configurers ...configurer) (*ObsClient, error)
 		info[2] = fmt.Sprintf("Access Mode=%s]", accessMode)
 		doLog(LEVEL_WARN, strings.Join(info, "];["))
 	}
+
+	if conf.httpClient != nil {
+		doLog(LEVEL_DEBUG, "Create obsclient with config:\n%s\n", conf)
+		obsClient := &ObsClient{conf: conf, httpClient: conf.httpClient}
+		return obsClient, nil
+	}
+
 	doLog(LEVEL_DEBUG, "Create obsclient with config:\n%s\n", conf)
 	obsClient := &ObsClient{conf: conf, httpClient: &http.Client{Transport: conf.transport, CheckRedirect: checkRedirectFunc}}
 	return obsClient, nil

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/client_bucket.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/client_bucket.go
@@ -167,6 +167,17 @@ func (obsClient ObsClient) GetBucketMetadata(input *GetBucketMetadataInput, exte
 	return
 }
 
+func (obsClient ObsClient) GetBucketFSStatus(input *GetBucketFSStatusInput, extensions ...extensionOptions) (output *GetBucketFSStatusOutput, err error) {
+	output = &GetBucketFSStatusOutput{}
+	err = obsClient.doActionWithBucket("GetBucketFSStatus", HTTP_HEAD, input.Bucket, input, output, extensions)
+	if err != nil {
+		output = nil
+	} else {
+		ParseGetBucketFSStatusOutput(output)
+	}
+	return
+}
+
 // GetBucketStorageInfo gets storage information about a bucket.
 //
 // You can use this API to obtain storage information about a bucket, including the

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/client_other.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/client_other.go
@@ -42,7 +42,7 @@ func (obsClient ObsClient) getSecurity() securityHolder {
 }
 
 // Close closes ObsClient.
-func (obsClient ObsClient) Close() {
+func (obsClient *ObsClient) Close() {
 	obsClient.httpClient = nil
 	obsClient.conf.transport.CloseIdleConnections()
 	obsClient.conf = nil

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/client_part.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/client_part.go
@@ -115,7 +115,9 @@ func (obsClient ObsClient) UploadPart(_input *UploadPartInput, extensions ...ext
 	output = &UploadPartOutput{}
 	var repeatable bool
 	if input.Body != nil {
-		_, repeatable = input.Body.(*strings.Reader)
+		if _, ok := input.Body.(*strings.Reader); !ok {
+			repeatable = false
+		}
 		if _, ok := input.Body.(*readerWrapper); !ok && input.PartSize > 0 {
 			input.Body = &readerWrapper{reader: input.Body, totalCount: input.PartSize}
 		}

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/conf.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/conf.go
@@ -52,6 +52,8 @@ type config struct {
 	maxConnsPerHost   int
 	pemCerts          []byte
 	transport         *http.Transport
+	roundTripper      http.RoundTripper
+	httpClient        *http.Client
 	ctx               context.Context
 	maxRedirectCount  int
 	userAgent         string
@@ -183,6 +185,12 @@ func WithSecurityToken(securityToken string) configurer {
 func WithHttpTransport(transport *http.Transport) configurer {
 	return func(conf *config) {
 		conf.transport = transport
+	}
+}
+
+func WithHttpClient(httpClient *http.Client) configurer {
+	return func(conf *config) {
+		conf.httpClient = httpClient
 	}
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/const.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/const.go
@@ -13,8 +13,8 @@
 package obs
 
 const (
-	obsSdkVersion          = "3.21.12"
-	USER_AGENT             = "obs-sdk-go/" + obsSdkVersion
+	OBS_SDK_VERSION        = "3.22.11"
+	USER_AGENT             = "obs-sdk-go/" + OBS_SDK_VERSION
 	HEADER_PREFIX          = "x-amz-"
 	HEADER_PREFIX_META     = "x-amz-meta-"
 	HEADER_PREFIX_OBS      = "x-obs-"
@@ -37,7 +37,10 @@ const (
 	HEADER_RANGE                            = "Range"
 	HEADER_STORAGE_CLASS                    = "x-default-storage-class"
 	HEADER_STORAGE_CLASS_OBS                = "x-obs-storage-class"
+	HEADER_FS_FILE_INTERFACE_OBS            = "x-obs-fs-file-interface"
+	HEADER_MODE                             = "mode"
 	HEADER_VERSION_OBS                      = "version"
+	HEADER_REQUEST_PAYER                    = "x-amz-request-payer"
 	HEADER_GRANT_READ_OBS                   = "grant-read"
 	HEADER_GRANT_WRITE_OBS                  = "grant-write"
 	HEADER_GRANT_READ_ACP_OBS               = "grant-read-acp"
@@ -274,6 +277,8 @@ var (
 		"x-image-save-bucket":          true,
 		"x-image-save-object":          true,
 		"ignore-sign-in-query":         true,
+		"name":                         true,
+		"rename":                       true,
 	}
 
 	mimeTypes = map[string]string{
@@ -653,6 +658,13 @@ var (
 		"yaml":    "text/yaml",
 		"yml":     "text/yaml",
 		"zip":     "application/zip",
+		"dotx":    "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+		"wps":     "application/vnd.ms-works",
+		"wpt":     "x-lml/x-gps",
+		"pptm":    "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+		"heic":    "image/heic",
+		"mkv":     "video/x-matroska",
+		"raw":     "image/x-panasonic-raw",
 	}
 )
 
@@ -743,6 +755,8 @@ const (
 
 	// SubResourceModify subResource value: modify
 	SubResourceModify SubResourceType = "modify"
+
+	SubResourceRename SubResourceType = "rename"
 )
 
 // objectKeyType defines the objectKey value

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/convert.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/convert.go
@@ -80,6 +80,18 @@ func ParseStringToStorageClassType(value string) (ret StorageClassType) {
 	return
 }
 
+func ParseStringToFSStatusType(value string) (ret FSStatusType) {
+	switch value {
+	case "Enabled":
+		ret = FSStatusEnabled
+	case "Disabled":
+		ret = FSStatusDisabled
+	default:
+		ret = ""
+	}
+	return
+}
+
 func prepareGrantURI(grant Grant) string {
 	if grant.Grantee.URI == GroupAllUsers || grant.Grantee.URI == GroupAuthenticatedUsers {
 		return fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/global/", grant.Grantee.URI)
@@ -1158,4 +1170,25 @@ func ParseModifyObjectOutput(output *ModifyObjectOutput) {
 	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
 		output.ETag = ret[0]
 	}
+}
+
+func ParseGetBucketFSStatusOutput(output *GetBucketFSStatusOutput) {
+	ParseGetBucketMetadataOutput(&output.GetBucketMetadataOutput)
+
+	if ret, ok := output.ResponseHeaders[HEADER_FS_FILE_INTERFACE_OBS]; ok {
+		output.FSStatus = ParseStringToFSStatusType(ret[0])
+	}
+}
+
+func ParseGetAttributeOutput(output *GetAttributeOutput) {
+	ParseGetObjectMetadataOutput(&output.GetObjectMetadataOutput)
+	if ret, ok := output.ResponseHeaders[HEADER_MODE]; ok {
+		output.Mode = StringToInt(ret[0], -1)
+	} else {
+		output.Mode = -1
+	}
+}
+
+func ParseNewFolderOutput(output *NewFolderOutput) {
+	ParsePutObjectOutput(&output.PutObjectOutput)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/http.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/http.go
@@ -464,6 +464,7 @@ func prepareRetry(resp *http.Response, headers map[string][]string, _data io.Rea
 		if err != nil {
 			return nil, nil, err
 		}
+		r.readedCount = 0
 	}
 	return _data, resp, nil
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/log.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/log.go
@@ -268,6 +268,10 @@ func initLogFile(_fullPath string) (os.FileInfo, *os.File, error) {
 
 	fd, err := os.OpenFile(_fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
+		_err := fd.Close()
+		if _err != nil {
+			doLog(LEVEL_WARN, "Failed to close file with reason: %v", _err)
+		}
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/model_bucket.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/model_bucket.go
@@ -366,3 +366,12 @@ type GetBucketFetchJobOutput struct {
 	BaseModel
 	GetBucketFetchJobResponse
 }
+
+type GetBucketFSStatusInput struct {
+	GetBucketMetadataInput
+}
+
+type GetBucketFSStatusOutput struct {
+	GetBucketMetadataOutput
+	FSStatus FSStatusType
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/model_object.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/model_object.go
@@ -177,6 +177,16 @@ type GetObjectMetadataOutput struct {
 	Metadata                map[string]string
 }
 
+type GetAttributeInput struct {
+	GetObjectMetadataInput
+	RequestPayer string
+}
+
+type GetAttributeOutput struct {
+	GetObjectMetadataOutput
+	Mode int
+}
+
 // GetObjectInput is the input parameter of GetObject function
 type GetObjectInput struct {
 	GetObjectMetadataInput
@@ -226,15 +236,25 @@ type ObjectOperationInput struct {
 // PutObjectBasicInput defines the basic object operation properties
 type PutObjectBasicInput struct {
 	ObjectOperationInput
-	ContentType   string
-	ContentMD5    string
-	ContentLength int64
+	ContentType     string
+	ContentMD5      string
+	ContentLength   int64
+	ContentEncoding string
 }
 
 // PutObjectInput is the input parameter of PutObject function
 type PutObjectInput struct {
 	PutObjectBasicInput
 	Body io.Reader
+}
+
+type NewFolderInput struct {
+	ObjectOperationInput
+	RequestPayer string
+}
+
+type NewFolderOutput struct {
+	PutObjectOutput
 }
 
 // PutFileInput is the input parameter of PutFile function
@@ -250,6 +270,7 @@ type PutObjectOutput struct {
 	SseHeader    ISseHeader
 	StorageClass StorageClassType
 	ETag         string
+	ObjectUrl    string
 }
 
 // CopyObjectInput is the input parameter of CopyObject function
@@ -342,4 +363,26 @@ type HeadObjectInput struct {
 	Bucket    string
 	Key       string
 	VersionId string
+}
+
+type RenameFileInput struct {
+	Bucket       string
+	Key          string
+	NewObjectKey string
+	RequestPayer string
+}
+
+type RenameFileOutput struct {
+	BaseModel
+}
+
+type RenameFolderInput struct {
+	Bucket       string
+	Key          string
+	NewObjectKey string
+	RequestPayer string
+}
+
+type RenameFolderOutput struct {
+	BaseModel
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/trait.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/trait.go
@@ -674,7 +674,9 @@ func (input PutObjectBasicInput) trans(isObs bool) (params map[string]string, he
 	if input.ContentType != "" {
 		headers[HEADER_CONTENT_TYPE_CAML] = []string{input.ContentType}
 	}
-
+	if input.ContentEncoding != "" {
+		headers[HEADER_CONTENT_ENCODING_CAMEL] = []string{input.ContentEncoding}
+	}
 	return
 }
 
@@ -971,5 +973,25 @@ func (input SetBucketFetchJobInput) trans(isObs bool) (params map[string]string,
 func (input GetBucketFetchJobInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	headers = make(map[string][]string, 1)
 	setHeaders(headers, headerOefMarker, []string{"yes"}, isObs)
+	return
+}
+
+func (input RenameFileInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceRename): ""}
+	params["name"] = input.NewObjectKey
+	headers = make(map[string][]string)
+	if requestPayer := string(input.RequestPayer); requestPayer != "" {
+		headers[HEADER_REQUEST_PAYER] = []string{requestPayer}
+	}
+	return
+}
+
+func (input RenameFolderInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceRename): ""}
+	params["name"] = input.NewObjectKey
+	headers = make(map[string][]string)
+	if requestPayer := string(input.RequestPayer); requestPayer != "" {
+		headers[HEADER_REQUEST_PAYER] = []string{requestPayer}
+	}
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/transfer.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/transfer.go
@@ -101,7 +101,7 @@ func (task *uploadPartTask) Run() interface{} {
 
 	var output *UploadPartOutput
 	var err error
-	if extensions != nil {
+	if len(extensions) != 0 {
 		output, err = task.obsClient.UploadPart(input, extensions...)
 	} else {
 		output, err = task.obsClient.UploadPart(input)
@@ -184,7 +184,7 @@ func prepareUpload(ufc *UploadCheckpoint, uploadFileStat os.FileInfo, input *Upl
 	initiateInput.EncodingType = input.EncodingType
 	var output *InitiateMultipartUploadOutput
 	var err error
-	if extensions != nil {
+	if len(extensions) != 0 {
 		output, err = obsClient.InitiateMultipartUpload(initiateInput, extensions...)
 	} else {
 		output, err = obsClient.InitiateMultipartUpload(initiateInput)
@@ -251,7 +251,7 @@ func abortTask(bucket, key, uploadID string, obsClient *ObsClient, extensions []
 	input.Bucket = bucket
 	input.Key = key
 	input.UploadId = uploadID
-	if extensions != nil {
+	if len(extensions) != 0 {
 		_, err := obsClient.AbortMultipartUpload(input, extensions...)
 		return err
 	}
@@ -288,7 +288,7 @@ func completeParts(ufc *UploadCheckpoint, enableCheckpoint bool, checkpointFileP
 	}
 	completeInput.Parts = parts
 	var completeOutput *CompleteMultipartUploadOutput
-	if extensions != nil {
+	if len(extensions) != 0 {
 		completeOutput, err = obsClient.CompleteMultipartUpload(completeInput, extensions...)
 	} else {
 		completeOutput, err = obsClient.CompleteMultipartUpload(completeInput)
@@ -512,7 +512,7 @@ func (task *downloadPartTask) Run() interface{} {
 
 	var output *GetObjectOutput
 	var err error
-	if task.extensions != nil {
+	if len(task.extensions) != 0 {
 		output, err = task.obsClient.GetObject(getObjectInput, task.extensions...)
 	} else {
 		output, err = task.obsClient.GetObject(getObjectInput)
@@ -542,7 +542,7 @@ func (task *downloadPartTask) Run() interface{} {
 }
 
 func getObjectInfo(input *DownloadFileInput, obsClient *ObsClient, extensions []extensionOptions) (getObjectmetaOutput *GetObjectMetadataOutput, err error) {
-	if extensions != nil {
+	if len(extensions) != 0 {
 		getObjectmetaOutput, err = obsClient.GetObjectMetadata(&input.GetObjectMetadataInput, extensions...)
 	} else {
 		getObjectmetaOutput, err = obsClient.GetObjectMetadata(&input.GetObjectMetadataInput)

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances/requests.go
@@ -28,6 +28,7 @@ type CreateInstanceOpts struct {
 	VolumeType    string   `json:"volume_type,omitempty"`
 	ClusterId     string   `json:"cluster_id,omitempty"`
 	PoolId        string   `json:"pool_id,omitempty"`
+	ResTenant     *bool    `json:"res_tenant,omitempty"`
 }
 
 // ListInstanceOpts the parameters in the querying request.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20221209082629-c3b7ec06a8b1
+# github.com/chnsz/golangsdk v0.0.0-20221216030113-b948477d408a
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
update obs sdk and obs sdk support roundTripper.
add user-agent
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->


```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObjectDataSource_content'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObjectDataSource_content -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketObjectDataSource_content 
=== PAUSE TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucketObjectDataSource_content
--- PASS: TestAccObsBucketObjectDataSource_content (15.47s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       15.523s

make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccDataSourceObsBuckets_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccDataSourceObsBuckets_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceObsBuckets_basic 
=== PAUSE TestAccDataSourceObsBuckets_basic
=== CONT  TestAccDataSourceObsBuckets_basic
--- PASS: TestAccDataSourceObsBuckets_basic (9.69s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       9.741s

make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObject_source -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketObject_source 
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (15.52s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       15.573s

make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketPolicy_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketPolicy_basic -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketPolicy_basic 
=== PAUSE TestAccObsBucketPolicy_basic
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucketPolicy_basic (9.58s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       9.623s

make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_basic -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_basic 
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (14.83s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       14.875s

```
