### PR TITLE
fix: fix code warning, and do the code format

### DIFF
--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_buckets.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_buckets.go
@@ -3,6 +3,7 @@ package obs
 import (
 	"context"
 	"errors"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -113,9 +114,9 @@ func dataSourceObsBucketsRead(_ context.Context, d *schema.ResourceData, meta in
 		ids = append(ids, v.Name)
 	}
 	d.SetId(hashcode.Strings(ids))
-	err = d.Set("buckets", buckets)
-	if err != nil {
-		return diag.Errorf("error setting OBS attributes: %s", err)
+	mErr := multierror.Append(nil, d.Set("buckets", buckets))
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting OBS attributes: %s", mErr)
 	}
 	return nil
 }

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -160,10 +160,14 @@ func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	log.Printf("[DEBUG] Response of putting %s to OBS Bucket %s: %#v", key, bucket, resp)
+	mErr := &multierror.Error{}
 	if resp.VersionId != "null" {
-		d.Set("version_id", resp.VersionId)
+		mErr = multierror.Append(mErr, d.Set("version_id", resp.VersionId))
 	} else {
-		d.Set("version_id", "")
+		mErr = multierror.Append(mErr, d.Set("version_id", ""))
+	}
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving versionId of OBS bucket %s: %s", bucket, mErr)
 	}
 	d.SetId(key)
 
@@ -309,18 +313,23 @@ func resourceObsBucketObjectDelete(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceObsBucketObjectImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceObsBucketObjectImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		err := fmt.Errorf("Invalid format specified for OBS bucket object. Format must be <bucket>/<key>")
+		err := fmt.Errorf("invalid format specified for OBS bucket object. Format must be <bucket>/<key>")
 		return nil, err
 	}
 
 	bucket := parts[0]
 	key := parts[1]
 
-	d.Set("bucket", bucket)
-	d.Set("key", key)
+	mErr := multierror.Append(nil,
+		d.Set("bucket", bucket),
+		d.Set("key", key),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return nil, fmt.Errorf("error setting attributes of OBS bucket %s: %s", bucket, mErr)
+	}
 	d.SetId(key)
 
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- fix code warning, and do the code format
- use go-multierror package in obs service

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist


* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObjectDataSource_content'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObjectDataSource_content -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketObjectDataSource_content 
=== PAUSE TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucketObjectDataSource_content
--- PASS: TestAccObsBucketObjectDataSource_content (14.89s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       14.943s



make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccDataSourceObsBuckets_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccDataSourceObsBuckets_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceObsBuckets_basic 
=== PAUSE TestAccDataSourceObsBuckets_basic
=== CONT  TestAccDataSourceObsBuckets_basic
--- PASS: TestAccDataSourceObsBuckets_basic (11.21s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       11.259s


make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObject_source -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketObject_source 
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (15.84s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       15.893s


 make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketPolicy_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketPolicy_basic -timeout 360m -parallel 4 
=== RUN   TestAccObsBucketPolicy_basic 
=== PAUSE TestAccObsBucketPolicy_basic 
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucketPolicy_basic (10.50s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       10.548s 



make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_basic -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_basic 
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (26.14s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       26.210s 

```
