### PR TITLE
feat(codecheck): check HuaweiCloud keyword in error and log message

### DIFF
--- a/scripts/codecheck.sh
+++ b/scripts/codecheck.sh
@@ -13,7 +13,7 @@ function checkImporter() {
         if [[ $f =~ "resource_huaweicloud_" ]]; then
             hasImporter=$(grep -w "Importer:" $dir/$f)
             if [ "X$hasImporter" == "X" ]; then
-                echo "-> the resource in $f should can be imported"
+                echo -e "\033[31m  -> the resource in $f should can be imported\n\033[0m"
             fi
         fi
     done
@@ -25,7 +25,7 @@ function checkMultierror() {
         if [[ $f =~ "_huaweicloud_" ]]; then
             hasMultierror=$(grep -w "go-multierror" $dir/$f)
             if [ "X$hasMultierror" == "X" ]; then
-                echo "-> please use go-multierror package in $f"
+                echo -e "\033[31m  -> please use go-multierror package in $f\n\033[0m"
             fi
         fi
     done
@@ -37,7 +37,8 @@ function checkHuaweiCloudKey() {
     for key in ${key_words[@]}; do
         result=$(grep -rn $key $dir | grep -i " huaweicloud")
         if [ "X$result" != "X" ]; then
-            echo -e "-> the following $key statements contain 'HuaweiCloud' key:\n$result\n"
+            echo -e "\033[31m  -> the following $key statements contain 'HuaweiCloud' key:\033[0m"
+            echo -e "$result\n"
         fi
     done
 }

--- a/scripts/codecheck.sh
+++ b/scripts/codecheck.sh
@@ -31,6 +31,17 @@ function checkMultierror() {
     done
 }
 
+function checkHuaweiCloudKey() {
+    dir=$1
+    key_words=("fmt.Errorf" "diag.Errorf" "log.Printf")
+    for key in ${key_words[@]}; do
+        result=$(grep -rn $key $dir | grep -i " huaweicloud")
+        if [ "X$result" != "X" ]; then
+            echo -e "-> the following $key statements contain 'HuaweiCloud' key:\n$result\n"
+        fi
+    done
+}
+
 # Check parameters
 package=$1
 if [ "X$package" == "X" ]; then
@@ -130,6 +141,7 @@ if [ "X$service" != "X..." ] && [[ $package == ./huaweicloud/services/* ]]; then
     echo -e "\n==> Checking for TF features in $service..."
     checkImporter $packageDir
     checkMultierror $packageDir
+    checkHuaweiCloudKey $packageDir
 
     echo -e "\n==> Checking for misspell in $service..."
     misspell ./docs | grep "/${service}_"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

sometimes the developer will forget to remove **"HuaweiCloud"** keyword in error and log message, so add a check item for this.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
