### PR TITLE
fix(aom): all parameters should be set when updating due to the API i…

### DIFF
--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_rule_test.go
@@ -128,9 +128,10 @@ func testAOMAlarmRule_basic(rName string) string {
 %s
 
 resource "huaweicloud_aom_alarm_rule" "test" {
-  name        = "%s"
-  alarm_level = 2
-  description = "test rule"
+  name                 = "%s"
+  alarm_level          = 2
+  alarm_action_enabled = false
+  description          = "test rule"
 
   namespace   = "PAAS.NODE"
   metric_name = "cupUsage"
@@ -155,9 +156,10 @@ func testAOMAlarmRule_update(rName string) string {
 %s
 
 resource "huaweicloud_aom_alarm_rule" "test" {
-  name        = "%s"
-  alarm_level = 3
-  description = "test rule update"
+  name                 = "%s"
+  alarm_level          = 3
+  alarm_action_enabled = false
+  description          = "test rule update"
 
   namespace   = "PAAS.NODE"
   metric_name = "cupUsage"

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rule.go
@@ -349,60 +349,28 @@ func resourceAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return fmtp.DiagErrorf("error creating AOM client: %s", err)
 	}
 
+	// all parameters should be set when updating due to the API issue
+	dimensions := buildDimensionsOpts(d.Get("dimensions").([]interface{}))
 	updateOpts := aom.UpdateAlarmRuleParam{
-		AlarmRuleName: d.Get("name").(string),
-	}
-
-	if d.HasChange("description") {
-		updateOpts.AlarmDescription = utils.String(d.Get("description").(string))
-	}
-	if d.HasChange("alarm_level") {
-		updateOpts.AlarmLevel = buildAlarmLevelOpts(d.Get("alarm_level").(int))
-	}
-
-	if d.HasChange("alarm_enabled") {
-		updateOpts.IdTurnOn = utils.Bool(d.Get("alarm_enabled").(bool))
-	}
-	if d.HasChange("alarm_actions") {
-		updateOpts.AlarmActions = buildActionOpts(d.Get("alarm_actions").([]interface{}))
-	}
-	if d.HasChange("ok_actions") {
-		updateOpts.OkActions = buildActionOpts(d.Get("ok_actions").([]interface{}))
-	}
-	if d.HasChange("insufficient_data_actions") {
-		updateOpts.InsufficientDataActions = buildActionOpts(d.Get("insufficient_data_actions").([]interface{}))
-	}
-	if d.HasChange("metric_name") {
-		updateOpts.MetricName = utils.String(d.Get("metric_name").(string))
-	}
-	if d.HasChange("namespace") {
-		updateOpts.Namespace = utils.String(d.Get("namespace").(string))
-	}
-	if d.HasChange("dimensions") {
-		dimensions := buildDimensionsOpts(d.Get("dimensions").([]interface{}))
-		updateOpts.Dimensions = &dimensions
-	}
-	if d.HasChange("period") {
-		updateOpts.Period = utils.Int32(int32(d.Get("period").(int)))
-	}
-	if d.HasChange("unit") {
-		updateOpts.Unit = utils.String(d.Get("unit").(string))
-	}
-	if d.HasChange("comparison_operator") {
-		updateOpts.ComparisonOperator = utils.String(d.Get("comparison_operator").(string))
-	}
-	if d.HasChange("statistic") {
-		updateOpts.Statistic = buildStatisticOpts(d.Get("statistic").(string))
-	}
-	if d.HasChange("threshold") {
-		updateOpts.Threshold = utils.String(d.Get("threshold").(string))
-	}
-	if d.HasChange("evaluation_periods") {
-		updateOpts.EvaluationPeriods = utils.Int32(int32(d.Get("evaluation_periods").(int)))
+		AlarmRuleName:           d.Get("name").(string),
+		AlarmLevel:              buildAlarmLevelOpts(d.Get("alarm_level").(int)),
+		AlarmDescription:        utils.String(d.Get("description").(string)),
+		IdTurnOn:                utils.Bool(d.Get("alarm_enabled").(bool)),
+		AlarmActions:            buildActionOpts(d.Get("alarm_actions").([]interface{})),
+		OkActions:               buildActionOpts(d.Get("ok_actions").([]interface{})),
+		InsufficientDataActions: buildActionOpts(d.Get("insufficient_data_actions").([]interface{})),
+		Namespace:               utils.String(d.Get("namespace").(string)),
+		MetricName:              utils.String(d.Get("metric_name").(string)),
+		Dimensions:              &dimensions,
+		Period:                  utils.Int32(int32(d.Get("period").(int))),
+		Unit:                    utils.String(d.Get("unit").(string)),
+		ComparisonOperator:      utils.String(d.Get("comparison_operator").(string)),
+		Statistic:               buildStatisticOpts(d.Get("statistic").(string)),
+		Threshold:               utils.String(d.Get("threshold").(string)),
+		EvaluationPeriods:       utils.Int32(int32(d.Get("evaluation_periods").(int))),
 	}
 
 	log.Printf("[DEBUG] Update %s Options: %#v", updateOpts.AlarmRuleName, updateOpts)
-
 	reqOpts := aom.UpdateAlarmRuleRequest{
 		Body: &updateOpts,
 	}


### PR DESCRIPTION
…ssue

API docs:
https://support.huaweicloud.com/api-aom/UpdateAlarmRule.html

actually , all parameters should be set to the request body, otherwise we will get an error:

```
API Response Code: 400
API Response Body: {
  "error_code": "AOM.02001SVCSTG_AMS_5000000",
  "error_msg": "Internal server error",
  "error_type": "BAD_REQUEST",
  "trace_id": ""
}
```

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAOMAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAOMAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAOMAlarmRule_basic
=== PAUSE TestAccAOMAlarmRule_basic
=== CONT  TestAccAOMAlarmRule_basic
--- PASS: TestAccAOMAlarmRule_basic (179.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       179.289s
```
