### PR TITLE
feat(cce): support root volume encryption in node and node pool

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -219,6 +219,8 @@ The following arguments are supported:
     Changing this parameter will create a new resource.
   + `extend_params` - (Optional, Map, ForceNew) Specifies the disk expansion parameters.
     Changing this parameter will create a new resource.
+  + `kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key. This is used to encrypt the volume.
+    Changing this parameter will create a new resource.
 
 * `data_volumes` - (Required, List, ForceNew) Specifies the configurations of the data disk.
   Changing this parameter will create a new resource.

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -151,6 +151,9 @@ The `root_volume` block supports:
 * `extend_params` - (Optional, Map, ForceNew) Specifies the disk expansion parameters.
   Changing this parameter will create a new resource.
 
+* `kms_key_id` - (Optional, String, ForceNew) Specifies the KMS key ID. This is used to encrypt the volume.
+  Changing this parameter will create a new resource.
+
 The `data_volumes` block supports:
 
 * `size` - (Required, Int, ForceNew) Specifies the disk size in GB. Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -120,7 +120,7 @@ func TestAccCCENodePool_tagsLabelsTaints(t *testing.T) {
 	})
 }
 
-func TestAccCCENodePool_data_volume_encryption(t *testing.T) {
+func TestAccCCENodePool_volume_encryption(t *testing.T) {
 	var nodePool nodepools.NodePool
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -137,10 +137,11 @@ func TestAccCCENodePool_data_volume_encryption(t *testing.T) {
 		CheckDestroy:      testAccCheckCCENodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCENodePool_data_volume_encryption(rName),
+				Config: testAccCCENodePool_volume_encryption(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "root_volume.0.kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "data_volumes.0.kms_key_id"),
 				),
 			},
@@ -419,7 +420,7 @@ resource "huaweicloud_cce_node_pool" "test" {
 `, testAccCCENodePool_Base(rName), rName)
 }
 
-func testAccCCENodePool_data_volume_encryption(rName string) string {
+func testAccCCENodePool_volume_encryption(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -446,6 +447,7 @@ resource "huaweicloud_cce_node_pool" "test" {
   root_volume {
     size       = 40
     volumetype = "SSD"
+    kms_key_id = huaweicloud_kms_key.test.id
   }
   data_volumes {
     size       = 100

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_v3_test.go
@@ -134,7 +134,7 @@ func TestAccCCENodeV3_volume_extendParams(t *testing.T) {
 	})
 }
 
-func TestAccCCENodeV3_data_volume_encryption(t *testing.T) {
+func TestAccCCENodeV3_volume_encryption(t *testing.T) {
 	var node nodes.Nodes
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -151,10 +151,11 @@ func TestAccCCENodeV3_data_volume_encryption(t *testing.T) {
 		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCENodeV3_data_volume_encryption(rName),
+				Config: testAccCCENodeV3_volume_encryption(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists(resourceName, clusterName, &node),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "root_volume.0.kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "data_volumes.0.kms_key_id"),
 				),
 			},
@@ -507,7 +508,7 @@ resource "huaweicloud_cce_node" "test" {
 `, testAccCCENodeV3_Base(rName), rName)
 }
 
-func testAccCCENodeV3_data_volume_encryption(rName string) string {
+func testAccCCENodeV3_volume_encryption(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -526,6 +527,7 @@ resource "huaweicloud_cce_node" "test" {
   root_volume {
     size       = 40
     volumetype = "SSD"
+    kms_key_id = huaweicloud_kms_key.test.id
   }
   data_volumes {
     size       = 100

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -107,6 +107,12 @@ func ResourceCCENodePool() *schema.Resource {
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 					}},
 			},
 			"data_volumes": {
@@ -521,6 +527,9 @@ func resourceCCENodePoolRead(_ context.Context, d *schema.ResourceData, meta int
 			"extend_params":  s.Spec.NodeTemplate.RootVolume.ExtendParam,
 			"extend_param":   "",
 		},
+	}
+	if s.Spec.NodeTemplate.RootVolume.Metadata != nil {
+		rootVolume[0]["kms_key_id"] = s.Spec.NodeTemplate.RootVolume.Metadata.SystemCmkid
 	}
 	mErr = multierror.Append(mErr, d.Set("root_volume", rootVolume))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support root volume encryption in node and node pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support root volume encryption in node and node pool
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodeV3_volume_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodeV3_volume_encryption -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_volume_encryption
=== PAUSE TestAccCCENodeV3_volume_encryption
=== CONT  TestAccCCENodeV3_volume_encryption
--- PASS: TestAccCCENodeV3_volume_encryption (881.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       881.298s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_volume_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_volume_encryption -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_volume_encryption
=== PAUSE TestAccCCENodePool_volume_encryption
=== CONT  TestAccCCENodePool_volume_encryption
--- PASS: TestAccCCENodePool_volume_encryption (855.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       855.274s
```
