### PR TITLE
fix(apig/instance): add computed behavior to optional arguments

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -114,6 +114,7 @@ func ResourceApigInstanceV2() *schema.Resource {
 			"availability_zones": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `schema: Required; The name list of availability zones for the dedicated instance.`,
@@ -138,12 +139,14 @@ func ResourceApigInstanceV2() *schema.Resource {
 			"bandwidth_size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 2000),
 				Description:  `The egress bandwidth size of the dedicated instance.`,
 			},
 			"eip_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The EIP ID associated with the dedicated instance.`,
 			},
 			"ipv6_enable": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some optional arguments are missing 'computed' behavior.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add computed behavior to optional arguments.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApigThrottlingPolicyV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApigThrottlingPolicyV2_basic -timeout 360m -parallel 4
=== RUN   TestAccApigThrottlingPolicyV2_basic
=== PAUSE TestAccApigThrottlingPolicyV2_basic
=== CONT  TestAccApigThrottlingPolicyV2_basic
--- PASS: TestAccApigThrottlingPolicyV2_basic (482.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      482.146s
```
