### PR TITLE
feat: add dms rocketmq group user data source

### DIFF
--- a/docs/data-sources/dms_rocketmq_group_user.md
+++ b/docs/data-sources/dms_rocketmq_group_user.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_group_user
+
+Use this data source to get the list of users that have been granted permissions for a consumer group.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group" {}
+
+data "huaweicloud_dms_rocketmq_group_user" "test" {
+  instance_id = var.instance_id
+  group       = var.group
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RocketMQ instance.
+
+* `group` - (Required, String) Specifies the name of the RocketMQ consumer group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `policies` - Indicates the list of user associated with the consumer group.
+  The [Policy](#DmsRocketMQGroupUser_Policy) structure is documented below.
+
+<a name="DmsRocketMQGroupUser_Policy"></a>
+The `Policy` block supports:
+
+* `access_key` - Indicates the access key of the user.
+
+* `secret_key` - Indicates the secret key of the user.
+
+* `white_remote_address` - Indicates the IP address whitelist.
+
+* `admin` - Indicates whether the user is an administrator.
+
+* `perm` - Indicates the permissions of the user.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -406,6 +406,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_product":         dms.DataSourceDmsProduct(),
 			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
 
+			"huaweicloud_dms_rocketmq_group_user": dms.DataSourceDmsRocketMQGroupUser(),
+
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
 			"huaweicloud_er_route_tables": er.DataSourceRouteTables(),

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_group_user_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_group_user_test.go
@@ -1,0 +1,87 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDmsRocketMQGroupUser_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	resourceName := "data.huaweicloud_dms_rocketmq_group_user.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDmsRocketMQGroupUser_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDmsRocketMQGroupUser_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  description = "test for DMS RocketMQ"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%[1]s"
+  description = "secgroup for rocketmq"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "c6.4u8g.cluster.small"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+}
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  broadcast   = "true"
+
+  brokers = [
+    "broker-0"
+  ]
+
+  name            = "%[1]s"
+  retry_max_times = "3"
+}
+
+data "huaweicloud_dms_rocketmq_group_user" "test" {
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  group       = huaweicloud_dms_rocketmq_consumer_group.test.name
+}
+`, name)
+}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_group_user.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_group_user.go
@@ -1,0 +1,156 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDmsRocketMQGroupUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDmsRocketMQGroupUserRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the RocketMQ instance.`,
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the RocketMQ consumer group.`,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Elem:        DmsRocketMQGroupUserPolicySchema(),
+				Computed:    true,
+				Description: `Indicates the list of user associated with the consumer group.`,
+			},
+		},
+	}
+}
+
+func DmsRocketMQGroupUserPolicySchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the access key of the user.`,
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the secret key of the user.`,
+			},
+			"white_remote_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the IP address whitelist.`,
+			},
+			"admin": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user is an administrator.`,
+			},
+			"perm": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the permissions of the user.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDmsRocketMQGroupUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getRocketmqGroupUser: Query DMS RocketMQ users that have been granted permissions for a consumer group.
+	var (
+		getRocketmqGroupUserHttpUrl = "v2/{engine}/{project_id}/instances/{instance_id}/groups/{group_id}/accesspolicy"
+		getRocketmqGroupUserProduct = "dms"
+	)
+	getRocketmqGroupUserClient, err := config.NewServiceClient(getRocketmqGroupUserProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQGroupUser Client: %s", err)
+	}
+
+	getRocketmqGroupUserPath := getRocketmqGroupUserClient.Endpoint + getRocketmqGroupUserHttpUrl
+	getRocketmqGroupUserPath = strings.ReplaceAll(getRocketmqGroupUserPath, "{engine}", "reliability")
+	getRocketmqGroupUserPath = strings.ReplaceAll(getRocketmqGroupUserPath, "{project_id}",
+		getRocketmqGroupUserClient.ProjectID)
+	getRocketmqGroupUserPath = strings.ReplaceAll(getRocketmqGroupUserPath, "{instance_id}",
+		fmt.Sprintf("%v", d.Get("instance_id")))
+	getRocketmqGroupUserPath = strings.ReplaceAll(getRocketmqGroupUserPath, "{group_id}",
+		fmt.Sprintf("%v", d.Get("group")))
+
+	getRocketmqGroupUserOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getRocketmqGroupUserResp, err := getRocketmqGroupUserClient.Request("GET", getRocketmqGroupUserPath,
+		&getRocketmqGroupUserOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DmsRocketMQGroupUser")
+	}
+
+	getRocketmqGroupUserRespBody, err := utils.FlattenResponse(getRocketmqGroupUserResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("policies", flattenGetRocketmqGroupUserResponseBodyPolicy(getRocketmqGroupUserRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetRocketmqGroupUserResponseBodyPolicy(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("policies", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"access_key":           utils.PathSearch("access_key", v, nil),
+			"secret_key":           utils.PathSearch("secret_key", v, nil),
+			"white_remote_address": utils.PathSearch("white_remote_address", v, nil),
+			"admin":                utils.PathSearch("admin", v, nil),
+			"perm":                 utils.PathSearch("perm", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dms rocketmq group user data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dms rocketmq group user data source
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDatasourceDmsRocketMQGroupUser_basic'  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDatasourceDmsRocketMQGroupUser_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDmsRocketMQGroupUser_basic
=== PAUSE TestAccDatasourceDmsRocketMQGroupUser_basic
=== CONT  TestAccDatasourceDmsRocketMQGroupUser_basic
--- PASS: TestAccDatasourceDmsRocketMQGroupUser_basic (659.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       659.572s
```
