### PR TITLE
fix: fix rocketmq instance updata param

### DIFF
--- a/docs/resources/dms_rocketmq_instance.md
+++ b/docs/resources/dms_rocketmq_instance.md
@@ -17,16 +17,16 @@ variable "availability_zones" {
 }
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
-  name                = "rocketmq_name_test"
-  description         = "this is a rocketmq instance"
-  engine_version      = "4.8.0"
-  storage_space       = 300
-  vpc_id              = var.vpc_id
-  subnet_id           = var.subnet_id
-  security_group_id   = var.security_group_id
-  availability_zones  = var.availability_zones
+  name               = "rocketmq_name_test"
+  description        = "this is a rocketmq instance"
+  engine_version     = "4.8.0"
+  storage_space      = 300
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+  security_group_id  = var.security_group_id
+  availability_zones = var.availability_zones
   flavor_id          = "c6.4u8g.cluster"
-  storage_spec_code   = "dms.physical.storage.high.v2"
+  storage_spec_code  = "dms.physical.storage.high.v2"
 }
 ```
 
@@ -99,7 +99,7 @@ The following arguments are supported:
 * `broker_num` - (Optional, Int, ForceNew) Specifies the broker numbers. Defaults to 1.
   Changing this parameter will create a new resource.
 
-* `retention_policy` - (Optional, Bool) Specifies the ACL access control.
+* `enable_acl` - (Optional, Bool) Specifies whether access control is enabled.
 
 ## Attributes Reference
 
@@ -127,8 +127,6 @@ In addition to all arguments above, the following attributes are exported:
 * `node_num` - Indicates the node quantity.
 
 * `new_spec_billing_enable` - Indicates whether billing based on new specifications is enabled.
-
-* `enable_acl` - Indicates whether access control is enabled.
 
 * `namesrv_address` - Indicates the metadata address.
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_instance_test.go
@@ -67,14 +67,16 @@ func TestAccDmsRocketMQInstance_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.8.0"),
+					resource.TestCheckResourceAttr(resourceName, "enable_acl", "true"),
 				),
 			},
 			{
-				Config: testDmsRocketMQInstance_basic(rName, updateName),
+				Config: testDmsRocketMQInstance_update(rName, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.8.0"),
+					resource.TestCheckResourceAttr(resourceName, "enable_acl", "false"),
 				),
 			},
 			{
@@ -115,18 +117,45 @@ func testDmsRocketMQInstance_basic(rName, updateName string) string {
 %s
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
-  name                = "%s"
-  engine_version      = "4.8.0"
-  storage_space       = 600
-  vpc_id              = huaweicloud_vpc.test.id
-  subnet_id           = huaweicloud_vpc_subnet.test.id
-  security_group_id   = huaweicloud_networking_secgroup.test.id
-  availability_zones  = [
+  name              = "%s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
-  flavor_id           = "c6.4u8g.cluster"
-  storage_spec_code   = "dms.physical.storage.high.v2"
-  broker_num          = 1
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+  enable_acl        = true
 }
 `, testAccDmsRocketmqInstance_Base(rName), updateName)
+}
+
+func testDmsRocketMQInstance_update(rName, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+  enable_acl        = false
+}
+`, testAccDmsRocketmqInstance_Base(rName), name)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
@@ -3,7 +3,6 @@ package dms
 import (
 	"context"
 	"fmt"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"regexp"
 	"strings"
 	"time"
@@ -142,11 +141,11 @@ func ResourceDmsRocketMQInstance() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the broker numbers.`,
 			},
-			"retention_policy": {
+			"enable_acl": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
-				Description: `Specifies the ACL access control.`,
+				Description: `Specifies whether access control is enabled.`,
 			},
 			"cross_vpc_accesses": {
 				Type:     schema.TypeList,
@@ -221,11 +220,6 @@ func ResourceDmsRocketMQInstance() *schema.Resource {
 				Computed:    true,
 				Description: `Indicates whether billing based on new specifications is enabled.`,
 			},
-			"enable_acl": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: `Indicates whether access control is enabled.`,
-			},
 			"namesrv_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -270,7 +264,8 @@ func resourceDmsRocketMQInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	createRocketmqInstancePath := createRocketmqInstanceClient.Endpoint + createRocketmqInstanceHttpUrl
-	createRocketmqInstancePath = strings.ReplaceAll(createRocketmqInstancePath, "{project_id}", createRocketmqInstanceClient.ProjectID)
+	createRocketmqInstancePath = strings.ReplaceAll(createRocketmqInstancePath, "{project_id}",
+		createRocketmqInstanceClient.ProjectID)
 
 	createRocketmqInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -291,7 +286,8 @@ func resourceDmsRocketMQInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 	createRocketmqInstanceOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqInstanceBodyParams(d, config, availableZones))
-	createRocketmqInstanceResp, err := createRocketmqInstanceClient.Request("POST", createRocketmqInstancePath, &createRocketmqInstanceOpt)
+	createRocketmqInstanceResp, err := createRocketmqInstanceClient.Request("POST", createRocketmqInstancePath,
+		&createRocketmqInstanceOpt)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQInstance: %s", err)
 	}
@@ -329,7 +325,48 @@ func resourceDmsRocketMQInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
+	if v, ok := d.GetOk("enable_acl"); ok {
+		err := updateEnableAcl(config, region, id.(string), v.(bool))
+		if err != nil {
+			return err
+		}
+	}
 	return resourceDmsRocketMQInstanceRead(ctx, d, meta)
+}
+
+func updateEnableAcl(config *config.Config, region, id string, enableAcl bool) diag.Diagnostics {
+	var (
+		updateRocketmqInstanceHttpUrl = "v2/{project_id}/instances/{instance_id}"
+		updateRocketmqInstanceProduct = "dms"
+	)
+	updateRocketmqInstanceClient, err := config.NewServiceClient(updateRocketmqInstanceProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQInstance Client: %s", err)
+	}
+
+	updateRocketmqInstancePath := updateRocketmqInstanceClient.Endpoint + updateRocketmqInstanceHttpUrl
+	updateRocketmqInstancePath = strings.ReplaceAll(updateRocketmqInstancePath, "{project_id}",
+		updateRocketmqInstanceClient.ProjectID)
+	updateRocketmqInstancePath = strings.ReplaceAll(updateRocketmqInstancePath, "{instance_id}", id)
+
+	updateRocketmqInstanceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	updateRocketmqInstanceOpt.JSONBody = utils.RemoveNil(buildUpdateEnableAclBodyParams(enableAcl))
+	_, err = updateRocketmqInstanceClient.Request("PUT", updateRocketmqInstancePath, &updateRocketmqInstanceOpt)
+	if err != nil {
+		return diag.Errorf("error open DmsRocketMQInstance ACL: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateEnableAclBodyParams(enableAcl bool) map[string]interface{} {
+	return map[string]interface{}{
+		"enable_acl": enableAcl,
+	}
 }
 
 func buildCreateRocketmqInstanceBodyParams(d *schema.ResourceData, config *config.Config,
@@ -363,7 +400,7 @@ func resourceDmsRocketMQInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 		"name",
 		"description",
 		"security_group_id",
-		"retention_policy",
+		"enable_acl",
 		"cross_vpc_accesses",
 	}
 
@@ -406,7 +443,7 @@ func buildUpdateRocketmqInstanceBodyParams(d *schema.ResourceData, config *confi
 	bodyParams := map[string]interface{}{
 		"description":       utils.ValueIngoreEmpty(d.Get("description")),
 		"security_group_id": utils.ValueIngoreEmpty(d.Get("security_group_id")),
-		"retention_policy":  utils.ValueIngoreEmpty(d.Get("retention_policy")),
+		"enable_acl":        utils.ValueIngoreEmpty(d.Get("enable_acl")),
 	}
 	if d.HasChange("name") {
 		bodyParams["name"] = utils.ValueIngoreEmpty(d.Get("name"))
@@ -551,8 +588,7 @@ func resourceDmsRocketMQInstanceDelete(ctx context.Context, d *schema.ResourceDa
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.DiagErrorf(
-			"error waiting for instance (%s) to delete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for instance (%s) to delete: %s", d.Id(), err)
 	}
 
 	d.SetId("")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rocketmq instance updata param enable_acl, so that it can open acl by the update function
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rocketmq instance updata param enable_acl
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRocketMQInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQInstance_basic
=== PAUSE TestAccDmsRocketMQInstance_basic
=== CONT  TestAccDmsRocketMQInstance_basic

--- PASS: TestAccDmsRocketMQInstance_basic (715.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       715.290s
```
