### PR TITLE
feat: add dms rocketmq topic user data source

### DIFF
--- a/docs/data-sources/dms_rocketmq_topic_user.md
+++ b/docs/data-sources/dms_rocketmq_topic_user.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_topic_user
+
+Use this data source to get the list of users that have been granted permissions for a topic.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "topic" {}
+
+data "huaweicloud_dms_rocketmq_topic_user" "test" {
+  instance_id = var.instance_id
+  topic       = var.topic
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RocketMQ instance.
+
+* `topic` - (Required, String) Specifies the name of the RocketMQ topic.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `policies` - Indicates the list of user associated with the topic.
+  The [Policy](#DmsRocketMQTopicUser_Policy) structure is documented below.
+
+<a name="DmsRocketMQTopicUser_Policy"></a>
+The `Policy` block supports:
+
+* `access_key` - Indicates the access key of the user.
+
+* `secret_key` - Indicates the secret key of the user.
+
+* `white_remote_address` - Indicates the IP address whitelist.
+
+* `admin` - Indicates whether the user is an administrator.
+
+* `perm` - Indicates the permissions of the user.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -409,6 +409,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_product":         dms.DataSourceDmsProduct(),
 			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
 
+			"huaweicloud_dms_rocketmq_topic_user": dms.DataSourceDmsRocketMQTopicUser(),
+
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
 			"huaweicloud_er_route_tables": er.DataSourceRouteTables(),

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_topic_user_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_topic_user_test.go
@@ -1,0 +1,86 @@
+package dms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDmsRocketMQTopicUser_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	resourceName := "data.huaweicloud_dms_rocketmq_topic_user.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDmsRocketMQTopicUser_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDmsRocketMQTopicUser_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  description = "test for DMS RocketMQ"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%[1]s"
+  description = "secgroup for rocketmq"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+}
+
+resource "huaweicloud_dms_rocketmq_topic" "test" {
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  name        = "%[1]s"
+  permission  = "all"
+  queue_num   = 3
+  
+  brokers {
+    name = "broker-0"
+  }
+}
+
+data "huaweicloud_dms_rocketmq_topic_user" "test" {
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  topic       = huaweicloud_dms_rocketmq_topic.test.name
+}
+`, name)
+}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_topic_user.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_topic_user.go
@@ -1,0 +1,158 @@
+package dms
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDmsRocketMQTopicUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDmsRocketMQTopicUserRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the RocketMQ instance.`,
+			},
+			"topic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the RocketMQ topic.`,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Elem:        DmsRocketMQTopicUserPolicySchema(),
+				Computed:    true,
+				Description: `Indicates the list of user associated with the topic.`,
+			},
+		},
+	}
+}
+
+func DmsRocketMQTopicUserPolicySchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the access key of the user.`,
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the secret key of the user.`,
+			},
+			"white_remote_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the IP address whitelist.`,
+			},
+			"admin": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user is an administrator.`,
+			},
+			"perm": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the permissions of the user.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDmsRocketMQTopicUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*config.Config)
+	region := config.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getRocketmqTopicUser: Query DMS RocketMQ users that have been granted permissions for a topic.
+	var (
+		getRocketmqTopicUserHttpUrl = "v2/{project_id}/instances/{instance_id}/topics/{topic}/accesspolicy"
+		getRocketmqTopicUserProduct = "dms"
+	)
+	getRocketmqTopicUserClient, err := config.NewServiceClient(getRocketmqTopicUserProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DmsRocketMQTopicUser Client: %s", err)
+	}
+
+	getRocketmqTopicUserPath := getRocketmqTopicUserClient.Endpoint + getRocketmqTopicUserHttpUrl
+	getRocketmqTopicUserPath = strings.ReplaceAll(getRocketmqTopicUserPath, "{project_id}",
+		getRocketmqTopicUserClient.ProjectID)
+	getRocketmqTopicUserPath = strings.ReplaceAll(getRocketmqTopicUserPath, "{instance_id}",
+		fmt.Sprintf("%v", d.Get("instance_id")))
+	getRocketmqTopicUserPath = strings.ReplaceAll(getRocketmqTopicUserPath, "{topic}",
+		fmt.Sprintf("%v", d.Get("topic")))
+
+	getRocketmqTopicUserResp, err := pagination.ListAllItems(
+		getRocketmqTopicUserClient,
+		"offset",
+		getRocketmqTopicUserPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DmsRocketMQTopicUser")
+	}
+
+	getRocketmqTopicUserRespJson, err := json.Marshal(getRocketmqTopicUserResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getRocketmqTopicUserRespBody interface{}
+	err = json.Unmarshal(getRocketmqTopicUserRespJson, &getRocketmqTopicUserRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("policies", flattenGetRocketmqTopicUserResponseBodyPolicy(getRocketmqTopicUserRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetRocketmqTopicUserResponseBodyPolicy(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("policies", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"access_key":           utils.PathSearch("access_key", v, nil),
+			"secret_key":           utils.PathSearch("secret_key", v, nil),
+			"white_remote_address": utils.PathSearch("white_remote_address", v, nil),
+			"admin":                utils.PathSearch("admin", v, nil),
+			"perm":                 utils.PathSearch("perm", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dms rocketmq topic user data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dms rocketmq topic user data source
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDatasourceDmsRocketMQTopicUser_basic'  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDatasourceDmsRocketMQTopicUser_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDmsRocketMQTopicUser_basic
=== PAUSE TestAccDatasourceDmsRocketMQTopicUser_basic
=== CONT  TestAccDatasourceDmsRocketMQTopicUser_basic
--- PASS: TestAccDatasourceDmsRocketMQTopicUser_basic (706.10s) 
PASS                                                                                                             
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       706.141s
```
