### PR TITLE
refactor(dms/datasource): fix lint issues

### DIFF
--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_maintainwindow_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_maintainwindow_test.go
@@ -1,7 +1,6 @@
 package dms
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,8 +28,8 @@ func TestAccDmsMaintainWindowDataSource_basic(t *testing.T) {
 	})
 }
 
-var testAccDmsMaintainWindowDataSource_basic = fmt.Sprintf(`
+var testAccDmsMaintainWindowDataSource_basic = `
 data "huaweicloud_dms_maintainwindow" "maintainwindow1" {
   seq = 1
 }
-`)
+`

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_product_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_product_test.go
@@ -1,7 +1,6 @@
 package dms
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -105,7 +104,7 @@ func TestAccDmsProductDataSource_rabbitmqCluster(t *testing.T) {
 	})
 }
 
-var testAccDmsProductDataSource_basic = fmt.Sprintf(`
+var testAccDmsProductDataSource_basic = `
 data "huaweicloud_dms_product" "product1" {
   engine            = "kafka"
   version           = "1.1.0"
@@ -114,29 +113,29 @@ data "huaweicloud_dms_product" "product1" {
   storage           = 600
   storage_spec_code = "dms.physical.storage.high"
 }
-`)
+`
 
-var testAccDmsProductDataSource_kafkaVmSpec = fmt.Sprintf(`
+var testAccDmsProductDataSource_kafkaVmSpec = `
 data "huaweicloud_dms_product" "test" {
   instance_type    = "cluster"
   version          = "2.3.0"
   engine           = "kafka"
   vm_specification = "c6.large.2"
 }
-`)
+`
 
-var testAccDmsProductDataSource_rabbitmqSingle = fmt.Sprintf(`
+var testAccDmsProductDataSource_rabbitmqSingle = `
 data "huaweicloud_dms_product" "product1" {
   engine            = "rabbitmq"
   instance_type     = "single"
   storage_spec_code = "dms.physical.storage.high"
 }
-`)
+`
 
-var testAccDmsProductDataSource_rabbitmqCluster = fmt.Sprintf(`
+var testAccDmsProductDataSource_rabbitmqCluster = `
 data "huaweicloud_dms_product" "product1" {
   engine            = "rabbitmq"
   instance_type     = "cluster"
   storage_spec_code = "dms.physical.storage.high"
 }
-`)
+`

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_product_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_product_test.go
@@ -1,6 +1,7 @@
 package dms
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -104,7 +105,9 @@ func TestAccDmsProductDataSource_rabbitmqCluster(t *testing.T) {
 	})
 }
 
-var testAccDmsProductDataSource_basic = `
+var testAccDmsProductDataSource_basic = fmt.Sprintf(`
+data "huaweicloud_availability_zones" "zones" {}
+
 data "huaweicloud_dms_product" "product1" {
   engine            = "kafka"
   version           = "1.1.0"
@@ -112,8 +115,10 @@ data "huaweicloud_dms_product" "product1" {
   partition_num     = 300
   storage           = 600
   storage_spec_code = "dms.physical.storage.high"
+
+  availability_zones = data.huaweicloud_availability_zones.zones.names
 }
-`
+`)
 
 var testAccDmsProductDataSource_kafkaVmSpec = `
 data "huaweicloud_dms_product" "test" {

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_maintainwindow.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_maintainwindow.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/dms/v2/maintainwindows"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_maintainwindow.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_maintainwindow.go
@@ -2,19 +2,17 @@ package dms
 
 import (
 	"context"
+	"log"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
-
 	"github.com/chnsz/golangsdk/openstack/dms/v2/maintainwindows"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func DataSourceDmsMaintainWindow() *schema.Resource {
@@ -52,13 +50,13 @@ func DataSourceDmsMaintainWindow() *schema.Resource {
 }
 
 func dataSourceDmsMaintainWindowRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	dmsV2Client, err := config.DmsV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud DMS client V2: %s", err)
+		return diag.Errorf("error creating DMS client V2: %s", err)
 	}
 
-	maintainWindows, err := maintainwindows.Get(dmsV2Client)
+	maintainWindow, err := maintainwindows.Get(dmsV2Client)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -77,16 +75,16 @@ func dataSourceDmsMaintainWindowRead(_ context.Context, d *schema.ResourceData, 
 		filter["Default"] = v.(bool)
 	}
 
-	data, err := utils.FilterSliceWithZeroField(maintainWindows, filter)
+	data, err := utils.FilterSliceWithZeroField(maintainWindow, filter)
 	if err != nil {
-		return fmtp.DiagErrorf("Error filtering DMS maintain window data, %s", err)
+		return diag.Errorf("error filtering DMS maintain window data, %s", err)
 	}
 	if len(data) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. Please change your filters and try again.")
+		return diag.Errorf("your query returned no results. Please change your filters and try again.")
 	}
 
 	mw := data[0].(maintainwindows.MaintainWindow)
-	logp.Printf("[DEBUG] Dms MaintainWindow : %#v", mw)
+	log.Printf("[DEBUG] Dms MaintainWindow : %#v", mw)
 
 	d.SetId(strconv.Itoa(mw.ID))
 	mErr := multierror.Append(
@@ -96,7 +94,7 @@ func dataSourceDmsMaintainWindowRead(_ context.Context, d *schema.ResourceData, 
 		d.Set("default", mw.Default),
 	)
 	if mErr.ErrorOrNil() != nil {
-		return fmtp.DiagErrorf("error setting DMS maintain window attributes: %s", mErr)
+		return diag.Errorf("error setting DMS maintain window attributes: %s", mErr)
 	}
 
 	return nil

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
@@ -2,13 +2,12 @@ package dms
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/chnsz/golangsdk/openstack/dms/v2/products"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -107,43 +106,44 @@ func DataSourceDmsProduct() *schema.Resource {
 	}
 }
 
-func getIObyIOtype(d *schema.ResourceData, IOs []products.IO) []products.IO {
-	io_type := d.Get("io_type").(string)
-	storage_spec_code := d.Get("storage_spec_code").(string)
+func getIOByType(d *schema.ResourceData, productIOs []products.IO) []products.IO {
+	ioType := d.Get("io_type").(string)
+	storageSpecCode := d.Get("storage_spec_code").(string)
 
-	if io_type != "" || storage_spec_code != "" {
-		var getIOs []products.IO
-		for _, io := range IOs {
-			if io_type == io.IOType || storage_spec_code == io.StorageSpecCode {
-				getIOs = append(getIOs, io)
+	if ioType != "" || storageSpecCode != "" {
+		matchedIOs := make([]products.IO,0)
+		for _, io := range productIOs {
+			if ioType == io.IOType || storageSpecCode == io.StorageSpecCode {
+				matchedIOs = append(matchedIOs, io)
 			}
 		}
-		return getIOs
+		return matchedIOs
 	}
 
-	return IOs
+	return productIOs
 }
 
 func getProducts(config *config.Config, region, engine string) (*products.GetResponse, error) {
 	dmsV2Client, err := config.DmsV2Client(region)
 	if err != nil {
-		return nil, fmtp.Errorf("Error get HuaweiCloud DMS product client V2: %s", err)
+		return nil, fmt.Errorf("error getting DMS product client V2: %s", err)
 	}
-	v, err := products.Get(dmsV2Client, engine)
+	v, err := products.Get(dmsV2Client, engine) //nolint: staticcheck
 	return v, err
 }
 
-func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
+// Currently the complex is 37 and will be repaired later.
+func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { //nolint: gocyclo
+	cfg := meta.(*config.Config)
 
 	instanceEngine := d.Get("engine").(string)
-	r, err := getProducts(config, config.GetRegion(d), instanceEngine)
+	r, err := getProducts(cfg, cfg.GetRegion(d), instanceEngine)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	hourlyProducts := r.Hourly
-	logp.Printf("[DEBUG] Get a list of DMS products, engine:%s, list: %+v", instanceEngine, hourlyProducts)
+	log.Printf("[DEBUG] Get a list of DMS products, engine:%s, list: %+v", instanceEngine, hourlyProducts)
 
 	instanceType := d.Get("instance_type").(string)
 	vmSpecification := d.Get("vm_specification").(string)
@@ -189,11 +189,11 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 						continue
 					}
 
-					IOs := getIObyIOtype(d, detail.IOs)
-					if len(IOs) == 0 {
+					productIOs := getIOByType(d, detail.IOs)
+					if len(productIOs) == 0 {
 						continue
 					}
-					detail.IOs = IOs
+					detail.IOs = productIOs
 				} else {
 					productInfos := make([]products.ProductInfo, 0)
 					for _, productInfo := range detail.ProductInfos {
@@ -207,11 +207,11 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 							continue
 						}
 
-						IOs := getIObyIOtype(d, productInfo.IOs)
-						if len(IOs) == 0 {
+						productIOs := getIOByType(d, productInfo.IOs)
+						if len(productIOs) == 0 {
 							continue
 						}
-						productInfo.IOs = IOs
+						productInfo.IOs = productIOs
 						productInfos = append(productInfos, productInfo)
 					}
 					if len(productInfos) == 0 {
@@ -233,7 +233,7 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 	}
 
 	if len(filteredProducts) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. Please change your filters and try again.")
+		return diag.Errorf("your query returned no results. Please change your filters and try again.")
 	}
 
 	pd := filteredProducts[0]
@@ -258,7 +258,7 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 		)
 	} else {
 		if len(pd.ProductInfos) < 1 {
-			return fmtp.DiagErrorf("Your query returned no results. Please change your filters and try again.")
+			return diag.Errorf("your query returned no results. Please change your filters and try again.")
 		}
 		pdInfo := pd.ProductInfos[0]
 		d.SetId(pdInfo.ProductID)
@@ -277,9 +277,9 @@ func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta in
 			d.Set("availability_zones", pdInfo.AvailableZones),
 		)
 	}
-	logp.Printf("[DEBUG] DMS product detail : %#v", pd)
+	log.Printf("[DEBUG] DMS product detail : %#v", pd)
 	if mErr.ErrorOrNil() != nil {
-		return fmtp.DiagErrorf("Error setting DMS product attributes: %s", mErr)
+		return diag.Errorf("error setting DMS product attributes: %s", mErr)
 	}
 
 	return nil

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_product.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/dms/v2/products"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -111,7 +111,7 @@ func getIOByType(d *schema.ResourceData, productIOs []products.IO) []products.IO
 	storageSpecCode := d.Get("storage_spec_code").(string)
 
 	if ioType != "" || storageSpecCode != "" {
-		matchedIOs := make([]products.IO,0)
+		matchedIOs := make([]products.IO, 0)
 		for _, io := range productIOs {
 			if ioType == io.IOType || storageSpecCode == io.StorageSpecCode {
 				matchedIOs = append(matchedIOs, io)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Fix some lint issues in `huaweicloud_dms_maintainwindow` and `huaweicloud_dms_product`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsMaintainWindowDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsMaintainWindowDataSource -timeout 360m -parallel 4
=== RUN   TestAccDmsMaintainWindowDataSource_basic
=== PAUSE TestAccDmsMaintainWindowDataSource_basic
=== CONT  TestAccDmsMaintainWindowDataSource_basic
--- PASS: TestAccDmsMaintainWindowDataSource_basic (12.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       12.947s

```

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsProductDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsProductDataSource -timeout 360m -parallel 4
=== RUN   TestAccDmsProductDataSource_basic
=== PAUSE TestAccDmsProductDataSource_basic
=== RUN   TestAccDmsProductDataSource_kafkaVmSpec
=== PAUSE TestAccDmsProductDataSource_kafkaVmSpec
=== RUN   TestAccDmsProductDataSource_rabbitmqSingle
=== PAUSE TestAccDmsProductDataSource_rabbitmqSingle
=== RUN   TestAccDmsProductDataSource_rabbitmqCluster
=== PAUSE TestAccDmsProductDataSource_rabbitmqCluster
=== CONT  TestAccDmsProductDataSource_basic
=== CONT  TestAccDmsProductDataSource_rabbitmqSingle
=== CONT  TestAccDmsProductDataSource_kafkaVmSpec
=== CONT  TestAccDmsProductDataSource_rabbitmqCluster
--- PASS: TestAccDmsProductDataSource_rabbitmqSingle (21.72s)
--- PASS: TestAccDmsProductDataSource_basic (23.58s)
--- PASS: TestAccDmsProductDataSource_rabbitmqCluster (23.59s)
--- PASS: TestAccDmsProductDataSource_kafkaVmSpec (24.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       24.336s

```
