### PR TITLE
fix(AS): Extend the end time of AS policy

### DIFF
--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
@@ -210,7 +210,7 @@ resource "huaweicloud_as_bandwidth_policy" "test" {
     recurrence_type  = "Weekly"
     recurrence_value = "1,3,5"
     start_time       = "2022-09-30T12:00Z"
-    end_time         = "2022-12-30T12:00Z"
+    end_time         = "2122-12-30T12:00Z"
   }
 }
 `, name)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The end time of the scaling action triggered periodically must be later than the current time

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run=TestAccASBandWidthPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASBandWidthPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_basic
--- PASS: TestAccASBandWidthPolicy_basic (47.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        47.636s
```
