### PR TITLE
refactor(dms/kafka_instance): fix lint issues

### DIFF
--- a/docs/data-sources/dms_kafka_instances.md
+++ b/docs/data-sources/dms_kafka_instances.md
@@ -121,7 +121,7 @@ The `instances` block supports:
 
 * `user_name` - The username who created the instance.
 
-* `manegement_connect_address` - The connection address of the Kafka manager of an instance.
+* `management_connect_address` - The connection address of the Kafka manager of an instance.
 
 * `tags` - The key/value pairs to associate with the instance.
 
@@ -129,7 +129,7 @@ The `instances` block supports:
 
 The `cross_vpc_accesses` block supports:
 
-* `lisenter_ip` - The listener IP address.
+* `listener_ip` - The listener IP address.
 
 * `advertised_ip` - The advertised IP Address.
 

--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -253,12 +253,12 @@ In addition to all arguments above, the following attributes are exported:
 * `user_id` - Indicates the ID of the user who created the DMS kafka instance
 * `user_name` - Indicates the name of the user who created the DMS kafka instance
 * `connect_address` - Indicates the IP address of the DMS kafka instance.
-* `manegement_connect_address` - Indicates the connection address of the Kafka Manager of a Kafka instance.
+* `management_connect_address` - Indicates the connection address of the Kafka Manager of a Kafka instance.
 * `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
 
 The `cross_vpc_accesses` block supports:
 
-* `lisenter_ip` - The listener IP address.
+* `listener_ip` - The listener IP address.
 * `port` - The port number.
 * `port_id` - The port ID associated with the address.
 

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
@@ -190,7 +190,7 @@ func DataSourceDmsKafkaInstances() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"manegement_connect_address": {
+						"management_connect_address": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -199,12 +199,18 @@ func DataSourceDmsKafkaInstances() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						// Typo, it is only kept in the code, will not be shown in the docs.
+						"manegement_connect_address": {
+							Type:       schema.TypeString,
+							Computed:   true,
+							Deprecated: "typo in manegement_connect_address, please use \"management_connect_address\" instead.",
+						},
 						"cross_vpc_accesses": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"lisenter_ip": {
+									"listener_ip": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
@@ -219,6 +225,12 @@ func DataSourceDmsKafkaInstances() *schema.Resource {
 									"port_id": {
 										Type:     schema.TypeString,
 										Computed: true,
+									},
+									// Typo, it is only kept in the code, will not be shown in the docs.
+									"lisenter_ip": {
+										Type:       schema.TypeString,
+										Computed:   true,
+										Deprecated: "typo in lisenter_ip, please use \"listener_ip\" instead.",
 									},
 								},
 							},
@@ -282,6 +294,7 @@ func flattenKafkaInstanceList(client *golangsdk.ServiceClient, conf *config.Conf
 			"resource_spec_code":         val.ResourceSpecCode,
 			"user_id":                    val.UserID,
 			"user_name":                  val.UserName,
+			"management_connect_address": val.ManagementConnectAddress,
 			"manegement_connect_address": val.ManagementConnectAddress,
 			"tags":                       utils.TagsToMap(val.Tags),
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Fix some lint issues in `huaweicloud_dms_rabbitmq_instance`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccKafkaInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccKafkaInstance -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstancesDataSource_basic
--- PASS: TestAccKafkaInstancesDataSource_basic (592.66s)
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_withEpsId
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_withEpsId (585.26s)
--- PASS: TestAccKafkaInstance_compatible (998.31s)
--- PASS: TestAccKafkaInstance_newFormat (2309.55s)
--- PASS: TestAccKafkaInstance_basic (2700.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3292.841s
```
