### PR TITLE
refactor(dms): fix resize issues caused by API changes

### DIFF
--- a/docs/resources/dms_rabbitmq_instance.md
+++ b/docs/resources/dms_rabbitmq_instance.md
@@ -138,7 +138,7 @@ In addition to all arguments above, the following attributes are exported:
 * `user_id` - Indicates the ID of the user who created the DMS RabbitMQ instance
 * `user_name` - Indicates the name of the user who created the DMS RabbitMQ instance
 * `connect_address` - Indicates the IP address of the DMS RabbitMQ instance.
-* `manegement_connect_address` - Indicates the management address of the DMS RabbitMQ instance.
+* `management_connect_address` - Indicates the management address of the DMS RabbitMQ instance.
 
 ## Timeouts
 

--- a/huaweicloud/resource_huaweicloud_bcs_instance.go
+++ b/huaweicloud/resource_huaweicloud_bcs_instance.go
@@ -548,7 +548,7 @@ func resourceBCSInstanceV2Delete(d *schema.ResourceData, meta interface{}) error
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"DELETING", "RUNNING"},
 			Target:     []string{"DELETED"},
-			Refresh:    dms.DmsKafkaInstanceStateRefreshFunc(dmsClient, kafkaID),
+			Refresh:    dms.KafkaInstanceStateRefreshFunc(dmsClient, kafkaID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -273,7 +273,7 @@ func testAccKafkaInstance_update(rName, updateName string) string {
 data "huaweicloud_dms_product" "test" {
   engine            = "kafka"
   instance_type     = "cluster"
-  version           = "2.3.0"
+  version           = "2.7"
   bandwidth         = "300MB"
   storage_spec_code = "dms.physical.storage.ultra"
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
@@ -187,14 +187,14 @@ resource "huaweicloud_networking_secgroup" "test" {
 data "huaweicloud_dms_product" "test1" {
   engine        = "rabbitmq"
   instance_type = "cluster"
-  version       = "3.7.17"
+  version       = "3.8.35"
   node_num      = 3
 }
 
 data "huaweicloud_dms_product" "test2" {
   engine        = "rabbitmq"
   instance_type = "cluster"
-  version       = "3.7.17"
+  version       = "3.8.35"
   node_num      = 5
 }
 
@@ -334,7 +334,7 @@ func testAccDmsRabbitmqInstance_single(rName string) string {
 data "huaweicloud_dms_product" "single" {
   engine           = "rabbitmq"
   instance_type    = "single"
-  version          = "3.7.17"
+  version          = "3.8.35"
   node_num         = 1
 }
 

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_instances.go
@@ -316,7 +316,7 @@ func flattenKafkaInstanceList(client *golangsdk.ServiceClient, conf *config.Conf
 			instance["public_conn_addresses"] = strings.TrimSpace(val.PublicConnectionAddress)
 		}
 
-		crossVpcAccess, err := flattenConnectPorts(val.CrossVpcInfo)
+		crossVpcAccess, err := flattenCrossVpcInfo(val.CrossVpcInfo)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error retrieving details of the cross-VPC information: %v", err)
 		}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_instances.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_instances.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -340,7 +341,7 @@ func flattenGetRocketmqInstancesResponseBodyInstanceRef(resp interface{}, config
 		crossVpcInfo := utils.PathSearch("cross_vpc_info", v, nil)
 		var crossVpcAccess []map[string]interface{}
 		if crossVpcInfo != nil {
-			crossVpcAccess, err = flattenConnectPorts(crossVpcInfo.(string))
+			crossVpcAccess, err = flattenCrossVpcInfo(crossVpcInfo.(string))
 			if err != nil {
 				return nil, err
 			}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
@@ -263,13 +263,13 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 				MaxItems: 3,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"listener_ip": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"advertised_ip": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
+						},
+						"listener_ip": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"port": {
@@ -293,29 +293,27 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 	}
 }
 
-func resourceDmsKafkaPublicIpIDs(d *schema.ResourceData, bandwidth string) (string, error) {
-	publicIpIDsRaw := d.Get("public_ip_ids").([]interface{})
-
-	IdNumMap := map[string]int{
+func validateAndBuildPublicIpIDParam(publicIpIDs []interface{}, bandwidth string) (string, error) {
+	bandwidthAndIPMapper := map[string]int{
 		"100MB":  3,
 		"300MB":  3,
 		"600MB":  4,
 		"1200MB": 8,
 	}
-	if IdNumMap[bandwidth] != len(publicIpIDsRaw) {
-		return "", fmt.Errorf("error creating DMS kafka instance: "+
-			"%d public ip IDs needed when bandwidth is set to %s, but got %d",
-			IdNumMap[bandwidth], bandwidth, len(publicIpIDsRaw))
-	}
+	needIpCount := bandwidthAndIPMapper[bandwidth]
 
-	publicIpIDs := utils.ExpandToStringList(publicIpIDsRaw)
-	return strings.Join(publicIpIDs, ","), nil
+	if needIpCount != len(publicIpIDs) {
+		return "", fmt.Errorf("error creating Kafka instance: "+
+			"%d public ip IDs needed when bandwidth is set to %s, but got %d",
+			needIpCount, bandwidth, len(publicIpIDs))
+	}
+	return strings.Join(utils.ExpandToStringList(publicIpIDs), ","), nil
 }
 
-func getKafkaProductDetail(config *config.Config, d *schema.ResourceData) (*products.Detail, error) {
-	productRsp, err := getProducts(config, config.GetRegion(d), "kafka")
+func getKafkaProductDetails(config *config.Config, d *schema.ResourceData) (*products.Detail, error) {
+	productRsp, err := getProducts(config, config.GetRegion(d), engineKafka)
 	if err != nil {
-		return nil, fmt.Errorf("error querying product detail, please check product_id, error: %s", err)
+		return nil, fmt.Errorf("error querying Kafka product list: %s", err)
 	}
 
 	productID := d.Get("product_id").(string)
@@ -333,65 +331,67 @@ func getKafkaProductDetail(config *config.Config, d *schema.ResourceData) (*prod
 			}
 		}
 	}
-	return nil, fmt.Errorf("can not found product detail base on product_id: %s", productID)
+	return nil, fmt.Errorf("can not found Kafka product details base on product_id: %s", productID)
 }
 
-func updateCrossVpcAccesses(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+func updateCrossVpcAccess(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	oldVal, newVal := d.GetChange("cross_vpc_accesses")
-	var crossVpcAccess []map[string]interface{}
+	var crossVpcAccessArr []map[string]interface{}
+
 	if len(oldVal.([]interface{})) < 1 {
-		v, err := instances.Get(client, d.Id()).Extract()
+		instance, err := instances.Get(client, d.Id()).Extract()
 		if err != nil {
 			return fmt.Errorf("error getting DMS instance: %v", err)
 		}
-		crossVpcAccess, err = flattenConnectPorts(v.CrossVpcInfo)
+
+		crossVpcAccessArr, err = flattenCrossVpcInfo(instance.CrossVpcInfo)
 		if err != nil {
-			return fmt.Errorf("[ERROR] error retrieving details of the cross-VPC information: %v", err)
+			return fmt.Errorf("error retrieving details of the cross-VPC: %v", err)
 		}
 	} else {
-		oldAccesses := oldVal.([]interface{})
-		for _, val := range oldAccesses {
-			crossVpcAccess = append(crossVpcAccess, val.(map[string]interface{}))
+		for _, val := range oldVal.([]interface{}) {
+			crossVpcAccessArr = append(crossVpcAccessArr, val.(map[string]interface{}))
 		}
 	}
 
-	newAccesses := newVal.([]interface{})
+	newAccessArr := newVal.([]interface{})
 	contentMap := make(map[string]string)
-	for i, oldAccess := range crossVpcAccess {
-		lisIp := oldAccess["listener_ip"].(string)
-		if lisIp == "" {
-			lisIp = oldAccess["lisenter_ip"].(string)
+	for i, oldAccess := range crossVpcAccessArr {
+		listenerIp := oldAccess["listener_ip"].(string)
+		if listenerIp == "" {
+			listenerIp = oldAccess["lisenter_ip"].(string)
 		}
-		// If we configure the advertised ip as ["192.168.0.19", "192.168.0.8"], the length of new accesses is 2, and
-		// the length of old accesses is always 3.
-		if len(newAccesses) > i {
+		// If we configure the advertised ip as ["192.168.0.19", "192.168.0.8"], the length of new accesses is 2,
+		// and the length of old accesses is always 3.
+		if len(newAccessArr) > i {
 			// Make sure the index is valid.
-			newAccess := newAccesses[i].(map[string]interface{})
+			newAccess := newAccessArr[i].(map[string]interface{})
 			// Since the "advertised_ip" is already a definition in the schema, the key name must exist.
 			if advIp, ok := newAccess["advertised_ip"].(string); ok && advIp != "" {
-				contentMap[lisIp] = advIp
+				contentMap[listenerIp] = advIp
 				continue
 			}
 		}
-		contentMap[lisIp] = lisIp
+		contentMap[listenerIp] = listenerIp
 	}
 
-	opts := instances.CrossVpcUpdateOpts{
+	log.Printf("[DEBUG} Update Kafka cross-vpc contentMap: %#v", contentMap)
+
+	updateRst, err := instances.UpdateCrossVpc(client, d.Id(), instances.CrossVpcUpdateOpts{
 		Contents: contentMap,
-	}
-	result, err := instances.UpdateCrossVpc(client, d.Id(), opts)
+	})
 	if err != nil {
 		return fmt.Errorf("error updating advertised IP: %v", err)
 	}
 
-	if !result.Success {
-		failureIp := make([]string, 0, len(result.Connections))
-		for _, val := range result.Connections {
-			if !val.Success {
-				failureIp = append(failureIp, val.ListenersIp)
+	if !updateRst.Success {
+		failedIps := make([]string, 0, len(updateRst.Connections))
+		for _, conn := range updateRst.Connections {
+			if !conn.Success {
+				failedIps = append(failedIps, conn.ListenersIp)
 			}
 		}
-		return fmt.Errorf("failed to update the advertised IPs corresponding to some listener IPs (%v)", failureIp)
+		return fmt.Errorf("failed to update the advertised IPs corresponding to some listener IPs (%v)", failedIps)
 	}
 	return nil
 }
@@ -404,9 +404,9 @@ func resourceDmsKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	var accessesBeforeChanges = d.Get("cross_vpc_accesses").([]interface{})
 	var dErr diag.Diagnostics
 	if _, ok := d.GetOk("flavor_id"); ok {
-		dErr = newKafkaInstanceCreate(ctx, d, meta)
+		dErr = createKafkaInstanceWithFlavor(ctx, d, meta)
 	} else {
-		dErr = oldKafkaInstanceCreate(ctx, d, meta)
+		dErr = createKafkaInstanceWithProductID(ctx, d, meta)
 	}
 	if dErr != nil {
 		return dErr
@@ -422,26 +422,26 @@ func resourceDmsKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		if err != nil {
 			return diag.Errorf("error creating DMS instance client: %s", err)
 		}
-		if err = updateCrossVpcAccesses(client, d); err != nil {
-			return diag.Errorf("failed to update default advertised IP: %v", err)
+		if err = updateCrossVpcAccess(client, d); err != nil {
+			return diag.Errorf("Failed to update default advertised IP: %v", err)
 		}
 	}
 
 	return resourceDmsKafkaInstanceRead(ctx, d, meta)
 }
 
-func newKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createKafkaInstanceWithFlavor(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	client, err := conf.DmsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS Kafka(v2) client: %s", err)
 	}
 
 	createOpts := &instances.CreateOps{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
-		Engine:              "kafka",
+		Engine:              engineKafka,
 		EngineVersion:       d.Get("engine_version").(string),
 		AccessUser:          d.Get("access_user").(string),
 		VPCID:               d.Get("vpc_id").(string),
@@ -465,15 +465,13 @@ func newKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		createOpts.PublicIpID = strings.Join(utils.ExpandToStringList(ids.([]interface{})), ",")
 	}
 
-	sslEnable := false
+	createOpts.SslEnable = false
 	if d.Get("access_user").(string) != "" && d.Get("password").(string) != "" {
-		sslEnable = true
+		createOpts.SslEnable = true
 	}
-	createOpts.SslEnable = sslEnable
 
 	var availableZones []string
-	zoneIDs, ok := d.GetOk("available_zones")
-	if ok {
+	if zoneIDs, ok := d.GetOk("available_zones"); ok {
 		availableZones = utils.ExpandToStringList(zoneIDs.([]interface{}))
 	} else {
 		// convert the codes of the availability zone into ids
@@ -486,44 +484,39 @@ func newKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	createOpts.AvailableZones = availableZones
 
 	// set tags
-	tagRaw := d.Get("tags").(map[string]interface{})
-	if len(tagRaw) > 0 {
-		taglist := utils.ExpandResourceTags(tagRaw)
-		createOpts.Tags = taglist
+	if tagRaw := d.Get("tags").(map[string]interface{}); len(tagRaw) > 0 {
+		createOpts.Tags = utils.ExpandResourceTags(tagRaw)
 	}
-
 	log.Printf("[DEBUG] Create DMS Kafka instance options: %#v", createOpts)
-	// Add password here so it wouldn't go in the above log entry
+	// Add password here, so it wouldn't go in the above log entry
 	createOpts.Password = d.Get("password").(string)
 	createOpts.KafkaManagerPassword = d.Get("manager_password").(string)
 
-	v, err := instances.Create(client, createOpts).Extract()
+	kafkaInstance, err := instances.Create(client, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("error creating DMS kafka instance: %s", err)
+		return diag.Errorf("error creating Kafka instance: %s", err)
 	}
-	log.Printf("[INFO] instance ID: %s", v.InstanceID)
-
-	// Store the instance ID now
-	d.SetId(v.InstanceID)
+	instanceID := kafkaInstance.InstanceID
+	log.Printf("[INFO] Creating Kafka instance, ID: %s", instanceID)
+	d.SetId(instanceID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"CREATING"},
 		Target:       []string{"RUNNING"},
-		Refresh:      DmsKafkaInstanceStateRefreshFunc(client, v.InstanceID),
+		Refresh:      KafkaInstanceStateRefreshFunc(client, instanceID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        300 * time.Second,
 		PollInterval: 15 * time.Second,
 	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error waiting for instance (%s) to become ready: %s", v.InstanceID, err)
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for Kafka instance (%s) to be ready: %s", instanceID, err)
 	}
 
 	// After the kafka instance is created, wait for the access port to complete the binding.
 	stateConf = &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"BOUND"},
-		Refresh:      portsBindStatusRefreshFunc(client, d.Id()),
+		Refresh:      portBindStatusRefreshFunc(client, d.Id()),
 		Timeout:      5 * time.Minute,
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -536,15 +529,15 @@ func newKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return resourceDmsKafkaInstanceRead(ctx, d, meta)
 }
 
-func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createKafkaInstanceWithProductID(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	dmsV2Client, err := cfg.DmsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS Kafka(v2) client: %s", err)
 	}
 
-	product, err := getKafkaProductDetail(cfg, d)
+	product, err := getKafkaProductDetails(cfg, d)
 	if err != nil {
 		return diag.Errorf("Error querying product detail: %s", err)
 	}
@@ -556,8 +549,8 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	// check storage
 	storageSpace, ok := d.GetOk("storage_space")
 	if ok && storageSpace.(int) < int(defaultStorageSpace) {
-		return diag.Errorf("The storage capacity is less than the default capacity of the product. "+
-			"The default storage capacity of product is %v, storage_space is %v.", defaultStorageSpace, storageSpace)
+		return diag.Errorf("storage capacity (storage_space) must be greater than the minimum capacity of the product, "+
+			"product capacity is %v, got: %v", defaultStorageSpace, storageSpace)
 	}
 
 	sslEnable := false
@@ -566,11 +559,10 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	var availableZones []string
-	zoneIDs, ok := d.GetOk("available_zones")
-	if ok {
+	if zoneIDs, ok := d.GetOk("available_zones"); ok {
 		availableZones = utils.ExpandToStringList(zoneIDs.([]interface{}))
 	} else {
-		// convert the codes of the availability zone into ids
+		// Convert AZ Codes to AZ IDs
 		azCodes := d.Get("availability_zones").(*schema.Set)
 		availableZones, err = getAvailableZoneIDByCode(cfg, region, azCodes.List())
 		if err != nil {
@@ -581,7 +573,7 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	createOpts := &instances.CreateOps{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
-		Engine:              "kafka",
+		Engine:              engineKafka,
 		EngineVersion:       d.Get("engine_version").(string),
 		Specification:       bandwidth,
 		StorageSpace:        int(defaultStorageSpace),
@@ -603,8 +595,8 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		EnterpriseProjectID: common.GetEnterpriseProjectID(d, cfg),
 	}
 
-	if _, ok := d.GetOk("public_ip_ids"); ok {
-		publicIpIDs, err := resourceDmsKafkaPublicIpIDs(d, bandwidth)
+	if pubIpIDs, ok := d.GetOk("public_ip_ids"); ok {
+		publicIpIDs, err := validateAndBuildPublicIpIDParam(pubIpIDs.([]interface{}), bandwidth)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -613,47 +605,44 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	// set tags
-	tagRaw := d.Get("tags").(map[string]interface{})
-	if len(tagRaw) > 0 {
-		taglist := utils.ExpandResourceTags(tagRaw)
-		createOpts.Tags = taglist
+	if tagsRaw := d.Get("tags").(map[string]interface{}); len(tagsRaw) > 0 {
+		createOpts.Tags = utils.ExpandResourceTags(tagsRaw)
 	}
-
 	log.Printf("[DEBUG] Create DMS Kafka instance options: %#v", createOpts)
-	// Add password here so it wouldn't go in the above log entry
+
+	// Add password here, so it wouldn't go in the above log entry
 	createOpts.Password = d.Get("password").(string)
 	createOpts.KafkaManagerPassword = d.Get("manager_password").(string)
 
-	v, err := instances.Create(dmsV2Client, createOpts).Extract()
+	kafkaInstance, err := instances.Create(dmsV2Client, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating DMS kafka instance: %s", err)
 	}
-	log.Printf("[INFO] instance ID: %s", v.InstanceID)
+	instanceID := kafkaInstance.InstanceID
+	log.Printf("[INFO] Creating Kafka instance, ID: %s", instanceID)
 
 	// Store the instance ID now
-	d.SetId(v.InstanceID)
+	d.SetId(instanceID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"CREATING"},
 		Target:       []string{"RUNNING"},
-		Refresh:      DmsKafkaInstanceStateRefreshFunc(dmsV2Client, v.InstanceID),
+		Refresh:      KafkaInstanceStateRefreshFunc(dmsV2Client, instanceID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        300 * time.Second,
 		PollInterval: 15 * time.Second,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error waiting for instance (%s) to become ready: %s", v.InstanceID, err)
+		return diag.Errorf("error waiting for Kafka instance (%s) to be ready: %s", instanceID, err)
 	}
 
 	// resize storage capacity of the instance
 	if ok && storageSpace.(int) != int(defaultStorageSpace) {
-		err = resizeInstance(ctx, d, meta, "kafka")
+		err = resizeInstance(ctx, d, meta, engineKafka)
 		if err != nil {
-			dErrs := diag.Errorf("Kafka instance has created, "+
-				"but an error occurred while resizing the storage capacity. "+
-				"Current storage capacity are %vGB, expected storage_space=%vGB, error message: %s ",
-				defaultStorageSpace, storageSpace.(int), err)
+			dErrs := diag.Errorf("Kafka instance is created, but fails resize the storage capacity, "+
+				"expected %v GB, but got %v GB, error: %s ", storageSpace.(int), defaultStorageSpace, err)
 			dErrs[0].Severity = diag.Warning
 			return dErrs
 		}
@@ -663,7 +652,7 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	stateConf = &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"BOUND"},
-		Refresh:      portsBindStatusRefreshFunc(dmsV2Client, d.Id()),
+		Refresh:      portBindStatusRefreshFunc(dmsV2Client, d.Id()),
 		Timeout:      5 * time.Minute,
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -676,41 +665,41 @@ func oldKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return resourceDmsKafkaInstanceRead(ctx, d, meta)
 }
 
-func flattenConnectPorts(strInfos string) (result []map[string]interface{}, err error) {
+func flattenCrossVpcInfo(crossVpcInfoStr string) ([]map[string]interface{}, error) {
+	if crossVpcInfoStr == "" {
+		return nil, nil
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("[ERROR] Recover panic when flattening cross-VPC infos structure: %#v", r)
 		}
 	}()
 
-	if strInfos == "" {
-		return nil, nil
-	}
-
 	crossVpcInfos := make(map[string]interface{})
-	err = json.Unmarshal([]byte(strInfos), &crossVpcInfos)
+	err := json.Unmarshal([]byte(crossVpcInfoStr), &crossVpcInfos)
 	if err != nil {
-		return
+		return nil, fmt.Errorf("failed to Unmarshal CrossVpcInfo, crossVpcInfo: %s, error: %s", crossVpcInfoStr, err)
 	}
 
-	keyList := make([]string, 0, len(crossVpcInfos))
-	result = make([]map[string]interface{}, len(crossVpcInfos))
-	for k := range crossVpcInfos {
-		keyList = append(keyList, k)
+	ipArr := make([]string, 0, len(crossVpcInfos))
+	for ip := range crossVpcInfos {
+		ipArr = append(ipArr, ip)
 	}
-	sort.Strings(keyList) // Sort by listeners IP.
-	for i, k := range keyList {
-		crossVpcInfo := crossVpcInfos[k].(map[string]interface{})
+	sort.Strings(ipArr) // Sort by listeners IP.
+
+	result := make([]map[string]interface{}, len(crossVpcInfos))
+	for i, ip := range ipArr {
+		crossVpcInfo := crossVpcInfos[ip].(map[string]interface{})
 		result[i] = map[string]interface{}{
-			"listener_ip":   k,
-			"lisenter_ip":   k,
+			"listener_ip":   ip,
+			"lisenter_ip":   ip,
 			"advertised_ip": crossVpcInfo["advertised_ip"],
 			"port":          crossVpcInfo["port"],
 			"port_id":       crossVpcInfo["port_id"],
 		}
 	}
-
-	return
+	return result, nil
 }
 
 func setKafkaFlavorId(d *schema.ResourceData, flavorId string) error {
@@ -725,30 +714,31 @@ func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, met
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
-	dmsV2Client, err := cfg.DmsV2Client(region)
+	client, err := cfg.DmsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS Kafka(v2) client: %s", err)
 	}
-	v, err := instances.Get(dmsV2Client, d.Id()).Extract()
+
+	v, err := instances.Get(client, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "DMS instance")
 	}
-	log.Printf("[DEBUG] DMS kafka instance created success %s: %+v", d.Id(), v)
+	log.Printf("[DEBUG] Get Kafka instance: %+v", v)
 
-	crossVpcAccess, err := flattenConnectPorts(v.CrossVpcInfo)
+	crossVpcAccess, err := flattenCrossVpcInfo(v.CrossVpcInfo)
 	if err != nil {
-		return diag.Errorf("[ERROR] error retrieving details of the cross-VPC information: %v", err)
+		return diag.Errorf("error parsing the cross-VPC information: %v", err)
 	}
 
 	partitionNum, _ := strconv.ParseInt(v.PartitionNum, 10, 64)
-	// convert the ids of the availability zone into codes
+	// Convert the AZ ids to AZ codes.
 	availableZoneIDs := v.AvailableZones
 	availableZoneCodes, err := getAvailableZoneCodeByID(cfg, region, availableZoneIDs)
 	mErr := multierror.Append(nil, err)
 
 	mErr = multierror.Append(mErr,
 		d.Set("region", cfg.GetRegion(d)),
-		setKafkaFlavorId(d, v.ProductID),
+		setKafkaFlavorId(d, v.ProductID), // Set flavor_id or product_id.
 		d.Set("name", v.Name),
 		d.Set("description", v.Description),
 		d.Set("engine", v.Engine),
@@ -787,20 +777,20 @@ func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("access_user", v.AccessUser),
 		d.Set("cross_vpc_accesses", crossVpcAccess),
 	)
+
 	// set tags
-	engine := "kafka"
-	if resourceTags, err := tags.Get(dmsV2Client, engine, d.Id()).Extract(); err == nil {
+	if resourceTags, err := tags.Get(client, engineKafka, d.Id()).Extract(); err == nil {
 		tagMap := utils.TagsToMap(resourceTags.Tags)
-		if err := d.Set("tags", tagMap); err != nil {
-			e := fmt.Errorf("error saving tags to state for DMS kafka instance (%s): %s", d.Id(), err)
-			mErr = multierror.Append(mErr, e)
+		if err = d.Set("tags", tagMap); err != nil {
+			mErr = multierror.Append(mErr,
+				fmt.Errorf("error saving tags to state for DMS kafka instance (%s): %s", d.Id(), err))
 		}
 	} else {
 		log.Printf("[WARN] error fetching tags of DMS kafka instance (%s): %s", d.Id(), err)
 	}
 
 	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("Error setting attributes for DMS kafka instance: %s", mErr)
+		return diag.Errorf("failed to set attributes for DMS kafka instance: %s", mErr)
 	}
 
 	return nil
@@ -811,14 +801,15 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	defer config.MutexKV.Unlock(lockKey)
 
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS Kafka(v2) client: %s", err)
 	}
 
 	var mErr *multierror.Error
 	if d.HasChanges("name", "description", "maintain_begin", "maintain_end",
 		"security_group_id", "retention_policy", "enterprise_project_id") {
+
 		description := d.Get("description").(string)
 		updateOpts := instances.UpdateOpts{
 			Description:         &description,
@@ -833,76 +824,78 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 			updateOpts.Name = d.Get("name").(string)
 		}
 
-		err = instances.Update(dmsV2Client, d.Id(), updateOpts).Err
+		err = instances.Update(client, d.Id(), updateOpts).Err
 		if err != nil {
-			e := fmt.Errorf("error updating DMS kafka Instance: %s", err)
-			mErr = multierror.Append(mErr, e)
+			mErr = multierror.Append(mErr, fmt.Errorf("error updating Kafka Instance: %s", err))
 		}
 	}
 
 	if d.HasChanges("storage_space", "product_id", "flavor_id") {
-		err = resizeInstance(ctx, d, meta, "kafka")
+		err = resizeInstance(ctx, d, meta, engineKafka)
 		if err != nil {
-			e := fmt.Errorf("error resizing DMS kafka Instance: %s", err)
-			mErr = multierror.Append(mErr, e)
+			mErr = multierror.Append(mErr, err)
 		}
 	}
 
 	if d.HasChange("tags") {
 		// update tags
-		engine := "kafka"
-		tagErr := utils.UpdateResourceTags(dmsV2Client, d, engine, d.Id())
-		if tagErr != nil {
-			e := fmt.Errorf("error updating tags of DMS kafka instance:%s, err:%s", d.Id(), tagErr)
-			mErr = multierror.Append(mErr, e)
+		if err = utils.UpdateResourceTags(client, d, engineKafka, d.Id()); err != nil {
+			mErr = multierror.Append(mErr, fmt.Errorf("error updating tags of Kafka instance: %s, err:%s",
+				d.Id(), err))
 		}
 	}
 
 	if d.HasChange("cross_vpc_accesses") {
-		if err = updateCrossVpcAccesses(dmsV2Client, d); err != nil {
+		if err = updateCrossVpcAccess(client, d); err != nil {
 			mErr = multierror.Append(mErr, err)
 		}
 	}
 
 	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error while updating DMS Kafka instances, there %s", mErr)
+		return diag.Errorf("error while updating DMS Kafka instances, %s", mErr)
 	}
 	return resourceDmsKafkaInstanceRead(ctx, d, meta)
 }
 
 func resizeInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, engineType string) error {
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating DMS instance client: %s", err)
+		return fmt.Errorf("error initializing DMS(v2) client: %s", err)
 	}
 
-	opts := instances.ResizeInstanceOpts{}
+	resizeOpts := instances.ResizeInstanceOpts{}
 	if _, ok := d.GetOk("product_id"); ok {
-		if engineType == "kafka" {
-			product, err := getKafkaProductDetail(cfg, d)
+		if engineType == engineKafka {
+			product, err := getKafkaProductDetails(cfg, d)
 			if err != nil {
-				return fmt.Errorf("change storage_space failed, error querying product detail: %s", err)
+				return fmt.Errorf("failed to resize Kafka instance, query product details error: %s", err)
 			}
-			opts.NewSpecCode = product.SpecCode
+			resizeOpts.NewSpecCode = product.SpecCode
+			resizeOpts.NewStorageSpace = d.Get("storage_space").(int)
 		} else {
 			product, err := getRabbitMQProductDetail(cfg, d)
 			if err != nil {
-				return fmt.Errorf("change storage_space failed, error querying product detail: %s", err)
+				return fmt.Errorf("failed to resize RabbitMQ instance, query product details error: %s", err)
 			}
-			opts.NewSpecCode = product.SpecCode
+			resizeOpts.NewSpecCode = product.SpecCode
+			storage, err := strconv.Atoi(product.Storage)
+			if err != nil {
+				return fmt.Errorf("failed to resize RabbitMQ instance, error parsing storage_space to int %v: %s",
+					product.Storage, err)
+			}
+			resizeOpts.NewStorageSpace = storage
 		}
-		opts.NewStorageSpace = d.Get("storage_space").(int)
 	} else {
-		opts.NewSpecCode = d.Get("storage_spec_code").(string)
-		opts.NewStorageSpace = d.Get("storage_space").(int)
+		resizeOpts.NewSpecCode = d.Get("storage_spec_code").(string)
+		resizeOpts.NewStorageSpace = d.Get("storage_space").(int)
 	}
 
-	log.Printf("[DEBUG] Resize DMS storage capacity option : %#v", opts)
+	log.Printf("[DEBUG] Resize DMS %s instance option : %#v", engineType, resizeOpts)
 
-	_, err = instances.Resize(dmsV2Client, d.Id(), opts)
+	_, err = instances.Resize(client, d.Id(), resizeOpts)
 	if err != nil {
-		return fmt.Errorf("resize failed, error: %s", err)
+		return fmt.Errorf("resize instance failed: %s", err)
 	}
 
 	var flavorId string
@@ -912,39 +905,39 @@ func resizeInstance(ctx context.Context, d *schema.ResourceData, meta interface{
 		flavorId = d.Get("flavor_id").(string)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"EXTENDING", "REFRESHING"},
+		Pending:      []string{"EXTENDING", "PENDING"},
 		Target:       []string{"RUNNING"},
-		Refresh:      refreshResizeProductIDFunc(dmsV2Client, d.Id(), flavorId),
+		Refresh:      productIDResizeStateRefresh(client, d.Id(), flavorId),
 		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		Delay:        300 * time.Second,
+		Delay:        180 * time.Second,
 		PollInterval: 15 * time.Second,
 	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return fmt.Errorf("error waiting for instance (%s) to resized: %v", d.Id(), err)
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for instance (%s) to resize: %v", d.Id(), err)
 	}
+
 	return nil
 }
 
 func resourceDmsKafkaInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS Kafka(v2) client: %s", err)
 	}
 
-	err = instances.Delete(dmsV2Client, d.Id()).ExtractErr()
+	err = instances.Delete(client, d.Id()).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting instance: %s", err)
+		return common.CheckDeletedDiag(d, err, "failed to delete Kafka instance")
 	}
 
 	// Wait for the instance to delete before moving on.
-	log.Printf("[DEBUG] Waiting for instance (%s) to delete", d.Id())
+	log.Printf("[DEBUG] Waiting for Kafka instance (%s) to be deleted", d.Id())
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"DELETING", "RUNNING", "ERROR"}, // Status may change to ERROR on deletion.
 		Target:       []string{"DELETED"},
-		Refresh:      DmsKafkaInstanceStateRefreshFunc(dmsV2Client, d.Id()),
+		Refresh:      KafkaInstanceStateRefreshFunc(client, d.Id()),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        120 * time.Second,
 		PollInterval: 15 * time.Second,
@@ -952,17 +945,15 @@ func resourceDmsKafkaInstanceDelete(ctx context.Context, d *schema.ResourceData,
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf(
-			"error waiting for instance (%s) to delete: %s",
-			d.Id(), err)
+		return diag.Errorf("error waiting for instance (%s) to be deleted: %s", d.Id(), err)
 	}
 
-	log.Printf("[DEBUG] DMS instance %s deactivated", d.Id())
+	log.Printf("[DEBUG] DMS Kafka instance %s has been deleted", d.Id())
 	d.SetId("")
 	return nil
 }
 
-func portsBindStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
+func portBindStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := instances.Get(client, instanceID).Extract()
 		if err != nil {
@@ -975,32 +966,31 @@ func portsBindStatusRefreshFunc(client *golangsdk.ServiceClient, instanceID stri
 	}
 }
 
-func DmsKafkaInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
+func KafkaInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		v, err := instances.Get(client, instanceID).Extract()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				return v, "DELETED", nil
 			}
-			return nil, "", err
+			return nil, "QUERY ERROR", err
 		}
 
 		return v, v.Status, nil
 	}
 }
 
-func refreshResizeProductIDFunc(client *golangsdk.ServiceClient, instanceID,
-	productID string) resource.StateRefreshFunc {
+func productIDResizeStateRefresh(client *golangsdk.ServiceClient, instanceID, productID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		v, err := instances.Get(client, instanceID).Extract()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return v, "DELETED", nil
+				return v, "failed", fmt.Errorf("unable to resize Kafka, instance has been deleted: %s", instanceID)
 			}
-			return nil, "", err
+			return nil, "failed", err
 		}
 		if v.Status == "RUNNING" && v.ProductID != productID {
-			return v, "REFRESHING", nil
+			return v, "PENDING", nil
 		}
 		return v, v.Status, nil
 	}
@@ -1008,7 +998,7 @@ func refreshResizeProductIDFunc(client *golangsdk.ServiceClient, instanceID,
 
 func getAvailableZoneIDByCode(config *config.Config, region string, azCodes []interface{}) ([]string, error) {
 	if len(azCodes) == 0 {
-		return nil, fmt.Errorf("availability_zones is required")
+		return nil, fmt.Errorf(`arguments "azCodes" is required`)
 	}
 
 	availableZones, err := getAvailableZones(config, region)
@@ -1016,25 +1006,24 @@ func getAvailableZoneIDByCode(config *config.Config, region string, azCodes []in
 		return nil, err
 	}
 
-	mappingData := make(map[string]availablezones.AvailableZone)
+	codeIDMapping := make(map[string]string)
 	for _, v := range availableZones {
-		mappingData[v.Code] = v
+		codeIDMapping[v.Code] = v.ID
 	}
 
 	azIDs := make([]string, 0, len(azCodes))
 	for _, code := range azCodes {
-		if az, ok := mappingData[code.(string)]; ok {
-			azIDs = append(azIDs, az.ID)
+		if id, ok := codeIDMapping[code.(string)]; ok {
+			azIDs = append(azIDs, id)
 		}
 	}
-	log.Printf("[DEBUG] DMS convert the codes of the availability zone into ids: \n%#v => \n%#v",
-		azCodes, azIDs)
+	log.Printf("[DEBUG] DMS converts the AZ codes to AZ IDs: \n%#v => \n%#v", azCodes, azIDs)
 	return azIDs, nil
 }
 
 func getAvailableZoneCodeByID(config *config.Config, region string, azIDs []string) ([]string, error) {
 	if len(azIDs) == 0 {
-		return nil, fmt.Errorf("availability_zones is required")
+		return nil, fmt.Errorf(`arguments "azIDs" is required`)
 	}
 
 	availableZones, err := getAvailableZones(config, region)
@@ -1042,29 +1031,28 @@ func getAvailableZoneCodeByID(config *config.Config, region string, azIDs []stri
 		return nil, err
 	}
 
-	mappingData := make(map[string]availablezones.AvailableZone)
+	idCodeMapping := make(map[string]string)
 	for _, v := range availableZones {
-		mappingData[v.ID] = v
+		idCodeMapping[v.ID] = v.Code
 	}
 
-	azCodes := make([]string, 0, len(mappingData))
+	azCodes := make([]string, 0, len(azIDs))
 	for _, id := range azIDs {
-		if az, ok := mappingData[id]; ok {
-			azCodes = append(azCodes, az.Code)
+		if code, ok := idCodeMapping[id]; ok {
+			azCodes = append(azCodes, code)
 		}
 	}
-	log.Printf("[DEBUG] DMS convert the ids of the availability zone into codes: \n%#v => \n%#v",
-		azIDs, azCodes)
+	log.Printf("[DEBUG] DMS converts the AZ IDs to AZ codes: \n%#v => \n%#v", azIDs, azCodes)
 	return azCodes, nil
 }
 
-func getAvailableZones(config *config.Config, region string) ([]availablezones.AvailableZone, error) {
-	dmsV2Client, err := config.DmsV2Client(region)
+func getAvailableZones(cfg *config.Config, region string) ([]availablezones.AvailableZone, error) {
+	client, err := cfg.DmsV2Client(region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DMS client V2: %s", err)
+		return nil, fmt.Errorf("error initializing DMS(v2) client: %s", err)
 	}
 
-	r, err := availablezones.Get(dmsV2Client)
+	r, err := availablezones.Get(client)
 	if err != nil {
 		return nil, fmt.Errorf("error querying available Zones: %s", err)
 	}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_instance.go
@@ -174,7 +174,7 @@ func ResourceDmsRabbitmqInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"manegement_connect_address": {
+			"management_connect_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -190,6 +190,12 @@ func ResourceDmsRabbitmqInstance() *schema.Resource {
 				Elem:         &schema.Schema{Type: schema.TypeString},
 				AtLeastOneOf: []string{"available_zones", "availability_zones"},
 				Deprecated:   "available_zones has deprecated, please use \"availability_zones\" instead.",
+			},
+			// Typo, it is only kept in the code, will not be shown in the docs.
+			"manegement_connect_address": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "typo in manegement_connect_address, please use \"management_connect_address\" instead.",
 			},
 		},
 	}
@@ -242,15 +248,15 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	dmsV2Client, err := cfg.DmsV2Client(region)
+	client, err := cfg.DmsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS RabbitMQ(v2) client: %s", err)
 	}
 
-	var availableZones []string
-	zoneIDs, ok := d.GetOk("available_zones")
+	var availableZones []string // Available zones IDs
+	azIDs, ok := d.GetOk("available_zones")
 	if ok {
-		availableZones = utils.ExpandToStringList(zoneIDs.([]interface{}))
+		availableZones = utils.ExpandToStringList(azIDs.([]interface{}))
 	} else {
 		// convert the codes of the availability zone into ids
 		azCodes := d.Get("availability_zones").(*schema.Set)
@@ -264,11 +270,13 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	if storageSpace == 0 {
 		product, err := getRabbitMQProductDetail(cfg, d)
 		if err != nil || product == nil {
-			return diag.Errorf("query DMS RabbimtMQ product failed: %s", err)
+			return diag.Errorf("failed to query DMS RabbitMQ product details: %s", err)
 		}
+
 		defaultStorageSpace, err := strconv.ParseInt(product.Storage, 10, 32)
 		if err != nil {
-			return diag.Errorf("Parse storage capacity to int error, %v: %s", product.Storage, err)
+			return diag.Errorf("failed to create RabbitMQ instance, error parsing storage_space to int %v: %s",
+				product.Storage, err)
 		}
 		storageSpace = int(defaultStorageSpace)
 	}
@@ -276,7 +284,7 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	createOpts := &instances.CreateOps{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
-		Engine:              "rabbitmq",
+		Engine:              engineRabbitMQ,
 		EngineVersion:       d.Get("engine_version").(string),
 		StorageSpace:        storageSpace,
 		AccessUser:          d.Get("access_user").(string),
@@ -292,42 +300,38 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		EnterpriseProjectID: common.GetEnterpriseProjectID(d, cfg),
 	}
 
-	if v, ok := d.GetOk("public_ip_id"); ok {
+	if pubIpID, ok := d.GetOk("public_ip_id"); ok {
 		createOpts.EnablePublicIP = true
-		createOpts.PublicIpID = v.(string)
+		createOpts.PublicIpID = pubIpID.(string)
 	}
 
 	// set tags
-	tagRaw := d.Get("tags").(map[string]interface{})
-	if len(tagRaw) > 0 {
-		taglist := utils.ExpandResourceTags(tagRaw)
-		createOpts.Tags = taglist
+	if tagRaw := d.Get("tags").(map[string]interface{}); len(tagRaw) > 0 {
+		createOpts.Tags = utils.ExpandResourceTags(tagRaw)
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] Create DMS RabbitMQ instance Options: %#v", createOpts)
 	// Add password here so it wouldn't go in the above log entry
 	createOpts.Password = d.Get("password").(string)
 
-	v, err := instances.Create(dmsV2Client, createOpts).Extract()
+	v, err := instances.Create(client, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("error creating DMS rabbitmq instance: %s", err)
+		return diag.Errorf("error creating DMS RabbitMQ instance: %s", err)
 	}
-	log.Printf("[INFO] instance ID: %s", v.InstanceID)
+	log.Printf("[INFO] Creating RabbitMQ instance, ID: %s", v.InstanceID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"CREATING"},
 		Target:       []string{"RUNNING"},
-		Refresh:      rabbitmqInstanceStateRefreshFunc(dmsV2Client, v.InstanceID),
+		Refresh:      rabbitmqInstanceStateRefreshFunc(client, v.InstanceID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        500 * time.Second,
-		MinTimeout:   3 * time.Second,
-		PollInterval: 10 * time.Second,
+		Delay:        300 * time.Second,
+		MinTimeout:   10 * time.Second,
+		PollInterval: 15 * time.Second,
 	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf(
-			"error waiting for instance (%s) to become ready: %s",
-			v.InstanceID, err)
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for RabbitMQ instance (%s) to be ready: %s", v.InstanceID, err)
 	}
 
 	// Store the instance ID now
@@ -340,19 +344,20 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
-	dmsV2Client, err := cfg.DmsV2Client(region)
+	client, err := cfg.DmsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
-	}
-	v, err := instances.Get(dmsV2Client, d.Id()).Extract()
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "DMS instance")
+		return diag.Errorf("error initializing DMS RabbitMQ(v2) client: %s", err)
 	}
 
-	log.Printf("[DEBUG] DMS rabbitmq instance %s: %+v", d.Id(), v)
+	v, err := instances.Get(client, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DMS RabbitMQ instance")
+	}
 
-	availableZoneIDs := v.AvailableZones
-	availableZoneCodes, err := getAvailableZoneCodeByID(cfg, region, availableZoneIDs)
+	log.Printf("[DEBUG] DMS RabbitMQ instance %+v", v)
+
+	azIDs := v.AvailableZones
+	asCodes, err := getAvailableZoneCodeByID(cfg, region, azIDs)
 	mErr := multierror.Append(nil, err)
 
 	d.SetId(v.InstanceID)
@@ -371,7 +376,7 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 		d.Set("security_group_id", v.SecurityGroupID),
 		d.Set("network_id", v.SubnetID),
 		d.Set("available_zones", v.AvailableZones),
-		d.Set("availability_zones", availableZoneCodes),
+		d.Set("availability_zones", asCodes),
 		d.Set("product_id", v.ProductID),
 		d.Set("maintain_begin", v.MaintainBegin),
 		d.Set("maintain_end", v.MaintainEnd),
@@ -382,6 +387,7 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 		d.Set("enterprise_project_id", v.EnterpriseProjectID),
 		d.Set("used_storage_space", v.UsedStorageSpace),
 		d.Set("connect_address", v.ConnectAddress),
+		d.Set("management_connect_address", v.ManagementConnectAddress),
 		d.Set("manegement_connect_address", v.ManagementConnectAddress),
 		d.Set("port", v.Port),
 		d.Set("status", v.Status),
@@ -393,21 +399,21 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 	)
 
 	// set tags
-	engine := "rabbitmq"
-	if resourceTags, err := tags.Get(dmsV2Client, engine, d.Id()).Extract(); err == nil {
-		tagmap := utils.TagsToMap(resourceTags.Tags)
-		err = d.Set("tags", tagmap)
+	if resourceTags, err := tags.Get(client, engineRabbitMQ, d.Id()).Extract(); err == nil {
+		tagMap := utils.TagsToMap(resourceTags.Tags)
+		err = d.Set("tags", tagMap)
 		if err != nil {
-			mErr = multierror.Append(mErr, err)
+			mErr = multierror.Append(mErr,
+				fmt.Errorf("error saving tags to state for DMS RabbitMQ instance (%s): %s", d.Id(), err))
 		}
 	} else {
-		log.Printf("[WARN] error fetching tags of DMS rabbitmq instance (%s): %s", d.Id(), err)
-		e := fmt.Errorf("error fetching tags of DMS rabbitmq instance (%s): %s", d.Id(), err)
+		log.Printf("[WARN] error fetching tags of DMS RabbitMQ instance (%s): %s", d.Id(), err)
+		e := fmt.Errorf("error fetching tags of DMS RabbitMQ instance (%s): %s", d.Id(), err)
 		mErr = multierror.Append(mErr, e)
 	}
 
 	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("Error setting attributes for DMS rabbitmq instance: %s", mErr)
+		return diag.Errorf("failed to set attributes for DMS kafka instance: %s", mErr)
 	}
 
 	return nil
@@ -418,9 +424,9 @@ func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 	defer config.MutexKV.Unlock(lockKey)
 
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS RabbitMQ(v2) client: %s", err)
 	}
 
 	var mErr *multierror.Error
@@ -440,42 +446,40 @@ func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 
 		if d.HasChange("public_ip_id") {
-			if v, ok := d.GetOk("public_ip_id"); ok {
+			if pubIpID, ok := d.GetOk("public_ip_id"); ok {
 				enablePublicIP := true
 				updateOpts.EnablePublicIP = &enablePublicIP
-				updateOpts.PublicIpID = v.(string)
+				updateOpts.PublicIpID = pubIpID.(string)
 			} else {
 				enablePublicIP := false
 				updateOpts.EnablePublicIP = &enablePublicIP
 			}
 		}
 
-		err = instances.Update(dmsV2Client, d.Id(), updateOpts).Err
+		err = instances.Update(client, d.Id(), updateOpts).Err
 		if err != nil {
-			e := fmt.Errorf("error updating DMS rabbitMQ Instance: %s", err)
+			e := fmt.Errorf("error updating DMS RabbitMQ Instance: %s", err)
 			mErr = multierror.Append(mErr, e)
 		}
 	}
 
 	if d.HasChange("tags") {
 		// update tags
-		engine := "rabbitmq"
-		tagErr := utils.UpdateResourceTags(dmsV2Client, d, engine, d.Id())
+		tagErr := utils.UpdateResourceTags(client, d, engineRabbitMQ, d.Id())
 		if tagErr != nil {
-			e := fmt.Errorf("error updating tags of DMS rabbitmq instance:%s, err:%s", d.Id(), tagErr)
-			mErr = multierror.Append(mErr, e)
+			mErr = multierror.Append(mErr, fmt.Errorf("error updating tags of DMS RabbitMQ instance: %s, err: %s",
+				d.Id(), tagErr))
 		}
 	}
 
 	if d.HasChange("product_id") {
-		err = resizeInstance(ctx, d, meta, "rabbitmq")
+		err = resizeInstance(ctx, d, meta, engineRabbitMQ)
 		if err != nil {
-			e := fmt.Errorf("error resizing DMS rabbitMQ Instance: %s", err)
-			mErr = multierror.Append(mErr, e)
+			mErr = multierror.Append(mErr, err)
 		}
 	}
 	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error while updating DMS rabbitMQ instances, there %s", mErr)
+		return diag.Errorf("error while updating DMS RabbitMQ instances, %s", mErr)
 	}
 
 	return resourceDmsRabbitmqInstanceRead(ctx, d, meta)
@@ -483,36 +487,35 @@ func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 
 func resourceDmsRabbitmqInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	dmsV2Client, err := cfg.DmsV2Client(cfg.GetRegion(d))
+	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating DMS instance client: %s", err)
+		return diag.Errorf("error initializing DMS RabbitMQ(v2) client: %s", err)
 	}
 
-	err = instances.Delete(dmsV2Client, d.Id()).ExtractErr()
+	err = instances.Delete(client, d.Id()).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting instance: %s", err)
+		return common.CheckDeletedDiag(d, err, "failed to delete DMS RabbitMQ instance")
 	}
 
 	// Wait for the instance to delete before moving on.
-	log.Printf("[DEBUG] Waiting for instance (%s) to delete", d.Id())
+	log.Printf("[DEBUG] Waiting for DMS RabbitMQ instance (%s) to be deleted", d.Id())
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"DELETING", "RUNNING", "ERROR"}, // Status may change to ERROR on deletion.
 		Target:       []string{"DELETED"},
-		Refresh:      rabbitmqInstanceStateRefreshFunc(dmsV2Client, d.Id()),
+		Refresh:      rabbitmqInstanceStateRefreshFunc(client, d.Id()),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        90 * time.Second,
-		MinTimeout:   3 * time.Second,
-		PollInterval: 10 * time.Second,
+		MinTimeout:   5 * time.Second,
+		PollInterval: 15 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf(
-			"error waiting for instance (%s) to delete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for DMS RabbitMQ instance (%s) to be deleted: %s", d.Id(), err)
 	}
 
-	log.Printf("[DEBUG] DMS instance %s deactivated", d.Id())
+	log.Printf("[DEBUG] DMS RabbitMQ instance %s has been deleted", d.Id())
 	d.SetId("")
 	return nil
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
@@ -14,10 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/jmespath/go-jmespath"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceDmsRocketMQInstance() *schema.Resource {
@@ -329,7 +330,7 @@ func resourceDmsRocketMQInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	d.SetId(id.(string))
 
 	if _, ok := d.GetOk("cross_vpc_accesses"); ok {
-		if err = updateCrossVpcAccesses(createRocketmqInstanceClient, d); err != nil {
+		if err = updateCrossVpcAccess(createRocketmqInstanceClient, d); err != nil {
 			return diag.Errorf("failed to update default advertised IP: %v", err)
 		}
 	}
@@ -402,7 +403,7 @@ func resourceDmsRocketMQInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 			return diag.Errorf("error updating DmsRocketMQInstance: %s", err)
 		}
 		if d.HasChange("cross_vpc_accesses") {
-			if err = updateCrossVpcAccesses(updateRocketmqInstanceClient, d); err != nil {
+			if err = updateCrossVpcAccess(updateRocketmqInstanceClient, d); err != nil {
 				return diag.Errorf("error updating DMS rocketMQ Cross-VPC access information: %s", err)
 			}
 		}
@@ -481,7 +482,7 @@ func resourceDmsRocketMQInstanceRead(ctx context.Context, d *schema.ResourceData
 	crossVpcInfo := utils.PathSearch("cross_vpc_info", getRocketmqInstanceRespBody, nil)
 	var crossVpcAccess []map[string]interface{}
 	if crossVpcInfo != nil {
-		crossVpcAccess, err = flattenConnectPorts(crossVpcInfo.(string))
+		crossVpcAccess, err = flattenCrossVpcInfo(crossVpcInfo.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsRabbitmqInstances'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRabbitmqInstances -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
--- PASS: TestAccDmsRabbitmqInstances_compatible (1239.81s)
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (1781.24s)
--- PASS: TestAccDmsRabbitmqInstances_single (2273.27s)
--- PASS: TestAccDmsRabbitmqInstances_basic (2635.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       2635.785s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccKafkaInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccKafkaInstance -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstancesDataSource_basic
--- PASS: TestAccKafkaInstancesDataSource_basic (599.94s)
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_withEpsId
--- PASS: TestAccKafkaInstance_withEpsId (605.65s)
--- PASS: TestAccKafkaInstance_compatible (996.82s)
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_withEpsId
--- PASS: TestAccKafkaInstance_withEpsId (605.65s)
--- PASS: TestAccKafkaInstance_compatible (996.82s)
--- PASS: TestAccKafkaInstance_newFormat (2269.91s)
--- PASS: TestAccKafkaInstance_basic (2693.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3293.952s
```
