### PR TITLE
feat(config): support update the region field in customizing OBS endpoint

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -160,6 +161,12 @@ func retryBackoffFunc(ctx context.Context, respErr *golangsdk.ErrUnexpectedRespo
 
 func getObsEndpoint(c *Config, region string) string {
 	if endpoint, ok := c.Endpoints["obs"]; ok {
+		// replace the region in customizing OBS endpoint
+		subparts := strings.Split(endpoint, ".")
+		if len(subparts) >= 3 && subparts[1] != region {
+			subparts[1] = region
+			return strings.Join(subparts, ".")
+		}
 		return endpoint
 	}
 	return fmt.Sprintf("https://obs.%s.%s/", region, c.Cloud)

--- a/huaweicloud/config/config_test.go
+++ b/huaweicloud/config/config_test.go
@@ -56,3 +56,27 @@ func TestRequestRetry(t *testing.T) {
 	t.Run("TestRequestSingleRetry", func(t *testing.T) { testRequestRetry(t, 1) })
 	t.Run("TestRequestZeroRetry", func(t *testing.T) { testRequestRetry(t, 0) })
 }
+
+func TestCheckObsEndpoint(t *testing.T) {
+	cfg := &Config{
+		Region: "region-0",
+		Cloud:  "myhuaweicloud.com",
+	}
+
+	// without customizing OBS endpoint in Config
+	expected := "https://obs.region-1.myhuaweicloud.com/"
+	th.AssertEquals(t, expected, getObsEndpoint(cfg, "region-1"))
+
+	// with customizing OBS endpoint in Config
+	cfg.Endpoints = map[string]string{
+		"obs": "https://oss.region-0.myhuaweicloud.com/",
+	}
+
+	// the region is equal to the region in customizing endpoint
+	expected = "https://oss.region-0.myhuaweicloud.com/"
+	th.AssertEquals(t, expected, getObsEndpoint(cfg, "region-0"))
+
+	// the region is not equal to the region in customizing endpoint
+	expected = "https://oss.region-1.myhuaweicloud.com/"
+	th.AssertEquals(t, expected, getObsEndpoint(cfg, "region-1"))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

related to FlexibleEngineCloud/terraform-provider-flexibleengine#876
 
This PR can update the the region field in customizing **OBS** endpoint.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```shell
go test -v ./huaweicloud/config/ -run TestCheckObsEndpoint
=== RUN   TestCheckObsEndpoint
--- PASS: TestCheckObsEndpoint (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config        0.013s
```
