### PR TITLE
refactor(elb): fix code format and change product name to uppercase

### DIFF
--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
@@ -16,7 +16,7 @@ import (
 func getELBResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating ELB v3 client: %s", err)
+		return nil, fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	eipID := state.Primary.Attributes["ipv4_eip_id"]
@@ -24,7 +24,7 @@ func getELBResourceFunc(c *config.Config, state *terraform.ResourceState) (inter
 	if eipType != "" && eipID != "" {
 		eipClient, err := c.NetworkingV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return nil, fmt.Errorf("Error creating VPC v1 client: %s", err)
+			return nil, fmt.Errorf("error creating VPC v1 client: %s", err)
 		}
 
 		if _, err := eips.Get(eipClient, eipID).Extract(); err != nil {

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_logtank_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_logtank_test.go
@@ -15,7 +15,7 @@ import (
 func getELBLogTankResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud ELB v3 client: %s", err)
+		return nil, fmt.Errorf("error creating ELB client: %s", err)
 	}
 	return logtanks.Get(client, state.Primary.ID).Extract()
 }

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_certificate.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_certificate.go
@@ -58,7 +58,7 @@ func dataSourceELbCertificateV3Read(_ context.Context, d *schema.ResourceData, m
 	config := meta.(*config.Config)
 	client, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Dedicated ELB(V3) Client: %s", err)
+		return diag.Errorf("error creating Dedicated ELB Client: %s", err)
 	}
 
 	listOpts := certificates.ListOpts{
@@ -70,7 +70,7 @@ func dataSourceELbCertificateV3Read(_ context.Context, d *schema.ResourceData, m
 	}
 	certs, err := certificates.ExtractCertificates(r)
 	if err != nil {
-		return diag.Errorf("unable to retrieve certs from Dedicated ELB(V3): %s", err)
+		return diag.Errorf("unable to retrieve certs from Dedicated ELB: %s", err)
 	}
 	log.Printf("[DEBUG] Get certificate list: %#v", certs)
 

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_flavors.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_flavors.go
@@ -91,7 +91,7 @@ func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb v3 client: %s", err)
+		return fmtp.Errorf("Error creating HuaweiCloud ELB client: %s", err)
 	}
 
 	listOpts := flavors.ListOpts{}
@@ -145,7 +145,7 @@ func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error 
 			"max_connections": flavor.Info.Connection,
 			"cps":             flavor.Info.Cps,
 			"qps":             flavor.Info.Qps,
-			"bandwidth":       int(flavor.Info.Bandwidth / 1000),
+			"bandwidth":       flavor.Info.Bandwidth / 1000,
 		}
 		s = append(s, mapping)
 	}

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_pools.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_pools.go
@@ -222,10 +222,10 @@ func resourcePoolsRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	listPoolsPath := listPoolsClient.Endpoint + listPoolsHttpUrl
-	listPoolsPath = strings.Replace(listPoolsPath, "{project_id}", listPoolsClient.ProjectID, -1)
+	listPoolsPath = strings.ReplaceAll(listPoolsPath, "{project_id}", listPoolsClient.ProjectID)
 
-	listPoolsqueryParams := buildListPoolsQueryParams(d)
-	listPoolsPath = listPoolsPath + listPoolsqueryParams
+	listPoolsQueryParams := buildListPoolsQueryParams(d)
+	listPoolsPath += listPoolsQueryParams
 
 	listPoolsResp, err := pagination.ListAllItems(
 		listPoolsClient,

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_certificate.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_certificate.go
@@ -106,7 +106,7 @@ func resourceCertificateV3Create(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	createOpts := certificates.CreateOpts{
@@ -135,7 +135,7 @@ func resourceCertificateV3Read(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	c, err := certificates.Get(elbClient, d.Id()).Extract()
@@ -167,7 +167,7 @@ func resourceCertificateV3Update(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts certificates.UpdateOpts
@@ -202,7 +202,7 @@ func resourceCertificateV3Delete(_ context.Context, d *schema.ResourceData, meta
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting certificate %s", d.Id())

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_ipgroup.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_ipgroup.go
@@ -95,7 +95,7 @@ func resourceIpGroupV3Create(ctx context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	ipList := resourceIpGroupAddresses(d)
@@ -121,7 +121,7 @@ func resourceIpGroupV3Read(_ context.Context, d *schema.ResourceData, meta inter
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	ig, err := ipgroups.Get(elbClient, d.Id()).Extract()
@@ -159,7 +159,7 @@ func resourceIpGroupV3Update(ctx context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts ipgroups.UpdateOpts
@@ -178,7 +178,7 @@ func resourceIpGroupV3Update(ctx context.Context, d *schema.ResourceData, meta i
 	log.Printf("[DEBUG] Updating ipgroup %s with options: %#v", d.Id(), updateOpts)
 	_, err = ipgroups.Update(elbClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("error updating elb ip group: %s", err)
+		return diag.Errorf("error updating ELB ip group: %s", err)
 	}
 
 	return resourceIpGroupV3Read(ctx, d, meta)
@@ -188,12 +188,12 @@ func resourceIpGroupV3Delete(_ context.Context, d *schema.ResourceData, meta int
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting ip group %s", d.Id())
 	if err = ipgroups.Delete(elbClient, d.Id()).ExtractErr(); err != nil {
-		return diag.Errorf("error deleting elb ip group: %s", err)
+		return diag.Errorf("error deleting ELB ip group: %s", err)
 	}
 
 	return nil

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_l7policy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_l7policy.go
@@ -69,7 +69,7 @@ func resourceL7PolicyV3Create(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	createOpts := l7policies.CreateOpts{
@@ -102,7 +102,7 @@ func resourceL7PolicyV3Read(_ context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	l7Policy, err := l7policies.Get(lbClient, d.Id()).Extract()
@@ -130,7 +130,7 @@ func resourceL7PolicyV3Update(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts l7policies.UpdateOpts
@@ -167,7 +167,7 @@ func resourceL7PolicyV3Delete(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Attempting to delete L7 Policy %s", d.Id())

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_l7rule.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_l7rule.go
@@ -83,7 +83,7 @@ func resourceL7RuleV3Create(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	l7policyID := d.Get("l7policy_id").(string)
@@ -118,7 +118,7 @@ func resourceL7RuleV3Read(_ context.Context, d *schema.ResourceData, meta interf
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	l7policyID := d.Get("l7policy_id").(string)
@@ -147,7 +147,7 @@ func resourceL7RuleV3Update(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	l7policyID := d.Get("l7policy_id").(string)
@@ -180,7 +180,7 @@ func resourceL7RuleV3Delete(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	l7policyID := d.Get("l7policy_id").(string)

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_listener.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_listener.go
@@ -164,7 +164,7 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	http2_enable := d.Get("http2_enable").(bool)
@@ -248,11 +248,11 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 	if len(tagRaw) > 0 {
 		elbV2Client, err := config.ElbV2Client(config.GetRegion(d))
 		if err != nil {
-			return diag.Errorf("error creating elb v2.0 client: %s", err)
+			return diag.Errorf("error creating ELB v2.0 client: %s", err)
 		}
 		taglist := utils.ExpandResourceTags(tagRaw)
 		if tagErr := tags.Create(elbV2Client, "listeners", listener.ID, taglist).ExtractErr(); tagErr != nil {
-			return diag.Errorf("error setting tags of elb listener %s: %s", listener.ID, tagErr)
+			return diag.Errorf("error setting tags of ELB listener %s: %s", listener.ID, tagErr)
 		}
 	}
 
@@ -263,13 +263,13 @@ func resourceListenerV3Read(_ context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	// client for fetching tags
 	elbV2Client, err := config.ElbV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb 2.0 client: %s", err)
+		return diag.Errorf("error creating ELB 2.0 client: %s", err)
 	}
 
 	listener, err := listeners.Get(elbClient, d.Id()).Extract()
@@ -316,7 +316,7 @@ func resourceListenerV3Read(_ context.Context, d *schema.ResourceData, meta inte
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		mErr = multierror.Append(mErr, d.Set("tags", tagmap))
 	} else {
-		log.Printf("[WARN] fetching tags of elb listener failed: %s", err)
+		log.Printf("[WARN] fetching tags of ELB listener failed: %s", err)
 	}
 
 	if err := mErr.ErrorOrNil(); err != nil {
@@ -330,7 +330,7 @@ func resourceListenerV3Update(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	// lintignore:R019
@@ -431,11 +431,11 @@ func resourceListenerV3Update(ctx context.Context, d *schema.ResourceData, meta 
 	if d.HasChange("tags") {
 		elbV2Client, err := config.ElbV2Client(config.GetRegion(d))
 		if err != nil {
-			return diag.Errorf("error creating elb 2.0 client: %s", err)
+			return diag.Errorf("error creating ELB 2.0 client: %s", err)
 		}
 		tagErr := utils.UpdateResourceTags(elbV2Client, d, "listeners", d.Id())
 		if tagErr != nil {
-			return diag.Errorf("error updating tags of elb listener:%s, err:%s", d.Id(), tagErr)
+			return diag.Errorf("error updating tags of ELB listener:%s, err:%s", d.Id(), tagErr)
 		}
 	}
 
@@ -447,7 +447,7 @@ func resourceListenerV3Delete(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	// Wait for LoadBalancer to become active before continuing

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_logtank.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_logtank.go
@@ -58,7 +58,7 @@ func resourceLogTankCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating ELB v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	createOpts := logtanks.CreateOpts{
@@ -70,7 +70,7 @@ func resourceLogTankCreate(ctx context.Context, d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	logTank, err := logtanks.Create(elbClient, createOpts).Extract()
 	if err != nil {
-		return diag.Errorf("error creating logtank: %s", err)
+		return diag.Errorf("error creating LogTank: %s", err)
 	}
 
 	d.SetId(logTank.ID)
@@ -82,7 +82,7 @@ func resourceLogTankRead(_ context.Context, d *schema.ResourceData, meta interfa
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating ELB v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	logTank, err := logtanks.Get(elbClient, d.Id()).Extract()
@@ -100,7 +100,7 @@ func resourceLogTankRead(_ context.Context, d *schema.ResourceData, meta interfa
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting Dedicated ELB logtank fields: %s", err)
+		return diag.Errorf("error setting Dedicated ELB LogTank fields: %s", err)
 	}
 
 	return nil
@@ -115,7 +115,7 @@ func resourceLogTankUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating ELB v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts logtanks.UpdateOpts
@@ -129,7 +129,7 @@ func resourceLogTankUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Updating logtank %s with options: %#v", d.Id(), updateOpts)
 	_, err = logtanks.Update(elbClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("unable to update logtank %s: %s", d.Id(), err)
+		return diag.Errorf("unable to update LogTank %s: %s", d.Id(), err)
 	}
 
 	return resourceLogTankRead(ctx, d, meta)
@@ -139,13 +139,13 @@ func resourceLogTankDelete(_ context.Context, d *schema.ResourceData, meta inter
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating ELB v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	log.Printf("[DEBUG] Attempting to delete logtank %s", d.Id())
+	log.Printf("[DEBUG] Attempting to delete LogTank %s", d.Id())
 	err = logtanks.Delete(elbClient, d.Id()).ExtractErr()
 	if err != nil {
-		return diag.Errorf("unable to delete logtank %s: %s", d.Id(), err)
+		return diag.Errorf("unable to delete LogTank %s: %s", d.Id(), err)
 	}
 	return nil
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_member.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_member.go
@@ -91,7 +91,7 @@ func resourceMemberV3Create(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	createOpts := pools.CreateMemberOpts{
@@ -122,7 +122,7 @@ func resourceMemberV3Read(_ context.Context, d *schema.ResourceData, meta interf
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	member, err := pools.GetMember(elbClient, d.Get("pool_id").(string), d.Id()).Extract()
@@ -151,7 +151,7 @@ func resourceMemberV3Update(ctx context.Context, d *schema.ResourceData, meta in
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts pools.UpdateMemberOpts
@@ -176,7 +176,7 @@ func resourceMemberV3Delete(_ context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	poolID := d.Get("pool_id").(string)

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_monitor.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_monitor.go
@@ -81,7 +81,7 @@ func resourceMonitorV3Create(ctx context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	createOpts := monitors.CreateOpts{
@@ -110,7 +110,7 @@ func resourceMonitorV3Read(_ context.Context, d *schema.ResourceData, meta inter
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	monitor, err := monitors.Get(lbClient, d.Id()).Extract()
@@ -149,7 +149,7 @@ func resourceMonitorV3Update(ctx context.Context, d *schema.ResourceData, meta i
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts monitors.UpdateOpts
@@ -185,7 +185,7 @@ func resourceMonitorV3Delete(_ context.Context, d *schema.ResourceData, meta int
 	config := meta.(*config.Config)
 	lbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting monitor %s", d.Id())

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_pool.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_pool.go
@@ -125,7 +125,7 @@ func resourcePoolV3Create(ctx context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var persistence pools.SessionPersistence
@@ -171,7 +171,7 @@ func resourcePoolV3Read(_ context.Context, d *schema.ResourceData, meta interfac
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	pool, err := pools.Get(elbClient, d.Id()).Extract()
@@ -226,7 +226,7 @@ func resourcePoolV3Update(ctx context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts pools.UpdateOpts
@@ -268,7 +268,7 @@ func resourcePoolV3Delete(ctx context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Attempting to delete pool %s", d.Id())

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_security_policy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_security_policy.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceSecurityPolicy() *schema.Resource {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refactor application resource:

1.  replace old method
2. remove client version
3. change product name to uppercase

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  refactor application resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/elb/'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v  -timeout 360m -parallel 4
=== RUN   TestAccDataSourceELbCertificateV3_basic 
--- PASS: TestAccDataSourceELbCertificateV3_basic (12.13s) 
=== RUN   TestAccElbFlavorsDataSource_basic 
=== PAUSE TestAccElbFlavorsDataSource_basic 
=== RUN   TestAccDatasourcePools_basic      
=== PAUSE TestAccDatasourcePools_basic
=== RUN   TestAccElbV3Certificate_basic
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== RUN   TestAccElbV3Certificate_withEpsId
=== PAUSE TestAccElbV3Certificate_withEpsId
=== RUN   TestAccElbV3IpGroup_basic
=== PAUSE TestAccElbV3IpGroup_basic
=== RUN   TestAccElbV3IpGroup_withEpsId
=== PAUSE TestAccElbV3IpGroup_withEpsId
=== RUN   TestAccElbV3L7Policy_basic
=== PAUSE TestAccElbV3L7Policy_basic
=== RUN   TestAccElbV3L7Rule_basic
=== PAUSE TestAccElbV3L7Rule_basic
=== RUN   TestAccElbV3Listener_basic
=== PAUSE TestAccElbV3Listener_basic
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== RUN   TestAccElbLogTank_basic
=== PAUSE TestAccElbLogTank_basic
=== RUN   TestAccElbV3Member_basic
=== PAUSE TestAccElbV3Member_basic
=== RUN   TestAccElbV3Member_crossVpcBackend
=== PAUSE TestAccElbV3Member_crossVpcBackend
=== RUN   TestAccElbV3Monitor_basic
=== PAUSE TestAccElbV3Monitor_basic
=== RUN   TestAccElbV3Pool_basic
=== PAUSE TestAccElbV3Pool_basic
=== RUN   TestAccSecurityPoliciesV3_basic
=== PAUSE TestAccSecurityPoliciesV3_basic
=== CONT  TestAccSecurityPoliciesV3_basic
=== CONT  TestAccElbFlavorsDataSource_basic
=== CONT  TestAccElbV3Pool_basic
=== CONT  TestAccElbV3Monitor_basic
--- PASS: TestAccElbFlavorsDataSource_basic (8.18s) 
=== CONT  TestAccElbV3Member_crossVpcBackend
--- PASS: TestAccSecurityPoliciesV3_basic (18.04s) 
=== CONT  TestAccElbV3Member_basic
--- PASS: TestAccElbV3Monitor_basic (51.84s) 
=== CONT  TestAccElbLogTank_basic
--- PASS: TestAccElbV3Pool_basic (84.78s) 
=== CONT  TestAccElbV3LoadBalancer_prePaid
    acceptance.go:280: This environment does not support prepaid tests
--- SKIP: TestAccElbV3LoadBalancer_prePaid (0.00s)
=== CONT  TestAccElbV3LoadBalancer_withEIP
--- PASS: TestAccElbV3Member_crossVpcBackend (82.48s)
=== CONT  TestAccElbV3LoadBalancer_withEpsId
    acceptance.go:181: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3LoadBalancer_withEpsId (0.00s)
=== CONT  TestAccElbV3LoadBalancer_basic
--- PASS: TestAccElbV3Member_basic (79.67s)
=== CONT  TestAccElbV3Listener_basic
--- PASS: TestAccElbV3LoadBalancer_withEIP (29.22s)
=== CONT  TestAccElbV3L7Rule_basic
--- PASS: TestAccElbV3LoadBalancer_basic (52.79s)
=== CONT  TestAccElbV3L7Policy_basic
--- PASS: TestAccElbLogTank_basic (97.54s)
=== CONT  TestAccElbV3IpGroup_withEpsId
    acceptance.go:181: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3IpGroup_withEpsId (0.00s)
=== CONT  TestAccElbV3IpGroup_basic
--- PASS: TestAccElbV3IpGroup_basic (16.28s)
=== CONT  TestAccElbV3Certificate_withEpsId
    acceptance.go:181: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3Certificate_withEpsId (0.00s)
=== CONT  TestAccElbV3Certificate_client
--- PASS: TestAccElbV3Certificate_client (9.72s)
=== CONT  TestAccElbV3Certificate_basic
--- PASS: TestAccElbV3Listener_basic (92.57s) 
=== CONT  TestAccDatasourcePools_basic
--- PASS: TestAccElbV3Certificate_basic (18.73s) 
--- PASS: TestAccElbV3L7Rule_basic (96.51s) 
--- PASS: TestAccElbV3L7Policy_basic (69.96s) 
--- PASS: TestAccDatasourcePools_basic (67.85s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       270.317s
```
