### PR TITLE
refactor(elb): remove the package of fmtp and replaced with fmt

### DIFF
--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_certificate_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccDataSourceELbCertificateV3_basic(t *testing.T) {
@@ -42,10 +41,10 @@ func testAccCheckELBCertDataSourceID(r string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
 		if !ok {
-			return fmtp.Errorf("Can't find Dedicated ELB data source: %s ", r)
+			return fmt.Errorf("can't find Dedicated ELB data source: %s ", r)
 		}
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("The Dedicated ELB Certificate data source ID not set.")
+			return fmt.Errorf("the Dedicated ELB Certificate data source ID not set")
 		}
 		return nil
 	}

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_flavors_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_flavors_test.go
@@ -1,13 +1,12 @@
 package elb
 
 import (
+	"fmt"
 	"testing"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccElbFlavorsDataSource_basic(t *testing.T) {
@@ -29,11 +28,11 @@ func testAccCheckElbFlavorDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find elb flavors data source: %s", n)
+			return fmt.Errorf("can't find elb flavors data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("Elb Flavors data source ID not set")
+			return fmt.Errorf("elb Flavors data source ID not set")
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/elb/v3/certificates"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3Certificate_basic(t *testing.T) {
@@ -96,7 +95,7 @@ func testAccCheckElbV3CertificateDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -106,7 +105,7 @@ func testAccCheckElbV3CertificateDestroy(s *terraform.State) error {
 
 		_, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("Certificate still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("certificate still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -118,17 +117,17 @@ func testAccCheckElbV3CertificateExists(
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("No ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("Error creating HuaweiCloud elb client: %s", err)
 		}
 
 		found, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
@@ -137,7 +136,7 @@ func testAccCheckElbV3CertificateExists(
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Certificate not found")
+			return fmt.Errorf("Certificate not found")
 		}
 
 		*c = *found

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_ipgroup_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_ipgroup_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/elb/v3/ipgroups"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3IpGroup_basic(t *testing.T) {
@@ -76,7 +75,7 @@ func testAccCheckElbV3IpGroupDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -86,7 +85,7 @@ func testAccCheckElbV3IpGroupDestroy(s *terraform.State) error {
 
 		_, err := ipgroups.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("IpGroup still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("ipGroup still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -98,17 +97,17 @@ func testAccCheckElbV3IpGroupExists(
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		found, err := ipgroups.Get(elbClient, rs.Primary.ID).Extract()
@@ -117,7 +116,7 @@ func testAccCheckElbV3IpGroupExists(
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("IpGroup not found")
+			return fmt.Errorf("ipGroup not found")
 		}
 
 		*c = *found

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7policy_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7policy_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/elb/v3/l7policies"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3L7Policy_basic(t *testing.T) {
@@ -48,7 +47,7 @@ func testAccCheckElbV3L7PolicyDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	lbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -58,7 +57,7 @@ func testAccCheckElbV3L7PolicyDestroy(s *terraform.State) error {
 
 		_, err := l7policies.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("L7 Policy still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("the L7 Policy still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -69,17 +68,17 @@ func testAccCheckElbV3L7PolicyExists(n string, l7Policy *l7policies.L7Policy) re
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		lbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		found, err := l7policies.Get(lbClient, rs.Primary.ID).Extract()
@@ -88,7 +87,7 @@ func testAccCheckElbV3L7PolicyExists(n string, l7Policy *l7policies.L7Policy) re
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Policy not found")
+			return fmt.Errorf("policy not found")
 		}
 
 		*l7Policy = *found

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7rule_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7rule_test.go
@@ -12,7 +12,6 @@ import (
 	l7rules "github.com/chnsz/golangsdk/openstack/elb/v3/l7policies"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3L7Rule_basic(t *testing.T) {
@@ -59,7 +58,7 @@ func testAccCheckElbV3L7RuleDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	lbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -76,12 +75,12 @@ func testAccCheckElbV3L7RuleDestroy(s *terraform.State) error {
 		}
 
 		if l7policyID == "" {
-			return fmtp.Errorf("Unable to find l7policy_id")
+			return fmt.Errorf("unable to find l7policy_id")
 		}
 
 		_, err := l7rules.GetRule(lbClient, l7policyID, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("L7 Rule still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("the L7 Rule still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -92,17 +91,17 @@ func testAccCheckElbV3L7RuleExists(n string, l7rule *l7rules.Rule) resource.Test
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		lbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud load balancing client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		l7policyID := ""
@@ -114,7 +113,7 @@ func testAccCheckElbV3L7RuleExists(n string, l7rule *l7rules.Rule) resource.Test
 		}
 
 		if l7policyID == "" {
-			return fmtp.Errorf("Unable to find l7policy_id")
+			return fmt.Errorf("unable to find l7policy_id")
 		}
 
 		found, err := l7rules.GetRule(lbClient, l7policyID, rs.Primary.ID).Extract()
@@ -123,7 +122,7 @@ func testAccCheckElbV3L7RuleExists(n string, l7rule *l7rules.Rule) resource.Test
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Policy not found")
+			return fmt.Errorf("policy not found")
 		}
 
 		*l7rule = *found

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_listener_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_listener_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func getELBListenerResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return nil, fmt.Errorf("error creating ELB client: %s", err)
 	}
 	return listeners.Get(client, state.Primary.ID).Extract()
 }

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_member_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_member_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/elb/v3/pools"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3Member_basic(t *testing.T) {
@@ -86,7 +85,7 @@ func testAccCheckElbV3MemberDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -97,7 +96,7 @@ func testAccCheckElbV3MemberDestroy(s *terraform.State) error {
 		poolId := rs.Primary.Attributes["pool_id"]
 		_, err := pools.GetMember(elbClient, poolId, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("Member still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("member still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -108,17 +107,17 @@ func testAccCheckElbV3MemberExists(n string, member *pools.Member) resource.Test
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
@@ -128,7 +127,7 @@ func testAccCheckElbV3MemberExists(n string, member *pools.Member) resource.Test
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Member not found")
+			return fmt.Errorf("member not found")
 		}
 
 		*member = *found

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/elb/v3/monitors"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3Monitor_basic(t *testing.T) {
@@ -59,7 +58,7 @@ func testAccCheckElbV3MonitorDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -69,7 +68,7 @@ func testAccCheckElbV3MonitorDestroy(s *terraform.State) error {
 
 		_, err := monitors.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("Monitor still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("monitor still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -80,17 +79,17 @@ func testAccCheckElbV3MonitorExists(n string, monitor *monitors.Monitor) resourc
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		found, err := monitors.Get(elbClient, rs.Primary.ID).Extract()
@@ -99,7 +98,7 @@ func testAccCheckElbV3MonitorExists(n string, monitor *monitors.Monitor) resourc
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Monitor not found")
+			return fmt.Errorf("monitor not found")
 		}
 
 		*monitor = *found

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/elb/v3/pools"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3Pool_basic(t *testing.T) {
@@ -53,7 +52,7 @@ func testAccCheckElbV3PoolDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -63,7 +62,7 @@ func testAccCheckElbV3PoolDestroy(s *terraform.State) error {
 
 		_, err := pools.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("Pool still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("pool still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -74,17 +73,17 @@ func testAccCheckElbV3PoolExists(n string, pool *pools.Pool) resource.TestCheckF
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		found, err := pools.Get(elbClient, rs.Primary.ID).Extract()
@@ -93,7 +92,7 @@ func testAccCheckElbV3PoolExists(n string, pool *pools.Pool) resource.TestCheckF
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Member not found")
+			return fmt.Errorf("member not found")
 		}
 
 		*pool = *found

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_flavors.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_flavors.go
@@ -1,12 +1,13 @@
 package elb
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/elb/v3/flavors"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceElbFlavorsV3() *schema.Resource {
@@ -91,7 +92,7 @@ func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(*config.Config)
 	elbClient, err := config.ElbV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb v3 client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	listOpts := flavors.ListOpts{}
@@ -106,7 +107,7 @@ func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error 
 
 	allFlavors, err := flavors.ExtractFlavors(pages)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve flavors: %s", err)
+		return fmt.Errorf("unable to retrieve flavors: %s", err)
 	}
 
 	max_connections := d.Get("max_connections").(int)
@@ -151,8 +152,8 @@ func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if len(ids) < 1 {
-		return fmtp.Errorf("Your query returned no results. " +
-			"Please change your search criteria and try again.")
+		return fmt.Errorf("your query returned no results. " +
+			"Please change your search criteria and try again")
 	}
 
 	d.SetId(hashcode.Strings(ids))

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -332,7 +332,7 @@ func resourceLoadBalancerV3Create(ctx context.Context, d *schema.ResourceData, m
 	// set the ID on the resource
 	d.SetId(loadBalancerID)
 
-	//set tags
+	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
 		elbV2Client, err := config.ElbV2Client(config.GetRegion(d))
@@ -422,7 +422,7 @@ func resourceLoadBalancerV3Update(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating elb v3 client: %s", err)
 	}
 
-	//lintignore:R019
+	// lintignore:R019
 	if d.HasChanges("name", "description", "cross_vpc_backend", "ipv4_subnet_id", "ipv6_network_id",
 		"ipv6_bandwidth_id", "ipv4_address", "l4_flavor_id", "l7_flavor_id", "autoscaling_enabled", "min_l7_flavor_id") {
 		var updateOpts loadbalancers.UpdateOpts
@@ -573,7 +573,7 @@ func resourceLoadBalancerV3Delete(ctx context.Context, d *schema.ResourceData, m
 		}
 	} else {
 		if err = loadbalancers.Delete(elbClient, d.Id()).ExtractErr(); err != nil {
-			return diag.Errorf("error deleting elb loadbalancer: %s", err)
+			return diag.Errorf("error deleting v3 loadbalancer: %s", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refactor application resource:

1. replace fmtp with fmt

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  refactor application resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/elb/'                      
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v  -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceELbCertificateV3_basic 
--- PASS: TestAccDataSourceELbCertificateV3_basic (9.40s) 
=== RUN   TestAccElbFlavorsDataSource_basic
=== PAUSE TestAccElbFlavorsDataSource_basic
=== RUN   TestAccDatasourcePools_basic
=== PAUSE TestAccDatasourcePools_basic
=== RUN   TestAccElbV3Certificate_basic
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== RUN   TestAccElbV3Certificate_withEpsId
=== PAUSE TestAccElbV3Certificate_withEpsId
=== RUN   TestAccElbV3IpGroup_basic
=== PAUSE TestAccElbV3IpGroup_basic
=== RUN   TestAccElbV3IpGroup_withEpsId
=== PAUSE TestAccElbV3IpGroup_withEpsId
=== RUN   TestAccElbV3L7Policy_basic
=== PAUSE TestAccElbV3L7Policy_basic
=== RUN   TestAccElbV3L7Rule_basic
=== PAUSE TestAccElbV3L7Rule_basic
=== RUN   TestAccElbV3Listener_basic
=== PAUSE TestAccElbV3Listener_basic
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId 
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid 
=== RUN   TestAccElbLogTank_basic
=== PAUSE TestAccElbLogTank_basic
=== RUN   TestAccElbV3Member_basic
=== PAUSE TestAccElbV3Member_basic
=== RUN   TestAccElbV3Member_crossVpcBackend
=== PAUSE TestAccElbV3Member_crossVpcBackend
=== RUN   TestAccElbV3Monitor_basic
=== PAUSE TestAccElbV3Monitor_basic
=== RUN   TestAccElbV3Pool_basic
=== PAUSE TestAccElbV3Pool_basic
=== RUN   TestAccSecurityPoliciesV3_basic
=== PAUSE TestAccSecurityPoliciesV3_basic
=== CONT  TestAccElbFlavorsDataSource_basic
=== CONT  TestAccElbV3LoadBalancer_basic 
=== CONT  TestAccElbV3IpGroup_basic 
=== CONT  TestAccElbV3Listener_basic
--- PASS: TestAccElbFlavorsDataSource_basic (7.55s) 
=== CONT  TestAccElbV3L7Rule_basic
--- PASS: TestAccElbV3IpGroup_basic (16.73s) 
=== CONT  TestAccElbV3L7Policy_basic
--- PASS: TestAccElbV3LoadBalancer_basic (57.67s) 
=== CONT  TestAccElbV3IpGroup_withEpsId
    acceptance.go:181: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3IpGroup_withEpsId (0.00s)
=== CONT  TestAccElbV3Member_basic
--- PASS: TestAccElbV3L7Policy_basic (67.80s) 
=== CONT  TestAccSecurityPoliciesV3_basic
--- PASS: TestAccElbV3Listener_basic (94.87s) 
=== CONT  TestAccElbV3Pool_basic
--- PASS: TestAccSecurityPoliciesV3_basic (16.39s) 
=== CONT  TestAccElbV3Monitor_basic
--- PASS: TestAccElbV3L7Rule_basic (98.77s) 
=== CONT  TestAccElbV3Member_crossVpcBackend
--- PASS: TestAccElbV3Member_basic (79.62s) 
=== CONT  TestAccElbV3Certificate_client
--- PASS: TestAccElbV3Certificate_client (9.07s) 
=== CONT  TestAccElbV3Certificate_withEpsId
    acceptance.go:181: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3Certificate_withEpsId (0.01s)
=== CONT  TestAccElbV3Certificate_basic
--- PASS: TestAccElbV3Monitor_basic (50.42s) 
=== CONT  TestAccElbV3LoadBalancer_prePaid
    acceptance.go:280: This environment does not support prepaid tests 
--- SKIP: TestAccElbV3LoadBalancer_prePaid (0.01s)
=== CONT  TestAccElbLogTank_basic
--- PASS: TestAccElbV3Certificate_basic (17.56s) 
=== CONT  TestAccDatasourcePools_basic
--- PASS: TestAccElbV3Pool_basic (85.16s) 
=== CONT  TestAccElbV3LoadBalancer_withEIP
--- PASS: TestAccElbV3Member_crossVpcBackend (79.91s) 
=== CONT  TestAccElbV3LoadBalancer_withEpsId
    acceptance.go:181: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3LoadBalancer_withEpsId (0.01s)
--- PASS: TestAccElbV3LoadBalancer_withEIP (32.34s) 
--- PASS: TestAccDatasourcePools_basic (67.02s) 
--- PASS: TestAccElbLogTank_basic (97.49s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       258.303s
```
