### PR TITLE
refactor(rocketmq): update the way of setting name in topic and consumer_group

### DIFF
--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
@@ -253,7 +253,7 @@ func resourceDmsRocketMQConsumerGroupRead(ctx context.Context, d *schema.Resourc
 		d.Set("enabled", utils.PathSearch("enabled", getRocketmqConsumerGroupRespBody, nil)),
 		d.Set("broadcast", utils.PathSearch("broadcast", getRocketmqConsumerGroupRespBody, nil)),
 		d.Set("brokers", utils.PathSearch("brokers", getRocketmqConsumerGroupRespBody, nil)),
-		d.Set("name", utils.PathSearch("name", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("name", name),
 		d.Set("retry_max_times", utils.PathSearch("retry_max_time", getRocketmqConsumerGroupRespBody, nil)),
 	)
 

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_topic.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_topic.go
@@ -285,7 +285,7 @@ func resourceDmsRocketMQTopicRead(ctx context.Context, d *schema.ResourceData, m
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("name", utils.PathSearch("name", getRocketmqTopicRespBody, nil)),
+		d.Set("name", topic),
 		d.Set("total_read_queue_num", utils.PathSearch("total_read_queue_num",
 			getRocketmqTopicRespBody, nil)),
 		d.Set("total_write_queue_num", utils.PathSearch("total_write_queue_num",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsRocketMQTopic_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRocketMQTopic_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQTopic_basic
=== PAUSE TestAccDmsRocketMQTopic_basic
=== CONT  TestAccDmsRocketMQTopic_basic
--- PASS: TestAccDmsRocketMQTopic_basic (720.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       721.076s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsRocketMQConsumerGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRocketMQConsumerGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQConsumerGroup_basic
=== PAUSE TestAccDmsRocketMQConsumerGroup_basic
=== CONT  TestAccDmsRocketMQConsumerGroup_basic
--- PASS: TestAccDmsRocketMQConsumerGroup_basic (724.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       724.598s
```
