### PR TITLE
chore(DLI): refactor DLI permission and fix

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/chnsz/golangsdk/openstack/dli/v1/auth"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -18,16 +17,16 @@ import (
 func getDliAuthResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating Dli v1 client, err=%s", err)
+		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}
 	obj, userName := dli.ParseAuthInfoFromId(state.Primary.ID)
 
 	permission, pErr := dli.QueryPermission(client, obj, userName)
-	if pErr == nil {
-		return permission, nil
+	if pErr != nil {
+		return nil, fmt.Errorf("this resource is not exist. Id=%s", state.Primary.ID)
 	}
 
-	return nil, fmtp.Errorf("This resource is not exist. Id=%s", state.Primary.ID)
+	return permission, nil
 }
 
 // test database permissions


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccResourceDliAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccResourceDliAuth -timeout 360m -parallel 4
=== RUN   TestAccResourceDliAuth_basic
=== PAUSE TestAccResourceDliAuth_basic
=== RUN   TestAccResourceDliAuth_flink
=== PAUSE TestAccResourceDliAuth_flink
=== RUN   TestAccResourceDliAuth_table
=== PAUSE TestAccResourceDliAuth_table
=== RUN   TestAccResourceDliAuth_package
=== PAUSE TestAccResourceDliAuth_package
=== RUN   TestAccResourceDliAuth_queue
=== PAUSE TestAccResourceDliAuth_queue
=== CONT  TestAccResourceDliAuth_basic
=== CONT  TestAccResourceDliAuth_package
=== CONT  TestAccResourceDliAuth_table
=== CONT  TestAccResourceDliAuth_queue
--- PASS: TestAccResourceDliAuth_basic (25.27s)
=== CONT  TestAccResourceDliAuth_flink
--- PASS: TestAccResourceDliAuth_package (27.00s)
--- PASS: TestAccResourceDliAuth_table (39.27s)
--- PASS: TestAccResourceDliAuth_flink (104.20s)
--- PASS: TestAccResourceDliAuth_queue (261.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       261.127s
```
