### PR TITLE
feat(cce): support server group in node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -78,6 +78,9 @@ The following arguments are supported:
 * `max_pods` - (Optional, Int, ForceNew) Specifies the maximum number of instances a node is allowed to create.
   Changing this parameter will create a new resource.
 
+* `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. If specified, the node will be created under
+  the cloud server group. Changing this parameter will create a new resource.
+
 * `preinstall` - (Optional, String, ForceNew) Specifies the script to be executed before installation.
   The input value can be a Base64 encoded string or not. Changing this parameter will create a new resource.
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -278,6 +278,11 @@ func ResourceCCENodePool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"ecs_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"current_node_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -372,6 +377,9 @@ func resourceCCENodePoolCreate(ctx context.Context, d *schema.ResourceData, meta
 			},
 			InitialNodeCount:  &initialNodeCount,
 			PodSecurityGroups: buildPodSecurityGroups(d.Get("pod_security_groups").([]interface{})),
+			NodeManagement: nodepools.NodeManagementSpec{
+				ServerGroupReference: d.Get("ecs_group_id").(string),
+			},
 		},
 	}
 
@@ -460,6 +468,7 @@ func resourceCCENodePoolRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("scale_down_cooldown_time", s.Spec.Autoscaling.ScaleDownCooldownTime),
 		d.Set("priority", s.Spec.Autoscaling.Priority),
 		d.Set("type", s.Spec.Type),
+		d.Set("ecs_group_id", s.Spec.NodeManagement.ServerGroupReference),
 	)
 
 	if s.Spec.NodeTemplate.BillingMode != 0 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support server group in node pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new parameter ecs_group_id
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1453.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1453.444s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_serverGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_serverGroup -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_serverGroup
=== PAUSE TestAccCCENodePool_serverGroup
=== CONT  TestAccCCENodePool_serverGroup
--- PASS: TestAccCCENodePool_serverGroup (909.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       909.219s
```
