### PR TITLE
refactor: move updateEcsInstanceKeyPair to common

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/resource_huaweicloud_compute_instance.go
@@ -114,10 +114,9 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				Optional: true,
 			},
 			"private_key": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				RequiredWith: []string{"key_pair"},
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"security_groups": {
 				Type:          schema.TypeSet,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
- move updateEcsInstanceKeyPair to common, it will be used by **CCE**
- remove RequiredWith in `private_key`, then we can unbind a keypair

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic

--- PASS: TestAccComputeInstance_basic (187.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       187.585s
```
