### PR TITLE
feat(CSS): support https_enable to cluster

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -102,6 +102,10 @@ The following arguments are supported:
   + The password must contain at least 3 of the following character types: uppercase letters, lowercase letters, digits,
     and special characters (~!@#$%^&*()-_=+\\|[{}];:,<.>/?).
 
+* `https_enabled` - (Optional, Bool, ForceNew) Specifies whether to enable HTTPS. Defaults to `false`.
+  When `https_enabled` is set to `true`, the `security_mode` needs to be set to `true`.
+  Changing this parameter will create a new resource.
+
 * `ess_node_config` - (Required, List, ForceNew) Specifies the config of data node.
   The [ess_node_config](#Css_ess_node_config) structure is documented below.
 

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
@@ -41,6 +41,8 @@ func TestAccCssCluster_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "security_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "https_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "1"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "7"),
@@ -88,6 +90,7 @@ func TestAccCssCluster_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "security_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "https_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "1"),
 					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.instance_number", "3"),
 					resource.TestCheckResourceAttr(resourceName, "client_node_config.0.instance_number", "1"),
@@ -145,8 +148,10 @@ func testAccCssCluster_basic(rName string, nodeNum int, keepDays int, tag string
 %s
 
 resource "huaweicloud_css_cluster" "test" {
-  name            = "%s"
-  engine_version  = "7.10.2"
+  name           = "%s"
+  engine_version = "7.10.2"
+  security_mode  = true
+  password       = "Test@passw0rd"
 
   ess_node_config {
     flavor          = "ess.spec-4u8g"
@@ -163,9 +168,9 @@ resource "huaweicloud_css_cluster" "test" {
   vpc_id            = huaweicloud_vpc.test.id
 
   backup_strategy {
-    keep_days  = %d
-    start_time = "00:00 GMT+08:00"
-    prefix     = "snapshot"
+    keep_days   = %d
+    start_time  = "00:00 GMT+08:00"
+    prefix      = "snapshot"
     bucket      = huaweicloud_obs_bucket.cssObs.bucket
     agency      = "css_obs_agency"
     backup_path = "css_repository/acctest"

--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
@@ -21,7 +21,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 const (
@@ -31,7 +30,7 @@ const (
 	InstanceTypeEssMaster = "ess-master"
 	InstanceTypeEssClient = "ess-client"
 
-	ClusterStatusInProcess   = "100" //The operation, such as instance creation, is in progress.
+	ClusterStatusInProcess   = "100" // The operation, such as instance creation, is in progress.
 	ClusterStatusAvailable   = "200"
 	ClusterStatusUnavailable = "303"
 )
@@ -91,6 +90,14 @@ func ResourceCssCluster() *schema.Resource {
 				Sensitive: true,
 				Optional:  true,
 				ForceNew:  true,
+			},
+
+			"https_enabled": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"security_mode"},
 			},
 
 			"ess_node_config": {
@@ -489,11 +496,11 @@ func resourceCssClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 	region := config.GetRegion(d)
 	cssV1Client, err := config.HcCssV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
 	cssV2Client, err := config.HcCssV2Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating CSS V2 client: %s", err)
+		return diag.Errorf("error creating CSS V2 client: %s", err)
 	}
 
 	createClusterOpts, paramErr := buildClusterCreateParameters(d, config)
@@ -605,11 +612,12 @@ func buildClusterCreateParameters(d *schema.ResourceData, config *config.Config)
 	if securityMode {
 		adminPassword := d.Get("password").(string)
 		if adminPassword == "" {
-			return nil, fmtp.Errorf("administrator password is required in security mode")
+			return nil, fmt.Errorf("administrator password is required in security mode")
 		}
-		createOpts.HttpsEnable = utils.Bool(true)
 		createOpts.AuthorityEnable = utils.Bool(true)
 		createOpts.AdminPwd = utils.String(adminPassword)
+
+		createOpts.HttpsEnable = utils.Bool(d.Get("https_enabled").(bool))
 	}
 
 	if _, ok := d.GetOk("vpcep_endpoint"); ok {
@@ -724,7 +732,7 @@ func resourceCssClusterRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	clusterDetail, err := cssV1Client.ShowClusterDetail(&model.ShowClusterDetailRequest{ClusterId: d.Id()})
 	if err != nil {
-		return diag.Errorf("query cluster detail failed, cluster_id=%s, err=%s", d.Id(), err)
+		return common.CheckDeletedDiag(d, err, "DLI cluster")
 	}
 
 	mErr := multierror.Append(
@@ -748,6 +756,7 @@ func resourceCssClusterRead(ctx context.Context, d *schema.ResourceData, meta in
 		d.Set("endpoint", clusterDetail.Endpoint),
 		d.Set("status", clusterDetail.Status),
 		d.Set("security_mode", flattenSecurity(clusterDetail.AuthorityEnable)),
+		d.Set("https_enabled", clusterDetail.HttpsEnable),
 		setClusterBackupStrategy(d, cssV1Client),
 	)
 
@@ -979,7 +988,7 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	//update backup strategy
+	// update backup strategy
 	if d.HasChange("backup_strategy") {
 		value, ok := d.GetOk("backup_strategy")
 		if !ok {
@@ -1021,7 +1030,7 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 				// check backup strategy, if the policy was disabled, we should enable it
 				policy, err := cssV1Client.ShowAutoCreatePolicy(&model.ShowAutoCreatePolicyRequest{ClusterId: d.Id()})
 				if err != nil {
-					return diag.Errorf("Error extracting Cluster backup_strategy, err: %s", err)
+					return diag.Errorf("error extracting Cluster backup_strategy, err: %s", err)
 				}
 
 				if utils.StringValue(policy.Enable) == "false" && raw["bucket"] == nil {
@@ -1136,7 +1145,7 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 				return diag.FromErr(err)
 			}
 		} else {
-			//update bandwidth
+			// update bandwidth
 			if d.HasChange("kibana_public_access.0.bandwidth") {
 				_, err := cssV1Client.UpdateAlterKibana(&model.UpdateAlterKibanaRequest{
 					ClusterId: d.Id(),
@@ -1367,7 +1376,7 @@ func resourceCssClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 	region := config.GetRegion(d)
 	cssV1Client, err := config.HcCssV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
 
 	_, err = cssV1Client.DeleteCluster(&model.DeleteClusterRequest{ClusterId: d.Id()})
@@ -1474,7 +1483,7 @@ func checkCssClusterIsReady(detail *model.ShowClusterDetailResponse) bool {
 		return false
 	}
 
-	//actions --- the behaviors on a cluster
+	// actions --- the behaviors on a cluster
 	if detail.Actions != nil && len(*detail.Actions) > 0 {
 		return false
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccCssCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_basic
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (1864.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1864.197s
```

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssCluster_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccCssCluster_prePaid -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_prePaid
=== PAUSE TestAccCssCluster_prePaid
=== CONT  TestAccCssCluster_prePaid
--- PASS: TestAccCssCluster_prePaid (1352.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1352.822s
hm@ecs-hm:~/git/terraform-provider-huaweicloud$ make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssCluster_basic'
```
