### PR TITLE
feat(cce/node): support updating key_pair and password

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -206,9 +206,10 @@ The following arguments are supported:
 * `key_pair` - (Optional, String) Specifies the key pair name when logging in to select the key pair mode.
   This parameter and `password` are alternative.
 
-* `password` - (Optional, String, ForceNew) Specifies the root password when logging in to select the password mode.
+* `password` - (Optional, String) Specifies the root password when logging in to select the password mode.
   This parameter can be plain or salted and is alternative to `key_pair`.
-  Changing this parameter will create a new resource.
+
+  -> A new password is in plain text and takes effect after the node is started or restarted.
 
 * `private_key` - (Optional, String) Specifies the private key of the in used `key_pair`. This parameter is mandatory
   when replacing or unbinding a keypair if the CCE node is in **Active** state.

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -203,12 +203,15 @@ The following arguments are supported:
   + For VM nodes, clusters of v1.13 and later support *EulerOS 2.5* and *CentOS 7.6*.
   + For BMS nodes purchased in the yearly/monthly billing mode, only *EulerOS 2.3* is supported.
 
-* `key_pair` - (Optional, String, ForceNew) Specifies the key pair name when logging in to select the key pair mode.
-  This parameter and `password` are alternative. Changing this parameter will create a new resource.
+* `key_pair` - (Optional, String) Specifies the key pair name when logging in to select the key pair mode.
+  This parameter and `password` are alternative.
 
 * `password` - (Optional, String, ForceNew) Specifies the root password when logging in to select the password mode.
   This parameter can be plain or salted and is alternative to `key_pair`.
   Changing this parameter will create a new resource.
+
+* `private_key` - (Optional, String) Specifies the private key of the in used `key_pair`. This parameter is mandatory
+  when replacing or unbinding a keypair if the CCE node is in **Active** state.
 
 * `root_volume` - (Required, List, ForceNew) Specifies the configuration of the system disk.
   Changing this parameter will create a new resource.

--- a/huaweicloud/common/ecs_instance_keypair.go
+++ b/huaweicloud/common/ecs_instance_keypair.go
@@ -25,6 +25,8 @@ type KeypairAuthOpts struct {
 	InUsedPrivateKey string
 	// the root password of the ECS instance, it's used to bind a new keypair
 	Password string
+	// whether to disable SSH login on the VM
+	DisablePassword bool
 	// the timeout to wait for the task
 	Timeout time.Duration
 }
@@ -53,8 +55,9 @@ func UpdateEcsInstanceKeyPair(ctx context.Context, ecsClient, kmsClient *golangs
 		bindOpts := keypairs.AssociateOpts{
 			Name: opts.NewKeyPair,
 			Server: keypairs.EcsServerOpts{
-				ID:   instanceID,
-				Auth: authOpts,
+				ID:              instanceID,
+				Auth:            authOpts,
+				DisablePassword: &opts.DisablePassword,
 			},
 		}
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_v3.go
@@ -35,6 +35,7 @@ func ResourceCCENodeV3() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
@@ -74,7 +75,6 @@ func ResourceCCENodeV3() *schema.Resource {
 			"key_pair": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ExactlyOneOf: []string{"password", "key_pair"},
 			},
 			"password": {
@@ -83,6 +83,11 @@ func ResourceCCENodeV3() *schema.Resource {
 				ForceNew:     true,
 				Sensitive:    true,
 				ExactlyOneOf: []string{"password", "key_pair"},
+			},
+			"private_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"root_volume": {
 				Type:     schema.TypeList,
@@ -931,17 +936,24 @@ func resourceCCENodeV3Read(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("status", s.Status.Phase),
 	)
 
-	// fetch tags from ECS instance
 	computeClient, err := config.ComputeV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
 	}
 
+	// fetch key_pair from ECS instance
+	if server, err := cloudservers.Get(computeClient, serverId).Extract(); err == nil {
+		mErr = multierror.Append(mErr, d.Set("key_pair", server.KeyName))
+	} else {
+		logp.Printf("[WARN] Error fetching ECS instance (%s): %s", serverId, err)
+	}
+
+	// fetch tags from ECS instance
 	if resourceTags, err := tags.Get(computeClient, "cloudservers", serverId).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		mErr = multierror.Append(mErr, d.Set("tags", tagmap))
 	} else {
-		logp.Printf("[WARN] Error fetching tags of CCE Node (%s): %s", serverId, err)
+		logp.Printf("[WARN] Error fetching tags of ECS instance (%s): %s", serverId, err)
 	}
 
 	if err = mErr.ErrorOrNil(); err != nil {
@@ -952,9 +964,15 @@ func resourceCCENodeV3Read(_ context.Context, d *schema.ResourceData, meta inter
 
 func resourceCCENodeV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	nodeClient, err := config.CceV3Client(config.GetRegion(d))
+	region := config.GetRegion(d)
+
+	nodeClient, err := config.CceV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
+	}
+	computeClient, err := config.ComputeV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
 	}
 
 	if d.HasChange("name") {
@@ -968,17 +986,34 @@ func resourceCCENodeV3Update(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	//update tags
-	if d.HasChange("tags") {
-		computeClient, err := config.ComputeV1Client(config.GetRegion(d))
-		if err != nil {
-			return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
-		}
+	serverId := d.Get("server_id").(string)
 
-		serverId := d.Get("server_id").(string)
+	// update node tags with ECS API
+	if d.HasChange("tags") {
 		tagErr := utils.UpdateResourceTags(computeClient, d, "cloudservers", serverId)
 		if tagErr != nil {
 			return fmtp.DiagErrorf("Error updating tags of cce node %s: %s", d.Id(), tagErr)
+		}
+	}
+
+	// update node key_pair with DEW API
+	if d.HasChange("key_pair") {
+		kmsClient, err := config.KmsV3Client(region)
+		if err != nil {
+			return diag.Errorf("error creating KMS v3 client: %s", err)
+		}
+
+		o, n := d.GetChange("key_pair")
+		keyPairOpts := &common.KeypairAuthOpts{
+			InstanceID:       serverId,
+			InUsedKeyPair:    o.(string),
+			NewKeyPair:       n.(string),
+			InUsedPrivateKey: d.Get("private_key").(string),
+			Password:         d.Get("password").(string),
+			Timeout:          d.Timeout(schema.TimeoutUpdate),
+		}
+		if err := common.UpdateEcsInstanceKeyPair(ctx, computeClient, kmsClient, keyPairOpts); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

there is an issue with acceptance if we update the key_pair with
```hcl
 private_key       = file(huaweicloud_compute_keypair.test.key_file)
```

```bash
$ make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodeV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
    resource_huaweicloud_cce_node_v3_test.go:28: Step 3/3 error: Error running pre-apply refresh: exit status 1

        Error: Invalid function argument

          on terraform_plugin_test.tf line 49, in resource "huaweicloud_cce_node" "test":
          49:   private_key       = file(huaweicloud_compute_keypair.test.key_file)
            ├────────────────
            │ huaweicloud_compute_keypair.test.key_file is "./kp-tf-acc-test-hv98p.pem"

        Invalid value for "path" parameter: no file exists at
        "./kp-tf-acc-test-hv98p.pem"; this function works only with files that are
        distributed as part of the configuration source code, so if this file will be
        created by a resource in this configuration you must instead obtain this
        result from an attribute of that resource.
--- FAIL: TestAccCCENodeV3_basic (875.00s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       875.059s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```

so, we can't test this feature by acceptance. It's tested well manually.