### PR TITLE
refactor(elb/certificate_ipgroup): fix elb certificate and ipgroup lint issues

### DIFF
--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/elb/v3/certificates"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3Certificate_basic(t *testing.T) {
@@ -93,10 +93,10 @@ func TestAccElbV3Certificate_withEpsId(t *testing.T) {
 }
 
 func testAccCheckElbV3CertificateDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	elbClient, err := cfg.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -106,7 +106,7 @@ func testAccCheckElbV3CertificateDestroy(s *terraform.State) error {
 
 		_, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("Certificate still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("certificate still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -118,17 +118,17 @@ func testAccCheckElbV3CertificateExists(
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		elbClient, err := cfg.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		found, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
@@ -137,7 +137,7 @@ func testAccCheckElbV3CertificateExists(
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Certificate not found")
+			return fmt.Errorf("certificate not found")
 		}
 
 		*c = *found
@@ -206,12 +206,6 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, name)
 }
@@ -276,12 +270,6 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, name)
 }

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_ipgroup_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_ipgroup_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/elb/v3/ipgroups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccElbV3IpGroup_basic(t *testing.T) {
@@ -73,10 +73,10 @@ func TestAccElbV3IpGroup_withEpsId(t *testing.T) {
 }
 
 func testAccCheckElbV3IpGroupDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	elbClient, err := cfg.ElbV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+		return fmt.Errorf("error creating ELB client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -86,7 +86,7 @@ func testAccCheckElbV3IpGroupDestroy(s *terraform.State) error {
 
 		_, err := ipgroups.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("IpGroup still exists: %s", rs.Primary.ID)
+			return fmt.Errorf("ipGroup still exists: %s", rs.Primary.ID)
 		}
 	}
 
@@ -98,17 +98,17 @@ func testAccCheckElbV3IpGroupExists(
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		elbClient, err := config.ElbV3Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		elbClient, err := cfg.ElbV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud elb client: %s", err)
+			return fmt.Errorf("error creating ELB client: %s", err)
 		}
 
 		found, err := ipgroups.Get(elbClient, rs.Primary.ID).Extract()
@@ -117,7 +117,7 @@ func testAccCheckElbV3IpGroupExists(
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("IpGroup not found")
+			return fmt.Errorf("ipGroup not found")
 		}
 
 		*c = *found

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_ipgroup.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_ipgroup.go
@@ -3,13 +3,13 @@ package elb
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/elb/v3/ipgroups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -22,12 +22,6 @@ func ResourceIpGroupV3() *schema.Resource {
 		DeleteContext: resourceIpGroupV3Delete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -76,26 +70,26 @@ func ResourceIpGroupV3() *schema.Resource {
 }
 
 func resourceIpGroupAddresses(d *schema.ResourceData) []ipgroups.IpListOpt {
-	var IpList []ipgroups.IpListOpt
+	var ipLists []ipgroups.IpListOpt
 	ipListRaw := d.Get("ip_list").([]interface{})
 
 	for _, v := range ipListRaw {
 		ipList := v.(map[string]interface{})
-		ipListOpts := ipgroups.IpListOpt{
+		ipListOpt := ipgroups.IpListOpt{
 			Ip:          ipList["ip"].(string),
 			Description: ipList["description"].(string),
 		}
-		IpList = append(IpList, ipListOpts)
+		ipLists = append(ipLists, ipListOpt)
 	}
 
-	return IpList
+	return ipLists
 }
 
 func resourceIpGroupV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.ElbV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	elbClient, err := cfg.ElbV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	ipList := resourceIpGroupAddresses(d)
@@ -104,49 +98,47 @@ func resourceIpGroupV3Create(ctx context.Context, d *schema.ResourceData, meta i
 		Name:                d.Get("name").(string),
 		Description:         &desc,
 		IpList:              &ipList,
-		EnterpriseProjectID: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	ig, err := ipgroups.Create(elbClient, createOpts).Extract()
+	log.Printf("[DEBUG] Create ELB IP Group options: %#v", createOpts)
+	ipGroup, err := ipgroups.Create(elbClient, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating IpGroup: %s", err)
 	}
-	d.SetId(ig.ID)
+	d.SetId(ipGroup.ID)
 
 	return resourceIpGroupV3Read(ctx, d, meta)
 }
 
 func resourceIpGroupV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.ElbV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	elbClient, err := cfg.ElbV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	ig, err := ipgroups.Get(elbClient, d.Id()).Extract()
+	ipGroup, err := ipgroups.Get(elbClient, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "ipgroup")
 	}
 
-	log.Printf("[DEBUG] Retrieved ip group %s: %#v", d.Id(), ig)
+	log.Printf("[DEBUG] Retrieved ip group %s: %#v", d.Id(), ipGroup)
 
-	mErr := multierror.Append(nil,
-		d.Set("name", ig.Name),
-		d.Set("description", ig.Description),
-		d.Set("region", config.GetRegion(d)),
-	)
-
-	ipList := make([]map[string]interface{}, len(ig.IpList))
-	for i, ip := range ig.IpList {
+	ipList := make([]map[string]interface{}, len(ipGroup.IpList))
+	for i, ip := range ipGroup.IpList {
 		ipList[i] = map[string]interface{}{
 			"ip":          ip.Ip,
 			"description": ip.Description,
 		}
 	}
-	d.Set("ip_list", ipList)
 
-	mErr = multierror.Append(mErr, d.Set("ip_list", ipList))
+	mErr := multierror.Append(nil,
+		d.Set("name", ipGroup.Name),
+		d.Set("description", ipGroup.Description),
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("ip_list", ipList),
+	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting Dedicated ELB ipgroup fields: %s", err)
@@ -156,10 +148,10 @@ func resourceIpGroupV3Read(_ context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceIpGroupV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.ElbV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	elbClient, err := cfg.ElbV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	var updateOpts ipgroups.UpdateOpts
@@ -178,22 +170,22 @@ func resourceIpGroupV3Update(ctx context.Context, d *schema.ResourceData, meta i
 	log.Printf("[DEBUG] Updating ipgroup %s with options: %#v", d.Id(), updateOpts)
 	_, err = ipgroups.Update(elbClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("error updating elb ip group: %s", err)
+		return diag.Errorf("error updating ELB ip group: %s", err)
 	}
 
 	return resourceIpGroupV3Read(ctx, d, meta)
 }
 
 func resourceIpGroupV3Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	elbClient, err := config.ElbV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	elbClient, err := cfg.ElbV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating elb v3 client: %s", err)
+		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting ip group %s", d.Id())
 	if err = ipgroups.Delete(elbClient, d.Id()).ExtractErr(); err != nil {
-		return diag.Errorf("error deleting elb ip group: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting ELB ip group")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix elb certificate and ipgroup lint issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix elb certificate and ipgroup lint issues
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_ipgroup_test.go'                      
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_ipgroup_test.go -v  -timeout 360m -parallel 4 
=== RUN   TestAccElbV3IpGroup_basic 
=== PAUSE TestAccElbV3IpGroup_basic
=== RUN   TestAccElbV3IpGroup_withEpsId
=== PAUSE TestAccElbV3IpGroup_withEpsId
=== CONT  TestAccElbV3IpGroup_basic
=== CONT  TestAccElbV3IpGroup_withEpsId
    acceptance.go:182: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3IpGroup_withEpsId (0.00s)
--- PASS: TestAccElbV3IpGroup_basic (16.60s) 
PASS
ok      command-line-arguments  16.646s

make testacc TEST='./huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go -v  -timeout 360m -parallel 4 
=== RUN   TestAccElbV3Certificate_basic 
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== RUN   TestAccElbV3Certificate_withEpsId
=== PAUSE TestAccElbV3Certificate_withEpsId
=== CONT  TestAccElbV3Certificate_basic
=== CONT  TestAccElbV3Certificate_withEpsId
=== CONT  TestAccElbV3Certificate_client
=== CONT  TestAccElbV3Certificate_withEpsId
    acceptance.go:182: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElbV3Certificate_withEpsId (0.00s)
--- PASS: TestAccElbV3Certificate_client (10.67s) 
--- PASS: TestAccElbV3Certificate_basic (19.44s) 
PASS
ok      command-line-arguments  19.478s
```
