### PR TITLE
feat(waf): add a new parameter charging_mode in cloud domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847
+	github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230106095447-ad00916fd479 h1:Rd+jUb/jJsSLTLL5iAXibxyPuojs3KyWsKRQ4w2E2bM=
-github.com/chnsz/golangsdk v0.0.0-20230106095447-ad00916fd479/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847 h1:GOiIXAjJ5beLf61NCg/cKaET0ge3oT1OpYtUJjhqLzY=
-github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225 h1:hiD6ICQq6spHKB4E8SGIrYURYrYhVuC+BthrKanauaI=
+github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -65,7 +65,7 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"keep_policy"},
+				ImportStateVerifyIgnore: []string{"keep_policy", "charging_mode"},
 			},
 		},
 	})
@@ -109,6 +109,71 @@ func TestAccWafDomainV1_policy(t *testing.T) {
 	})
 }
 
+func testAccWafDomainV1_base(randName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_certificate" "certificate_1" {
+  name = "%s"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+}
+`, testAccCloudInstance_basic, randName)
+}
+
 func testAccWafDomainV1_basic(randName, domainName string) string {
 	return fmt.Sprintf(`
 %s
@@ -126,8 +191,12 @@ resource "huaweicloud_waf_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8080
   }
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
 }
-`, testAccWafCertificateV1_conf(randName), domainName)
+`, testAccWafDomainV1_base(randName), domainName)
 }
 
 func testAccWafDomainV1_update(randName, domainName string) string {
@@ -148,8 +217,11 @@ resource "huaweicloud_waf_domain" "domain_1" {
     port            = 8443
   }
 
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
 }
-`, testAccWafCertificateV1_conf(randName), domainName)
+`, testAccWafDomainV1_base(randName), domainName)
 }
 
 func testAccWafDomainV1_policy(randName, domainName string) string {
@@ -173,6 +245,10 @@ resource "huaweicloud_waf_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8080
   }
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
 }
-`, testAccWafCertificateV1_conf(randName), randName, domainName)
+`, testAccWafDomainV1_base(randName), randName, domainName)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -14,6 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
+var PaidType = "prePaid"
+
 const (
 	PROTOCOL_HTTP  = "HTTP"
 	PROTOCOL_HTTPS = "HTTPS"
@@ -102,6 +104,16 @@ func ResourceWafDomainV1() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"charging_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     PaidType,
+				Description: "schema: Internal",
+				ValidateFunc: validation.StringInSlice([]string{
+					PaidType,
+				}, false),
+			},
 			"protect_status": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -151,6 +163,7 @@ func resourceWafDomainV1Create(d *schema.ResourceData, meta interface{}) error {
 		CertificateName: d.Get("certificate_name").(string),
 		Servers:         buildWafDomainServers(d),
 		Proxy:           &proxy,
+		PaidType:        d.Get("charging_mode").(string),
 	}
 	logp.Printf("[DEBUG] CreateOpts: %#v", createOpts)
 
@@ -197,6 +210,7 @@ func resourceWafDomainV1Read(d *schema.ResourceData, meta interface{}) error {
 		return common.CheckDeleted(d, err, "Error obtain WAF domain information")
 	}
 
+	// keep_policy and charging_mode not returned by API
 	mErr := multierror.Append(nil,
 		d.Set("region", config.GetRegion(d)),
 		d.Set("domain", n.HostName),

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
@@ -22,6 +22,7 @@ type CreateOpts struct {
 	CertificateId   string       `json:"certificateid,omitempty"`
 	CertificateName string       `json:"certificatename,omitempty"`
 	Proxy           *bool        `json:"proxy,omitempty"`
+	PaidType        string       `json:"paid_type,omitempty"`
 }
 
 // ServerOpts contains the origin server information.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230116070640-a00589724847
+# github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (83.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       83.856s

make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_policy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_policy -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_policy
=== PAUSE TestAccWafDomainV1_policy
=== CONT  TestAccWafDomainV1_policy
--- PASS: TestAccWafDomainV1_policy (82.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       82.910s
```
