### PR TITLE
refactor(dms/rocketmq_consumerGroup): fix dms rocketmq consumer group lint issues

### DIFF
--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
@@ -9,19 +9,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getDmsRocketMQConsumerGroupResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getDmsRocketMQConsumerGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getRocketmqConsumerGroup: query DMS rocketmq consumer group
 	var (
 		getRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
-		getRocketmqConsumerGroupProduct = "dms"
+		getRocketmqConsumerGroupProduct = "dmsv2"
 	)
-	getRocketmqConsumerGroupClient, err := config.NewServiceClient(getRocketmqConsumerGroupProduct, region)
+	getRocketmqConsumerGroupClient, err := cfg.NewServiceClient(getRocketmqConsumerGroupProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
 	}
@@ -34,7 +35,8 @@ func getDmsRocketMQConsumerGroupResourceFunc(config *config.Config, state *terra
 	instanceID := parts[0]
 	name := parts[1]
 	getRocketmqConsumerGroupPath := getRocketmqConsumerGroupClient.Endpoint + getRocketmqConsumerGroupHttpUrl
-	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{project_id}", getRocketmqConsumerGroupClient.ProjectID)
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{project_id}",
+		getRocketmqConsumerGroupClient.ProjectID)
 	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{instance_id}", instanceID)
 	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{group}", name)
 
@@ -44,7 +46,8 @@ func getDmsRocketMQConsumerGroupResourceFunc(config *config.Config, state *terra
 			200,
 		},
 	}
-	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath, &getRocketmqConsumerGroupOpt)
+	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath,
+		&getRocketmqConsumerGroupOpt)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving DmsRocketMQConsumerGroup: %s", err)
 	}
@@ -119,18 +122,20 @@ resource "huaweicloud_networking_secgroup" "test" {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
-  name                = "%[1]s"
-  engine_version      = "4.8.0"
-  storage_space       = 600
-  vpc_id              = huaweicloud_vpc.test.id
-  subnet_id           = huaweicloud_vpc_subnet.test.id
-  security_group_id   = huaweicloud_networking_secgroup.test.id
-  availability_zones  = [
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
-  flavor_id           = "c6.4u8g.cluster"
-  storage_spec_code   = "dms.physical.storage.high.v2"
-  broker_num          = 1
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
 }
 `, rName)
 }
@@ -140,11 +145,13 @@ func testDmsRocketMQConsumerGroup_basic(name string) string {
 %s
 
 resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
-  instance_id    = huaweicloud_dms_rocketmq_instance.test.id
-  broadcast      = true
-  brokers        = [
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  broadcast   = true
+
+  brokers = [
     "broker-0"
   ]
+
   name            = "%s"
   retry_max_times = "3"
 }
@@ -156,11 +163,13 @@ func testDmsRocketMQConsumerGroup_basic_update(name string) string {
 %s
 
 resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
-  instance_id    = huaweicloud_dms_rocketmq_instance.test.id
-  broadcast      = false
-  brokers        = [
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  broadcast   = false
+
+  brokers = [
     "broker-0"
   ]
+
   name            = "%s"
   retry_max_times = "5"
   enabled         = false

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
@@ -9,12 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceDmsRocketMQConsumerGroup() *schema.Resource {
@@ -82,22 +83,23 @@ func ResourceDmsRocketMQConsumerGroup() *schema.Resource {
 }
 
 func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createRocketmqConsumerGroup: create DMS rocketmq consumer group
 	var (
 		createRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups"
-		createRocketmqConsumerGroupProduct = "dms"
+		createRocketmqConsumerGroupProduct = "dmsv2"
 	)
-	createRocketmqConsumerGroupClient, err := config.NewServiceClient(createRocketmqConsumerGroupProduct, region)
+	createRocketmqConsumerGroupClient, err := cfg.NewServiceClient(createRocketmqConsumerGroupProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
 	}
 
 	instanceID := d.Get("instance_id").(string)
 	createRocketmqConsumerGroupPath := createRocketmqConsumerGroupClient.Endpoint + createRocketmqConsumerGroupHttpUrl
-	createRocketmqConsumerGroupPath = strings.ReplaceAll(createRocketmqConsumerGroupPath, "{project_id}", createRocketmqConsumerGroupClient.ProjectID)
+	createRocketmqConsumerGroupPath = strings.ReplaceAll(createRocketmqConsumerGroupPath, "{project_id}",
+		createRocketmqConsumerGroupClient.ProjectID)
 	createRocketmqConsumerGroupPath = strings.ReplaceAll(createRocketmqConsumerGroupPath, "{instance_id}", instanceID)
 
 	createRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
@@ -106,8 +108,9 @@ func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.Resou
 			200,
 		},
 	}
-	createRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqConsumerGroupBodyParams(d, config))
-	createRocketmqConsumerGroupResp, err := createRocketmqConsumerGroupClient.Request("POST", createRocketmqConsumerGroupPath, &createRocketmqConsumerGroupOpt)
+	createRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqConsumerGroupBodyParams(d, cfg))
+	createRocketmqConsumerGroupResp, err := createRocketmqConsumerGroupClient.Request("POST",
+		createRocketmqConsumerGroupPath, &createRocketmqConsumerGroupOpt)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQConsumerGroup: %s", err)
 	}
@@ -127,7 +130,7 @@ func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.Resou
 	return resourceDmsRocketMQConsumerGroupRead(ctx, d, meta)
 }
 
-func buildCreateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
 	var enabled interface{} = true
 	if v, ok := d.GetOk("enabled"); ok {
 		enabled = v
@@ -143,22 +146,22 @@ func buildCreateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, config *
 }
 
 func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
-	updateRocketmqConsumerGrouphasChanges := []string{
+	updateRocketmqConsumerGroupHasChanges := []string{
 		"enabled",
 		"broadcast",
 		"retry_max_times",
 	}
 
-	if d.HasChanges(updateRocketmqConsumerGrouphasChanges...) {
+	if d.HasChanges(updateRocketmqConsumerGroupHasChanges...) {
 		// updateRocketmqConsumerGroup: update DMS rocketmq consumer group
 		var (
 			updateRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
-			updateRocketmqConsumerGroupProduct = "dms"
+			updateRocketmqConsumerGroupProduct = "dmsv2"
 		)
-		updateRocketmqConsumerGroupClient, err := config.NewServiceClient(updateRocketmqConsumerGroupProduct, region)
+		updateRocketmqConsumerGroupClient, err := cfg.NewServiceClient(updateRocketmqConsumerGroupProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
 		}
@@ -170,7 +173,8 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 		instanceID := parts[0]
 		name := parts[1]
 		updateRocketmqConsumerGroupPath := updateRocketmqConsumerGroupClient.Endpoint + updateRocketmqConsumerGroupHttpUrl
-		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{project_id}", updateRocketmqConsumerGroupClient.ProjectID)
+		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{project_id}",
+			updateRocketmqConsumerGroupClient.ProjectID)
 		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{instance_id}", instanceID)
 		updateRocketmqConsumerGroupPath = strings.ReplaceAll(updateRocketmqConsumerGroupPath, "{group}", name)
 
@@ -180,8 +184,9 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 				204,
 			},
 		}
-		updateRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildUpdateRocketmqConsumerGroupBodyParams(d, config))
-		_, err = updateRocketmqConsumerGroupClient.Request("PUT", updateRocketmqConsumerGroupPath, &updateRocketmqConsumerGroupOpt)
+		updateRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildUpdateRocketmqConsumerGroupBodyParams(d))
+		_, err = updateRocketmqConsumerGroupClient.Request("PUT", updateRocketmqConsumerGroupPath,
+			&updateRocketmqConsumerGroupOpt)
 		if err != nil {
 			return diag.Errorf("error updating DmsRocketMQConsumerGroup: %s", err)
 		}
@@ -190,7 +195,7 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 	return resourceDmsRocketMQConsumerGroupRead(ctx, d, meta)
 }
 
-func buildUpdateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildUpdateRocketmqConsumerGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"broadcast":      utils.ValueIngoreEmpty(d.Get("broadcast")),
 		"retry_max_time": utils.ValueIngoreEmpty(d.Get("retry_max_times")),
@@ -202,18 +207,18 @@ func buildUpdateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, config *
 	return bodyParams
 }
 
-func resourceDmsRocketMQConsumerGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceDmsRocketMQConsumerGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
 	// getRocketmqConsumerGroup: query DMS rocketmq consumer group
 	var (
 		getRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
-		getRocketmqConsumerGroupProduct = "dms"
+		getRocketmqConsumerGroupProduct = "dmsv2"
 	)
-	getRocketmqConsumerGroupClient, err := config.NewServiceClient(getRocketmqConsumerGroupProduct, region)
+	getRocketmqConsumerGroupClient, err := cfg.NewServiceClient(getRocketmqConsumerGroupProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
 	}
@@ -225,7 +230,8 @@ func resourceDmsRocketMQConsumerGroupRead(ctx context.Context, d *schema.Resourc
 	instanceID := parts[0]
 	name := parts[1]
 	getRocketmqConsumerGroupPath := getRocketmqConsumerGroupClient.Endpoint + getRocketmqConsumerGroupHttpUrl
-	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{project_id}", getRocketmqConsumerGroupClient.ProjectID)
+	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{project_id}",
+		getRocketmqConsumerGroupClient.ProjectID)
 	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{instance_id}", instanceID)
 	getRocketmqConsumerGroupPath = strings.ReplaceAll(getRocketmqConsumerGroupPath, "{group}", name)
 
@@ -235,7 +241,8 @@ func resourceDmsRocketMQConsumerGroupRead(ctx context.Context, d *schema.Resourc
 			200,
 		},
 	}
-	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath, &getRocketmqConsumerGroupOpt)
+	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath,
+		&getRocketmqConsumerGroupOpt)
 
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving DmsRocketMQConsumerGroup")
@@ -260,16 +267,16 @@ func resourceDmsRocketMQConsumerGroupRead(ctx context.Context, d *schema.Resourc
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceDmsRocketMQConsumerGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceDmsRocketMQConsumerGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteRocketmqConsumerGroup: delete DMS rocketmq consumer group
 	var (
 		deleteRocketmqConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
-		deleteRocketmqConsumerGroupProduct = "dms"
+		deleteRocketmqConsumerGroupProduct = "dmsv2"
 	)
-	deleteRocketmqConsumerGroupClient, err := config.NewServiceClient(deleteRocketmqConsumerGroupProduct, region)
+	deleteRocketmqConsumerGroupClient, err := cfg.NewServiceClient(deleteRocketmqConsumerGroupProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
 	}
@@ -281,7 +288,8 @@ func resourceDmsRocketMQConsumerGroupDelete(ctx context.Context, d *schema.Resou
 	instanceID := parts[0]
 	name := parts[1]
 	deleteRocketmqConsumerGroupPath := deleteRocketmqConsumerGroupClient.Endpoint + deleteRocketmqConsumerGroupHttpUrl
-	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{project_id}", deleteRocketmqConsumerGroupClient.ProjectID)
+	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{project_id}",
+		deleteRocketmqConsumerGroupClient.ProjectID)
 	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{instance_id}", instanceID)
 	deleteRocketmqConsumerGroupPath = strings.ReplaceAll(deleteRocketmqConsumerGroupPath, "{group}", name)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dms rocketmq consumer group lint issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dms rocketmq consumer group lint issues
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRocketMQConsumerGroup_basic'        
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQConsumerGroup_basic -timeout 360m -parallel 4 
=== RUN   TestAccDmsRocketMQConsumerGroup_basic 
=== PAUSE TestAccDmsRocketMQConsumerGroup_basic 
=== CONT  TestAccDmsRocketMQConsumerGroup_basic
--- PASS: TestAccDmsRocketMQConsumerGroup_basic (717.06s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       717.107s
```
