### PR TITLE
refactor(dms/rocketmq_user): fix dms rocketmq user lint issues

### DIFF
--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
@@ -9,19 +9,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getDmsRocketMQUserResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getDmsRocketMQUserResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getRocketmqUser: query DMS rocketmq user
 	var (
 		getRocketmqUserHttpUrl = "v2/{project_id}/instances/{instance_id}/users/{user_name}"
 		getRocketmqUserProduct = "dms"
 	)
-	getRocketmqUserClient, err := config.NewServiceClient(getRocketmqUserProduct, region)
+	getRocketmqUserClient, err := cfg.NewServiceClient(getRocketmqUserProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DmsRocketMQUser Client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dms rocketmq user lint issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dms rocketmq user lint issues
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRocketMQUser_basic'                 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQUser_basic -timeout 360m -parallel 4 
=== RUN   TestAccDmsRocketMQUser_basic 
=== PAUSE TestAccDmsRocketMQUser_basic
=== CONT  TestAccDmsRocketMQUser_basic
--- PASS: TestAccDmsRocketMQUser_basic (722.84s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       722.889s
```
