### PR TITLE
refactor(dms/rocketmq_dataSource): fix dms rocketmq data source lint issues 

### DIFF
--- a/docs/data-sources/dms_rocketmq_instances.md
+++ b/docs/data-sources/dms_rocketmq_instances.md
@@ -114,7 +114,7 @@ The `instances` block supports:
 <a name="DmsRocketMQInstances_InstanceCrossVpc"></a>
 The `cross_vpc_accesses` block supports:
 
-* `lisenter_ip` - Indicates the IP of the listener.
+* `listener_ip` - Indicates the IP of the listener.
 
 * `advertised_ip` - Indicates the advertised IP.
 

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_broker_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_broker_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
@@ -51,18 +52,20 @@ resource "huaweicloud_networking_secgroup" "test" {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
-  name                = "%[1]s"
-  engine_version      = "4.8.0"
-  storage_space       = 600
-  vpc_id              = huaweicloud_vpc.test.id
-  subnet_id           = huaweicloud_vpc_subnet.test.id
-  security_group_id   = huaweicloud_networking_secgroup.test.id
-  availability_zones  = [
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
-  flavor_id           = "c6.4u8g.cluster"
-  storage_spec_code   = "dms.physical.storage.high.v2"
-  broker_num          = 1
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
 }
 `, name)
 }

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_instances_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_instances_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
@@ -59,18 +60,20 @@ resource "huaweicloud_networking_secgroup" "test" {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
-  name                = "%[1]s"
-  engine_version      = "4.8.0"
-  storage_space       = 600
-  vpc_id              = huaweicloud_vpc.test.id
-  subnet_id           = huaweicloud_vpc_subnet.test.id
-  security_group_id   = huaweicloud_networking_secgroup.test.id
-  availability_zones  = [
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 600
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
-  flavor_id           = "c6.4u8g.cluster.small"
-  storage_spec_code   = "dms.physical.storage.high.v2"
-  broker_num          = 1
+
+  flavor_id         = "c6.4u8g.cluster.small"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
 }
 `, name)
 }

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_broker.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_broker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -40,18 +41,18 @@ func DataSourceDmsRocketMQBroker() *schema.Resource {
 	}
 }
 
-func resourceDmsRocketMQBrokerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceDmsRocketMQBrokerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
 	// getRocketmqBroker: Query the List of rocketMQ broker
 	var (
 		getRocketmqBrokerHttpUrl = "v2/{project_id}/instances/{instance_id}/brokers"
-		getRocketmqBrokerProduct = "dms"
+		getRocketmqBrokerProduct = "dmsv2"
 	)
-	getRocketmqBrokerClient, err := config.NewServiceClient(getRocketmqBrokerProduct, region)
+	getRocketmqBrokerClient, err := cfg.NewServiceClient(getRocketmqBrokerProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQBroker Client: %s", err)
 	}
@@ -77,11 +78,11 @@ func resourceDmsRocketMQBrokerRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	dataSourceId, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(dataSourceId)
 
 	mErr = multierror.Append(
 		mErr,

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_instances.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_rocketmq_instances.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -50,7 +51,7 @@ instance name.`,
 			},
 			"instances": {
 				Type:        schema.TypeList,
-				Elem:        DmsRocketMQInstancesInstanceRefSchema(),
+				Elem:        rocketMQInstancesInstanceRefSchema(),
 				Computed:    true,
 				Description: `Indicates the list of DMS rocketMQ instances.`,
 			},
@@ -58,7 +59,7 @@ instance name.`,
 	}
 }
 
-func DmsRocketMQInstancesInstanceRefSchema() *schema.Resource {
+func rocketMQInstancesInstanceRefSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -165,7 +166,7 @@ func DmsRocketMQInstancesInstanceRefSchema() *schema.Resource {
 			},
 			"cross_vpc_accesses": {
 				Type:        schema.TypeList,
-				Elem:        DmsRocketMQInstancesInstanceRefCrossVpcInfoRefSchema(),
+				Elem:        rocketMQInstancesInstanceRefCrossVpcInfoRefSchema(),
 				Computed:    true,
 				Description: `Indicates the Cross-VPC access information.`,
 			},
@@ -229,14 +230,14 @@ func DmsRocketMQInstancesInstanceRefSchema() *schema.Resource {
 	return &sc
 }
 
-func DmsRocketMQInstancesInstanceRefCrossVpcInfoRefSchema() *schema.Resource {
+func rocketMQInstancesInstanceRefCrossVpcInfoRefSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"lisenter_ip": {
+			"advertised_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"advertised_ip": {
+			"listener_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -248,23 +249,29 @@ func DmsRocketMQInstancesInstanceRefCrossVpcInfoRefSchema() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			// Typo, it is only kept in the code, will not be shown in the docs.
+			"lisenter_ip": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "typo in lisenter_ip, please use \"listener_ip\" instead.",
+			},
 		},
 	}
 	return &sc
 }
 
-func resourceDmsRocketMQInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceDmsRocketMQInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
 	// getRocketmqInstances: Query DMS rocketmq instances list
 	var (
 		getRocketmqInstancesHttpUrl = "v2/{project_id}/instances"
-		getRocketmqInstancesProduct = "dms"
+		getRocketmqInstancesProduct = "dmsv2"
 	)
-	getRocketmqInstancesClient, err := config.NewServiceClient(getRocketmqInstancesProduct, region)
+	getRocketmqInstancesClient, err := cfg.NewServiceClient(getRocketmqInstancesProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating DmsRocketMQInstances Client: %s", err)
 	}
@@ -294,13 +301,13 @@ func resourceDmsRocketMQInstancesRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	dataSourceId, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(dataSourceId)
 
-	instances, err := flattenGetRocketmqInstancesResponseBodyInstanceRef(getRocketmqInstancesRespBody, config, region)
+	instances, err := flattenGetRocketmqInstancesResponseBodyInstanceRef(getRocketmqInstancesRespBody, cfg, region)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -312,8 +319,7 @@ func resourceDmsRocketMQInstancesRead(ctx context.Context, d *schema.ResourceDat
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func flattenGetRocketmqInstancesResponseBodyInstanceRef(resp interface{}, config *config.Config,
-	region string) ([]interface{}, error) {
+func flattenGetRocketmqInstancesResponseBodyInstanceRef(resp interface{}, cfg *config.Config, region string) ([]interface{}, error) {
 	if resp == nil {
 		return nil, nil
 	}
@@ -332,7 +338,7 @@ func flattenGetRocketmqInstancesResponseBodyInstanceRef(resp interface{}, config
 			for _, availableZoneID := range availableZoneIDs.([]interface{}) {
 				azIDs = append(azIDs, availableZoneID.(string))
 			}
-			availableZoneCodes, err = getAvailableZoneCodeByID(config, region, azIDs)
+			availableZoneCodes, err = getAvailableZoneCodeByID(cfg, region, azIDs)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dms rocketmq data source lint issues 
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dms rocketmq data source lint issues 
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDatasourceDmsRocketMQBroker_basic' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDatasourceDmsRocketMQBroker_basic -timeout 360m -parallel 4 
=== RUN   TestAccDatasourceDmsRocketMQBroker_basic 
=== PAUSE TestAccDatasourceDmsRocketMQBroker_basic
=== CONT  TestAccDatasourceDmsRocketMQBroker_basic

--- PASS: TestAccDatasourceDmsRocketMQBroker_basic (706.96s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       707.013s

make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDatasourceDmsRocketMQInstances_basic'  
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDatasourceDmsRocketMQInstances_basic -timeout 360m -parallel 4 
=== RUN   TestAccDatasourceDmsRocketMQInstances_basic 
=== PAUSE TestAccDatasourceDmsRocketMQInstances_basic 
=== CONT  TestAccDatasourceDmsRocketMQInstances_basic 
--- PASS: TestAccDatasourceDmsRocketMQInstances_basic (675.85s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       675.901s
```
