### PR TITLE
fix(dms): update the API for resizing RabbitMQ and Kafka instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
+	github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225 h1:hiD6ICQq6spHKB4E8SGIrYURYrYhVuC+BthrKanauaI=
-github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf h1:AnwSui9+iUeCSEBsrBR6jrgHw3kpexwGdU/2thOya4U=
+github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
@@ -6,6 +6,10 @@ import (
 	"github.com/chnsz/golangsdk/pagination"
 )
 
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
 // CreateOpsBuilder is used for creating instance parameters.
 // any struct providing the parameters should implement this interface
 type CreateOpsBuilder interface {
@@ -119,12 +123,12 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	return
 }
 
-//UpdateOptsBuilder is an interface which can build the map paramter of update function
+// UpdateOptsBuilder is an interface which can build the map paramter of update function
 type UpdateOptsBuilder interface {
 	ToInstanceUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the parameters of update function
+// UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	// Indicates the name of an instance.
 	// An instance name starts with a letter,
@@ -221,4 +225,32 @@ func List(client *golangsdk.ServiceClient, opts ListOpsBuilder) pagination.Pager
 	})
 
 	return pageList
+}
+
+type ResizeInstanceOpts struct {
+	NewSpecCode     string `json:"new_spec_code" required:"true"`
+	NewStorageSpace int    `json:"new_storage_space" required:"true"`
+}
+
+func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts) (string, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	var rst golangsdk.Result
+	_, err = client.Post(extend(client, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r struct {
+			JobID string `json:"job_id"`
+		}
+		if err = rst.ExtractInto(&r); err != nil {
+			return "", err
+		}
+		return r.JobID, nil
+	}
+	return "", err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
@@ -28,3 +28,7 @@ func getURL(client *golangsdk.ServiceClient, id string) string {
 func listURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }
+
+func extend(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(client.ProjectID, resourcePath, id, "extend")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
+# github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Use RabbitMQ's API to resize RabbitMQ instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_compatible
--- PASS: TestAccDmsRabbitmqInstances_compatible (1114.07s)
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_single
--- PASS: TestAccDmsRabbitmqInstances_single (505.12s)
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (2247.60s)
--- PASS: TestAccDmsRabbitmqInstances_basic (2571.71s)
PASS
```
