### PR TITLE
fix(dms): update the API for resizing RabbitMQ and Kafka instances

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -8,7 +8,7 @@ Manage DMS Kafka instance resources within HuaweiCloud.
 
 ## Example Usage
 
-### Create a kafka instance using flavor ID
+### Create a Kafka instance using flavor ID
 
 ```hcl
 variable "vpc_id" {}
@@ -54,7 +54,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
 }
 ```
 
-### Create a kafka instance using product ID
+### Create a Kafka instance using product ID
 
 ```hcl
 variable "vpc_id" {}
@@ -98,16 +98,16 @@ resource "huaweicloud_dms_kafka_instance" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the DMS kafka instance resource. If omitted, the
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS Kafka instance resource. If omitted, the
   provider-level region will be used. Changing this creates a new instance resource.
 
-* `name` - (Required, String) Specifies the name of the DMS kafka instance. An instance name starts with a letter,
+* `name` - (Required, String) Specifies the name of the DMS Kafka instance. An instance name starts with a letter,
   consists of 4 to 64 characters, and supports only letters, digits, hyphens (-) and underscores (_).
 
-* `flavor_id` - (Optional, String) Specifies the kafka [flavor ID](https://support.huaweicloud.com/intl/en-us/productdesc-kafka/Kafka-specification.html),
+* `flavor_id` - (Optional, String) Specifies the Kafka [flavor ID](https://support.huaweicloud.com/intl/en-us/productdesc-kafka/Kafka-specification.html),
   e.g. **c6.2u4g.cluster**. This parameter and `product_id` are alternative.
 
-  -> The flavor IDs are not supported in some regions.
+  -> It is recommended to use `flavor_id` if the region supports it.
 
 * `product_id` - (Optional, String) Specifies a product ID, which includes bandwidth, partition, broker and default
   storage capacity.
@@ -116,7 +116,7 @@ The following arguments are supported:
   broker changes may cause storage capacity changes. So, if you specify the value of `storage_space`, you need to
   manually modify the value of `storage_space` after changing the `product_id`.
 
-* `engine_version` - (Required, String, ForceNew) Specifies the version of the kafka engine. Valid values are **1.1.0**
+* `engine_version` - (Required, String, ForceNew) Specifies the version of the Kafka engine. Valid values are **1.1.0**
   and **2.3.0**. Changing this creates a new instance resource.
 
 * `storage_spec_code` - (Required, String, ForceNew) Specifies the storage I/O specification.
@@ -165,24 +165,22 @@ The following arguments are supported:
   + **c6.12u12g.cluster**: `3,600` to `90,000` GB
   + **c6.16u32g.cluster** (1,200MB bandwidth): `4,800` to `90,000` GB
 
-  If the instance is created with `flavor_id`, this parameter is required.
-  If the instance is created with `product_id` and the `storage_space` is omitted, the storage capacity of the product
-  is used by default.
+  It is required when creating an instance with `flavor_id`.
 
-* `broker_num` - (Optional, Int, ForceNew) Specifies the broker numbers. Changing this creates a new instance resource.
-  If the instance is created with `flavor_id`, this parameter is required.
+* `broker_num` - (Optional, Int) Specifies the broker numbers.
+  It is required when creating an instance with `flavor_id`.
 
 * `access_user` - (Optional, String, ForceNew) Specifies a username. A username consists of 4 to 64 characters and
   supports only letters, digits, and hyphens (-). Changing this creates a new instance resource.
 
-* `password` - (Optional, String, ForceNew) Specifies the password of the DMS kafka instance. A password must meet the
+* `password` - (Optional, String, ForceNew) Specifies the password of the DMS Kafka instance. A password must meet the
   following complexity requirements: Must be 8 to 32 characters long. Must contain at least 2 of the following character
   types: lowercase letters, uppercase letters, digits, and special characters (`~!@#$%^&*()-_=+\\|[{}]:'",<.>/?).
   Changing this creates a new instance resource.
 
   -> **NOTE:** If `access_user` and `password` are specified, Kafka SASL_SSL will be automatically enabled.
 
-* `description` - (Optional, String) Specifies the description of the DMS kafka instance. It is a character string
+* `description` - (Optional, String) Specifies the description of the DMS Kafka instance. It is a character string
   containing not more than 1,024 characters.
 
 * `maintain_begin` - (Optional, String) Specifies the time at which a maintenance time window starts. Format: HH:mm. The
@@ -199,7 +197,7 @@ The following arguments are supported:
   `maintain_begin` is also blank. In this case, the system automatically allocates the default end time 06:00.
 
 * `public_ip_ids` - (Optional, List, ForceNew) Specifies the IDs of the elastic IP address (EIP)
-  bound to the DMS kafka instance. Changing this creates a new instance resource.
+  bound to the DMS Kafka instance. Changing this creates a new instance resource.
   + If the instance is created with `flavor_id`, the total number of public IPs is equal to `broker_num`.
   + If the instance is created with `product_id`, the total number of public IPs must provide as follows:
 
@@ -222,9 +220,9 @@ The following arguments are supported:
   topic creation is enabled, a topic will be automatically created with 3 partitions and 3 replicas when a message is
   produced to or consumed from a topic that does not exist. Changing this creates a new instance resource.
 
-* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the kafka instance.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the Kafka instance.
 
-* `tags` - (Optional, Map) The key/value pairs to associate with the DMS kafka instance.
+* `tags` - (Optional, Map) The key/value pairs to associate with the DMS Kafka instance.
 
 * `cross_vpc_accesses` - (Optional, List) Specifies the access information of cross-VPC.
   The [object](#dms_cross_vpc_accesses) structure is documented below.
@@ -242,17 +240,17 @@ In addition to all arguments above, the following attributes are exported:
 * `engine` - Indicates the message engine.
 * `bandwidth` - The Bandwidth of a Kafka instance, that is the maximum amount of data transferred per unit time.
   Unit: MB.
-* `partition_num` - Indicates the maximum number of topics in the DMS kafka instance.
+* `partition_num` - Indicates the maximum number of topics in the DMS Kafka instance.
 * `used_storage_space` - Indicates the used message storage space. Unit: GB
-* `port` - Indicates the port number of the DMS kafka instance.
-* `status` - Indicates the status of the DMS kafka instance.
+* `port` - Indicates the port number of the DMS Kafka instance.
+* `status` - Indicates the status of the DMS Kafka instance.
 * `ssl_enable` - Indicates whether the Kafka SASL_SSL is enabled.
-* `enable_public_ip` - Indicates whether public access to the DMS kafka instance is enabled.
+* `enable_public_ip` - Indicates whether public access to the DMS Kafka instance is enabled.
 * `resource_spec_code` - Indicates a resource specifications identifier.
-* `type` - Indicates the DMS kafka instance type.
-* `user_id` - Indicates the ID of the user who created the DMS kafka instance
-* `user_name` - Indicates the name of the user who created the DMS kafka instance
-* `connect_address` - Indicates the IP address of the DMS kafka instance.
+* `type` - Indicates the DMS Kafka instance type.
+* `user_id` - Indicates the ID of the user who created the DMS Kafka instance
+* `user_name` - Indicates the name of the user who created the DMS Kafka instance
+* `connect_address` - Indicates the IP address of the DMS Kafka instance.
 * `management_connect_address` - Indicates the connection address of the Kafka Manager of a Kafka instance.
 * `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
 
@@ -272,7 +270,7 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-DMS kafka instance can be imported using the instance id, e.g.
+DMS Kafka instance can be imported using the instance id, e.g.
 
 ```
  $ terraform import huaweicloud_dms_kafka_instance.instance_1 8d3c7938-dc47-4937-a30f-c80de381c5e3
@@ -281,7 +279,7 @@ DMS kafka instance can be imported using the instance id, e.g.
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
 `password`, `manager_password` and `public_ip_ids`. It is generally recommended running `terraform plan` after importing
-a DMS kafka instance. You can then decide if changes should be applied to the instance, or the resource definition
+a DMS Kafka instance. You can then decide if changes should be applied to the instance, or the resource definition
 should be updated to align with the instance. Also you can ignore changes as below.
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
+	github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225 h1:hiD6ICQq6spHKB4E8SGIrYURYrYhVuC+BthrKanauaI=
-github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf h1:AnwSui9+iUeCSEBsrBR6jrgHw3kpexwGdU/2thOya4U=
+github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -162,26 +162,29 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.id"),
 					resource.TestCheckResourceAttrPair(resourceName, "storage_spec_code",
 						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.ios.0.storage_spec_code"),
+					resource.TestCheckResourceAttr(resourceName, "broker_num", "3"),
+
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.1.advertised_ip", "www.terraform-test.com"),
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.2.advertised_ip", "192.168.0.53"),
 				),
 			},
 			{
-				// todo: flavor_id argument does not support changes(#2675)
 				Config: testAccKafkaInstance_newFormatUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "engine", "kafka"),
-					resource.TestCheckResourceAttrPair(resourceName, "broker_num",
-						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.properties.0.min_broker"),
+					resource.TestCheckResourceAttr(resourceName, "broker_num", "4"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor_id",
-						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.id"),
+						"data.huaweicloud_dms_kafka_flavors.test", "flavors.1.id"),
 					resource.TestCheckResourceAttrPair(resourceName, "storage_spec_code",
 						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.ios.0.storage_spec_code"),
+					resource.TestCheckResourceAttr(resourceName, "storage_space", "600"),
+
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.0.advertised_ip", "172.16.35.62"),
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.1.advertised_ip", "www.terraform-test-1.com"),
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.2.advertised_ip", "192.168.0.53"),
+					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.3.advertised_ip", "192.168.0.54"),
 				),
 			},
 		},
@@ -295,7 +298,7 @@ func testAccKafkaInstance_withEpsId(rName string) string {
 data "huaweicloud_dms_product" "test" {
   engine            = "kafka"
   instance_type     = "cluster"
-  version           = "2.3.0"
+  version           = "2.7"
   bandwidth         = "300MB"
   storage_spec_code = "dms.physical.storage.ultra"
 }
@@ -381,7 +384,7 @@ data "huaweicloud_dms_kafka_flavors" "test" {
 locals {
   query_results = data.huaweicloud_dms_kafka_flavors.test
 
-  advertised_ips = ["", "www.terraform-test.com", "192.168.0.53"]
+  flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
 }
 
 resource "huaweicloud_dms_kafka_instance" "test" {
@@ -390,23 +393,26 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
 
-  flavor_id          = local.query_results.flavors[0].id
-  storage_spec_code  = local.query_results.flavors[0].ios[0].storage_spec_code
-  availability_zones = local.query_results.flavors[0].ios[0].availability_zones
+  flavor_id          = local.flavor.id
+  storage_spec_code  = local.flavor.ios[0].storage_spec_code
+  availability_zones = local.flavor.ios[0].availability_zones
   engine_version     = element(local.query_results.versions, length(local.query_results.versions)-1)
-  storage_space      = local.query_results.flavors[0].properties[0].min_broker * local.query_results.flavors[0].properties[0].min_storage_per_node
-  broker_num         = local.query_results.flavors[0].properties[0].min_broker
+  storage_space      = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
+  broker_num         = 3
 
   access_user      = "user"
   password         = "Kafkatest@123"
   manager_user     = "kafka-user"
   manager_password = "Kafkatest@123"
 
-  dynamic "cross_vpc_accesses" {
-    for_each = local.advertised_ips
-    content {
-      advertised_ip = cross_vpc_accesses.value
-    }
+  cross_vpc_accesses {
+    advertised_ip = ""
+  }
+  cross_vpc_accesses {
+    advertised_ip = "www.terraform-test.com"
+  }
+  cross_vpc_accesses {
+    advertised_ip = "192.168.0.53"
   }
 }`, testAccKafkaInstance_base(rName), rName)
 }
@@ -422,7 +428,8 @@ data "huaweicloud_dms_kafka_flavors" "test" {
 locals {
   query_results = data.huaweicloud_dms_kafka_flavors.test
 
-  advertised_ips = ["172.16.35.62", "www.terraform-test-1.com", "192.168.0.53"]
+  flavor    = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
+  newFlavor = data.huaweicloud_dms_kafka_flavors.test.flavors[1]
 }
 
 resource "huaweicloud_dms_kafka_instance" "test" {
@@ -431,23 +438,29 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
 
-  flavor_id          = local.query_results.flavors[0].id
-  storage_spec_code  = local.query_results.flavors[0].ios[0].storage_spec_code
-  availability_zones = local.query_results.flavors[0].ios[0].availability_zones
+  flavor_id          = local.newFlavor.id
+  storage_spec_code  = local.flavor.ios[0].storage_spec_code
+  availability_zones = local.flavor.ios[0].availability_zones
   engine_version     = element(local.query_results.versions, length(local.query_results.versions)-1)
-  storage_space      = local.query_results.flavors[0].properties[0].min_broker * local.query_results.flavors[0].properties[0].min_storage_per_node
-  broker_num         = local.query_results.flavors[0].properties[0].min_broker
+  storage_space      = 600
+  broker_num         = 4
 
   access_user      = "user"
   password         = "Kafkatest@123"
   manager_user     = "kafka-user"
   manager_password = "Kafkatest@123"
 
-  dynamic "cross_vpc_accesses" {
-    for_each = local.advertised_ips
-    content {
-      advertised_ip = cross_vpc_accesses.value
-    }
+  cross_vpc_accesses {
+    advertised_ip = "172.16.35.62"
+  }
+  cross_vpc_accesses {
+    advertised_ip = "www.terraform-test-1.com"
+  }
+  cross_vpc_accesses {
+    advertised_ip = "192.168.0.53"
+  }
+  cross_vpc_accesses {
+    advertised_ip = "192.168.0.54"
   }
 }`, testAccKafkaInstance_base(rName), rName)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -162,12 +162,12 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	return
 }
 
-//UpdateOptsBuilder is an interface which can build the map paramter of update function
+// UpdateOptsBuilder is an interface which can build the map paramter of update function
 type UpdateOptsBuilder interface {
 	ToInstanceUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the parameters of update function
+// UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	// Indicates the name of an instance.
 	// An instance name starts with a letter,
@@ -266,8 +266,12 @@ func List(client *golangsdk.ServiceClient, opts ListOpsBuilder) pagination.Pager
 }
 
 type ResizeInstanceOpts struct {
-	NewSpecCode     string `json:"new_spec_code,omitempty"`
-	NewStorageSpace int    `json:"new_storage_space,omitempty"`
+	NewSpecCode     *string `json:"new_spec_code,omitempty"`
+	NewStorageSpace *int    `json:"new_storage_space,omitempty"`
+	OperType        *string `json:"oper_type,omitempty"`
+	NewBrokerNum    *int    `json:"new_broker_num,omitempty"`
+	NewProductID    *string `json:"new_product_id,omitempty"`
+	PublicIpID      *string `json:"publicip_id,omitempty"`
 }
 
 func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts) (string, error) {
@@ -285,7 +289,9 @@ func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts)
 		var r struct {
 			JobID string `json:"job_id"`
 		}
-		rst.ExtractInto(&r)
+		if err = rst.ExtractInto(&r); err != nil {
+			return "", err
+		}
 		return r.JobID, nil
 	}
 	return "", err

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
@@ -6,6 +6,10 @@ import (
 	"github.com/chnsz/golangsdk/pagination"
 )
 
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
 // CreateOpsBuilder is used for creating instance parameters.
 // any struct providing the parameters should implement this interface
 type CreateOpsBuilder interface {
@@ -119,12 +123,12 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	return
 }
 
-//UpdateOptsBuilder is an interface which can build the map paramter of update function
+// UpdateOptsBuilder is an interface which can build the map paramter of update function
 type UpdateOptsBuilder interface {
 	ToInstanceUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the parameters of update function
+// UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	// Indicates the name of an instance.
 	// An instance name starts with a letter,
@@ -221,4 +225,32 @@ func List(client *golangsdk.ServiceClient, opts ListOpsBuilder) pagination.Pager
 	})
 
 	return pageList
+}
+
+type ResizeInstanceOpts struct {
+	NewSpecCode     string `json:"new_spec_code" required:"true"`
+	NewStorageSpace int    `json:"new_storage_space" required:"true"`
+}
+
+func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts) (string, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	var rst golangsdk.Result
+	_, err = client.Post(extend(client, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r struct {
+			JobID string `json:"job_id"`
+		}
+		if err = rst.ExtractInto(&r); err != nil {
+			return "", err
+		}
+		return r.JobID, nil
+	}
+	return "", err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
@@ -28,3 +28,7 @@ func getURL(client *golangsdk.ServiceClient, id string) string {
 func listURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }
+
+func extend(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(client.ProjectID, resourcePath, id, "extend")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230201034636-8b278fe90225
+# github.com/chnsz/golangsdk v0.0.0-20230202085751-3506a80f6cbf
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Use RabbitMQ's API to resize RabbitMQ instances.
- Use Kafka's API to resize Kafka instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2675

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_compatible
--- PASS: TestAccDmsRabbitmqInstances_compatible (1114.07s)
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_single
--- PASS: TestAccDmsRabbitmqInstances_single (505.12s)
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (2247.60s)
--- PASS: TestAccDmsRabbitmqInstances_basic (2571.71s)
PASS
```

```
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_basic
--- PASS: TestAccKafkaInstance_basic (885.70s)
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== CONT  TestAccKafkaInstance_withEpsId
--- PASS: TestAccKafkaInstance_withEpsId (715.33s)
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_compatible
--- PASS: TestAccKafkaInstance_compatible (811.28s)
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_newFormat (2227.86s)
PASS
```
