### PR TITLE
fix(eip): append two bgp types for beta and elb

### DIFF
--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -37,6 +37,8 @@ type NormalizeStatus string // The Normalized status value.
 const (
 	BgpTypeDynamic BgpType = "5_bgp"  // Dynamic BGP
 	BgpTypeStatic  BgpType = "5_sbgp" // Static BGP
+	BgpTypeBeta    BgpType = "5_g-vm" // Beta environment BGP
+	BgpTypeElb     BgpType = "5_gray" // ELB BGP
 
 	IpVersionV4 IpVersion = 4 // IPv4
 	IpVersionV6 IpVersion = 6 // IPv6
@@ -92,7 +94,10 @@ func ResourceVpcEIPV1() *schema.Resource {
 							Default:  string(BgpTypeDynamic),
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								string(BgpTypeDynamic), string(BgpTypeStatic),
+								string(BgpTypeDynamic),
+								string(BgpTypeStatic),
+								string(BgpTypeBeta),
+								string(BgpTypeElb),
 							}, false),
 							Description: `The EIP type.`,
 						},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We have the dynamic BGP (5_bgp) and the static BGP (5_sbgp) support, except these, the Beta environment BGP (5_g-vm) and the ELB BGP (5_gray) should be supported.
The region support of the BGP are as follows:
- the Beta environment BGP (5_g-vm): cn-north-5, cn-north-7, cn-north-9
- the ELB BGP (5_gray): cn-south-1, la-south-2

In this feature, dynamic BGP may be used in place of them, but now, these types should be retained.
I think the parameter descriptions of the documentation is unnecessary, because of these types are usually not used.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. append two bgp types for beta and elb
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
PENDING
```
