### PR TITLE
fix(ecs/bind): Lock the instance ID when the related resources are binding

### DIFF
--- a/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/resource_huaweicloud_compute_servergroup_test.go
@@ -87,6 +87,25 @@ func TestAccComputeServerGroup_members(t *testing.T) {
 	})
 }
 
+func TestAccComputeServerGroup_concurrency(t *testing.T) {
+	name := fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeServerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeServerGroup_concurrency(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("members_attached", "true"),
+					resource.TestCheckOutput("volumes_attached", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeServerGroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*config.Config)
 	ecsClient, err := config.ComputeV1Client(HW_REGION_NAME)
@@ -211,4 +230,111 @@ resource "huaweicloud_compute_instance" "instance_1" {
   }
 }
 `, testAccCompute_data, rName, rName)
+}
+
+func testAccComputeServerGroup_concurrency(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  flavor_id  = data.huaweicloud_compute_flavors.test.ids[0]
+  os         = "Ubuntu"
+  visibility = "public"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.192.0/20"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  count = 2
+
+  name               = format("%[1]s_%%d", count.index)
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  image_id           = data.huaweicloud_images_images.test.images[0].id
+  security_groups    = [huaweicloud_networking_secgroup.test.name]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  key_pair = huaweicloud_kps_keypair.test.name
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_compute_servergroup" "test" {
+  count = 2
+
+  name     = format("%[1]s_%%d", count.index)
+  policies = ["anti-affinity"]
+
+  members = [
+    huaweicloud_compute_instance.test[count.index].id,
+  ]
+}
+
+resource "huaweicloud_evs_volume" "test" {
+  count = 10
+
+  name              = format("%[1]s-%%d", count.index)
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+
+  device_type = "SCSI"
+  volume_type = "SAS"
+  size        = 1000 * (count.index+1)
+  multiattach = true
+}
+
+resource "huaweicloud_compute_volume_attach" "attach_volumes_to_compute_test_1" {
+  count = 10
+
+  instance_id = huaweicloud_compute_instance.test[0].id
+  volume_id   = huaweicloud_evs_volume.test[count.index].id
+}
+
+resource "huaweicloud_compute_volume_attach" "attach_volumes_to_compute_test_2" {
+  count = 10
+
+  instance_id = huaweicloud_compute_instance.test[1].id
+  volume_id   = huaweicloud_evs_volume.test[count.index].id
+}
+
+locals {
+  attach_members_1 = huaweicloud_compute_servergroup.test[0].members
+  attach_members_2 = huaweicloud_compute_servergroup.test[1].members
+
+  attach_devices_1 = [for d in huaweicloud_compute_volume_attach.attach_volumes_to_compute_test_1[*].device : d != ""]
+  attach_devices_2 = [for d in huaweicloud_compute_volume_attach.attach_volumes_to_compute_test_2[*].device : d != ""]
+}
+
+output "members_attached" {
+  value = length(local.attach_members_1) == 1 && length(local.attach_members_2) == 1
+}
+
+output "volumes_attached" {
+  value = length(local.attach_devices_1) == 10 && length(local.attach_devices_2) == 10
+}
+`, name)
 }

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
@@ -177,7 +177,7 @@ func resourceComputeVolumeAttachDelete(ctx context.Context, d *schema.ResourceDa
 	}
 	job, err := block_devices.Detach(computeClient, volumeId, opts)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, parseRequestError(err), "error detaching volume")
 	}
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"RUNNING"},

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
@@ -78,7 +78,11 @@ func resourceComputeVolumeAttachCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error creating compute v1 client: %s", err)
 	}
 
+	// The ECS instances do not support mounting multiple volumes at the same time.
 	instanceId := d.Get("instance_id").(string)
+	config.MutexKV.Lock(instanceId)
+	defer config.MutexKV.Unlock(instanceId)
+	// The EVS volumes also do not support being mounted to multiple instances at the same time.
 	volumeId := d.Get("volume_id").(string)
 	config.MutexKV.Lock(volumeId)
 	defer config.MutexKV.Unlock(volumeId)
@@ -159,7 +163,11 @@ func resourceComputeVolumeAttachDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("Error creating compute V1 client: %s", err)
 	}
 
+	// The ECS instances do not support unmounting multiple volumes at the same time.
 	instanceId := d.Get("instance_id").(string)
+	config.MutexKV.Lock(instanceId)
+	defer config.MutexKV.Unlock(instanceId)
+	// The EVS volumes also do not support being unmounted from multiple instances at the same time.
 	volumeId := d.Get("volume_id").(string)
 	config.MutexKV.Lock(volumeId)
 	defer config.MutexKV.Unlock(volumeId)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Multiple operations that may race the resource cannot be performed on an ECS instance at the same time, such as: creating a cloud server group and binding a ECS volume.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Lock the instance ID when the related resoures are bind or creation.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
