### PR TITLE
fix(attach/status): Increase number of the status check to make sure the job is complete

### DIFF
--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
@@ -107,7 +107,9 @@ func resourceComputeVolumeAttachCreate(ctx context.Context, d *schema.ResourceDa
 		Refresh:      AttachmentJobRefreshFunc(computeClient, job.ID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        10 * time.Second,
-		PollInterval: 15 * time.Second,
+		PollInterval: 10 * time.Second,
+		// Sometime, the status on the EVS side is not complete yet, but the job status shows as "SUCCESS".
+		ContinuousTargetOccurence: 2,
 	}
 
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
@@ -177,7 +179,9 @@ func resourceComputeVolumeAttachDelete(ctx context.Context, d *schema.ResourceDa
 		Refresh:      AttachmentJobRefreshFunc(computeClient, job.ID),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        10 * time.Second,
-		PollInterval: 15 * time.Second,
+		PollInterval: 10 * time.Second,
+		// Sometime, the status on the EVS side is not complete yet, but the job status shows as "SUCCESS".
+		ContinuousTargetOccurence: 2,
 	}
 
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Increase number of the status check to make sure the job is complete.
Sometime, the status shows 'SUCCESS' to tell us the job is complete when we attach or detach a volume, but actually, the job is running. It is a bug for the ECS service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Increase number of the status check to make sure the job is complete
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
