### PR TITLE
fix: waf-dedicated-domain support tls config

### DIFF
--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -56,6 +56,9 @@ The following arguments are supported:
   and basically all other non-HTTP/S traffic. If a proxy such as public network ELB (or Nginx) has been used, set
   proxy `true` to ensure that the WAF security policy takes effect for the real source IP address.
 
+* `tls` - (Optional, String) Specifies the minimum required TLS version. The options include `TLS v1.0`, `TLS v1.1`,
+  `TLS v1.2`.
+
 * `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
   Defaults to `true`.
 
@@ -94,8 +97,6 @@ The following attributes are exported:
   + `1` - The domain name is connected to WAF.
 
 * `protocol` - The protocol type of the client. The options are `HTTP` and `HTTPS`.
-
-* `tls` - The TLS configuration of domain.
 
 * `cihper` - The cipher suite of domain.
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -31,6 +31,7 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
@@ -55,6 +56,7 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.1"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
@@ -69,6 +71,7 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
 					resource.TestCheckResourceAttr(resourceName, "protect_status", "0"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
@@ -145,6 +148,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   certificate_id = huaweicloud_waf_certificate.certificate_1.id
   keep_policy    = false
   proxy          = false
+  tls            = "TLS v1.2"
 
   server {
     client_protocol = "HTTPS"
@@ -171,6 +175,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   certificate_id = huaweicloud_waf_certificate.certificate_1.id
   keep_policy    = false
   proxy          = true
+  tls            = "TLS v1.1"
 
   server {
     client_protocol = "HTTPS"
@@ -211,6 +216,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   policy_id      = huaweicloud_waf_policy.policy_1.id
   keep_policy    = true
   proxy          = true
+  tls            = "TLS v1.2"
   protect_status = 0
 
   server {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
waf dedicated domain support tls config.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_basic
--- PASS: TestAccWafDedicateDomainV1_basic (407.03s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf	407.084s
```
