### PR TITLE
feat(rms/policy): add new policy definition query data source

### DIFF
--- a/docs/data-sources/rms_policy_definitions.md
+++ b/docs/data-sources/rms_policy_definitions.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Resource Management Service (RMS)"
+---
+
+# huaweicloud_rms_policy_definitions
+
+Use this data source to query policy definition list.
+
+## Example Usage
+
+```hcl
+variable "trigger_type" {}
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  trigger_type = var.trigger_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the policy definitions are located.  
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the policy definitions used to query definition list.
+
+* `policy_type` - (Optional, String) Specifies the policy type used to query definition list.  
+  The valid value is **builtin**.
+
+* `policy_rule_type` - (Optional, String) Specifies the policy rule type used to query definition list.
+
+* `trigger_type` - (Optional, String) Specifies the trigger type used to query definition list.  
+  The valid values are **resource** and **period**.
+
+* `keywords` - (Optional, List) Specifies the keyword list used to query definition list.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `definitions` - The policy definition list.
+  The [object](#policy_definitions) structure is documented below.
+
+<a name="policy_definitions"></a>
+The `definitions` block supports:
+
+* `id` - The ID of the policy definition.
+
+* `name` - The name of the policy definition.
+
+* `policy_type` - The policy type of the policy definition.
+
+* `description` - The description of the policy definition.
+
+* `policy_rule_type` - The policy rule type of the policy definition.
+
+* `policy_rule` - The policy rule of the policy definition.
+
+* `trigger_type` - The trigger type of the policy definition.
+
+* `keywords` - The keyword list of the policy definition.
+
+* `parameters` - The parameter reference map of the policy definition.

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -690,6 +690,10 @@ func (c *Config) SmnV2TagClient(region string) (*golangsdk.ServiceClient, error)
 	return c.NewServiceClient("smn-tag", region)
 }
 
+func (c *Config) RmsV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("rms", region)
+}
+
 // ********** client for Security **********
 func (c *Config) AntiDDosV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("anti-ddos", region)

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -418,6 +418,12 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		WithOutProjectID: true,
 		Product:          "TMS",
 	},
+	"rms": {
+		Name:             "rms",
+		Version:          "v1",
+		WithOutProjectID: true,
+		Product:          "RMS",
+	},
 	// catalog for Meeting service, only used for API scan
 	"meeting": {
 		Name:             "api.meeting",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -945,6 +945,18 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	}
 	t.Logf("SMN endpoint:\t %s", actualURL)
 
+	// test the endpoint of RMS service
+	serviceClient, err = config.RmsV1Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud RMS v1 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://rms.%s.%s/v1/", HW_REGION_NAME, config.Cloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("RMS endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("RMS endpoint:\t %s", actualURL)
+
 	serviceClient, err = config.CdmV11Client(HW_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud cdm client: %s", err)

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -74,6 +74,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/projectman"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rf"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
@@ -493,6 +494,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_instances":       rds.DataSourceRdsInstances(),
 			"huaweicloud_rds_backups":         rds.DataSourceBackup(),
 			"huaweicloud_rds_storage_types":   rds.DataSourceStoragetype(),
+
+			"huaweicloud_rms_policy_definitions": rms.DataSourcePolicyDefinitions(),
 
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 

--- a/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_policy_definitions_test.go
+++ b/huaweicloud/services/acceptance/rms/data_source_huaweicloud_rms_policy_definitions_test.go
@@ -1,0 +1,118 @@
+package rms
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataPolicyDefinitions_basic(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_rms_policy_definitions.test"
+		dc    = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPolicyDefinitions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dName, "definitions.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataPolicyDefinitions_basic = `
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "allowed-ecs-flavors"
+}
+`
+
+func TestAccDataPolicyDefinitions_keywords(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_rms_policy_definitions.test"
+		dc    = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPolicyDefinitions_keywords,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dName, "definitions.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataPolicyDefinitions_keywords = `
+data "huaweicloud_rms_policy_definitions" "test" {
+  keywords = ["ecs"]
+}
+`
+
+func TestAccDataPolicyDefinitions_policyRuleType(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_rms_policy_definitions.test"
+		dc    = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPolicyDefinitions_policyRuleType,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dName, "definitions.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataPolicyDefinitions_policyRuleType = `
+data "huaweicloud_rms_policy_definitions" "test" {
+  policy_rule_type = "dsl"
+}
+`
+
+func TestAccDataPolicyDefinitions_triggerType(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_rms_policy_definitions.test"
+		dc    = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPolicyDefinitions_triggerType,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dName, "definitions.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataPolicyDefinitions_triggerType = `
+data "huaweicloud_rms_policy_definitions" "test" {
+  trigger_type = "resource"
+}
+`

--- a/huaweicloud/services/rms/data_source_huaweicloud_rms_policy_definitions.go
+++ b/huaweicloud/services/rms/data_source_huaweicloud_rms_policy_definitions.go
@@ -1,0 +1,218 @@
+package rms
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourcePolicyDefinitions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePolicyDefinitionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region where the policy definitions are located.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the policy definitions used to query definition list.",
+			},
+			"policy_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The policy type used to query definition list.",
+			},
+			"policy_rule_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The policy rule type used to query definition list.",
+			},
+			"trigger_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The trigger type used to query definition list.",
+			},
+			"keywords": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The keyword list used to query definition list.",
+			},
+			"definitions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the policy definition.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the policy definition.",
+						},
+						"policy_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The policy type of the policy definition.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the policy definition.",
+						},
+						"policy_rule_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The policy rule type of the policy definition.",
+						},
+						"policy_rule": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The policy rule of the policy definition.",
+						},
+						"trigger_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The trigger type of the policy definition.",
+						},
+						"keywords": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The keyword list of the policy definition.",
+						},
+						"parameters": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The parameter reference map of the policy definition.",
+						},
+					},
+				},
+				Description: "The policy definition list.",
+			},
+		},
+	}
+}
+
+func filterPolicyDefinitionsByKeywords(definitions []policyassignments.PolicyDefinition,
+	keywords []interface{}) []policyassignments.PolicyDefinition {
+	if len(keywords) < 1 {
+		return definitions
+	}
+
+	filter := utils.ExpandToStringList(keywords)
+	result := make([]policyassignments.PolicyDefinition, 0, len(definitions))
+	for _, v := range definitions {
+		if utils.StrSliceContainsAnother(v.Keywords, filter) {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func flattenDefinitionParameters(parameters map[string]policyassignments.PolicyParameterDefinition) (
+	map[string]interface{}, error) {
+	if len(parameters) < 1 {
+		return nil, nil
+	}
+
+	result := make(map[string]interface{})
+	for k, v := range parameters {
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("generate json string failed: %s", err)
+		}
+		result[k] = string(jsonBytes)
+	}
+	return result, nil
+}
+
+func filterPolicyDefinitions(definitions []policyassignments.PolicyDefinition,
+	d *schema.ResourceData) ([]map[string]interface{}, []string, error) {
+	filter := map[string]interface{}{
+		"Name":           d.Get("name"),
+		"PolicyType":     d.Get("policy_type"),
+		"PolicyRuleType": d.Get("policy_rule_type"),
+		"TriggerType":    d.Get("trigger_type"),
+	}
+	filtResult, err := utils.FilterSliceWithField(definitions, filter)
+	if err != nil {
+		return nil, nil, fmt.Errorf("filter component runtimes failed: %s", err)
+	}
+	log.Printf("[DEBUG] Filter %d policy definitions from server through options: %v", len(filtResult), filter)
+
+	result := make([]map[string]interface{}, len(filtResult))
+	ids := make([]string, len(filtResult))
+	for i, val := range filtResult {
+		definition := val.(policyassignments.PolicyDefinition)
+		ids[i] = definition.ID
+		dm := map[string]interface{}{
+			"id":               definition.ID,
+			"name":             definition.Name,
+			"policy_type":      definition.PolicyType,
+			"description":      definition.Description,
+			"policy_rule_type": definition.PolicyRuleType,
+			"policy_rule":      definition.PolicyRule,
+			"trigger_type":     definition.TriggerType,
+			"keywords":         definition.Keywords,
+		}
+
+		params, err := flattenDefinitionParameters(definition.Parameters)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to flatten definition parameters: %s", err)
+		}
+		dm["parameters"] = params
+
+		jsonBytes, err := json.Marshal(definition.PolicyRule)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to generate json string: %s", err)
+		}
+		dm["policy_rule"] = string(jsonBytes)
+
+		result[i] = dm
+	}
+	return result, ids, nil
+}
+
+func dataSourcePolicyDefinitionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.RmsV1Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RMS v1 client: %s", err)
+	}
+
+	definitions, err := policyassignments.ListDefinitions(client)
+	if err != nil {
+		return diag.Errorf("error getting the policy definition list form server: %s", err)
+	}
+
+	filterResult := filterPolicyDefinitionsByKeywords(definitions, d.Get("keywords").([]interface{}))
+	dm, ids, err := filterPolicyDefinitions(filterResult, d)
+	if err != nil {
+		return diag.Errorf("error query policy definitions: %s", err)
+	}
+	d.SetId(hashcode.Strings(ids))
+
+	if err = d.Set("definitions", dm); err != nil {
+		return diag.Errorf("error saving the information of the policy definitions to state: %s", err)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments/requests.go
@@ -1,0 +1,163 @@
+package policyassignments
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure required by the 'Create' method to assign a specified policy.
+type CreateOpts struct {
+	// The name of the policy assignment.
+	Name string `json:"name" required:"true"`
+	// The description of the policy assignment.
+	Description string `json:"description,omitempty"`
+	// The type of the policy assignment.
+	// The valid values are as follow:
+	// + builtin
+	// + custom
+	Type string `json:"policy_assignment_type,omitempty"`
+	// The period of the policy rule check.
+	Period string `json:"period,omitempty"`
+	// The configuration used to filter resources.
+	PolicyFilter PolicyFilter `json:"policy_filter,omitempty"`
+	// The ID of the policy definition.
+	PolicyDefinitionId string `json:"policy_definition_id,omitempty"`
+	// The configuration of the custom policy.
+	CustomPolicy *CustomPolicy `json:"custom_policy,omitempty"`
+	// The rule definition of the policy assignment.
+	Parameters map[string]PolicyParameterValue `json:"parameters,omitempty"`
+}
+
+// PolicyFilter is an object specifying the filter parameters.
+type PolicyFilter struct {
+	// The name of the region to which the filtered resources belong.
+	RegionId string `json:"region_id,omitempty"`
+	// The service name to which the filtered resources belong.
+	ResourceProvider string `json:"resource_provider,omitempty"`
+	// The resource type of the filtered resources.
+	ResourceType string `json:"resource_type,omitempty"`
+	// The ID used to filter resources.
+	ResourceId string `json:"resource_id,omitempty"`
+	// The tag name used to filter resources.
+	TagKey string `json:"tag_key,omitempty"`
+	// The tag value used to filter resources.
+	TagValue string `json:"tag_value,omitempty"`
+}
+
+// CustomPolicy is an object specifying the configuration of the custom policy.
+type CustomPolicy struct {
+	// The function URN used to create the custom policy.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// The authorization type of the custom policy.
+	AuthType string `json:"auth_type" required:"true"`
+	// The authorization value of the custom policy.
+	AuthValue map[string]interface{} `json:"auth_value,omitempty"`
+}
+
+// PolicyParameterValue is an object specifying the definition of the policy parameter value.
+type PolicyParameterValue struct {
+	// The value of the rule definition.
+	Value interface{} `json:"value,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to assign a policy using given parameters.
+func Create(c *golangsdk.ServiceClient, domainId string, opts CreateOpts) (*Assignment, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Assignment
+	_, err = c.Put(rootURL(c, domainId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Get is a method to obtain the assignment detail by its ID.
+func Get(c *golangsdk.ServiceClient, domainId, assignmentId string) (*Assignment, error) {
+	var r Assignment
+	_, err := c.Get(resourceURL(c, domainId, assignmentId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// UpdateOpts is the structure required by the Update method to update the assignment configuration.
+type UpdateOpts struct {
+	// The name of the policy assignment.
+	Name string `json:"name" required:"true"`
+	// The description of the policy assignment.
+	Description *string `json:"description,omitempty"`
+	// The type of the policy assignment.
+	// The valid values are as follow:
+	// + builtin
+	// + custom
+	Type string `json:"policy_assignment_type,omitempty"`
+	// The period of the policy rule check.
+	Period string `json:"period,omitempty"`
+	// The configuration used to filter resources.
+	PolicyFilter PolicyFilter `json:"policy_filter,omitempty"`
+	// The ID of the policy definition.
+	PolicyDefinitionId string `json:"policy_definition_id,omitempty"`
+	// The configuration of the custom policy.
+	CustomPolicy *CustomPolicy `json:"custom_policy,omitempty"`
+	// The rule definition of the policy assignment.
+	Parameters map[string]PolicyParameterValue `json:"parameters,omitempty"`
+}
+
+// Update is a method to update the assignment configuration.
+func Update(c *golangsdk.ServiceClient, domainId, assignmentId string, opts UpdateOpts) (*Assignment, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Assignment
+	_, err = c.Put(resourceURL(c, domainId, assignmentId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Enable is a method to enable the resource function of the policy assignment.
+func Enable(c *golangsdk.ServiceClient, domainId, assignmentId string) error {
+	_, err := c.Post(enableURL(c, domainId, assignmentId), nil, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}
+
+// Disable is a method to disable the resource function of the policy assignment.
+func Disable(c *golangsdk.ServiceClient, domainId, assignmentId string) error {
+	_, err := c.Post(disableURL(c, domainId, assignmentId), nil, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}
+
+// Delete is a method to remove the specified policy assignment using its ID.
+func Delete(c *golangsdk.ServiceClient, domainId, assignmentId string) error {
+	_, err := c.Delete(resourceURL(c, domainId, assignmentId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}
+
+// ListDefinitions is a method to query the list of the built-in policy definitions using given parameters.
+func ListDefinitions(client *golangsdk.ServiceClient) ([]PolicyDefinition, error) {
+	pages, err := pagination.NewPager(client, queryDefinitionURL(client), func(r pagination.PageResult) pagination.Page {
+		p := DefinitionPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractDefinitions(pages)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments/results.go
@@ -1,0 +1,119 @@
+package policyassignments
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// Assignment is the structure that represents the detail of the policy assignment.
+type Assignment struct {
+	// The type of the policy assignment.
+	Type string `json:"policy_assignment_type"`
+	// The ID of the policy assignment.
+	ID string `json:"id"`
+	// The name of the policy assignment.
+	Name string `json:"name"`
+	// The description of the policy assignment.
+	Description string `json:"description"`
+	// The configuration used to filter resources.
+	PolicyFilter PolicyFilter `json:"policy_filter"`
+	// The period of the policy rule check.
+	Period string `json:"period"`
+	// The status of the policy assignment.
+	Status string `json:"state"`
+	// The ID of the policy definition.
+	PolicyDefinitionId string `json:"policy_definition_id"`
+	// The configuration of the custom policy.
+	CustomPolicy CustomPolicy `json:"custom_policy"`
+	// The rule definition of the policy assignment.
+	Parameters map[string]PolicyParameterValue `json:"parameters"`
+	// The creation time of the policy assignment.
+	CreatedAt string `json:"created"`
+	// The latest update time of the policy assignment.
+	UpdatedAt string `json:"updated"`
+}
+
+// listDefinitionResp is the structure that represents the page details of the built-in policy definitions.
+type listDefinitionResp struct {
+	Definitions []PolicyDefinition `json:"value"`
+	// The information of the current query page.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// PolicyDefinition is the structure that represents the details of the built-in policy definition.
+type PolicyDefinition struct {
+	// The ID of the policy definition.
+	ID string `json:"id"`
+	// The name of the policy definition.
+	Name string `json:"name"`
+	// The policy type of the policy definition.
+	PolicyType string `json:"policy_type"`
+	// The description of the policy definition.
+	Description string `json:"description"`
+	// The rule type of the policy definition.
+	PolicyRuleType string `json:"policy_rule_type"`
+	// The rule details of the policy definition.
+	PolicyRule interface{} `json:"policy_rule"`
+	// The trigger type of the policy definition.
+	TriggerType string `json:"trigger_type"`
+	// The keywords that policy definition has.
+	Keywords []string `json:"keywords"`
+	// The parameters of the policy definition.
+	Parameters map[string]PolicyParameterDefinition `json:"parameters"`
+}
+
+// PolicyParameterDefinition is the structure that represents the parameter configuration.
+type PolicyParameterDefinition struct {
+	// The name of the parameter definition.
+	Name string `json:"name"`
+	// The description of the parameter definition.
+	Description string `json:"description"`
+	// The allow value list of the parameter definition.
+	AllowedValues []interface{} `json:"allowed_values"`
+	// The default value of the parameter definition.m
+	DefaultValue string `json:"default_value"`
+	// The type of the parameter definition.
+	Type string `json:"type"`
+}
+
+// pageInfo is the structure that represents the information of the policy definition page.
+type pageInfo struct {
+	// The policy definition count of the current page.
+	CurrentCount int `json:"current_count"`
+	// The next marker of the policy definition page.
+	NextMarker string `json:"next_marker"`
+}
+
+// DefinitionPage represents the response pages of the List method.
+type DefinitionPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a query result no policy definition.
+func (r DefinitionPage) IsEmpty() (bool, error) {
+	resp, err := extractDefinitions(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a query result.
+func (r DefinitionPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listDefinitionResp
+	err := r.(DefinitionPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractDefinitions is a method which to extract the response to a policy definition list.
+func extractDefinitions(r pagination.Page) ([]PolicyDefinition, error) {
+	var s listDefinitionResp
+	err := r.(DefinitionPage).Result.ExtractInto(&s)
+	return s.Definitions, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments/urls.go
@@ -1,0 +1,23 @@
+package policyassignments
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, domainId string) string {
+	return client.ServiceURL("resource-manager/domains", domainId, "policy-assignments")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, domainId, assignmentId string) string {
+	return client.ServiceURL("resource-manager/domains", domainId, "policy-assignments", assignmentId)
+}
+
+func enableURL(client *golangsdk.ServiceClient, domainId, assignmentId string) string {
+	return client.ServiceURL("resource-manager/domains", domainId, "policy-assignments", assignmentId, "enable")
+}
+
+func disableURL(client *golangsdk.ServiceClient, domainId, assignmentId string) string {
+	return client.ServiceURL("resource-manager/domains", domainId, "policy-assignments", assignmentId, "disable")
+}
+
+func queryDefinitionURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("resource-manager/policy-definitions")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,6 +264,7 @@ github.com/chnsz/golangsdk/openstack/rds/v3/flavors
 github.com/chnsz/golangsdk/openstack/rds/v3/instances
 github.com/chnsz/golangsdk/openstack/rds/v3/securities
 github.com/chnsz/golangsdk/openstack/rf/v1/stacks
+github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments
 github.com/chnsz/golangsdk/openstack/scm/v3/certificates
 github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories
 github.com/chnsz/golangsdk/openstack/servicestage/v2/applications


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support new data source used to query policy definitions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rms' TESTARGS='-run=TestAccDataPolicyDefinitions_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run=TestAccDataPolicyDefinitions_ -timeout 360m -parallel 4
=== RUN   TestAccDataPolicyDefinitions_basic
=== PAUSE TestAccDataPolicyDefinitions_basic
=== RUN   TestAccDataPolicyDefinitions_keywords
=== PAUSE TestAccDataPolicyDefinitions_keywords
=== RUN   TestAccDataPolicyDefinitions_policyRuleType
=== PAUSE TestAccDataPolicyDefinitions_policyRuleType
=== RUN   TestAccDataPolicyDefinitions_triggerType
=== PAUSE TestAccDataPolicyDefinitions_triggerType
=== CONT  TestAccDataPolicyDefinitions_basic
=== CONT  TestAccDataPolicyDefinitions_policyRuleType
=== CONT  TestAccDataPolicyDefinitions_keywords
=== CONT  TestAccDataPolicyDefinitions_triggerType
--- PASS: TestAccDataPolicyDefinitions_policyRuleType (14.17s)
--- PASS: TestAccDataPolicyDefinitions_basic (15.08s)
--- PASS: TestAccDataPolicyDefinitions_triggerType (15.31s)
--- PASS: TestAccDataPolicyDefinitions_keywords (15.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       15.727s
```
