### PR TITLE
feat(rms/policy): add new policy assignment resource

### DIFF
--- a/docs/resources/rms_policy_assignment.md
+++ b/docs/resources/rms_policy_assignment.md
@@ -1,0 +1,187 @@
+---
+subcategory: "Resource Management Service (RMS)"
+---
+
+# huaweicloud_rms_policy_assignment
+
+Using this resource to assign the policy and evaluate HuaweiCloud resources.
+
+## Example Usage
+
+### Assign a built-in policy to check a specified instance by a flavor
+
+```hcl
+variable "policy_assignment_name" {}
+variable "region_name" {}
+variable "ecs_instance_id" {}
+variable "compliant_flavor" {}
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "allowed-ecs-flavors"
+}
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = var.policy_assignment_name
+  description          = "An ECS is noncompliant if its flavor is not in the specified flavor list (filter by resource ID)."
+  policy_definition_id = try(data.huaweicloud_rms_policy_definitions.test.definitions[0].id, "")
+  status               = "Enabled"
+
+  policy_filter {
+    region            = var.region_name
+    resource_provider = "ecs"
+    resource_type     = "cloudservers"
+    resource_id       = var.ecs_instance_id
+  }
+
+  parameters = {
+    listOfAllowedFlavors = "[\"${var.compliant_flavor}\"]"
+  }
+}
+```
+
+### Assign a built-in policy to periodically check whether an OBS bucket is tracked by CTS
+
+```hcl
+variable "policy_assignment_name" {}
+variable "bucket_name" {}
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "cts-obs-bucket-track"
+}
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = var.policy_assignment_name
+  description          = "An account is noncompliant if none of its CTS trackers track specified OBS buckets."
+  period               = "Six_Hours"
+  policy_definition_id = try(data.huaweicloud_rms_policy_definitions.test.definitions[0].id, "")
+  status               = "Enabled"
+
+  parameters = {
+    trackBucket = "\"${var.bucket_name}\""
+  }
+}
+```
+
+### Assign a custom policy
+
+```hcl
+variable "policy_assignment_name" {}
+variable "function_urn" {}
+variable "function_version" {}
+variable "rms_admin_trust_agency" {}
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name        = var.policy_assignment_name
+  description = "The ECS instances that do not conform to the custom function logic are considered non-compliant."
+  status      = "Enabled"
+
+  custom_policy {
+    function_urn = "${var.function_urn}:${var.function_version}"
+    auth_type    = "agency"
+    auth_value   = {
+      agency_name = "\"${var.rms_admin_trust_agency}\""
+    }
+  }
+
+  parameters = {
+    string_example = "\"string_value\""
+    array_example  = "[\"array_element\"]"
+    object_example = "{\"terraform_version\":\"1.xx.x\"}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the name of the policy assignment.  
+  The valid length is limited from `1` to `64`, only letters, digits, hyphens (-) and underscores (_) are allowed.  
+  The name must start with a letter.
+
+* `description` - (Optional, String) Specifies the description of the policy assignment, which contain maximum of
+  `512` characters.
+
+* `policy_definition_id` - (Optional, String) Specifies the ID of the built-in policy definition.  
+  This parameter and `custom_policy` are alternative.
+
+* `period` - (Optional, String) Specifies the period of the policy assignment.  
+  The valid values are as follows:
+  + **One_Hour**
+  + **Three_Hours**
+  + **Six_Hours**
+  + **Twelve_Hours**
+  + **TwentyFour_Hours**
+
+  Most one of `period` and `policy_filter` can be configured.
+
+* `policy_filter` - (Optional, List) Specifies the configuration used to filter resources.  
+  The [object](#rms_policy_filter) structure is documented below.
+
+-> If the `period` is configured, it means that the evaluation is performed periodically.
+  If the `policy_filter` is configured, it means that the evaluation is performed on the specified resources through
+  the filter. If neither parameter is configured, it means that the evaluation is performed on all resources under the
+  account.
+
+* `custom_policy` - (Optional, List) Specifies the configuration of the custom policy.  
+  The [object](#rms_custom_policy) structure is documented below.
+
+* `parameters` - (Optional, Map) Specifies the rule definition of the policy assignment.
+
+* `status` - (Optional, String) Specifies the expect status of the policy.
+
+<a name="rms_policy_filter"></a>
+The `policy_filter` block supports:
+
+* `region` - (Optional, String) Specifies the name of the region to which the filtered resources belong.
+
+* `resource_provider` - (Optional, String) Specifies the service name to which the filtered resources belong.
+
+* `resource_type` - (Optional, String) Specifies the resource type of the filtered resources.
+
+* `resource_id` - (Optional, String) Specifies the resource ID used to filter a specified resource.
+
+* `tag_key` - (Optional, String) Specifies the tag name used to filter resources.  
+  This parameter and `resource_id` are alternative.
+
+* `tag_value` - (Optional, String) Specifies the tag value used to filter resources.  
+  Required if `tag_key` is set.
+
+<a name="rms_custom_policy"></a>
+The `custom_policy` block supports:
+
+* `function_urn` - (Required, String) Specifies the function URN used to create the custom policy.
+
+* `auth_type` - (Required, String) Specifies the authorization type of the custom policy.
+
+* `auth_value` - (Optional, Map) Specifies the authorization value of the custom policy.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the policy assignment.
+
+* `type` - The type of the policy assignment.  
+  The valid values are as follows:
+  + **builtin**
+  + **custom**
+
+* `created_at` - The creation time of the policy assignment.
+
+* `updated_at` - The latest update time of the policy assignment.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+
+## Import
+
+Policy assignments can be imported using their `id`, e.g.
+
+```
+$ terraform import huaweicloud_rms_policy_assignment.test 63f48e3762ce955981ab7e25
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -875,6 +875,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_read_replica_instance": rds.ResourceRdsReadReplicaInstance(),
 			"huaweicloud_rds_backup":                rds.ResourceBackup(),
 
+			"huaweicloud_rms_policy_assignment": rms.ResourcePolicyAssignment(),
+
 			"huaweicloud_servicestage_application":                 servicestage.ResourceApplication(),
 			"huaweicloud_servicestage_component_instance":          servicestage.ResourceComponentInstance(),
 			"huaweicloud_servicestage_component":                   servicestage.ResourceComponent(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -151,6 +151,13 @@ func TestAccPreCheck(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPrecheckDomainId(t *testing.T) {
+	if HW_DOMAIN_ID == "" {
+		t.Fatal("HW_DOMAIN_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
 func TestAccPrecheckCustomRegion(t *testing.T) {
 	if HW_CUSTOM_REGION_NAME == "" {
 		t.Skip("HW_CUSTOM_REGION_NAME must be set for acceptance tests")

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_policy_assignment_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_policy_assignment_test.go
@@ -1,0 +1,514 @@
+package rms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rms"
+)
+
+func getPolicyAssignmentResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.RmsV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RMS v1 client: %s", err)
+	}
+
+	return policyassignments.Get(client, acceptance.HW_DOMAIN_ID, state.Primary.ID)
+}
+
+// Test the builtin policy (resource type) assignment.
+func TestAccPolicyAssignment_basic(t *testing.T) {
+	var (
+		obj policyassignments.Assignment
+
+		rName       = "huaweicloud_rms_policy_assignment.test"
+		name        = acceptance.RandomAccResourceNameWithDash()
+		updateName  = acceptance.RandomAccResourceNameWithDash()
+		basicConfig = testAccPolicyAssignment_ecsConfig(name)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPolicyAssignmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// Test to delete policy assignment in enabled status.
+		CheckDestroy: rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAssignment_basic(basicConfig, name, "Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeBuiltin),
+					resource.TestCheckResourceAttr(rName, "description", "An ECS is noncompliant if its flavor is "+
+						"not in the specified flavor list (filter by resource ID)."),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "policy_definition_id",
+						"data.huaweicloud_rms_policy_definitions.test", "definitions.0.id"),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.resource_provider", "ecs"),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.resource_type", "cloudservers"),
+					resource.TestCheckResourceAttrPair(rName, "policy_filter.0.resource_id",
+						"huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "status", "Disabled"),
+					resource.TestCheckResourceAttrSet(rName, "parameters.listOfAllowedFlavors"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_basic(basicConfig, name, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_basicUpdate(basicConfig, updateName, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeBuiltin),
+					resource.TestCheckResourceAttr(rName, "description", "An ECS is noncompliant if its flavor is "+
+						"not in the specified flavor list (filter by resource tag)."),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttrPair(rName, "policy_definition_id",
+						"data.huaweicloud_rms_policy_definitions.test", "definitions.0.id"),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.resource_provider", "ecs"),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.resource_type", "cloudservers"),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.tag_key", "foo"),
+					resource.TestCheckResourceAttr(rName, "policy_filter.0.tag_value", "bar"),
+					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
+					resource.TestCheckResourceAttrSet(rName, "parameters.listOfAllowedFlavors"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPolicyAssignment_ecsConfig(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  flavor_id = data.huaweicloud_compute_flavors.test.ids[0]
+
+  os         = "Ubuntu"
+  visibility = "public"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = "%[1]s"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name              = "%[1]s"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  image_id          = data.huaweicloud_images_images.test.images[0].id
+  security_groups   = [huaweicloud_networking_secgroup.test.name]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  key_pair          = huaweicloud_kps_keypair.test.name
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, name)
+}
+
+func testAccPolicyAssignment_basic(basicConfig, name, status string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "allowed-ecs-flavors"
+}
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = "%[2]s"
+  description          = "An ECS is noncompliant if its flavor is not in the specified flavor list (filter by resource ID)."
+  policy_definition_id = try(data.huaweicloud_rms_policy_definitions.test.definitions[0].id, "")
+  status               = "%[3]s"
+
+  policy_filter {
+    region            = "%[4]s"
+    resource_provider = "ecs"
+    resource_type     = "cloudservers"
+    resource_id       = huaweicloud_compute_instance.test.id
+  }
+
+  parameters = {
+    listOfAllowedFlavors = "[\"${data.huaweicloud_compute_flavors.test.ids[0]}\"]"
+  }
+}
+`, basicConfig, name, status, acceptance.HW_REGION_NAME)
+}
+
+func testAccPolicyAssignment_basicUpdate(basicConfig, name, status string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "allowed-ecs-flavors"
+}
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = "%[2]s"
+  description          = "An ECS is noncompliant if its flavor is not in the specified flavor list (filter by resource tag)."
+  policy_definition_id = try(data.huaweicloud_rms_policy_definitions.test.definitions[0].id, "")
+  status               = "%[3]s"
+
+  policy_filter {
+    region            = "%[4]s"
+    resource_provider = "ecs"
+    resource_type     = "cloudservers"
+    tag_key           = "foo"
+    tag_value         = "bar"
+  }
+
+  parameters = {
+    listOfAllowedFlavors = "[\"${data.huaweicloud_compute_flavors.test.ids[0]}\"]"
+  }
+}
+`, basicConfig, name, status, acceptance.HW_REGION_NAME)
+}
+
+// Test the builtin policy (period type) assignment.
+func TestAccPolicyAssignment_period(t *testing.T) {
+	var (
+		obj policyassignments.Assignment
+
+		rName       = "huaweicloud_rms_policy_assignment.test"
+		name        = acceptance.RandomAccResourceNameWithDash()
+		updateName  = acceptance.RandomAccResourceNameWithDash()
+		basicConfig = testAccPolicyAssignment_periodConfig(name)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPolicyAssignmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// Test to delete policy assignment in disabled status.
+		CheckDestroy: rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAssignment_period(basicConfig, name, "Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeBuiltin),
+					resource.TestCheckResourceAttr(rName, "description", "An account is noncompliant if none of its "+
+						"CTS trackers track specified OBS buckets."),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "policy_definition_id",
+						"data.huaweicloud_rms_policy_definitions.test", "definitions.0.id"),
+					resource.TestCheckResourceAttr(rName, "period", "One_Hour"),
+					resource.TestCheckResourceAttr(rName, "status", "Disabled"),
+					resource.TestCheckResourceAttrSet(rName, "parameters.trackBucket"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_period(basicConfig, name, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_periodUpdate(basicConfig, updateName, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeBuiltin),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttrPair(rName, "policy_definition_id",
+						"data.huaweicloud_rms_policy_definitions.test", "definitions.0.id"),
+					resource.TestCheckResourceAttr(rName, "period", "Six_Hours"),
+					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
+					resource.TestCheckResourceAttrSet(rName, "parameters.trackBucket"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_periodUpdate(basicConfig, name, "Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "Disabled"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPolicyAssignment_periodConfig(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "complian" {
+  bucket        = "%[1]s"
+  storage_class = "STANDARD"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_obs_bucket" "non_complian" {
+  bucket        = "%[1]s-non-complian"
+  storage_class = "STANDARD"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_cts_tracker" "test" {
+  bucket_name = huaweicloud_obs_bucket.complian.bucket
+  file_prefix = "cts-updated"
+  lts_enabled = false
+  enabled     = false
+}
+`, name)
+}
+
+func testAccPolicyAssignment_period(periodConfig, name, status string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "cts-obs-bucket-track"
+}
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = "%[2]s"
+  description          = "An account is noncompliant if none of its CTS trackers track specified OBS buckets."
+  period               = "One_Hour"
+  policy_definition_id = try(data.huaweicloud_rms_policy_definitions.test.definitions[0].id, "")
+  status               = "%[3]s"
+
+  parameters = {
+    trackBucket = "\"${huaweicloud_obs_bucket.complian.bucket}\""
+  }
+}
+`, periodConfig, name, status)
+}
+
+func testAccPolicyAssignment_periodUpdate(periodConfig, name, status string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rms_policy_definitions" "test" {
+  name = "cts-obs-bucket-track"
+}
+
+# Set the description to an empty value.
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name                 = "%[2]s"
+  status               = "%[3]s"
+  period               = "Six_Hours"
+  policy_definition_id = try(data.huaweicloud_rms_policy_definitions.test.definitions[0].id, "")
+
+  parameters = {
+    trackBucket = "\"${huaweicloud_obs_bucket.non_complian.bucket}\""
+  }
+}
+`, periodConfig, name, status)
+}
+
+// Test the custom policy assignment.
+func TestAccPolicyAssignment_custom(t *testing.T) {
+	var (
+		obj policyassignments.Assignment
+
+		rName        = "huaweicloud_rms_policy_assignment.test"
+		name         = acceptance.RandomAccResourceNameWithDash()
+		updateName   = acceptance.RandomAccResourceNameWithDash()
+		customConfig = testAccPolicyAssignment_customConfig(name)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPolicyAssignmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAssignment_custom(customConfig, name, "Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeCustom),
+					resource.TestCheckResourceAttr(rName, "description", "The ECS instances that do not conform to "+
+						"the custom function logic are considered non-compliant"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "status", "Disabled"),
+					resource.TestCheckResourceAttr(rName, "parameters.string_test", "\"string_value\""),
+					resource.TestCheckResourceAttr(rName, "parameters.array_test", "[\"array_element\"]"),
+					resource.TestCheckResourceAttr(rName, "parameters.object_test", "{\"terraform_version\":\"1.xx.x\"}"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_custom(customConfig, name, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
+				),
+			},
+			{
+				Config: testAccPolicyAssignment_customUpdate(customConfig, updateName, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
+					resource.TestCheckResourceAttr(rName, "parameters.string_test", "\"update_string_value\""),
+					resource.TestCheckResourceAttr(rName, "parameters.update_array_test", "[\"array_element\"]"),
+					resource.TestCheckResourceAttr(rName, "parameters.object_test", "{\"update_terraform_version\":\"1.xx.xx\"}"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPolicyAssignment_customConfig(name string) string {
+	customConfig := testAccPolicyAssignment_ecsConfig(name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_fgs_function" "test" {
+  name                  = "%[2]s"
+  code_type             = "inline"
+  handler               = "index.handler"
+  runtime               = "Node.js10.16"
+  functiongraph_version = "v2"
+  app                   = "default"
+  enterprise_project_id = "0"
+  memory_size           = 128
+  timeout               = 3
+}
+`, customConfig, name)
+}
+
+func testAccPolicyAssignment_custom(customConfig, name, status string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name        = "%[2]s"
+  description = "The ECS instances that do not conform to the custom function logic are considered non-compliant"
+  status      = "%[3]s"
+
+  custom_policy {
+    function_urn = "${huaweicloud_fgs_function.test.urn}:${huaweicloud_fgs_function.test.version}"
+    auth_type    = "agency"
+    auth_value   = {
+      agency_name = "\"rms_admin_trust\""
+    }
+  }
+
+  parameters = {
+    string_test = "\"string_value\""
+    array_test  = "[\"array_element\"]"
+    object_test = "{\"terraform_version\":\"1.xx.x\"}"
+  }
+}
+`, customConfig, name, status)
+}
+
+func testAccPolicyAssignment_customUpdate(customConfig, name, status string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rms_policy_assignment" "test" {
+  name        = "%[2]s"
+  description = "The ECS instances that do not conform to the custom function logic are considered non-compliant"
+  status      = "%[3]s"
+
+  custom_policy {
+    function_urn = "${huaweicloud_fgs_function.test.urn}:${huaweicloud_fgs_function.test.version}"
+    auth_type    = "agency"
+    auth_value   = {
+      agency_name = "\"rms_admin_trust\""
+    }
+  }
+
+  parameters = {
+    string_test       = "\"update_string_value\""
+    update_array_test = "[\"array_element\"]"
+    object_test       = "{\"update_terraform_version\":\"1.xx.xx\"}"
+  }
+}
+`, customConfig, name, status)
+}

--- a/huaweicloud/services/rms/resource_huaweicloud_rms_policy_assignment.go
+++ b/huaweicloud/services/rms/resource_huaweicloud_rms_policy_assignment.go
@@ -1,0 +1,560 @@
+package rms
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	AssignmentTypeBuiltin = "builtin"
+	AssignmentTypeCustom  = "custom"
+
+	AssignmentStatusDisabled   = "Disabled"
+	AssignmentStatusEnabled    = "Enabled"
+	AssignmentStatusEvaluating = "Evaluating"
+)
+
+func ResourcePolicyAssignment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceePolicyAssignmentCreate,
+		ReadContext:   resourceePolicyAssignmentRead,
+		UpdateContext: resourceePolicyAssignmentUpdate,
+		DeleteContext: resourceePolicyAssignmentDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z][\w-]*$`),
+						"Only letters, digits, hyphens and underscores are allowed, and must start with a letter."),
+					validation.StringLenBetween(1, 64),
+				),
+				Description: "The name of the policy assignment.",
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 512),
+				Description:  "The description of the policy assignment.",
+			},
+			"policy_definition_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "The ID of the policy definition.",
+				ConflictsWith: []string{"custom_policy"},
+			},
+			"period": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"One_Hour",
+					"Three_Hours",
+					"Six_Hours",
+					"Twelve_Hours",
+					"TwentyFour_Hours",
+				}, false),
+				Description:   "The period of the policy rule check.",
+				ConflictsWith: []string{"policy_filter"},
+			},
+			"policy_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the region to which the filtered resources belong.",
+						},
+						"resource_provider": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The service name to which the filtered resources belong.",
+						},
+						"resource_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The resource type of the filtered resources.",
+						},
+						"resource_id": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"policy_filter.0.tag_key"},
+							Description:   "The resource ID used to filter a specified resources.",
+						},
+						"tag_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The tag name used to filter resources.",
+						},
+						"tag_value": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							RequiredWith: []string{"policy_filter.0.tag_key"},
+							Description:  "The tag value used to filter resources.",
+						},
+					},
+				},
+				Description:   "The configuration used to filter resources.",
+				ConflictsWith: []string{"period"},
+			},
+			"custom_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"function_urn": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The function URN used to create the custom policy.",
+						},
+						"auth_type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The authorization type of the custom policy.",
+						},
+						"auth_value": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringIsJSON,
+							},
+							Description: "The authorization value of the custom policy.",
+						},
+					},
+				},
+				Description: "The configuration of the custom policy.",
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				Description: "The rule definition of the policy assignment.",
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					AssignmentStatusDisabled,
+					AssignmentStatusEnabled,
+				}, false),
+				Description: "The expect status of the policy.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the policy assignment.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time.",
+			},
+		},
+	}
+}
+
+func buildPolicyFilter(filters []interface{}) policyassignments.PolicyFilter {
+	if len(filters) < 1 {
+		return policyassignments.PolicyFilter{}
+	}
+	filter := filters[0].(map[string]interface{})
+	return policyassignments.PolicyFilter{
+		RegionId:         filter["region"].(string),
+		ResourceProvider: filter["resource_provider"].(string),
+		ResourceType:     filter["resource_type"].(string),
+		ResourceId:       filter["resource_id"].(string),
+		TagKey:           filter["tag_key"].(string),
+		TagValue:         filter["tag_value"].(string),
+	}
+}
+
+func buildCustomPolicy(policies []interface{}) (*policyassignments.CustomPolicy, error) {
+	if len(policies) < 1 {
+		return nil, nil
+	}
+	policy := policies[0].(map[string]interface{})
+	result := policyassignments.CustomPolicy{
+		FunctionUrn: policy["function_urn"].(string),
+		AuthType:    policy["auth_type"].(string),
+	}
+	authValues := make(map[string]interface{})
+	for k, jsonVal := range policy["auth_value"].(map[string]interface{}) {
+		var value interface{}
+		err := json.Unmarshal([]byte(jsonVal.(string)), &value)
+		if err != nil {
+			return &result, fmt.Errorf("error analyzing authorization value: %s", err)
+		}
+		authValues[k] = value
+	}
+	result.AuthValue = authValues
+
+	return &result, nil
+}
+
+func buildRuleParameters(parameters map[string]interface{}) (map[string]policyassignments.PolicyParameterValue, error) {
+	if len(parameters) < 1 {
+		return nil, nil
+	}
+	result := make(map[string]policyassignments.PolicyParameterValue)
+	for k, jsonVal := range parameters {
+		var value interface{}
+		err := json.Unmarshal([]byte(jsonVal.(string)), &value)
+		if err != nil {
+			return result, fmt.Errorf("error analyzing parameter value: %s", err)
+		}
+		result[k] = policyassignments.PolicyParameterValue{
+			Value: value,
+		}
+	}
+	return result, nil
+}
+
+func buildPolicyAssignmentCreateOpts(d *schema.ResourceData) (policyassignments.CreateOpts, error) {
+	result := policyassignments.CreateOpts{
+		Name:               d.Get("name").(string),
+		Description:        d.Get("description").(string),
+		Type:               AssignmentTypeBuiltin,
+		PolicyFilter:       buildPolicyFilter(d.Get("policy_filter").([]interface{})),
+		PolicyDefinitionId: d.Get("policy_definition_id").(string),
+		Period:             d.Get("period").(string),
+	}
+	customPolicy, err := buildCustomPolicy(d.Get("custom_policy").([]interface{}))
+	if err != nil {
+		return result, err
+	}
+	result.CustomPolicy = customPolicy
+	if customPolicy != nil {
+		result.Type = AssignmentTypeCustom
+	}
+
+	parameters, err := buildRuleParameters(d.Get("parameters").(map[string]interface{}))
+	if err != nil {
+		return result, err
+	}
+	result.Parameters = parameters
+
+	return result, nil
+}
+
+func updatePolicyAssignmentStatus(client *golangsdk.ServiceClient, domainId, assignmentId,
+	statusConfig string) (err error) {
+	switch statusConfig {
+	case AssignmentStatusDisabled:
+		err = policyassignments.Disable(client, domainId, assignmentId)
+	case AssignmentStatusEnabled:
+		err = policyassignments.Enable(client, domainId, assignmentId)
+	}
+	return
+}
+
+func policyAssignmentRefreshFunc(client *golangsdk.ServiceClient, domainId,
+	assignmentId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := policyassignments.Get(client, domainId, assignmentId)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+		return resp, resp.Status, nil
+	}
+}
+
+func resourceePolicyAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.RmsV1Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RMS v1 client: %s", err)
+	}
+	opts, err := buildPolicyAssignmentCreateOpts(d)
+	if err != nil {
+		return diag.Errorf("error creating the create option structure of the RMS policy assignment: %s", err)
+	}
+	domainId := cfg.DomainID
+	resp, err := policyassignments.Create(client, domainId, opts)
+	if err != nil {
+		return diag.Errorf("error creating policy assignment resource: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	assignmentId := d.Id()
+	log.Printf("[DEBUG] Waiting for the policy assignment (%s) status to become enabled.", assignmentId)
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{AssignmentStatusDisabled, AssignmentStatusEvaluating},
+		Target:                    []string{AssignmentStatusEnabled},
+		Refresh:                   policyAssignmentRefreshFunc(client, domainId, assignmentId),
+		Timeout:                   d.Timeout(schema.TimeoutCreate),
+		Delay:                     10 * time.Second,
+		PollInterval:              10 * time.Second,
+		ContinuousTargetOccurence: 2,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the policy assignment (%s) status to become enabled: %s",
+			assignmentId, err)
+	}
+
+	if statusConfig := d.Get("status").(string); statusConfig == AssignmentStatusDisabled {
+		err = updatePolicyAssignmentStatus(client, domainId, assignmentId, statusConfig)
+		if err != nil {
+			return diag.Errorf("error updating the status of the policy assignment: %s", err)
+		}
+	}
+	return resourceePolicyAssignmentRead(ctx, d, meta)
+}
+
+func flattenPolicyFilter(filter policyassignments.PolicyFilter) []map[string]interface{} {
+	if reflect.DeepEqual(filter, policyassignments.PolicyFilter{}) {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"region":            filter.RegionId,
+			"resource_provider": filter.ResourceProvider,
+			"resource_type":     filter.ResourceType,
+			"resource_id":       filter.ResourceId,
+			"tag_key":           filter.TagKey,
+			"tag_value":         filter.TagValue,
+		},
+	}
+}
+
+func flattenCustomPolicy(customPolicy policyassignments.CustomPolicy) ([]map[string]interface{}, error) {
+	if reflect.DeepEqual(customPolicy, policyassignments.CustomPolicy{}) {
+		return nil, nil
+	}
+
+	authValues := make(map[string]interface{})
+	for k, v := range customPolicy.AuthValue {
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("generate json string failed: %s", err)
+		}
+		authValues[k] = string(jsonBytes)
+	}
+	return []map[string]interface{}{
+		{
+			"function_urn": customPolicy.FunctionUrn,
+			"auth_type":    customPolicy.AuthType,
+			"auth_value":   authValues,
+		},
+	}, nil
+}
+
+func flattenPolicyParameters(parameters map[string]policyassignments.PolicyParameterValue) (map[string]interface{},
+	error) {
+	if len(parameters) < 1 {
+		return nil, nil
+	}
+
+	result := make(map[string]interface{})
+	for k, v := range parameters {
+		jsonBytes, err := json.Marshal(v.Value)
+		if err != nil {
+			return nil, fmt.Errorf("generate json string failed: %s", err)
+		}
+		result[k] = string(jsonBytes)
+	}
+	return result, nil
+}
+
+func resourceePolicyAssignmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.RmsV1Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RMS v1 client: %s", err)
+	}
+
+	assignmentId := d.Id()
+	resp, err := policyassignments.Get(client, cfg.DomainID, assignmentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "RMS policy assignment")
+	}
+
+	customPolicy, err := flattenCustomPolicy(resp.CustomPolicy)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	parameters, err := flattenPolicyParameters(resp.Parameters)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	mErr := multierror.Append(nil,
+		d.Set("type", resp.Type),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("policy_definition_id", resp.PolicyDefinitionId),
+		d.Set("period", resp.Period),
+		d.Set("policy_filter", flattenPolicyFilter(resp.PolicyFilter)),
+		d.Set("custom_policy", customPolicy),
+		d.Set("parameters", parameters),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving policy assignment resource (%s) fields: %s", assignmentId, mErr)
+	}
+	return nil
+}
+
+func buildPolicyAssignmentUpdateOpts(d *schema.ResourceData) (policyassignments.UpdateOpts, error) {
+	result := policyassignments.UpdateOpts{
+		Name:               d.Get("name").(string),
+		Description:        utils.String(d.Get("description").(string)),
+		Type:               AssignmentTypeBuiltin,
+		PolicyFilter:       buildPolicyFilter(d.Get("policy_filter").([]interface{})),
+		PolicyDefinitionId: d.Get("policy_definition_id").(string),
+		Period:             d.Get("period").(string),
+	}
+	customPolicy, err := buildCustomPolicy(d.Get("custom_policy").([]interface{}))
+	if err != nil {
+		return result, err
+	}
+	result.CustomPolicy = customPolicy
+	if customPolicy != nil {
+		result.Type = AssignmentTypeCustom
+	}
+
+	parameters, err := buildRuleParameters(d.Get("parameters").(map[string]interface{}))
+	if err != nil {
+		return result, err
+	}
+	result.Parameters = parameters
+
+	return result, nil
+}
+
+func resourceePolicyAssignmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.RmsV1Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RMS v1 client: %s", err)
+	}
+
+	assignmentId := d.Id()
+	domainId := cfg.DomainID
+
+	if d.HasChange("status") {
+		oldVal, newVal := d.GetChange("status")
+		err = updatePolicyAssignmentStatus(client, domainId, d.Id(), d.Get("status").(string))
+		if err != nil {
+			return diag.Errorf("error updating the status of the policy assignment (%s): %s", assignmentId, err)
+		}
+
+		if newVal.(string) == AssignmentStatusEnabled {
+			log.Printf("[DEBUG] Waiting for the policy assignment (%s) status to become %s.", assignmentId,
+				strings.ToLower(newVal.(string)))
+			stateConf := &resource.StateChangeConf{
+				Pending:                   []string{oldVal.(string), AssignmentStatusEvaluating},
+				Target:                    []string{newVal.(string)},
+				Refresh:                   policyAssignmentRefreshFunc(client, domainId, assignmentId),
+				Timeout:                   d.Timeout(schema.TimeoutUpdate),
+				Delay:                     10 * time.Second,
+				PollInterval:              10 * time.Second,
+				ContinuousTargetOccurence: 2,
+			}
+			_, err = stateConf.WaitForStateContext(ctx)
+			if err != nil {
+				return diag.Errorf("error waiting for the policy assignment (%s) status to become %s: %s",
+					assignmentId, strings.ToLower(newVal.(string)), err)
+			}
+		}
+	}
+	if d.HasChangeExcept("status") {
+		opts, err := buildPolicyAssignmentUpdateOpts(d)
+		if err != nil {
+			return diag.Errorf("error creating the update option structure of the RMS policy assignment: %s", err)
+		}
+
+		_, err = policyassignments.Update(client, domainId, assignmentId, opts)
+		if err != nil {
+			return diag.Errorf("error updating policy assignment resource (%s): %s", assignmentId, err)
+		}
+		currentStatus := d.Get("status").(string)
+		log.Printf("[DEBUG] Waiting for the policy assignment (%s) status to become %s.", assignmentId,
+			strings.ToLower(currentStatus))
+		stateConf := &resource.StateChangeConf{
+			Target:                    []string{currentStatus},
+			Refresh:                   policyAssignmentRefreshFunc(client, domainId, assignmentId),
+			Timeout:                   d.Timeout(schema.TimeoutUpdate),
+			Delay:                     10 * time.Second,
+			PollInterval:              10 * time.Second,
+			ContinuousTargetOccurence: 2,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for the policy assignment (%s) status to become %s: %s",
+				assignmentId, strings.ToLower(currentStatus), err)
+		}
+	}
+
+	return resourceePolicyAssignmentRead(ctx, d, meta)
+}
+
+func resourceePolicyAssignmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.RmsV1Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RMS v1 client: %s", err)
+	}
+	var (
+		assignmentId = d.Id()
+		domainId     = cfg.DomainID
+	)
+	if d.Get("status").(string) == AssignmentStatusEnabled {
+		// Before delete policy assignment, we need to disable it.
+		err = policyassignments.Disable(client, domainId, assignmentId)
+		if err != nil {
+			return diag.Errorf("failed to disable the policy assignment (%s): %s", assignmentId, err)
+		}
+	}
+
+	err = policyassignments.Delete(client, domainId, assignmentId)
+	if err != nil {
+		return diag.Errorf("error deleting the policy assignment (%s): %s", assignmentId, err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new policy assignment resource support for RMS service.
Some parameters have the following constraints:
- If the `period` is configured, it means that the evaluation is performed periodically.
- If the `policy_filter` is configured, it means that the evaluation is performed on the specified resources through the filter.
- If neither parameter is configured, it means that the evaluation is performed on all resources under the account.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new policy assignment resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rms' TESTARGS='-run=TestAccPolicyAssignment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run=TestAccPolicyAssignment_ -timeout 360m -parallel 4
=== RUN   TestAccPolicyAssignment_basic
=== PAUSE TestAccPolicyAssignment_basic
=== RUN   TestAccPolicyAssignment_period
=== PAUSE TestAccPolicyAssignment_period
=== RUN   TestAccPolicyAssignment_custom
=== PAUSE TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_basic
=== CONT  TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_period
--- PASS: TestAccPolicyAssignment_period (143.01s)
--- PASS: TestAccPolicyAssignment_custom (281.59s)
--- PASS: TestAccPolicyAssignment_basic (299.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       299.923s
```
