### PR TITLE
feat(nat/tags): gateway resource support tags parameter

### DIFF
--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -48,6 +48,8 @@ The following arguments are supported:
   value can contains maximum of 36 characters which it is string "0" or in UUID format with hyphens (-). Changing this
   creates a new nat gateway.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the NAT geteway.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
+++ b/huaweicloud/resource_huaweicloud_nat_gateway_v2_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/natgateways"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -29,6 +30,8 @@ func TestAccNatGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "test for terraform"),
 					resource.TestCheckResourceAttr(resourceName, "spec", "1"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
@@ -42,6 +45,8 @@ func TestAccNatGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("nat-gateway-updated-%s", randSuffix)),
 					resource.TestCheckResourceAttr(resourceName, "description", "test for terraform updated"),
 					resource.TestCheckResourceAttr(resourceName, "spec", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.newkey", "value"),
 				),
 			},
 		},
@@ -146,6 +151,11 @@ resource "huaweicloud_nat_gateway" "nat_1" {
   spec        = "1"
   vpc_id      = huaweicloud_vpc.vpc_1.id
   subnet_id   = huaweicloud_vpc_subnet.subnet_1.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 	`, testAccNatPreCondition(suffix), suffix)
 }
@@ -160,6 +170,11 @@ resource "huaweicloud_nat_gateway" "nat_1" {
   spec        = "2"
   vpc_id      = huaweicloud_vpc.vpc_1.id
   subnet_id   = huaweicloud_vpc_subnet.subnet_1.id
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
 }
 	`, testAccNatPreCondition(suffix), suffix)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
NAT gateway resource support tags parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. NAT gateway resource support tags parameter
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccNatGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run=TestAccNatGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatGateway_basic (102.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       102.647s
```
