### PR TITLE
feat: as support as-configuration data source

### DIFF
--- a/docs/data-sources/as_configurations.md
+++ b/docs/data-sources/as_configurations.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# huaweicloud_as_configurations
+
+Use this data source to get a list of AS configurations.
+
+```hcl
+data "huaweicloud_as_configurations" "configurations" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the AS configurations.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the AS configuration name. Supports fuzzy search.
+
+* `image_id` - (Optional, String) Specifies the image ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the list.
+
+* `configurations` - A list of AS configurations.
+
+The `configurations` block supports:
+
+* `scaling_configuration_name` - The AS configuration name.
+
+* `instance_config` - The list of information about instance configurations.
+  The [object](#instance_config_object) structure is documented below.
+
+* `status` - The AS configuration status, the value can be **Bound** or **Unbound**.
+
+<a name="instance_config_object"></a>
+The `instance_config` block supports:
+
+* `instance_id` - The ECS instance ID when using its specification as the template to create AS configurations.
+
+* `flavor` - The ECS flavor name.
+
+* `image` - The ECS image ID.
+
+* `disk` - The list of disk group information. The [object](#instance_config_disk_object) structure is documented below.
+
+* `key_name` - The name of the SSH key pair used to log in to the instance.
+
+* `security_group_ids` - An array of one or more security group IDs.
+
+* `charging_mode` - The billing mode for ECS, the value can be **postPaid** or **spot**.
+
+* `flavor_priority_policy` - The priority policy used when there are multiple flavors
+  and instances to be created using an AS configuration. The value can be `PICK_FIRST` and `COST_FIRST`.
+
+* `ecs_group_id` - The ECS group ID.
+
+* `user_data` - The user data to provide when launching the instance.
+
+* `public_ip` - The EIP list of the ECS instance.
+  The [object](#instance_config_public_ip_object) structure is documented below.
+
+* `metadata` - The key/value pairs to make available from within the instance.
+
+* `personality` - The list of information about the injected file.
+  The [object](#instance_config_personality_object) structure is documented below.
+
+<a name="instance_config_disk_object"></a>
+The `disk` block supports:
+
+* `size` - The disk size. The unit is GB.
+
+* `volume_type` - The volume type.
+
+* `disk_type` - The disk type.
+
+* `kms_id` - The encryption KMS ID of the **DATA** disk.
+
+<a name="instance_config_public_ip_object"></a>
+The `public_ip` block supports:
+
+* `eip` - The list of EIP configuration that will be automatically assigned to the instance.
+  The object structure is documented below.
+
+The `eip` block supports:
+
+* `ip_type` - The EIP type.
+
+* `bandwidth` - The list of bandwidth information. The object structure is documented below.
+
+The `bandwidth` block supports:
+
+* `share_type` - The bandwidth sharing type.
+
+* `charging_mode` - The bandwidth billing mode, the value can be **traffic** or **bandwidth**.
+
+* `size` - The bandwidth (Mbit/s).
+
+<a name="instance_config_personality_object"></a>
+The `personality` block supports:
+
+* `path` - The path of the injected file.
+
+* `content` - The content of the injected file.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -371,6 +371,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_apig_environments": apig.DataSourceEnvironments(),
 
+			"huaweicloud_as_configurations": as.DataSourceASConfigurations(),
+
 			"huaweicloud_availability_zones": DataSourceAvailabilityZones(),
 
 			"huaweicloud_bms_flavors": bms.DataSourceBmsFlavors(),

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_configurations_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_configurations_test.go
@@ -1,0 +1,45 @@
+package as
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceASConfiguration_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_as_configurations.configurations"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceASConfiguration_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "configurations.0.scaling_configuration_name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceASConfiguration_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_as_configurations" "configurations" {
+  name     = huaweicloud_as_configuration.acc_as_config.scaling_configuration_name
+  image_id = huaweicloud_as_configuration.acc_as_config.instance_config.0.image
+
+  depends_on = [huaweicloud_as_configuration.acc_as_config]
+}
+`, testAccASConfiguration_basic(name))
+}

--- a/huaweicloud/services/as/data_source_huaweicloud_as_configurations.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_configurations.go
@@ -1,0 +1,270 @@
+package as
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+)
+
+func DataSourceASConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceASConfigurationRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the AS configurations are located.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The AS configuration name used to query configuration list.",
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The AS image id used to query configuration list.",
+			},
+			"configurations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The information about AS instance configurations.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"scaling_configuration_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the AS configuration.",
+						},
+						"instance_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ECS instance ID of the AS configuration.",
+									},
+									"flavor": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ECS flavor name of the AS configuration.",
+									},
+									"image": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ECS image ID of the AS configuration.",
+									},
+									"key_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The name of the SSH key pair used to log in to the instance.",
+									},
+									"security_group_ids": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "An array of one or more security group IDs.",
+									},
+									"charging_mode": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The billing mode for ECS.",
+									},
+									"flavor_priority_policy": {
+										Type:     schema.TypeString,
+										Computed: true,
+										Description: "The priority policy used when there are multiple flavors and " +
+											"instances to be created using an AS configuration.",
+									},
+									"ecs_group_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ECS group ID of the AS configuration.",
+									},
+									"disk": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        ConfigurationDiskSchema(),
+										Description: "The disk group information of the AS configuration.",
+									},
+									"personality": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        ConfigurationPersonalitySchema(),
+										Description: "The customize personality of the AS configuration.",
+									},
+									"public_ip": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        ConfigurationPublicIpSchema(),
+										Description: "The EIP of the ECS instance.",
+									},
+									"user_data": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user data to provide when launching the instance.",
+									},
+									"metadata": {
+										Type:        schema.TypeMap,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "The key/value pairs to make available from within the instance.",
+									},
+								},
+							},
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the AS configuration.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ConfigurationDiskSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The disk size. The unit is GB.",
+			},
+			"volume_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The volume type.",
+			},
+			"disk_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The disk type.",
+			},
+			"kms_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The encryption KMS ID.",
+			},
+		},
+	}
+}
+
+func ConfigurationPersonalitySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The path of the injected file.",
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The content of the injected file.",
+			},
+		},
+	}
+}
+
+func ConfigurationPublicIpSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"eip": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of EIP configuration that will be automatically assigned to the instance.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The EIP type.",
+						},
+						"bandwidth": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The list of bandwidth information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"size": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: "The bandwidth (Mbit/s).",
+									},
+									"share_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The bandwidth sharing type.",
+									},
+									"charging_mode": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The bandwidth billing mode.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceASConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	asClient, err := conf.AutoscalingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating autoscaling client: %s", err)
+	}
+
+	opts := configurations.ListOpts{
+		Name:    d.Get("name").(string),
+		ImageID: d.Get("image_id").(string),
+	}
+	page, err := configurations.List(asClient, opts).AllPages()
+	if err != nil {
+		return diag.Errorf("error getting AS Configuration list: %s", err)
+	}
+
+	configurationList, err := page.(configurations.ConfigurationPage).Extract()
+	if err != nil {
+		return diag.Errorf("error extract to AS Configuration list: %s", err)
+	}
+
+	ids := make([]string, 0, len(configurationList))
+	elements := make([]map[string]interface{}, 0, len(configurationList))
+	for _, configuration := range configurationList {
+		configurationMap := map[string]interface{}{
+			"scaling_configuration_name": configuration.Name,
+			"instance_config":            flattenInstanceConfig(configuration.InstanceConfig),
+			"status":                     normalizeConfigurationStatus(configuration.ScalingGroupID),
+		}
+		ids = append(ids, configuration.ID)
+		elements = append(elements, configurationMap)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	mErr := multierror.Append(nil,
+		d.Set("configurations", elements),
+		d.Set("region", region),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting AS Configuration fields: %s", mErr)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/results.go
@@ -109,6 +109,6 @@ func (r ConfigurationPage) IsEmpty() (bool, error) {
 
 func (r ConfigurationPage) Extract() ([]Configuration, error) {
 	var cs []Configuration
-	err := r.Result.ExtractIntoSlicePtr(&cs, "scaling_groups")
+	err := r.Result.ExtractIntoSlicePtr(&cs, "scaling_configurations")
 	return cs, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
as support as configuration data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceASConfiguration_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceASConfiguration_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceASConfiguration_basic 
=== PAUSE TestAccDataSourceASConfiguration_basic 
=== CONT  TestAccDataSourceASConfiguration_basic
--- PASS: TestAccDataSourceASConfiguration_basic (24.81s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        24.873s
```
