### PR TITLE
refactor(dds): set err to 404 when the list of role or user is empty

### DIFF
--- a/huaweicloud/services/dds/resource_huaweicloud_dds_database_role.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_database_role.go
@@ -279,8 +279,7 @@ func resourceDatabaseRoleRead(_ context.Context, d *schema.ResourceData, meta in
 			name, instanceId))
 	}
 	if len(resp) < 1 {
-		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find database role (%s) from DDS instance (%s)",
-			name, instanceId))
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 	role := resp[0]
 	log.Printf("[DEBUG] The role response is: %#v", role)

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_database_user.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_database_user.go
@@ -188,7 +188,7 @@ func resourceDatabaseUserRead(_ context.Context, d *schema.ResourceData, meta in
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting user (%s) from DDS instance (%s)", name, instanceId))
 	}
 	if len(resp) < 1 {
-		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find user (%s) from DDS instance (%s)", name, instanceId))
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 	user := resp[0]
 	log.Printf("[DEBUG] The user response is: %#v", user)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
set err to 404 when the list of role or user is empty, this will avoid error when the resource dose not exist
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dds' TESTARGS='-run TestAccDatabaseRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDatabaseRole_basic -timeout 360m -parallel 4
=== RUN   TestAccDatabaseRole_basic
=== PAUSE TestAccDatabaseRole_basic
=== CONT  TestAccDatabaseRole_basic
--- PASS: TestAccDatabaseRole_basic (791.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       791.132s

make testacc TEST='./huaweicloud/services/acceptance/dds' TESTARGS='-run TestAccDatabaseUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDatabaseUser_basic -timeout 360m -parallel 4
=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (828.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       828.187s
```
