### PR TITLE
feat(iam): add password policy support

### DIFF
--- a/docs/resources/identity_password_policy.md
+++ b/docs/resources/identity_password_policy.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_password_policy
+
+Manages the account password policy within HuaweiCloud.
+
+-> **NOTE:**
+  You *must* have admin privileges to use this resource.  
+  This resource overwrites an existing configuration, make sure one resource per account.  
+  During action `terraform destroy` it sets values the same as defaults for this resource.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_identity_password_policy" "enhanced" {
+  password_char_combination             = 4
+  minimum_password_length               = 12
+  number_of_recent_passwords_disallowed = 2
+  password_validity_period              = 180
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `password_char_combination` - (Optional, Int) Specifies the minimum number of character types that a password must contain.
+  The value ranges from `2` to `4` and defaults to `2` which indicates that a password must contain at least two of the following:
+  uppercase letters, lowercase letters, digits, and special characters.
+
+* `minimum_password_length` - (Optional, Int) Specifies the minimum number of characters that a password must contain.
+  The value ranges from `6` to `32` and defaults to `8`.
+
+* `maximum_consecutive_identical_chars` - (Optional, Int) Specifies the maximum number of times that a character is allowed
+  to consecutively present in a password. The value ranges from `0` to `32` and defaults to `0` which indicates that
+  consecutive identical characters are allowed in a password. For example, value `2` indicates that two consecutive
+  identical characters are not allowed in a password.
+
+* `number_of_recent_passwords_disallowed` - (Optional, Int) Specifies the mumber of previously used passwords that are
+  not allowed. The value ranges from `0` to `10` and defaults to `1`. For example, value `3` indicates that the user cannot
+  set the last three passwords that the user has previously used when setting a new password.
+
+* `password_validity_period` - (Optional, Int) Specifies the password validity period (days).
+  The value ranges from `0` to `180` and defaults to `0` which indicates that this requirement does not apply.
+
+* `minimum_password_age` - (Optional, Int) Specifies the minimum period (minutes) after which users are allowed to make
+  a password change. The value ranges from `0` to `1440` and defaults to `0`.
+
+* `password_not_username_or_invert` - (Optional, Bool) Specifies whether the password can be the username or the username
+  spelled backwards. Defaults to `true`, which indicates that the username or the inversion of username is not allowed to
+  be used as a password.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of account password policy, which is the same as the account ID.
+
+* `maximum_password_length` - The maximum number of characters that a password can contain.
+
+## Import
+
+Identity password policy can be imported using the account ID or domain ID, e.g.
+
+```bash
+$ terraform import huaweicloud_identity_password_policy.example <your account ID>
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230222031848-d1ae93e84d49
+	github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230222031848-d1ae93e84d49 h1:JwrAqZ0G9iuo3FL4YCgOGXLls9JLmGnlpRU439EoBdM=
-github.com/chnsz/golangsdk v0.0.0-20230222031848-d1ae93e84d49/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0 h1:0RTqu9PD7WB6cYWQ7QYM1+WJYleqnIgJjZZuqmwF1/8=
+github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -768,6 +768,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_role_assignment":  iam.ResourceIdentityRoleAssignmentV3(),
 			"huaweicloud_identity_user":             iam.ResourceIdentityUserV3(),
 			"huaweicloud_identity_provider":         iam.ResourceIdentityProvider(),
+			"huaweicloud_identity_password_policy":  iam.ResourceIdentityPasswordPolicy(),
 
 			"huaweicloud_iec_eip":                 resourceIecNetworkEip(),
 			"huaweicloud_iec_keypair":             resourceIecKeypair(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_password_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_password_policy_test.go
@@ -1,0 +1,131 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3.0/security"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccPasswordPolicy_basic(t *testing.T) {
+	resourceName := "huaweicloud_identity_password_policy.enhanced"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckPasswordPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPasswordPolicy_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPasswordPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "password_char_combination", "4"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "12"),
+					resource.TestCheckResourceAttr(resourceName, "number_of_recent_passwords_disallowed", "2"),
+					resource.TestCheckResourceAttr(resourceName, "password_validity_period", "180"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_password_age", "0"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_consecutive_identical_chars", "0"),
+					resource.TestCheckResourceAttr(resourceName, "password_not_username_or_invert", "true"),
+				),
+			},
+			{
+				Config: testAccPasswordPolicy_update(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password_char_combination", "2"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "12"),
+					resource.TestCheckResourceAttr(resourceName, "number_of_recent_passwords_disallowed", "1"),
+					resource.TestCheckResourceAttr(resourceName, "password_validity_period", "90"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_password_age", "60"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_consecutive_identical_chars", "4"),
+					resource.TestCheckResourceAttr(resourceName, "password_not_username_or_invert", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPasswordPolicyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is not set")
+		}
+
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := cfg.IAMV3Client("")
+		if err != nil {
+			return fmt.Errorf("error creating IAM client: %s", err)
+		}
+
+		_, err = security.GetPasswordPolicy(client, rs.Primary.ID)
+		return err
+	}
+}
+
+func testAccCheckPasswordPolicyDestroy(s *terraform.State) error {
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := cfg.IAMV3Client("")
+	if err != nil {
+		return fmt.Errorf("error creating IAM client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_identity_password_policy" {
+			continue
+		}
+
+		policy, err := security.GetPasswordPolicy(client, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error fetching the IAM account password policy")
+		}
+
+		if policy.MinCharCombination != 2 || policy.MinPasswordLength != 8 || policy.RecentPasswordsDisallowedCount != 1 ||
+			policy.PasswordValidityPeriod != 0 || policy.MinPasswordAge != 0 {
+			return fmt.Errorf("the password policy failed to reset to defaults")
+		}
+	}
+
+	return nil
+}
+
+func testAccPasswordPolicy_basic() string {
+	return `
+resource "huaweicloud_identity_password_policy" "enhanced" {
+  password_char_combination             = 4
+  minimum_password_length               = 12
+  number_of_recent_passwords_disallowed = 2
+  password_validity_period              = 180 
+}
+`
+}
+
+func testAccPasswordPolicy_update() string {
+	return `
+resource "huaweicloud_identity_password_policy" "enhanced" {
+  password_char_combination             = 2
+  minimum_password_length               = 12
+  number_of_recent_passwords_disallowed = 1
+  maximum_consecutive_identical_chars   = 4
+  minimum_password_age                  = 60
+  password_validity_period              = 90  
+}
+`
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_password_policy.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_password_policy.go
@@ -1,0 +1,160 @@
+package iam
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3.0/security"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceIdentityPasswordPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePasswordPolicyUpdate,
+		UpdateContext: resourcePasswordPolicyUpdate,
+		ReadContext:   resourcePasswordPolicyRead,
+		DeleteContext: resourcePasswordPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"password_char_combination": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				ValidateFunc: validation.IntBetween(2, 4),
+			},
+			"minimum_password_length": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      8,
+				ValidateFunc: validation.IntBetween(6, 32),
+			},
+			"maximum_consecutive_identical_chars": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 32),
+			},
+			"number_of_recent_passwords_disallowed": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(0, 10),
+			},
+			"password_validity_period": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 180),
+			},
+			"minimum_password_age": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 1440),
+			},
+			"password_not_username_or_invert": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"maximum_password_length": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePasswordPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	iamClient, err := cfg.IAMV3Client("")
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	domainID := cfg.DomainID
+	updateOpts := &security.PasswordPolicyOpts{
+		MinCharCombination:             utils.Int(d.Get("password_char_combination").(int)),
+		MinPasswordLength:              utils.Int(d.Get("minimum_password_length").(int)),
+		MaxConsecutiveIdenticalChars:   utils.Int(d.Get("maximum_consecutive_identical_chars").(int)),
+		RecentPasswordsDisallowedCount: utils.Int(d.Get("number_of_recent_passwords_disallowed").(int)),
+		PasswordValidityPeriod:         utils.Int(d.Get("password_validity_period").(int)),
+		MinPasswordAge:                 utils.Int(d.Get("minimum_password_age").(int)),
+		PasswordNotUsernameOrInvert:    utils.Bool(d.Get("password_not_username_or_invert").(bool)),
+	}
+
+	_, err = security.UpdatePasswordPolicy(iamClient, updateOpts, domainID)
+	if err != nil {
+		return diag.Errorf("error updating the IAM account password policy: %s", err)
+	}
+
+	// set the ID only when creating
+	if d.IsNewResource() {
+		d.SetId(domainID)
+	}
+
+	return resourcePasswordPolicyRead(ctx, d, meta)
+}
+
+func resourcePasswordPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	iamClient, err := cfg.IAMV3Client("")
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	policy, err := security.GetPasswordPolicy(iamClient, d.Id())
+	if err != nil {
+		return diag.Errorf("error fetching the IAM account password policy")
+	}
+
+	log.Printf("[DEBUG] Retrieved the IAM account password policy: %#v", policy)
+	mErr := multierror.Append(nil,
+		d.Set("password_char_combination", policy.MinCharCombination),
+		d.Set("minimum_password_length", policy.MinPasswordLength),
+		d.Set("maximum_consecutive_identical_chars", policy.MaxConsecutiveIdenticalChars),
+		d.Set("number_of_recent_passwords_disallowed", policy.RecentPasswordsDisallowedCount),
+		d.Set("password_validity_period", policy.PasswordValidityPeriod),
+		d.Set("minimum_password_age", policy.MinPasswordAge),
+		d.Set("password_not_username_or_invert", policy.PasswordNotUsernameOrInvert),
+		d.Set("maximum_password_length", policy.MaxPasswordLength),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePasswordPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	iamClient, err := cfg.IAMV3Client("")
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	defaultOpts := &security.PasswordPolicyOpts{
+		MinCharCombination:             utils.Int(2),
+		MinPasswordLength:              utils.Int(8),
+		MaxConsecutiveIdenticalChars:   utils.Int(0),
+		RecentPasswordsDisallowedCount: utils.Int(1),
+		PasswordValidityPeriod:         utils.Int(0),
+		MinPasswordAge:                 utils.Int(0),
+		PasswordNotUsernameOrInvert:    utils.Bool(true),
+	}
+
+	_, err = security.UpdatePasswordPolicy(iamClient, defaultOpts, d.Id())
+	if err != nil {
+		return diag.Errorf("error resetting the IAM account password policy: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/results.go
@@ -109,6 +109,6 @@ func (r ConfigurationPage) IsEmpty() (bool, error) {
 
 func (r ConfigurationPage) Extract() ([]Configuration, error) {
 	var cs []Configuration
-	err := r.Result.ExtractIntoSlicePtr(&cs, "scaling_groups")
+	err := r.Result.ExtractIntoSlicePtr(&cs, "scaling_configurations")
 	return cs, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/requests.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/pagination"
 )
 
@@ -104,6 +105,9 @@ type CreateOps struct {
 
 	// Indicates the action to be taken when the memory usage reaches the disk capacity threshold.
 	RetentionPolicy string `json:"retention_policy,omitempty"`
+
+	// Indicates the tags of the instance
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
 }
 
 // ToInstanceCreateMap is used for type convert

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/requests.go
@@ -1,0 +1,44 @@
+package security
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// PasswordPolicyOpts provides options used to update the account password policy
+type PasswordPolicyOpts struct {
+	// Minimum number of character types that a password must contain. Value range: 2–4.
+	MinCharCombination *int `json:"password_char_combination,omitempty"`
+	// Minimum number of characters that a password must contain. Value range: 6–32.
+	MinPasswordLength *int `json:"minimum_password_length,omitempty"`
+	// Maximum number of times that a character is allowed to consecutively present in a password.
+	// Value range: 0–32.
+	MaxConsecutiveIdenticalChars *int `json:"maximum_consecutive_identical_chars,omitempty"`
+	// Number of previously used passwords that are not allowed. Value range: 0–10.
+	RecentPasswordsDisallowedCount *int `json:"number_of_recent_passwords_disallowed,omitempty"`
+	// Password validity period (days). Value range: 0–180. Value 0 indicates that this requirement does not apply.
+	PasswordValidityPeriod *int `json:"password_validity_period,omitempty"`
+	// Minimum period (minutes) after which users are allowed to make a password change.
+	// Value range: 0–1440.
+	MinPasswordAge *int `json:"minimum_password_age,omitempty"`
+	// Indicates whether the password can be the username or the username spelled backwards.
+	PasswordNotUsernameOrInvert *bool `json:"password_not_username_or_invert,omitempty"`
+}
+
+// UpdatePasswordPolicy can update the account password policy
+func UpdatePasswordPolicy(client *golangsdk.ServiceClient, opts *PasswordPolicyOpts, domainID string) (*PasswordPolicy, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "password_policy")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PasswordPolicyResp
+	_, err = client.Put(passwordPolicyURL(client, domainID), &b, &resp, nil)
+	return &resp.Body, err
+}
+
+// GetPasswordPolicy retrieves details of the account password policy
+func GetPasswordPolicy(client *golangsdk.ServiceClient, domainID string) (*PasswordPolicy, error) {
+	var resp PasswordPolicyResp
+	_, err := client.Get(passwordPolicyURL(client, domainID), &resp, nil)
+	return &resp.Body, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/results.go
@@ -1,0 +1,26 @@
+package security
+
+type PasswordPolicy struct {
+	// Minimum number of character types that a password must contain. Value range: 2–4.
+	MinCharCombination int `json:"password_char_combination"`
+	// Minimum number of characters that a password must contain. Value range: 6–32.
+	MinPasswordLength int `json:"minimum_password_length"`
+	// Maximum number of characters that a password can contain.
+	MaxPasswordLength int `json:"maximum_password_length"`
+	// Maximum number of times that a character is allowed to consecutively present in a password.
+	MaxConsecutiveIdenticalChars int `json:"maximum_consecutive_identical_chars"`
+	// Number of previously used passwords that are not allowed. Value range: 0–10.
+	RecentPasswordsDisallowedCount int `json:"number_of_recent_passwords_disallowed"`
+	// Password validity period (days). Value range: 0–180. Value 0 indicates that this requirement does not apply.
+	PasswordValidityPeriod int `json:"password_validity_period"`
+	// Minimum period (minutes) after which users are allowed to make a password change.
+	MinPasswordAge int `json:"minimum_password_age"`
+	// Indicates whether the password can be the username or the username spelled backwards.
+	PasswordNotUsernameOrInvert bool `json:"password_not_username_or_invert"`
+	// Characters that a password must contain.
+	PasswordRequirements string `json:"password_requirements"`
+}
+
+type PasswordPolicyResp struct {
+	Body PasswordPolicy `json:"password_policy"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/urls.go
@@ -1,0 +1,9 @@
+package security
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "OS-SECURITYPOLICY"
+
+func passwordPolicyURL(client *golangsdk.ServiceClient, domainID string) string {
+	return client.ServiceURL(rootPath, "domains", domainID, "password-policy")
+}

--- a/vendor/github.com/chnsz/golangsdk/pagination/http.go
+++ b/vendor/github.com/chnsz/golangsdk/pagination/http.go
@@ -55,7 +55,7 @@ func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 func Request(client *golangsdk.ServiceClient, headers map[string]string, url string) (*http.Response, error) {
 	return client.Get(url, nil, &golangsdk.RequestOpts{
 		MoreHeaders:      headers,
-		OkCodes:          []int{200, 204, 300},
+		OkCodes:          []int{200, 202, 204, 300},
 		KeepResponseBody: true,
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230222031848-d1ae93e84d49
+# github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -174,6 +174,7 @@ github.com/chnsz/golangsdk/openstack/identity/v2/tokens
 github.com/chnsz/golangsdk/openstack/identity/v3.0/acl
 github.com/chnsz/golangsdk/openstack/identity/v3.0/credentials
 github.com/chnsz/golangsdk/openstack/identity/v3.0/policies
+github.com/chnsz/golangsdk/openstack/identity/v3.0/security
 github.com/chnsz/golangsdk/openstack/identity/v3.0/users
 github.com/chnsz/golangsdk/openstack/identity/v3/agency
 github.com/chnsz/golangsdk/openstack/identity/v3/catalog


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
add new resource **huaweicloud_identity_password_policy**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ export HW_ADMIN=true
$ make testacc TEST='./huaweicloud/services/acceptance/iam' TESTARGS='-run TestAccPasswordPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccPasswordPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccPasswordPolicy_basic
=== PAUSE TestAccPasswordPolicy_basic
=== CONT  TestAccPasswordPolicy_basic
--- PASS: TestAccPasswordPolicy_basic (18.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       18.371s
```
