### PR TITLE
feat(apig/api): refactor policy structure and support backend auth parameters

### DIFF
--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -189,6 +189,9 @@ The `backend_params` block supports:
 * `description` - (Optional, String) Specifies the description of the constant or system parameter.  
   The description contains a maximum of `255` characters and the angle brackets (< and >) are not allowed.
 
+* `system_param_type` - (Optional, String) Specifies the type of the system parameter.  
+  The valid values are **frontend**, **backend** and **internal**, defaults to **internal**.
+
 <a name="apig_api_mock"></a>
 The `mock` block supports:
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
@@ -67,7 +67,9 @@ func TestAccApiPublishment_basic(t *testing.T) {
 	})
 }
 
-func testAccApiPublishment_basic(rName string) string {
+func testAccApiPublishment_basic(name string) string {
+	relatedConfig := testAccApi_basic(testAccApi_base(name), name)
+
 	return fmt.Sprintf(`
 %[1]s
 
@@ -81,5 +83,5 @@ resource "huaweicloud_apig_api_publishment" "test" {
   env_id      = huaweicloud_apig_environment.test.id
   api_id      = huaweicloud_apig_api.test.id
 }
-`, testAccApi_basic(rName), rName)
+`, relatedConfig, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor policy structures.
2. the backend parameter structure support `system_param_type` parameter.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApi_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApi_ -timeout 360m -parallel 4
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== CONT  TestAccApi_basic
--- PASS: TestAccApi_basic (514.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      514.357s
```
