### PR TITLE
fix(rms/definitions): adjust endpoint URL and remove the region parameter

### DIFF
--- a/docs/data-sources/rms_policy_definitions.md
+++ b/docs/data-sources/rms_policy_definitions.md
@@ -20,9 +20,6 @@ data "huaweicloud_rms_policy_definitions" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region where the policy definitions are located.  
-  If omitted, the provider-level region will be used.
-
 * `name` - (Optional, String) Specifies the name of the policy definitions used to query definition list.
 
 * `policy_type` - (Optional, String) Specifies the policy type used to query definition list.  

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -420,6 +420,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	},
 	"rms": {
 		Name:             "rms",
+		Scope:            "global",
 		Version:          "v1",
 		WithOutProjectID: true,
 		Product:          "RMS",

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -950,7 +950,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud RMS v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://rms.%s.%s/v1/", HW_REGION_NAME, config.Cloud)
+	expectedURL = fmt.Sprintf("https://rms.%s/v1/", config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("RMS endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))

--- a/huaweicloud/services/rms/data_source_huaweicloud_rms_policy_definitions.go
+++ b/huaweicloud/services/rms/data_source_huaweicloud_rms_policy_definitions.go
@@ -21,11 +21,6 @@ func DataSourcePolicyDefinitions() *schema.Resource {
 		ReadContext: dataSourcePolicyDefinitionsRead,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The region where the policy definitions are located.",
-			},
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The endpoint URL of the rms service should be type `global`, not type `region`.
So, the region parameter should be removed from the `huaweicloud_rms_policy_definitions` data-source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the endpoint URL of the RMS service.
2. remove the region parameter form the `huaweicloud_rms_policy_definitions` data-source.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rms' TESTARGS='-run=TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run=TestAcc -timeout 360m -parallel 4
=== RUN   TestAccDataPolicyDefinitions_basic
=== PAUSE TestAccDataPolicyDefinitions_basic
=== RUN   TestAccDataPolicyDefinitions_keywords
=== PAUSE TestAccDataPolicyDefinitions_keywords
=== RUN   TestAccDataPolicyDefinitions_policyRuleType
=== PAUSE TestAccDataPolicyDefinitions_policyRuleType
=== RUN   TestAccDataPolicyDefinitions_triggerType
=== PAUSE TestAccDataPolicyDefinitions_triggerType
=== CONT  TestAccDataPolicyDefinitions_basic
=== CONT  TestAccDataPolicyDefinitions_policyRuleType
=== CONT  TestAccDataPolicyDefinitions_triggerType
=== CONT  TestAccDataPolicyDefinitions_keywords
--- PASS: TestAccDataPolicyDefinitions_keywords (9.94s)
--- PASS: TestAccDataPolicyDefinitions_policyRuleType (10.14s)
--- PASS: TestAccDataPolicyDefinitions_triggerType (10.75s)
--- PASS: TestAccDataPolicyDefinitions_basic (10.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       10.871s
```
