### PR TITLE
fix(css/flavors): fix the wrong name of the fileter parameters

### DIFF
--- a/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_flavors_test.go
+++ b/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_flavors_test.go
@@ -9,9 +9,12 @@ import (
 )
 
 func TestAccCssFlavorsDataSource_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_css_flavors.test"
-
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	var (
+		typeFilter    = acceptance.InitDataSourceCheck("data.huaweicloud_css_flavors.type_filter")
+		versionFilter = acceptance.InitDataSourceCheck("data.huaweicloud_css_flavors.version_filter")
+		vcpusFilter   = acceptance.InitDataSourceCheck("data.huaweicloud_css_flavors.vcpus_filter")
+		memoryFilter  = acceptance.InitDataSourceCheck("data.huaweicloud_css_flavors.memory_filter")
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,15 +23,14 @@ func TestAccCssFlavorsDataSource_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceCssFlavors_basic,
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.type", "ess"),
-					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.version", "7.9.3"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.region"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.memory"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.vcpus"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.0.disk_range"),
+					typeFilter.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					versionFilter.CheckResourceExists(),
+					resource.TestCheckOutput("is_version_filter_useful", "true"),
+					vcpusFilter.CheckResourceExists(),
+					resource.TestCheckOutput("is_vcpus_filter_useful", "true"),
+					memoryFilter.CheckResourceExists(),
+					resource.TestCheckOutput("is_memory_filter_useful", "true"),
 				),
 			},
 		},
@@ -36,9 +38,37 @@ func TestAccCssFlavorsDataSource_basic(t *testing.T) {
 }
 
 const testAccDataSourceCssFlavors_basic = `
-data "huaweicloud_css_flavors" "test" {
-  type    = "ess"
+
+data "huaweicloud_css_flavors" "type_filter" {
+  type = "ess"
+}
+
+output "is_type_filter_useful" {
+  value = !contains([for v in data.huaweicloud_css_flavors.type_filter.flavors[*].type : v == "ess"], "false")
+}
+
+data "huaweicloud_css_flavors" "version_filter" {
   version = "7.9.3"
+}
+
+output "is_version_filter_useful" {
+  value = !contains([for v in data.huaweicloud_css_flavors.version_filter.flavors[*].version : v == "7.9.3"], "false")
+}
+
+data "huaweicloud_css_flavors" "vcpus_filter" {
+  vcpus = 32
+}
+
+output "is_vcpus_filter_useful" {
+  value = !contains([for v in data.huaweicloud_css_flavors.vcpus_filter.flavors[*].vcpus : v == 32], "false")
+}
+
+data "huaweicloud_css_flavors" "memory_filter" {
+  memory = 256
+}
+
+output "is_memory_filter_useful" {
+  value = !contains([for v in data.huaweicloud_css_flavors.memory_filter.flavors[*].memory : v == 256], "false")
 }
 `
 

--- a/huaweicloud/services/css/data_source_huaweicloud_css_flavors.go
+++ b/huaweicloud/services/css/data_source_huaweicloud_css_flavors.go
@@ -115,11 +115,11 @@ func dataSourceCssFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 		"Version": d.Get("version"),
 	}
 
-	if v, ok := d.GetOk("cpu"); ok {
+	if v, ok := d.GetOk("vcpus"); ok {
 		filter["Cpu"] = v
 	}
 
-	if v, ok := d.GetOk("ram"); ok {
+	if v, ok := d.GetOk("memory"); ok {
 		filter["Ram"] = v
 	}
 

--- a/huaweicloud/services/css/data_source_huaweicloud_css_flavors.go
+++ b/huaweicloud/services/css/data_source_huaweicloud_css_flavors.go
@@ -129,10 +129,6 @@ func dataSourceCssFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	}
 	logp.Printf("filter %d CSS flavors from %d through options %v", len(filterFlavors), len(allFlavors), filter)
 
-	if len(filterFlavors) < 1 {
-		return fmtp.DiagErrorf("No data found. Please change your search criteria and try again.")
-	}
-
 	mErr := d.Set("flavors", buildFlavors(filterFlavors))
 	if mErr != nil {
 		return fmtp.DiagErrorf("set flavors err:%s", mErr)
@@ -170,6 +166,10 @@ func flatternFlavors(flavors *cluster.EsFlavorsResp) []flavor {
 }
 
 func buildFlavors(flavors []interface{}) []map[string]interface{} {
+	if len(flavors) < 1 {
+		return nil
+	}
+
 	var rst []map[string]interface{}
 	for _, v := range flavors {
 		f := v.(flavor)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The fileter parameter `vcpus` and the parameter `memory` does not work because of the filter references are wrong.
- The parameter `vpu` does not exist, should be `vcpus`.
- The parameter `ram` does not exist, should be `memory`.

So fix them.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong name of the fileter parameters.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccCssFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCssFlavorsDataSource_basic
=== PAUSE TestAccCssFlavorsDataSource_basic
=== CONT  TestAccCssFlavorsDataSource_basic
--- PASS: TestAccCssFlavorsDataSource_basic (24.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       24.980s
```
