### PR TITLE
feat(WAF): support pci_3ds and pci_dss

### DIFF
--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -56,14 +56,28 @@ The following arguments are supported:
   and basically all other non-HTTP/S traffic. If a proxy such as public network ELB (or Nginx) has been used, set
   proxy `true` to ensure that the WAF security policy takes effect for the real source IP address.
 
-* `tls` - (Optional, String) Specifies the minimum required TLS version. The options include `TLS v1.0`, `TLS v1.1`,
-  `TLS v1.2`.
-
 * `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
   Defaults to `true`.
 
 * `protect_status` - (Optional, Int) The protection status of domain, `0`: suspended, `1`: enabled.
   Default value is `1`.
+
+* `tls` - (Optional, String) Specifies the minimum required TLS version. The options include `TLS v1.0`, `TLS v1.1`,
+  `TLS v1.2`.
+
+* `cipher` - (Optional, String) Specifies the cipher suite of domain. The options include `cipher_1`, `cipher_2`,
+  `cipher_3`, `cipher_4`, `cipher_default`.
+
+* `pci_3ds` - (Optional, Bool) Specifies the status of the PCI 3DS compliance certification check. The options
+  include `true` and `false`. This parameter must be used together with tls and cipher.
+
+  -> **NOTE:** Tls must be set to TLS v1.2, and cipher must be set to cipher_2. The PCI 3DS compliance certification
+  check cannot be disabled after being enabled.
+
+* `pci_dss` - (Optional, Bool) Specifies the status of the PCI DSS compliance certification check. The options
+  include `true` and `false`. This parameter must be used together with tls and cipher.
+
+  -> **NOTE:** Tls must be set to TLS v1.2, and cipher must be set to cipher_2.
 
 The `server` block supports:
 
@@ -97,8 +111,6 @@ The following attributes are exported:
   + `1` - The domain name is connected to WAF.
 
 * `protocol` - The protocol type of the client. The options are `HTTP` and `HTTPS`.
-
-* `cihper` - The cipher suite of domain.
 
 * `compliance_certification` - The compliance certifications of the domain, values are:
   + `pci_dss` - The status of domain PCI DSS, `true`: enabled, `false`: disabled.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0
+	github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0 h1:0RTqu9PD7WB6cYWQ7QYM1+WJYleqnIgJjZZuqmwF1/8=
-github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26 h1:JZAcwKJ45fxlt+QLC3AuWbs3LqcJBvC7dHOzBuEwe/M=
+github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -31,7 +31,8 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
-					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.1"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_1"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
@@ -56,7 +57,10 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
-					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.1"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_2"),
+					resource.TestCheckResourceAttr(resourceName, "pci_3ds", "true"),
+					resource.TestCheckResourceAttr(resourceName, "pci_dss", "true"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
@@ -148,7 +152,8 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   certificate_id = huaweicloud_waf_certificate.certificate_1.id
   keep_policy    = false
   proxy          = false
-  tls            = "TLS v1.2"
+  tls            = "TLS v1.1"
+  cipher         = "cipher_1"
 
   server {
     client_protocol = "HTTPS"
@@ -175,7 +180,10 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   certificate_id = huaweicloud_waf_certificate.certificate_1.id
   keep_policy    = false
   proxy          = true
-  tls            = "TLS v1.1"
+  tls            = "TLS v1.2"
+  cipher         = "cipher_2"
+  pci_3ds        = true
+  pci_dss        = true
 
   server {
     client_protocol = "HTTPS"

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_domains/requests.go
@@ -101,6 +101,12 @@ type UpdatePremiumHostOpts struct {
 	CertificateName string `json:"certificatename,omitempty"`
 	Tls             string `json:"tls,omitempty"`
 	Cipher          string `json:"cipher,omitempty"`
+	Flag            *Flag  `json:"flag,omitempty"`
+}
+
+type Flag struct {
+	Pci3ds string `json:"pci_3ds,omitempty"`
+	PciDss string `json:"pci_dss,omitempty"`
 }
 
 // Update update premium domains according to UpdatePremiumHostOpts.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230224082108-1bbc8c6047b0
+# github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
WAF dedicated domain support pci_3ds and pci_dss.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_basic -timeout 360m -parallel 4 
=== RUN   TestAccWafDedicateDomainV1_basic 
=== PAUSE TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_basic
--- PASS: TestAccWafDedicateDomainV1_basic (374.24s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       374.296s
```
