### PR TITLE
feat(CPH): add a new dataSource to get phone flavors

### DIFF
--- a/docs/data-sources/cph_phone_flavors.md
+++ b/docs/data-sources/cph_phone_flavors.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Cloud Phone (CPH)"
+---
+
+# huaweicloud_cph_phone_flavors
+
+Use this data source to get available flavors of CPH phone.
+
+## Example Usage
+
+```
+data "huaweicloud_cph_phone_flavors" "test" {
+  type = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `status` - (Optional, String) The flavor status. Defaults to **1**.  
+  The options are as follows:
+    - **0**: offline.
+    - **1**: normal.
+
+* `type` - (Optional, String) The cloud phone type.  
+  The options are as follows:
+    - **0**: Cloud phone.
+    - **1**: Cloud mobile gaming.
+
+* `vcpus` - (Optional, Int) The vcpus of the CPH phone.
+
+* `memory` - (Optional, Int) The ram of the CPH phone in MB.
+
+* `server_flavor_id` - (Optional, String) The CPH server flavor.
+
+* `image_label` - (Optional, String) The label of image.
+  The valid values are **cloud_phone**, **cloud_game**, **qemu_phone**, **cloud_phone_1620**, and **cloud_game_1620**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `flavors` - The list of flavor detail.
+  The [Flavors](#phoneFlavors_Flavors) structure is documented below.
+
+<a name="phoneFlavors_Flavors"></a>
+The `Flavors` block supports:
+
+* `flavor_id` - The name of the flavor.
+
+* `server_flavor_id` - The name of the CPH server flavor.
+
+* `vcpus` - The vcpus of the CPH phone.
+
+* `memory` - The ram of the CPH phone in MB.
+
+* `disk` - The storage size in GB.
+
+* `resolution` - The resolution of the CPH phone.
+
+* `phone_capacity` - The number of cloud phones of the current flavor.
+
+* `status` - The flavor status.  
+  The options are as follows:
+    - **0**: offline.
+    - **1**: normal.
+
+* `type` - The cloud phone type.  
+  The options are as follows:
+    - **0**: Cloud phone.
+    - **1**: Cloud mobile gaming.
+
+* `image_label` - (Optional, String) The label of image.
+  The valid values are **cloud_phone**, **cloud_game**, **qemu_phone**, **cloud_phone_1620**, and **cloud_game_1620**.
+
+* `extend_spec` - The extended description, which is a string in JSON format and can contain a maximum of 512 bytes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -402,6 +402,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_servergroups": ecs.DataSourceComputeServerGroups(),
 
 			"huaweicloud_cph_server_flavors": cph.DataSourceServerFlavors(),
+			"huaweicloud_cph_phone_flavors":  cph.DataSourcePhoneFlavors(),
 
 			"huaweicloud_csbs_backup":        dataSourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy": dataSourceCSBSBackupPolicyV1(),

--- a/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_phone_flavors_test.go
+++ b/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_phone_flavors_test.go
@@ -1,0 +1,71 @@
+package cph
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourcePhoneFlavors_basic(t *testing.T) {
+	rName := "data.huaweicloud_cph_phone_flavors.status_filter"
+	statusFilter := acceptance.InitDataSourceCheck("data.huaweicloud_cph_phone_flavors.status_filter")
+	typeFilter := acceptance.InitDataSourceCheck("data.huaweicloud_cph_phone_flavors.type_filter")
+	vcpusFilter := acceptance.InitDataSourceCheck("data.huaweicloud_cph_phone_flavors.vcpus_filter")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourcePhoneFlavors_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					statusFilter.CheckResourceExists(),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.server_flavor_id"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.vcpus"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.memory"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.disk"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.resolution"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.phone_capacity"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.extend_spec"),
+
+					typeFilter.CheckResourceExists(),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+
+					vcpusFilter.CheckResourceExists(),
+					resource.TestCheckOutput("vcpus_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourcePhoneFlavors_basic() string {
+	return `
+data "huaweicloud_cph_phone_flavors" "status_filter" {
+  status = "1"
+}
+output "status_filter_is_useful" {
+  value = !contains([for v in data.huaweicloud_cph_phone_flavors.status_filter.flavors[*].status : v == "1"], "false")
+}
+
+data "huaweicloud_cph_phone_flavors" "type_filter" {
+  type = "0"
+}
+output "type_filter_is_useful" {
+  value = !contains([for v in data.huaweicloud_cph_phone_flavors.type_filter.flavors[*].type : v == "0"], "false")
+}
+
+data "huaweicloud_cph_phone_flavors" "vcpus_filter" {
+  vcpus = 4
+}
+output "vcpus_filter_is_useful" {
+  value = !contains([for v in data.huaweicloud_cph_phone_flavors.vcpus_filter.flavors[*].vcpus : v == 4], "false")
+}
+`
+}

--- a/huaweicloud/services/cph/data_source_huaweicloud_cph_phone_flavors.go
+++ b/huaweicloud/services/cph/data_source_huaweicloud_cph_phone_flavors.go
@@ -1,0 +1,264 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CPH
+// ---------------------------------------------------------------
+
+package cph
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourcePhoneFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourcePhoneFlavorsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "1",
+				Description: `The flavor status.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"0", "1",
+				}, false),
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cloud phone type.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"0", "1",
+				}, false),
+			},
+			"vcpus": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The vcpus of the CPH phone.`,
+			},
+			"memory": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The ram of the CPH phone in MB.`,
+			},
+			"server_flavor_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The CPH server flavor.`,
+			},
+			"image_label": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The label of image.`,
+			},
+			"flavors": {
+				Type:        schema.TypeList,
+				Elem:        phoneFlavorsFlavorsSchema(),
+				Computed:    true,
+				Description: `The list of flavor detail.`,
+			},
+		},
+	}
+}
+
+func phoneFlavorsFlavorsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the flavor.`,
+			},
+			"server_flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the CPH server flavor.`,
+			},
+			"vcpus": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The vcpus of the CPH phone.`,
+			},
+			"memory": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The ram of the CPH phone in MB.`,
+			},
+			"disk": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The storage size in GB.`,
+			},
+			"resolution": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resolution of the CPH phone.`,
+			},
+			"phone_capacity": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of cloud phones of the current flavor.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor status.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cloud phone type.`,
+			},
+			"extend_spec": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extended description, which is a string in JSON format and can contain a maximum of 512 bytes.`,
+			},
+			"image_label": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The label of image.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourcePhoneFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// listFlavors: Query the list of CPH phone flavors
+	var (
+		listFlavorsHttpUrl = "v1/{project_id}/cloud-phone/phone-models"
+		listFlavorsProduct = "cph"
+	)
+	listFlavorsClient, err := cfg.NewServiceClient(listFlavorsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CPH Client: %s", err)
+	}
+
+	listFlavorsPath := listFlavorsClient.Endpoint + listFlavorsHttpUrl
+	listFlavorsPath = strings.ReplaceAll(listFlavorsPath, "{project_id}", listFlavorsClient.ProjectID)
+
+	listFlavorsqueryParams := buildListPhoneFlavorsQueryParams(d)
+	listFlavorsPath += listFlavorsqueryParams
+
+	listFlavorsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	listFlavorsResp, err := listFlavorsClient.Request("GET", listFlavorsPath, &listFlavorsOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving PhoneFlavors")
+	}
+
+	listFlavorsRespBody, err := utils.FlattenResponse(listFlavorsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("flavors", filterListPhoneModelsFlavors(
+			flattenListPhoneModelsFlavors(listFlavorsRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListPhoneModelsFlavors(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("phone_models", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"flavor_id":        utils.PathSearch("phone_model_name", v, nil),
+			"server_flavor_id": utils.PathSearch("server_model_name", v, nil),
+			"vcpus":            utils.PathSearch("cpu", v, nil),
+			"memory":           utils.PathSearch("memory", v, nil),
+			"disk":             utils.PathSearch("disk", v, nil),
+			"resolution":       utils.PathSearch("resolution", v, nil),
+			"phone_capacity":   utils.PathSearch("phone_capacity", v, nil),
+			"status":           fmt.Sprint(utils.PathSearch("status", v, "")),
+			"type":             fmt.Sprint(utils.PathSearch("product_type", v, "")),
+			"image_label":      utils.PathSearch("image_label", v, ""),
+			"extend_spec":      utils.PathSearch("extend_spec", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListPhoneModelsFlavors(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("type"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("type", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("vcpus"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("vcpus", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("memory"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("memory", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("server_flavor_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("server_flavor_id", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("image_label"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("image_label", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func buildListPhoneFlavorsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}

--- a/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
+++ b/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
@@ -504,7 +504,7 @@ func createCphServerWaitingForStateCompleted(ctx context.Context, d *schema.Reso
 			return createCphServerRespBody, "PENDING", nil
 		},
 		Timeout:      t,
-		Delay:        25 * time.Second,
+		Delay:        120 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1.  add a new dataSource to get phone flavors

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cph' TESTARGS='-run=TestAccDatasourcePhoneFlavors_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run=TestAccDatasourcePhoneFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePhoneFlavors_basic
=== PAUSE TestAccDatasourcePhoneFlavors_basic
=== CONT  TestAccDatasourcePhoneFlavors_basic
--- PASS: TestAccDatasourcePhoneFlavors_basic (10.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       10.770s
```
