### PR TITLE
fix(gaussdb): fix dnNum issue for opengauss

### DIFF
--- a/docs/data-sources/gaussdb_opengauss_instance.md
+++ b/docs/data-sources/gaussdb_opengauss_instance.md
@@ -57,7 +57,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `sharding_num` - Indicates the sharding num.
 
+* `replica_num` - Indicates the replica num.
+
 * `private_ips` - Indicates the list of private IP address of the nodes.
+* `public_ips` - Indicates the public IP address of the DB instance.
 
 * `volume` - Indicates the volume information. Structure is documented below.
 

--- a/docs/data-sources/gaussdb_opengauss_instances.md
+++ b/docs/data-sources/gaussdb_opengauss_instances.md
@@ -69,7 +69,11 @@ The `instances` block supports:
 
 * `sharding_num` - Indicates the sharding num.
 
+* `replica_num` - Indicates the replica num.
+
 * `private_ips` - Indicates the list of private IP address of the nodes.
+
+* `public_ips` - Indicates the public IP address of the DB instance.
 
 * `volume` - Indicates the volume information. Structure is documented below.
 

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccOpenGaussInstanceDataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.huaweicloud_gaussdb_opengauss_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -22,7 +23,30 @@ func TestAccOpenGaussInstanceDataSource_basic(t *testing.T) {
 			{
 				Config: testAccOpenGaussInstanceDataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenGaussInstanceDataSourceID("data.huaweicloud_gaussdb_opengauss_instance.test"),
+					testAccCheckOpenGaussInstanceDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "sharding_num", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "coordinator_num", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.size", "40"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenGaussInstanceDataSource_haModeCentralized(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.huaweicloud_gaussdb_opengauss_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenGaussInstanceDataSource_haModeCentralized(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenGaussInstanceDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "replica_num", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.size", "40"),
 				),
 			},
 		},
@@ -46,15 +70,15 @@ func testAccCheckOpenGaussInstanceDataSourceID(n string) resource.TestCheckFunc 
 
 func testAccOpenGaussInstanceDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_networking_secgroup" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   description = "terraform security group rule acceptance test"
 }
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   password    = "Test@12345678"
   flavor      = "gaussdb.opengauss.ee.dn.m6.2xlarge.8.in"
   vpc_id      = huaweicloud_vpc.test.id
@@ -83,5 +107,46 @@ data "huaweicloud_gaussdb_opengauss_instance" "test" {
     huaweicloud_gaussdb_opengauss_instance.test,
   ]
 }
-`, testAccVpcConfig_Base(rName), rName, rName)
+`, testAccVpcConfig_Base(rName), rName)
+}
+
+func testAccOpenGaussInstanceDataSource_haModeCentralized(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name        = "%[2]s"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  name        = "%[2]s"
+  password    = "Test@12345678"
+  flavor      = "gaussdb.opengauss.ee.m6.2xlarge.x868.ha"
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+
+  availability_zone = "cn-north-4a,cn-north-4a,cn-north-4a"
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  ha {
+    mode             = "centralization_standard"
+    replication_mode = "sync"
+    consistency      = "strong"
+  }
+  volume {
+    type = "ULTRAHIGH"
+    size = 40
+  }
+
+  replica_num = 3
+}
+
+data "huaweicloud_gaussdb_opengauss_instance" "test" {
+  name = huaweicloud_gaussdb_opengauss_instance.test.name
+  depends_on = [
+    huaweicloud_gaussdb_opengauss_instance.test,
+  ]
+}
+`, testAccVpcConfig_Base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1814 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run=TestAccOpenGaussInstanceDataSource_basic'
...
=== RUN   make testacc TestAccOpenGaussInstanceDataSource_basic
--- PASS: TestAccOpenGaussInstanceDataSource_basic (1898.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1898.828s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run=TestAccOpenGaussInstanceDataSource_haModeCentralized'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run=TestAccOpenGaussInstanceDataSource_haModeCentralized -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstanceDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstanceDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstanceDataSource_haModeCentralized (1706.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1706.043s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run=TestAccOpenGaussInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run=TestAccOpenGaussInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstancesDataSource_basic
=== PAUSE TestAccOpenGaussInstancesDataSource_basic
=== CONT  TestAccOpenGaussInstancesDataSource_basic
--- PASS: TestAccOpenGaussInstancesDataSource_basic (1835.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1835.066s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run=TestAccOpenGaussInstancesDataSource_haModeCentralized'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run=TestAccOpenGaussInstancesDataSource_haModeCentralized -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstancesDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstancesDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstancesDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstancesDataSource_haModeCentralized (1808.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1808.322s

```
