### PR TITLE
fix(cdm): unset the default cluster version

### DIFF
--- a/docs/resources/cdm_cluster.md
+++ b/docs/resources/cdm_cluster.md
@@ -44,15 +44,14 @@ The following arguments are supported:
 
 * `flavor_id` - (Required, String, ForceNew) Specifies flavor id. Changing this parameter will create a new resource.
 
-* `version` - (Optional, String, ForceNew) Specifies cluster version. Default value is `2.8.6.2`.
- Changing this parameter will create a new resource.
-
 * `vpc_id` - (Required, String, ForceNew) Specifies VPC ID. Changing this parameter will create a new resource.
 
 * `subnet_id` - (Required, String, ForceNew) Specifies subnet ID. Changing this parameter will create a new resource.
 
 * `security_group_id` - (Required, String, ForceNew) Specifies security group ID.
  Changing this parameter will create a new resource.
+
+* `version` - (Optional, String, ForceNew) Specifies the cluster version. Changing this parameter will create a new resource.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id.
  Changing this parameter will create a new resource.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26
+	github.com/chnsz/golangsdk v0.0.0-20230307072400-f06ac1ada943
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26 h1:JZAcwKJ45fxlt+QLC3AuWbs3LqcJBvC7dHOzBuEwe/M=
-github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230307072400-f06ac1ada943 h1:Bf9h+igBu9Gw8ZKEbrqVOUk+RwY70l9HYXEBvkHP8Og=
+github.com/chnsz/golangsdk v0.0.0-20230307072400-f06ac1ada943/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_cluster_test.go
+++ b/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_cluster_test.go
@@ -42,8 +42,9 @@ func TestAccResourceCdmCluster_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttrSet(resourceName, "created"),
 					resource.TestCheckResourceAttr(resourceName, "status", "Normal"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttrSet(resourceName, "created"),
 				),
 			},
 			{

--- a/huaweicloud/services/cdm/resource_huaweicloud_cdm_cluster.go
+++ b/huaweicloud/services/cdm/resource_huaweicloud_cdm_cluster.go
@@ -48,13 +48,6 @@ func ResourceCdmCluster() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "2.8.6.2",
-			},
-
 			"flavor_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -77,6 +70,13 @@ func ResourceCdmCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 
 			"enterprise_project_id": {
@@ -236,7 +236,6 @@ func buildClusterParamter(d *schema.ResourceData, opts *clusters.ClusterCreateOp
 
 	cluster := clusters.ClusterRequest{
 		Name:      d.Get("name").(string),
-		Datastore: clusters.Datastore{Type: "cdm", Version: d.Get("version").(string)},
 		VpcId:     d.Get("vpc_id").(string),
 		IsAutoOff: utils.Bool(d.Get("is_auto_off").(bool)),
 		Instances: []clusters.InstanceReq{
@@ -252,6 +251,13 @@ func buildClusterParamter(d *schema.ResourceData, opts *clusters.ClusterCreateOp
 				},
 			},
 		},
+	}
+
+	if v, ok := d.GetOk("version"); ok {
+		cluster.Datastore = &clusters.Datastore{
+			Type:    "cdm",
+			Version: v.(string),
+		}
 	}
 
 	// set Schedule boot/off

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdm/v1/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdm/v1/clusters/requests.go
@@ -26,7 +26,7 @@ type ClusterRequest struct {
 	// Node list.
 	Instances []InstanceReq `json:"instances,omitempty"`
 	// Cluster information. For details, see the description of the datastore parameter.
-	Datastore Datastore `json:"datastore,omitempty"`
+	Datastore *Datastore `json:"datastore,omitempty"`
 	// Time for scheduled shutdown of a CDM cluster. The system shuts down directly at this time every day without waiting for unfinished jobs to complete.
 	ScheduleOffTime string `json:"scheduleOffTime,omitempty"`
 	// VPC ID, which is used for configuring a network for the cluster

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230302033842-efa70a163e26
+# github.com/chnsz/golangsdk v0.0.0-20230307072400-f06ac1ada943
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1929 

the default cluster version in schema is `2.8.6.2`, but  the latest version is `2.9.2.200`.
Unsetting the default cluster version will deploy a latest cluster.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
