### PR TITLE
test(rms/precheck): skip acc test if the domain ID is not set

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -153,7 +153,7 @@ func TestAccPreCheck(t *testing.T) {
 // lintignore:AT003
 func TestAccPrecheckDomainId(t *testing.T) {
 	if HW_DOMAIN_ID == "" {
-		t.Fatal("HW_DOMAIN_ID must be set for acceptance tests")
+		t.Skip("HW_DOMAIN_ID must be set for acceptance tests")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skip the acc test if the `HW_DOMAIN_ID` is not set:
- using `Skip` function to instead of `Fatal` function.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. skip acc test if the domain ID is not set
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

Configured environment variable `HW_DOMAIN_ID`
```
make testacc TEST='./huaweicloud/services/acceptance/rms' TESTARGS='-run=TestAccPolicyAssignment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run=TestAccPolicyAssignment_ -timeout 360m -parallel 4
=== RUN   TestAccPolicyAssignment_basic
=== PAUSE TestAccPolicyAssignment_basic
=== RUN   TestAccPolicyAssignment_period
=== PAUSE TestAccPolicyAssignment_period
=== RUN   TestAccPolicyAssignment_custom
=== PAUSE TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_basic
=== CONT  TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_period
--- PASS: TestAccPolicyAssignment_period (142.53s)
--- PASS: TestAccPolicyAssignment_custom (277.55s)
--- PASS: TestAccPolicyAssignment_basic (302.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       302.674s
```
The environment variable `HW_DOMAIN_ID` is empty.
```
make testacc TEST='./huaweicloud/services/acceptance/rms' TESTARGS='-run=TestAccPolicyAssignment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run=TestAccPolicyAssignment_ -timeout 360m -parallel 4
=== RUN   TestAccPolicyAssignment_basic
=== PAUSE TestAccPolicyAssignment_basic
=== RUN   TestAccPolicyAssignment_period
=== PAUSE TestAccPolicyAssignment_period
=== RUN   TestAccPolicyAssignment_custom
=== PAUSE TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_basic
=== CONT  TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_period
=== CONT  TestAccPolicyAssignment_basic
    acceptance.go:156: HW_DOMAIN_ID must be set for acceptance tests
--- SKIP: TestAccPolicyAssignment_basic (0.01s)
=== CONT  TestAccPolicyAssignment_custom
    acceptance.go:156: HW_DOMAIN_ID must be set for acceptance tests
--- SKIP: TestAccPolicyAssignment_custom (0.01s)
=== CONT  TestAccPolicyAssignment_period
    acceptance.go:156: HW_DOMAIN_ID must be set for acceptance tests
--- SKIP: TestAccPolicyAssignment_period (0.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       0.064s
```