### PR TITLE
fix: waf dedicated instance support res_tenant

### DIFF
--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
@@ -106,11 +107,16 @@ func ResourceWafDedicatedInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"res_tenant": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "schema: Internal; Specifies whether this is resource tenant.",
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			// The following are the attributes
 			"server_id": {
 				Type:     schema.TypeString,
@@ -157,6 +163,7 @@ func buildCreateOpts(d *schema.ResourceData, region string) *instances.CreateIns
 		SecurityGroup: groups,
 		Count:         defaultCount,
 		PoolId:        d.Get("group_id").(string),
+		ResTenant:     utils.Bool(d.Get("res_tenant").(bool)),
 	}
 	return &createOpts
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
waf dedicated instance support res_tenant
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_basic -timeout 360m -parallel 4 
=== RUN   TestAccWafDedicatedInstance_basic 
=== PAUSE TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_basic
--- PASS: TestAccWafDedicatedInstance_basic (587.57s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       587.754s
```
