### PR TITLE
feat(ELB): lb add public ip

### DIFF
--- a/docs/data-sources/lb_loadbalancer.md
+++ b/docs/data-sources/lb_loadbalancer.md
@@ -43,3 +43,5 @@ In addition to all arguments above, the following attributes are exported:
 * `tags` - The tags associated with the load balancer.
 
 * `vip_port_id` - The ID of the port bound to the private IP address of the load balancer.
+
+* `public_ip` - The EIP address that is associated to the Load Balancer instance.

--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -65,6 +65,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `vip_port_id` - The Port ID of the Load Balancer IP.
 
+* `public_ip` - The EIP address that is associated to the Load Balancer instance.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/lb/data_source_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/data_source_huaweicloud_lb_loadbalancer.go
@@ -70,6 +70,10 @@ func DataSourceELBV2Loadbalancer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -107,6 +111,11 @@ func dataSourceELBV2LoadbalancerRead(d *schema.ResourceData, meta interface{}) e
 
 	lb := lbList[0]
 	d.SetId(lb.ID)
+
+	var publicIp string
+	if len(lb.PublicIps) > 0 {
+		publicIp = lb.PublicIps[0].PublicIpAddress
+	}
 	mErr := multierror.Append(
 		d.Set("region", config.GetRegion(d)),
 		d.Set("name", lb.Name),
@@ -116,6 +125,7 @@ func dataSourceELBV2LoadbalancerRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("vip_subnet_id", lb.VipSubnetID),
 		d.Set("enterprise_project_id", lb.EnterpriseProjectID),
 		d.Set("vip_port_id", lb.VipPortID),
+		d.Set("public_ip", publicIp),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmtp.Errorf("Error setting elb load balancer fields: %s", err)

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -116,6 +116,11 @@ func ResourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+
+			"public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -212,6 +217,11 @@ func resourceLoadBalancerV2Read(_ context.Context, d *schema.ResourceData, meta 
 
 	logp.Printf("[DEBUG] Retrieved loadbalancer %s: %#v", d.Id(), lb)
 
+	var publicIp string
+	if len(lb.PublicIps) > 0 {
+		publicIp = lb.PublicIps[0].PublicIpAddress
+	}
+
 	mErr := multierror.Append(nil,
 		d.Set("region", config.GetRegion(d)),
 		d.Set("name", lb.Name),
@@ -224,6 +234,7 @@ func resourceLoadBalancerV2Read(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("flavor", lb.Flavor),
 		d.Set("loadbalancer_provider", lb.Provider),
 		d.Set("enterprise_project_id", lb.EnterpriseProjectID),
+		d.Set("public_ip", publicIp),
 	)
 
 	// Get any security groups on the VIP Port


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  lb add public ip
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  lb add public ip
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lb/' TESTARGS='-run TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (56.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        56.520s

make testacc TEST='./huaweicloud/services/acceptance/lb/' TESTARGS='-run TestAccELBV2LoadbalancerDataSource_basic'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccELBV2LoadbalancerDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccELBV2LoadbalancerDataSource_basic
=== PAUSE TestAccELBV2LoadbalancerDataSource_basic
=== CONT  TestAccELBV2LoadbalancerDataSource_basic
--- PASS: TestAccELBV2LoadbalancerDataSource_basic (33.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        33.731s
```
