### PR TITLE
fix(test): fix Reference to undeclared resource issue

### DIFF
--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -219,13 +219,13 @@ func testASGroup_basic(rName string) string {
 resource "huaweicloud_as_group" "acc_as_group"{
   scaling_group_name       = "%s"
   scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
-  vpc_id                   = data.huaweicloud_vpc.test.id
+  vpc_id                   = huaweicloud_vpc.test.id
 
   networks {
-    id = data.huaweicloud_vpc_subnet.test.id
+    id = huaweicloud_vpc_subnet.test.id
   }
   security_groups {
-    id = huaweicloud_networking_secgroup.secgroup.id
+    id = huaweicloud_networking_secgroup.test.id
   }
   lbaas_listeners {
     pool_id       = huaweicloud_lb_pool.pool_1.id
@@ -246,14 +246,14 @@ func testASGroup_basic_disable(rName string) string {
 resource "huaweicloud_as_group" "acc_as_group"{
   scaling_group_name       = "%s"
   scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
-  vpc_id                   = data.huaweicloud_vpc.test.id
+  vpc_id                   = huaweicloud_vpc.test.id
   enable                   = false
 
   networks {
-    id = data.huaweicloud_vpc_subnet.test.id
+    id = huaweicloud_vpc_subnet.test.id
   }
   security_groups {
-    id = huaweicloud_networking_secgroup.secgroup.id
+    id = huaweicloud_networking_secgroup.test.id
   }
   lbaas_listeners {
     pool_id       = huaweicloud_lb_pool.pool_1.id
@@ -274,7 +274,7 @@ func testASGroup_basic_enable(rName string) string {
 resource "huaweicloud_as_group" "acc_as_group"{
   scaling_group_name       = "%s"
   scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
-  vpc_id                   = data.huaweicloud_vpc.test.id
+  vpc_id                   = huaweicloud_vpc.test.id
   enable                   = true
 
   multi_az_scaling_policy            = "PICK_FIRST"
@@ -283,10 +283,10 @@ resource "huaweicloud_as_group" "acc_as_group"{
   health_periodic_audit_grace_period = 900
 
   networks {
-    id = data.huaweicloud_vpc_subnet.test.id
+    id = huaweicloud_vpc_subnet.test.id
   }
   security_groups {
-    id = huaweicloud_networking_secgroup.secgroup.id
+    id = huaweicloud_networking_secgroup.test.id
   }
   lbaas_listeners {
     pool_id       = huaweicloud_lb_pool.pool_1.id
@@ -307,14 +307,14 @@ func testASGroup_withEpsId(rName string) string {
 resource "huaweicloud_as_group" "acc_as_group"{
   scaling_group_name       = "%s"
   scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
-  vpc_id                   = data.huaweicloud_vpc.test.id
+  vpc_id                   = huaweicloud_vpc.test.id
   enterprise_project_id    = "%s"
 
   networks {
-    id = data.huaweicloud_vpc_subnet.test.id
+    id = huaweicloud_vpc_subnet.test.id
   }
   security_groups {
-    id = huaweicloud_networking_secgroup.secgroup.id
+    id = huaweicloud_networking_secgroup.test.id
   }
   lbaas_listeners {
     pool_id       = huaweicloud_lb_pool.pool_1.id
@@ -338,13 +338,13 @@ resource "huaweicloud_as_group" "acc_as_group"{
   min_instance_number      = 2
   max_instance_number      = 5
   force_delete             = true
-  vpc_id                   = data.huaweicloud_vpc.test.id
+  vpc_id                   = huaweicloud_vpc.test.id
 
   networks {
-    id = data.huaweicloud_vpc_subnet.test.id
+    id = huaweicloud_vpc_subnet.test.id
   }
   security_groups {
-    id = huaweicloud_networking_secgroup.secgroup.id
+    id = huaweicloud_networking_secgroup.test.id
   }
 }
 `, testASGroup_Base(rName), rName)

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -178,7 +178,7 @@ resource "huaweicloud_as_group" "acc_as_group"{
     id = huaweicloud_vpc_subnet.test.id
   }
   security_groups {
-    id = huaweicloud_networking_secgroup.secgroup.id
+    id = huaweicloud_networking_secgroup.test.id
   }
 }
 `, common.TestBaseComputeResources(rName), rName)

--- a/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_cluster_test.go
+++ b/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_cluster_test.go
@@ -69,7 +69,7 @@ resource "huaweicloud_cdm_cluster" "test" {
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   flavor_id         = data.huaweicloud_cdm_flavors.test.flavors[0].id
   name              = "%s"
-  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
 }
@@ -134,7 +134,7 @@ resource "huaweicloud_cdm_cluster" "test" {
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   flavor_id         = data.huaweicloud_cdm_flavors.test.flavors[0].id
   name              = "%s"
-  security_group_id = huaweicloud_networking_secgroup.secgroup.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
   is_auto_off       = true
@@ -156,7 +156,7 @@ resource "huaweicloud_cdm_cluster" "test" {
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   flavor_id          = data.huaweicloud_cdm_flavors.test.flavors[0].id
   name               = "%s"
-  security_group_id  = huaweicloud_networking_secgroup.secgroup.id
+  security_group_id  = huaweicloud_networking_secgroup.test.id
   subnet_id          = huaweicloud_vpc_subnet.test.id
   vpc_id             = huaweicloud_vpc.test.id
   email              = ["test@test.com"]

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
@@ -55,32 +55,32 @@ func testAccWafInsGroupAssociate_conf(name string) string {
 
 resource "huaweicloud_waf_instance_group" "group_1" {
   name   = "%[2]s"
-  vpc_id = huaweicloud_vpc.vpc_1.id
+  vpc_id = huaweicloud_vpc.test.id
 }
 
 resource "huaweicloud_waf_dedicated_instance" "instance_1" {
   name               = "%[2]s"
-  available_zone     = data.huaweicloud_availability_zones.zones.names[1]
+  available_zone     = data.huaweicloud_availability_zones.test.names[1]
   specification_code = "waf.instance.professional"
-  ecs_flavor         = data.huaweicloud_compute_flavors.flavors.ids[0]
-  vpc_id             = huaweicloud_vpc.vpc_1.id
-  subnet_id          = huaweicloud_vpc_subnet.vpc_subnet_1.id
+  ecs_flavor         = data.huaweicloud_compute_flavors.test.ids[0]
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
   group_id           = huaweicloud_waf_instance_group.group_1.id
   
   security_group = [
-    huaweicloud_networking_secgroup.secgroup.id
+    huaweicloud_networking_secgroup.test.id
   ]
 }
 
 resource "huaweicloud_elb_loadbalancer" "elb" {
   name              = "%[2]s"
-  vpc_id            = huaweicloud_vpc.vpc_1.id
+  vpc_id            = huaweicloud_vpc.test.id
   cross_vpc_backend = true
-  ipv4_subnet_id    = huaweicloud_vpc_subnet.vpc_subnet_1.ipv4_subnet_id
+  ipv4_subnet_id    = huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
   availability_zone = [
-    data.huaweicloud_availability_zones.zones.names[0],
-    data.huaweicloud_availability_zones.zones.names[1]
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[1]
   ]
 }
 


### PR DESCRIPTION
following up 1c6dc94

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
fix the error like this:

```bash
          Error: Reference to undeclared resource

          on terraform_plugin_test.tf line 51, in resource "huaweicloud_waf_dedicated_instance" "instance_1":
          51:   available_zone     = data.huaweicloud_availability_zones.zones.names[1]

        A data resource "huaweicloud_availability_zones" "zones" has not been
        declared in the root module.

        Error: Reference to undeclared resource

          on terraform_plugin_test.tf line 53, in resource "huaweicloud_waf_dedicated_instance" "instance_1":
          53:   ecs_flavor         = data.huaweicloud_compute_flavors.flavors.ids[0]

        A data resource "huaweicloud_compute_flavors" "flavors" has not been declared
        in the root module.

        Error: Reference to undeclared resource

          on terraform_plugin_test.tf line 70, in resource "huaweicloud_elb_loadbalancer" "elb":
          70:     data.huaweicloud_availability_zones.zones.names[0],

        A data resource "huaweicloud_availability_zones" "zones" has not been
        declared in the root module.

        Error: Reference to undeclared resource

          on terraform_plugin_test.tf line 71, in resource "huaweicloud_elb_loadbalancer" "elb":
          71:     data.huaweicloud_availability_zones.zones.names[1]

        A data resource "huaweicloud_availability_zones" "zones" has not been
        declared in the root module.
```
```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== RUN   TestAccASGroup_withEpsId
=== PAUSE TestAccASGroup_withEpsId
=== RUN   TestAccASGroup_forceDelete
=== PAUSE TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_basic
=== CONT  TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_withEpsId
    acceptance.go:189: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccASGroup_withEpsId (0.00s)
--- PASS: TestAccASGroup_forceDelete (183.14s)
--- PASS: TestAccASGroup_basic (204.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        204.591s

$ make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== CONT  TestAccASPolicy_basic
--- PASS: TestAccASPolicy_basic (99.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        99.306s

$ make testacc TEST='./huaweicloud/services/acceptance/cdm' TESTARGS='-run TestAccResourceCdmCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdm -v -run TestAccResourceCdmCluster -timeout 360m -parallel 4
=== RUN   TestAccResourceCdmCluster_basic
=== PAUSE TestAccResourceCdmCluster_basic
=== RUN   TestAccResourceCdmCluster_all
=== PAUSE TestAccResourceCdmCluster_all
=== CONT  TestAccResourceCdmCluster_basic
=== CONT  TestAccResourceCdmCluster_all
--- PASS: TestAccResourceCdmCluster_basic (902.68s)
--- PASS: TestAccResourceCdmCluster_all (1647.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdm       1647.872s
```
