### PR TITLE
fix(fgs/function): VPC access can be enabled normally when creating function

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -64,6 +64,7 @@ variable "image_url" {}
 resource "huaweicloud_fgs_function" "by_swr_image" {
   name        = var.function_name
   agency      = var.agency_name
+  handler     = "-"
   app         = "default"
   runtime     = "Custom Image"
   memory_size = 128
@@ -90,7 +91,7 @@ The following arguments are supported:
 * `memory_size` - (Required, Int) Specifies the memory size(MB) allocated to the function.
 
 * `runtime` - (Required, String, ForceNew) Specifies the environment for executing the function.
-  If the function is created using a SWR image, set this parameter to `Custom Image`.
+  If the function is created using an SWR image, set this parameter to `Custom Image`.
   Changing this will create a new resource.
 
 * `timeout` - (Required, Int) Specifies the timeout interval of the function, ranges from 3s to 900s.
@@ -101,9 +102,9 @@ The following arguments are supported:
   + **jar**: JAR file or java functions.
   + **obs**: function code stored in an OBS bucket.
 
-* `handler` - (Optional, String) Specifies the entry point of the function.
+* `handler` - (Required, String) Specifies the entry point of the function.
 
--> If the function is created using a SWR image, keep `code_type` and `handler` empty.
+-> If the function is created using an SWR image, keep `code_type` empty and use **-** to set the handler.
 
 * `functiongraph_version` - (Optional, String, ForceNew) Specifies the FunctionGraph version, defaults to **v1**.
   + **v1**: Hosts event-driven functions in a serverless context.

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -62,9 +62,10 @@ func ResourceFgsFunctionV2() *schema.Resource {
 				Computed: true,
 			},
 			"handler": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `schema: Required; The entry point of the function.`,
 			},
 			"functiongraph_version": {
 				Type:     schema.TypeString,
@@ -214,7 +215,7 @@ func ResourceFgsFunctionV2() *schema.Resource {
 					},
 				},
 				ConflictsWith: []string{
-					"code_type", "handler",
+					"code_type",
 				},
 			},
 			"version": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter 'handler' is required even if the function is created by SWR image.
```
Error: Error updating metadata of HuaweiCloud function: Missing input for argument [Handler]
│ 
│   with huaweicloud_fgs_function.test,
│   on main.tf line 14, in resource "huaweicloud_fgs_function" "test":
│   14: resource "huaweicloud_fgs_function" "test" {
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a default value to the schema configuration of the parameter `handler`.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_createByImage'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_createByImage -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_createByImage
--- PASS: TestAccFgsV2Function_createByImage (64.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       64.468s
```
```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFgsV2Function_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFgsV2Function_ -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== RUN   TestAccFgsV2Function_withEpsId
=== PAUSE TestAccFgsV2Function_withEpsId
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_withEpsId
=== CONT  TestAccFgsV2Function_createByImage
--- PASS: TestAccFgsV2Function_withEpsId (13.80s)
--- PASS: TestAccFgsV2Function_text (14.51s)
--- PASS: TestAccFgsV2Function_basic (60.61s)
--- PASS: TestAccFgsV2Function_createByImage (66.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       66.985s
```
