### PR TITLE
fix(config): don't query catalog by API any more

### DIFF
--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -236,12 +236,13 @@ func buildClientByAKSK(c *Config) error {
 		ao.IdentityEndpoint = c.IdentityEndpoint
 		ao.AccessKey = c.AccessKey
 		ao.SecretKey = c.SecretKey
+		ao.WithUserCatalog = true
+
 		if c.Region != "" {
 			ao.Region = c.Region
 		}
 		if c.SecurityToken != "" {
 			ao.SecurityToken = c.SecurityToken
-			ao.WithUserCatalog = true
 		}
 	}
 	return genClients(c, projectAuthOptions, domainAuthOptions)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**WithUserCatalog** is the flag of whether using the customer catalog, and the default value is **false**.

HuaweiCloud provider and other partner cloud providers, except Orange, will get the service endpoints by themselves not by API.
so, it's unnecessary to call the API anymore.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST='./huaweicloud' TESTARGS='-run TestAccServiceEndpoints_Global'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_Global -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_Global
    endpoints_test.go:65: IAM endpoint:  https://iam.myhuaweicloud.com/v3.0/
    endpoints_test.go:77: Identity endpoint:     https://iam.myhuaweicloud.com/v3/
    endpoints_test.go:89: IAM endpoint without version number:   https://iam.myhuaweicloud.com/
    endpoints_test.go:101: CDN endpoint:         https://cdn.myhuaweicloud.com/v1.0/
    endpoints_test.go:113: BSS v1 endpoint:      https://bss.myhuaweicloud.com/v1.0/
    endpoints_test.go:125: BSS v2 endpoint:      https://bss.myhuaweicloud.com/v2/
--- PASS: TestAccServiceEndpoints_Global (0.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.533s
```
