### PR TITLE
chore: move dns resources to service dir

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -46,6 +46,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dis"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dns"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
@@ -731,9 +732,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
 			"huaweicloud_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),
 
-			"huaweicloud_dns_ptrrecord": ResourceDNSPtrRecordV2(),
-			"huaweicloud_dns_recordset": ResourceDNSRecordSetV2(),
-			"huaweicloud_dns_zone":      ResourceDNSZoneV2(),
+			"huaweicloud_dns_ptrrecord": dns.ResourceDNSPtrRecordV2(),
+			"huaweicloud_dns_recordset": dns.ResourceDNSRecordSetV2(),
+			"huaweicloud_dns_zone":      dns.ResourceDNSZoneV2(),
 
 			"huaweicloud_drs_job":     drs.ResourceDrsJob(),
 			"huaweicloud_dws_cluster": dws.ResourceDwsCluster(),
@@ -992,9 +993,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_servergroup_v2":      ResourceComputeServerGroupV2(),
 			"huaweicloud_compute_volume_attach_v2":    ecs.ResourceComputeVolumeAttach(),
 
-			"huaweicloud_dns_ptrrecord_v2": ResourceDNSPtrRecordV2(),
-			"huaweicloud_dns_recordset_v2": ResourceDNSRecordSetV2(),
-			"huaweicloud_dns_zone_v2":      ResourceDNSZoneV2(),
+			"huaweicloud_dns_ptrrecord_v2": dns.ResourceDNSPtrRecordV2(),
+			"huaweicloud_dns_recordset_v2": dns.ResourceDNSRecordSetV2(),
+			"huaweicloud_dns_zone_v2":      dns.ResourceDNSZoneV2(),
 
 			"huaweicloud_dcs_instance_v1": dcs.ResourceDcsInstance(),
 			"huaweicloud_dds_instance_v3": dds.ResourceDdsInstanceV3(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -25,6 +25,8 @@ var (
 	HW_ENTERPRISE_PROJECT_ID_TEST         = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
 	HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST = os.Getenv("HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST")
 
+	HW_DNS_ENVIRONMENT = os.Getenv("HW_DNS_ENVIRONMENT")
+
 	HW_FLAVOR_ID             = os.Getenv("HW_FLAVOR_ID")
 	HW_FLAVOR_NAME           = os.Getenv("HW_FLAVOR_NAME")
 	HW_IMAGE_ID              = os.Getenv("HW_IMAGE_ID")
@@ -194,6 +196,13 @@ func TestAccPreCheckEpsID(t *testing.T) {
 func TestAccPreCheckMigrateEpsID(t *testing.T) {
 	if HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST == "" {
 		t.Skip("The environment variables does not support Migrate Enterprise Project ID for acc tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDNS(t *testing.T) {
+	if HW_DNS_ENVIRONMENT == "" {
+		t.Skip("This environment does not support DNS tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package acceptance
 
 import (
@@ -24,8 +25,7 @@ var (
 	HW_DOMAIN_NAME                        = os.Getenv("HW_DOMAIN_NAME")
 	HW_ENTERPRISE_PROJECT_ID_TEST         = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
 	HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST = os.Getenv("HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST")
-
-	HW_DNS_ENVIRONMENT = os.Getenv("HW_DNS_ENVIRONMENT")
+	HW_DNS_ENVIRONMENT                    = os.Getenv("HW_DNS_ENVIRONMENT")
 
 	HW_FLAVOR_ID             = os.Getenv("HW_FLAVOR_ID")
 	HW_FLAVOR_NAME           = os.Getenv("HW_FLAVOR_NAME")

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -25,7 +26,7 @@ func getDNSPtrRecordResourceFunc(c *config.Config, state *terraform.ResourceStat
 func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 	var ptrrecord ptrrecords.Ptr
 	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-ptr-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -60,7 +61,7 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 func TestAccDNSV2PtrRecord_withEpsId(t *testing.T) {
 	var ptrrecord ptrrecords.Ptr
 	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-ptr-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_v2_test.go
@@ -1,17 +1,18 @@
-package huaweicloud
+package dns
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func randomPtrName() string {
@@ -24,8 +25,8 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -53,15 +54,15 @@ func TestAccDNSV2PtrRecord_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t); testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t); acceptance.TestAccPreCheckEpsID(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDNSV2PtrRecord_withEpsId(ptrName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -69,8 +70,8 @@ func TestAccDNSV2PtrRecord_withEpsId(t *testing.T) {
 }
 
 func testAccCheckDNSV2PtrRecordDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	dnsClient, err := config.DnsV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	dnsClient, err := config.DnsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}
@@ -100,8 +101,8 @@ func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resou
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		dnsClient, err := config.DnsV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		dnsClient, err := config.DnsV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 		}
@@ -192,5 +193,5 @@ resource "huaweicloud_dns_ptrrecord" "ptr_1" {
   ttl                   = 6000
   enterprise_project_id = "%s"
 }
-`, ptrName, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, ptrName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_ptrrecord_v2_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -15,31 +14,41 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
-func randomPtrName() string {
-	return fmt.Sprintf("acpttest-%s.com.", acctest.RandString(5))
+func getDNSPtrRecordResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.DnsV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("Error creating DNS client : %s", err)
+	}
+	return ptrrecords.Get(client, state.Primary.ID).Extract()
 }
 
 func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 	var ptrrecord ptrrecords.Ptr
-	ptrName := randomPtrName()
 	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&ptrrecord,
+		getDNSPtrRecordResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDNS(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2PtrRecord_basic(ptrName),
+				Config: testAccDNSV2PtrRecord_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "description", "a ptr record"),
 				),
 			},
 			{
-				Config: testAccDNSV2PtrRecord_update(ptrName),
+				Config: testAccDNSV2PtrRecord_update(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "description", "ptr record updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
@@ -50,76 +59,29 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 
 func TestAccDNSV2PtrRecord_withEpsId(t *testing.T) {
 	var ptrrecord ptrrecords.Ptr
-	ptrName := randomPtrName()
 	resourceName := "huaweicloud_dns_ptrrecord.ptr_1"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&ptrrecord,
+		getDNSPtrRecordResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t); acceptance.TestAccPreCheckEpsID(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckDNS(t); acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2PtrRecord_withEpsId(ptrName),
+				Config: testAccDNSV2PtrRecord_withEpsId(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckDNSV2PtrRecordDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	dnsClient, err := config.DnsV2Client(acceptance.HW_REGION_NAME)
-	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_dns_ptrrecord" {
-			continue
-		}
-
-		_, err = ptrrecords.Get(dnsClient, rs.Primary.ID).Extract()
-		if err == nil {
-			return fmtp.Errorf("Ptr record still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
-		}
-
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		dnsClient, err := config.DnsV2Client(acceptance.HW_REGION_NAME)
-		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
-		}
-
-		found, err := ptrrecords.Get(dnsClient, rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Ptr record not found")
-		}
-
-		*ptrrecord = *found
-
-		return nil
-	}
 }
 
 func testAccDNSV2PtrRecord_basic(ptrName string) string {

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -22,29 +23,19 @@ func getDNSRecordsetResourceFunc(c *config.Config, state *terraform.ResourceStat
 		return nil, fmtp.Errorf("Error creating DNS client: %s", err)
 	}
 
-	zoneID, recordsetID, err := parseDNSV2RecordSetID(state.Primary.ID)
-	if err != nil {
-		return nil, err
-	}
-	return recordsets.Get(client, zoneID, recordsetID).Extract()
-}
-
-func parseDNSV2RecordSetID(id string) (string, string, error) {
-	idParts := strings.Split(id, "/")
+	idParts := strings.Split(state.Primary.ID, "/")
 	if len(idParts) != 2 {
-		return "", "", fmtp.Errorf("Unable to determine DNS record set ID from raw ID: %s", id)
+		return nil, fmtp.Errorf("Unable to determine DNS record set ID from raw ID: %s", state.Primary.ID)
 	}
-
 	zoneID := idParts[0]
 	recordsetID := idParts[1]
-
-	return zoneID, recordsetID, nil
+	return recordsets.Get(client, zoneID, recordsetID).Extract()
 }
 
 func TestAccDNSV2RecordSet_basic(t *testing.T) {
 	var recordset recordsets.RecordSet
 	resourceName := "huaweicloud_dns_recordset.recordset_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -98,7 +89,7 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 	var recordset recordsets.RecordSet
 	resourceName := "huaweicloud_dns_recordset.recordset_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -126,7 +117,7 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 func TestAccDNSV2RecordSet_private(t *testing.T) {
 	var recordset recordsets.RecordSet
 	resourceName := "huaweicloud_dns_recordset.recordset_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-recordset-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_v2_test.go
@@ -1,18 +1,19 @@
-package huaweicloud
+package dns
 
 import (
 	"fmt"
 	"regexp"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/dns/v2/zones"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccDNSV2Zone_basic(t *testing.T) {
@@ -21,8 +22,8 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 	resourceName := "huaweicloud_dns_zone.zone_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -63,8 +64,8 @@ func TestAccDNSV2Zone_private(t *testing.T) {
 	resourceName := "huaweicloud_dns_zone.zone_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -90,8 +91,8 @@ func TestAccDNSV2Zone_readTTL(t *testing.T) {
 	resourceName := "huaweicloud_dns_zone.zone_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -111,8 +112,8 @@ func TestAccDNSV2Zone_withEpsId(t *testing.T) {
 	resourceName := "huaweicloud_dns_zone.zone_1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckDNS(t); testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
+		PreCheck:     func() { acceptance.TestAccPreCheckDNS(t); acceptance.TestAccPreCheckEpsID(t) },
+		Providers:    acceptance.TestAccProviders,
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -121,7 +122,7 @@ func TestAccDNSV2Zone_withEpsId(t *testing.T) {
 					testAccCheckDNSV2ZoneExists(resourceName, &zone),
 					resource.TestCheckResourceAttr(resourceName, "name", zoneName),
 					resource.TestCheckResourceAttr(resourceName, "zone_type", "private"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -129,8 +130,8 @@ func TestAccDNSV2Zone_withEpsId(t *testing.T) {
 }
 
 func testAccCheckDNSV2ZoneDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	dnsClient, err := config.DnsV2Client(HW_REGION_NAME)
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	dnsClient, err := config.DnsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}
@@ -160,8 +161,8 @@ func testAccCheckDNSV2ZoneExists(n string, zone *zones.Zone) resource.TestCheckF
 			return fmtp.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		dnsClient, err := config.DnsV2Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		dnsClient, err := config.DnsV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {
 			return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 		}
@@ -264,5 +265,5 @@ resource "huaweicloud_dns_zone" "zone_1" {
     owner     = "terraform"
   }
 }
-	`, zoneName, HW_ENTERPRISE_PROJECT_ID_TEST)
+	`, zoneName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_v2_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -26,7 +27,7 @@ func getDNSZoneResourceFunc(c *config.Config, state *terraform.ResourceState) (i
 func TestAccDNSV2Zone_basic(t *testing.T) {
 	var zone zones.Zone
 	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -74,7 +75,7 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 func TestAccDNSV2Zone_private(t *testing.T) {
 	var zone zones.Zone
 	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -107,7 +108,7 @@ func TestAccDNSV2Zone_private(t *testing.T) {
 func TestAccDNSV2Zone_readTTL(t *testing.T) {
 	var zone zones.Zone
 	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -134,7 +135,7 @@ func TestAccDNSV2Zone_readTTL(t *testing.T) {
 func TestAccDNSV2Zone_withEpsId(t *testing.T) {
 	var zone zones.Zone
 	resourceName := "huaweicloud_dns_zone.zone_1"
-	name := acceptance.RandomAccResourceName()
+	name := fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord_v2.go
@@ -1,9 +1,14 @@
 package dns
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -15,18 +20,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceDNSPtrRecordV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDNSPtrRecordV2Create,
-		Read:   resourceDNSPtrRecordV2Read,
-		Update: resourceDNSPtrRecordV2Update,
-		Delete: resourceDNSPtrRecordV2Delete,
+		CreateContext: resourceDNSPtrRecordV2Create,
+		ReadContext:   resourceDNSPtrRecordV2Read,
+		UpdateContext: resourceDNSPtrRecordV2Update,
+		DeleteContext: resourceDNSPtrRecordV2Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -75,12 +78,12 @@ func ResourceDNSPtrRecordV2() *schema.Resource {
 	}
 }
 
-func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSPtrRecordV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	tagmap := d.Get("tags").(map[string]interface{})
@@ -101,14 +104,14 @@ func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) erro
 		EnterpriseProjectID: common.GetEnterpriseProjectID(d, conf),
 	}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	fip_id := d.Get("floatingip_id").(string)
 	n, err := ptrrecords.Create(dnsClient, region, fip_id, createOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS PTR record: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS PTR record: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"ACTIVE"},
 		Pending:    []string{"PENDING_CREATE"},
@@ -118,65 +121,70 @@ func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) erro
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for PTR record (%s) to become ACTIVE for creation: %s",
+		return diag.Errorf(
+			"error waiting for PTR record (%s) to become ACTIVE for creation: %s",
 			n.ID, err)
 	}
 	d.SetId(n.ID)
 
-	logp.Printf("[DEBUG] Created HuaweiCloud DNS PTR record %s: %#v", n.ID, n)
-	return resourceDNSPtrRecordV2Read(d, meta)
+	log.Printf("[DEBUG] Created HuaweiCloud DNS PTR record %s: %#v", n.ID, n)
+	return resourceDNSPtrRecordV2Read(ctx, d, meta)
 }
 
-func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSPtrRecordV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	dnsClient, err := conf.DnsV2Client(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	n, err := ptrrecords.Get(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "ptr_record")
+		return common.CheckDeletedDiag(d, err, "ptr_record")
 	}
 
-	logp.Printf("[DEBUG] Retrieved PTR record %s: %#v", d.Id(), n)
+	log.Printf("[DEBUG] Retrieved PTR record %s: %#v", d.Id(), n)
 
 	// Obtain relevant info from parsing the ID
 	fipID, err := parseDNSV2PtrRecordID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	d.Set("name", n.PtrName)
-	d.Set("description", n.Description)
-	d.Set("floatingip_id", fipID)
-	d.Set("ttl", n.TTL)
-	d.Set("address", n.Address)
-	d.Set("enterprise_project_id", n.EnterpriseProjectID)
+	mErr := multierror.Append(nil,
+		d.Set("name", n.PtrName),
+		d.Set("description", n.Description),
+		d.Set("floatingip_id", fipID),
+		d.Set("ttl", n.TTL),
+		d.Set("address", n.Address),
+		d.Set("enterprise_project_id", n.EnterpriseProjectID),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting resource: %s", mErr)
+	}
 
 	// save tags
 	if resourceTags, err := tags.Get(dnsClient, "DNS-ptr_record", d.Id()).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return fmtp.Errorf("Error saving tags to state for DNS ptr record (%s): %s", d.Id(), err)
+			return diag.Errorf("error saving tags to state for DNS ptr record (%s): %s", d.Id(), err)
 		}
 	} else {
-		logp.Printf("[WARN] Error fetching tags of DNS ptr record (%s): %s", d.Id(), err)
+		log.Printf("[WARN] Error fetching tags of DNS ptr record (%s): %s", d.Id(), err)
 	}
 
 	return nil
 }
 
-func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSPtrRecordV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	if d.HasChanges("name", "description", "ttl") {
@@ -186,14 +194,14 @@ func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) erro
 			TTL:         d.Get("ttl").(int),
 		}
 
-		logp.Printf("[DEBUG] Update Options: %#v", updateOpts)
+		log.Printf("[DEBUG] Update Options: %#v", updateOpts)
 		fip_id := d.Get("floatingip_id").(string)
 		n, err := ptrrecords.Create(dnsClient, region, fip_id, updateOpts).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error updating HuaweiCloud DNS PTR record: %s", err)
+			return diag.Errorf("error updating HuaweiCloud DNS PTR record: %s", err)
 		}
 
-		logp.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
+		log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
 		stateConf := &resource.StateChangeConf{
 			Target:     []string{"ACTIVE"},
 			Pending:    []string{"PENDING_CREATE"},
@@ -203,39 +211,38 @@ func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) erro
 			MinTimeout: 3 * time.Second,
 		}
 
-		_, err = stateConf.WaitForState()
+		_, err = stateConf.WaitForStateContext(ctx)
 		if err != nil {
-			return fmtp.Errorf(
-				"Error waiting for PTR record (%s) to become ACTIVE for update: %s",
+			return diag.Errorf(
+				"error waiting for PTR record (%s) to become ACTIVE for update: %s",
 				n.ID, err)
 		}
 
-		logp.Printf("[DEBUG] Updated HuaweiCloud DNS PTR record %s: %#v", n.ID, n)
+		log.Printf("[DEBUG] Updated HuaweiCloud DNS PTR record %s: %#v", n.ID, n)
 	}
 
 	// update tags
 	tagErr := utils.UpdateResourceTags(dnsClient, d, "DNS-ptr_record", d.Id())
 	if tagErr != nil {
-		return fmtp.Errorf("Error updating tags of DNS PTR record %s: %s", d.Id(), tagErr)
+		return diag.Errorf("error updating tags of DNS PTR record %s: %s", d.Id(), tagErr)
 	}
 
-	return resourceDNSPtrRecordV2Read(d, meta)
-
+	return resourceDNSPtrRecordV2Read(ctx, d, meta)
 }
 
-func resourceDNSPtrRecordV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSPtrRecordV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	dnsClient, err := conf.DnsV2Client(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	err = ptrrecords.Delete(dnsClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmtp.Errorf("Error deleting HuaweiCloud DNS PTR record: %s", err)
+		return diag.Errorf("error deleting HuaweiCloud DNS PTR record: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Waiting for DNS PTR record (%s) to be deleted", d.Id())
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to be deleted", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"DELETED"},
 		Pending:    []string{"ACTIVE", "PENDING_DELETE", "ERROR"},
@@ -245,10 +252,10 @@ func resourceDNSPtrRecordV2Delete(d *schema.ResourceData, meta interface{}) erro
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for PTR record (%s) to become DELETED for deletion: %s",
+		return diag.Errorf(
+			"error waiting for PTR record (%s) to become DELETED for deletion: %s",
 			d.Id(), err)
 	}
 
@@ -267,7 +274,7 @@ func waitForDNSPtrRecord(dnsClient *golangsdk.ServiceClient, id string) resource
 			return nil, "", err
 		}
 
-		logp.Printf("[DEBUG] HuaweiCloud DNS PTR record (%s) current status: %s", ptrrecord.ID, ptrrecord.Status)
+		log.Printf("[DEBUG] HuaweiCloud DNS PTR record (%s) current status: %s", ptrrecord.ID, ptrrecord.Status)
 		return ptrrecord, ptrrecord.Status, nil
 	}
 }
@@ -275,7 +282,7 @@ func waitForDNSPtrRecord(dnsClient *golangsdk.ServiceClient, id string) resource
 func parseDNSV2PtrRecordID(id string) (string, error) {
 	idParts := strings.Split(id, ":")
 	if len(idParts) != 2 {
-		return "", fmtp.Errorf("Unable to determine DNS PTR record ID from raw ID: %s", id)
+		return "", fmt.Errorf("unable to determine DNS PTR record ID from raw ID: %s", id)
 	}
 
 	fipID := idParts[1]

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord_v2.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package dns
 
 import (
 	"strings"
@@ -11,6 +11,8 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -64,7 +66,7 @@ func ResourceDNSPtrRecordV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
-			"tags": tagsSchema(),
+			"tags": common.TagsSchema(),
 			"address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -74,9 +76,9 @@ func ResourceDNSPtrRecordV2() *schema.Resource {
 }
 
 func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := GetRegion(d, config)
-	dnsClient, err := config.DnsV2Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}
@@ -96,7 +98,7 @@ func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) erro
 		Description:         d.Get("description").(string),
 		TTL:                 d.Get("ttl").(int),
 		Tags:                taglist,
-		EnterpriseProjectID: GetEnterpriseProjectID(d, config),
+		EnterpriseProjectID: common.GetEnterpriseProjectID(d, conf),
 	}
 
 	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -130,15 +132,15 @@ func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	dnsClient, err := conf.DnsV2Client(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	n, err := ptrrecords.Get(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "ptr_record")
+		return common.CheckDeleted(d, err, "ptr_record")
 	}
 
 	logp.Printf("[DEBUG] Retrieved PTR record %s: %#v", d.Id(), n)
@@ -170,9 +172,9 @@ func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := GetRegion(d, config)
-	dnsClient, err := config.DnsV2Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}
@@ -222,8 +224,8 @@ func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceDNSPtrRecordV2Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
+	conf := meta.(*config.Config)
+	dnsClient, err := conf.DnsV2Client(conf.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
 	}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -1,10 +1,14 @@
 package dns
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -17,18 +21,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceDNSRecordSetV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDNSRecordSetV2Create,
-		Read:   resourceDNSRecordSetV2Read,
-		Update: resourceDNSRecordSetV2Update,
-		Delete: resourceDNSRecordSetV2Delete,
+		CreateContext: resourceDNSRecordSetV2Create,
+		ReadContext:   resourceDNSRecordSetV2Read,
+		UpdateContext: resourceDNSRecordSetV2Update,
+		DeleteContext: resourceDNSRecordSetV2Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -84,11 +86,11 @@ func ResourceDNSRecordSetV2() *schema.Resource {
 	}
 }
 
-func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSRecordSetV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	zoneID := d.Get("zone_id").(string)
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	recordsraw := d.Get("records").([]interface{})
@@ -105,16 +107,16 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 		Type:        d.Get("type").(string),
 	}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	n, err := recordsets.Create(dnsClient, zoneID, createOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS record set: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS record set: %s", err)
 	}
 
 	id := fmt.Sprintf("%s/%s", zoneID, n.ID)
 	d.SetId(id)
 
-	logp.Printf("[DEBUG] Waiting for DNS record set (%s) to become available", n.ID)
+	log.Printf("[DEBUG] Waiting for DNS record set (%s) to become available", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"ACTIVE"},
 		Pending:    []string{"PENDING"},
@@ -124,11 +126,11 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for record set (%s) to become ACTIVE for creation: %s",
+		return diag.Errorf(
+			"error waiting for record set (%s) to become ACTIVE for creation: %s",
 			n.ID, err)
 	}
 
@@ -137,76 +139,79 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 	if len(tagRaw) > 0 {
 		resourceType, err := utils.GetDNSRecordSetTagType(zoneType)
 		if err != nil {
-			return fmtp.Errorf("Error getting resource type of DNS record set %s: %s", n.ID, err)
+			return diag.Errorf("error getting resource type of DNS record set %s: %s", n.ID, err)
 		}
 
 		taglist := utils.ExpandResourceTags(tagRaw)
 		if tagErr := tags.Create(dnsClient, resourceType, n.ID, taglist).ExtractErr(); tagErr != nil {
-			return fmtp.Errorf("Error setting tags of DNS record set %s: %s", n.ID, tagErr)
+			return diag.Errorf("error setting tags of DNS record set %s: %s", n.ID, tagErr)
 		}
 	}
 
-	logp.Printf("[DEBUG] Created HuaweiCloud DNS record set %s: %#v", n.ID, n)
-	return resourceDNSRecordSetV2Read(d, meta)
+	log.Printf("[DEBUG] Created HuaweiCloud DNS record set %s: %#v", n.ID, n)
+	return resourceDNSRecordSetV2Read(ctx, d, meta)
 }
 
-func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSRecordSetV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	// Obtain relevant info from parsing the ID
 	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	n, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "record_set")
+		return common.CheckDeletedDiag(d, err, "record_set")
 	}
 
-	logp.Printf("[DEBUG] Retrieved  record set %s: %#v", recordsetID, n)
+	log.Printf("[DEBUG] Retrieved  record set %s: %#v", recordsetID, n)
 
-	d.Set("name", n.Name)
-	d.Set("description", n.Description)
-	d.Set("ttl", n.TTL)
-	d.Set("type", n.Type)
-	if err := d.Set("records", n.Records); err != nil {
-		return fmtp.Errorf("[DEBUG] Error saving records to state for HuaweiCloud DNS record set (%s): %s", d.Id(), err)
+	mErr := multierror.Append(nil,
+		d.Set("name", n.Name),
+		d.Set("description", n.Description),
+		d.Set("ttl", n.TTL),
+		d.Set("type", n.Type),
+		d.Set("records", n.Records),
+		d.Set("region", conf.GetRegion(d)),
+		d.Set("zone_id", zoneID),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting resource: %s", mErr)
 	}
-	d.Set("region", conf.GetRegion(d))
-	d.Set("zone_id", zoneID)
 
 	// save tags
 	resourceType, err := utils.GetDNSRecordSetTagType(zoneType)
 	if err != nil {
-		return fmtp.Errorf("Error getting resource type of DNS record set %s: %s", recordsetID, err)
+		return diag.Errorf("error getting resource type of DNS record set %s: %s", recordsetID, err)
 	}
 	if resourceTags, err := tags.Get(dnsClient, resourceType, recordsetID).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return fmtp.Errorf("Error saving tags to state for DNS record set (%s): %s", recordsetID, err)
+			return diag.Errorf("error saving tags to state for DNS record set (%s): %s", recordsetID, err)
 		}
 	} else {
-		logp.Printf("[WARN] Error fetching tags of DNS record set (%s): %s", recordsetID, err)
+		log.Printf("[WARN] Error fetching tags of DNS record set (%s): %s", recordsetID, err)
 	}
 
 	return nil
 }
 
-func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSRecordSetV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Obtain relevant info from parsing the ID
 	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if d.HasChanges("description", "ttl", "records") {
@@ -228,13 +233,13 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 			updateOpts.Description = d.Get("description").(string)
 		}
 
-		logp.Printf("[DEBUG] Updating  record set %s with options: %#v", recordsetID, updateOpts)
+		log.Printf("[DEBUG] Updating  record set %s with options: %#v", recordsetID, updateOpts)
 		_, err = recordsets.Update(dnsClient, zoneID, recordsetID, updateOpts).Extract()
 		if err != nil {
-			return fmtp.Errorf("Error updating HuaweiCloud DNS  record set: %s", err)
+			return diag.Errorf("error updating HuaweiCloud DNS  record set: %s", err)
 		}
 
-		logp.Printf("[DEBUG] Waiting for DNS record set (%s) to update", recordsetID)
+		log.Printf("[DEBUG] Waiting for DNS record set (%s) to update", recordsetID)
 		stateConf := &resource.StateChangeConf{
 			Target:     []string{"ACTIVE"},
 			Pending:    []string{"PENDING"},
@@ -244,10 +249,10 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 			MinTimeout: 3 * time.Second,
 		}
 
-		_, err = stateConf.WaitForState()
+		_, err = stateConf.WaitForStateContext(ctx)
 		if err != nil {
-			return fmtp.Errorf(
-				"Error waiting for record set (%s) to become ACTIVE for updation: %s",
+			return diag.Errorf(
+				"error waiting for record set (%s) to become ACTIVE for updation: %s",
 				recordsetID, err)
 		}
 	}
@@ -255,35 +260,35 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 	// update tags
 	resourceType, err := utils.GetDNSRecordSetTagType(zoneType)
 	if err != nil {
-		return fmtp.Errorf("Error getting resource type of DNS record set %s: %s", d.Id(), err)
+		return diag.Errorf("error getting resource type of DNS record set %s: %s", d.Id(), err)
 	}
 
 	tagErr := utils.UpdateResourceTags(dnsClient, d, resourceType, recordsetID)
 	if tagErr != nil {
-		return fmtp.Errorf("Error updating tags of DNS record set %s: %s", d.Id(), tagErr)
+		return diag.Errorf("error updating tags of DNS record set %s: %s", d.Id(), tagErr)
 	}
 
-	return resourceDNSRecordSetV2Read(d, meta)
+	return resourceDNSRecordSetV2Read(ctx, d, meta)
 }
 
-func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSRecordSetV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Obtain relevant info from parsing the ID
 	zoneID, recordsetID, err := parseDNSV2RecordSetID(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	dnsClient, _, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	err = recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()
 	if err != nil {
-		return fmtp.Errorf("Error deleting HuaweiCloud DNS record set: %s", err)
+		return diag.Errorf("error deleting HuaweiCloud DNS record set: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Waiting for DNS record set (%s) to be deleted", recordsetID)
+	log.Printf("[DEBUG] Waiting for DNS record set (%s) to be deleted", recordsetID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"DELETED"},
 		Pending:    []string{"ACTIVE", "PENDING", "ERROR"},
@@ -293,10 +298,10 @@ func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) erro
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for record set (%s) to become DELETED for deletion: %s",
+		return diag.Errorf(
+			"error waiting for record set (%s) to become DELETED for deletion: %s",
 			recordsetID, err)
 	}
 
@@ -321,7 +326,7 @@ func waitForDNSRecordSet(dnsClient *golangsdk.ServiceClient, zoneID, recordsetId
 			return nil, "", err
 		}
 
-		logp.Printf("[DEBUG] HuaweiCloud DNS record set (%s) current status: %s", recordset.ID, recordset.Status)
+		log.Printf("[DEBUG] HuaweiCloud DNS record set (%s) current status: %s", recordset.ID, recordset.Status)
 		return recordset, parseStatus(recordset.Status), nil
 	}
 }
@@ -329,7 +334,7 @@ func waitForDNSRecordSet(dnsClient *golangsdk.ServiceClient, zoneID, recordsetId
 func parseDNSV2RecordSetID(id string) (string, string, error) {
 	idParts := strings.Split(id, "/")
 	if len(idParts) != 2 {
-		return "", "", fmtp.Errorf("Unable to determine DNS record set ID from raw ID: %s", id)
+		return "", "", fmt.Errorf("unable to determine DNS record set ID from raw ID: %s", id)
 	}
 
 	zoneID := idParts[0]
@@ -347,13 +352,13 @@ func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interfa
 	// Firstly, try to ues the DNS global endpoint
 	client, err := conf.DnsV2Client(region)
 	if err != nil {
-		return nil, "", fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return nil, "", fmt.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	// get zone with DNS global endpoint
 	zoneInfo, err = zones.Get(client, zoneID).Extract()
 	if err != nil {
-		logp.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
+		log.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
 
 		// try to ues the DNS region endpoint
 		var clientErr error

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone_v2.go
@@ -1,8 +1,13 @@
 package dns
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -14,18 +19,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceDNSZoneV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceDNSZoneV2Create,
-		Read:   resourceDNSZoneV2Read,
-		Update: resourceDNSZoneV2Update,
-		Delete: resourceDNSZoneV2Delete,
+		CreateContext: resourceDNSZoneV2Create,
+		ReadContext:   resourceDNSZoneV2Read,
+		UpdateContext: resourceDNSZoneV2Update,
+		DeleteContext: resourceDNSZoneV2Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -120,14 +123,14 @@ func resourceDNSRouter(d *schema.ResourceData, region string) *zones.RouterOpts 
 	return nil
 }
 
-func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSZoneV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	var dnsClient *golangsdk.ServiceClient
 
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	zoneType := d.Get("zone_type").(string)
@@ -136,12 +139,12 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 	// router is required when creating private zone
 	if zoneType == "private" {
 		if len(router) < 1 {
-			return fmtp.Errorf("The argument (router) is required when creating HuaweiCloud DNS private zone")
+			return diag.Errorf("the argument (router) is required when creating HuaweiCloud DNS private zone")
 		}
 		// update the endpoint with region when creating private zone
 		dnsClient, err = conf.DnsWithRegionClient(conf.GetRegion(d))
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud DNS region client: %s", err)
+			return diag.Errorf("error creating HuaweiCloud DNS region client: %s", err)
 		}
 	}
 
@@ -155,14 +158,14 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 		Router:              resourceDNSRouter(d, region),
 	}
 
-	logp.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	n, err := zones.Create(dnsClient, createOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS zone: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS zone: %s", err)
 	}
 
 	d.SetId(n.ID)
-	logp.Printf("[DEBUG] Waiting for DNS Zone (%s) to become available", n.ID)
+	log.Printf("[DEBUG] Waiting for DNS Zone (%s) to become available", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"ACTIVE"},
 		Pending:    []string{"PENDING"},
@@ -172,10 +175,10 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for DNS Zone (%s) to become ACTIVE for creation: %s",
+		return diag.Errorf(
+			"error waiting for DNS Zone (%s) to become ACTIVE for creation: %s",
 			n.ID, err)
 	}
 
@@ -187,13 +190,13 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 			for i := range routerList {
 				// Skip the first router
 				if i > 0 {
-					logp.Printf("[DEBUG] Creating AssociateZone Options: %#v", routerList[i])
+					log.Printf("[DEBUG] Creating AssociateZone Options: %#v", routerList[i])
 					_, err := zones.AssociateZone(dnsClient, n.ID, routerList[i]).Extract()
 					if err != nil {
-						return fmtp.Errorf("Error AssociateZone: %s", err)
+						return diag.Errorf("error AssociateZone: %s", err)
 					}
 
-					logp.Printf("[DEBUG] Waiting for AssociateZone (%s) to Router (%s) become ACTIVE",
+					log.Printf("[DEBUG] Waiting for AssociateZone (%s) to Router (%s) become ACTIVE",
 						n.ID, routerList[i].RouterID)
 					stateRouterConf := &resource.StateChangeConf{
 						Target:     []string{"ACTIVE"},
@@ -204,13 +207,13 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 						MinTimeout: 3 * time.Second,
 					}
 
-					_, err = stateRouterConf.WaitForState()
+					_, err = stateRouterConf.WaitForStateContext(ctx)
 					if err != nil {
-						return fmtp.Errorf("Error waiting for AssociateZone (%s) to Router (%s) become ACTIVE: %s",
+						return diag.Errorf("error waiting for AssociateZone (%s) to Router (%s) become ACTIVE: %s",
 							n.ID, routerList[i].RouterID, err)
 					}
 				} else {
-					logp.Printf("[DEBUG] First Router Options: %#v", routerList[i])
+					log.Printf("[DEBUG] First Router Options: %#v", routerList[i])
 				}
 			}
 		}
@@ -221,83 +224,87 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 	if len(tagRaw) > 0 {
 		resourceType, err := utils.GetDNSZoneTagType(zoneType)
 		if err != nil {
-			return fmtp.Errorf("Error getting resource type of DNS zone %s: %s", n.ID, err)
+			return diag.Errorf("error getting resource type of DNS zone %s: %s", n.ID, err)
 		}
 
 		taglist := utils.ExpandResourceTags(tagRaw)
 		if tagErr := tags.Create(dnsClient, resourceType, n.ID, taglist).ExtractErr(); tagErr != nil {
-			return fmtp.Errorf("Error setting tags of DNS zone %s: %s", n.ID, tagErr)
+			return diag.Errorf("error setting tags of DNS zone %s: %s", n.ID, tagErr)
 		}
 	}
 
-	logp.Printf("[DEBUG] Created HuaweiCloud DNS Zone %s: %#v", n.ID, n)
-	return resourceDNSZoneV2Read(d, meta)
+	log.Printf("[DEBUG] Created HuaweiCloud DNS Zone %s: %#v", n.ID, n)
+	return resourceDNSZoneV2Read(ctx, d, meta)
 }
 
-func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSZoneV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 
 	// we can not get the corresponding client by zone type in import scene
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	var zoneInfo *zones.Zone
 	zoneInfo, err = zones.Get(dnsClient, d.Id()).Extract()
 	if err != nil {
-		logp.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
+		log.Printf("[WARN] fetching zone failed with DNS global endpoint: %s", err)
 		// an error occurred while fetching the zone with DNS global endpoint
 		// try to fetch it again with DNS region endpoint
 		var clientErr error
 		dnsClient, clientErr = conf.DnsWithRegionClient(conf.GetRegion(d))
 		if clientErr != nil {
 			// it looks tricky as we return the fetching error rather than clientErr
-			return common.CheckDeleted(d, err, "zone")
+			return common.CheckDeletedDiag(d, err, "zone")
 		}
 
 		zoneInfo, err = zones.Get(dnsClient, d.Id()).Extract()
 		if err != nil {
-			return common.CheckDeleted(d, err, "zone")
+			return common.CheckDeletedDiag(d, err, "zone")
 		}
 	}
 
-	logp.Printf("[DEBUG] Retrieved Zone %s: %#v", d.Id(), zoneInfo)
+	log.Printf("[DEBUG] Retrieved Zone %s: %#v", d.Id(), zoneInfo)
 
-	d.Set("name", zoneInfo.Name)
-	d.Set("email", zoneInfo.Email)
-	d.Set("description", zoneInfo.Description)
-	d.Set("ttl", zoneInfo.TTL)
-	if err = d.Set("masters", zoneInfo.Masters); err != nil {
-		return fmtp.Errorf("[DEBUG] Error saving masters to state for HuaweiCloud DNS zone (%s): %s", d.Id(), err)
-	}
-	d.Set("region", region)
-	d.Set("zone_type", zoneInfo.ZoneType)
-	d.Set("enterprise_project_id", zoneInfo.EnterpriseProjectID)
+	mErr := multierror.Append(nil,
+		d.Set("name", zoneInfo.Name),
+		d.Set("email", zoneInfo.Email),
+		d.Set("description", zoneInfo.Description),
+		d.Set("ttl", zoneInfo.TTL),
+		d.Set("masters", zoneInfo.Masters),
+		d.Set("region", region),
+		d.Set("zone_type", zoneInfo.ZoneType),
+		d.Set("enterprise_project_id", zoneInfo.EnterpriseProjectID),
+	)
 
 	// save tags
 	if resourceType, err := utils.GetDNSZoneTagType(zoneInfo.ZoneType); err == nil {
 		resourceTags, err := tags.Get(dnsClient, resourceType, d.Id()).Extract()
 		if err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
-			d.Set("tags", tagmap)
+			mErr = multierror.Append(mErr, d.Set("tags", tagmap))
 		} else {
-			logp.Printf("[WARN] Error fetching HuaweiCloud DNS zone tags: %s", err)
+			log.Printf("[WARN] Error fetching HuaweiCloud DNS zone tags: %s", err)
 		}
+	}
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting resource: %s", mErr)
 	}
 
 	return nil
 }
 
-func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
+func resourceDNSZoneV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	var dnsClient *golangsdk.ServiceClient
 
 	dnsClient, err := conf.DnsV2Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	zoneType := d.Get("zone_type").(string)
@@ -306,130 +313,140 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 	// router is required when updating private zone
 	if zoneType == "private" {
 		if len(router) < 1 {
-			return fmtp.Errorf("The argument (router) is required when updating HuaweiCloud DNS private zone")
+			return diag.Errorf("the argument (router) is required when updating HuaweiCloud DNS private zone")
 		}
 		// update the endpoint with region when creating private zone
 		dnsClient, err = conf.DnsWithRegionClient(conf.GetRegion(d))
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud DNS region client: %s", err)
+			return diag.Errorf("error creating HuaweiCloud DNS region client: %s", err)
 		}
 	}
 
 	if d.HasChanges("description", "ttl", "email") {
-		var updateOpts zones.UpdateOpts
-		if d.HasChange("email") {
-			updateOpts.Email = d.Get("email").(string)
-		}
-		if d.HasChange("ttl") {
-			updateOpts.TTL = d.Get("ttl").(int)
-		}
-		if d.HasChange("description") {
-			updateOpts.Description = d.Get("description").(string)
-		}
-
-		logp.Printf("[DEBUG] Updating Zone %s with options: %#v", d.Id(), updateOpts)
-		_, err = zones.Update(dnsClient, d.Id(), updateOpts).Extract()
-		if err != nil {
-			return fmtp.Errorf("Error updating HuaweiCloud DNS Zone: %s", err)
-		}
-
-		logp.Printf("[DEBUG] Waiting for DNS Zone (%s) to update", d.Id())
-		stateConf := &resource.StateChangeConf{
-			Target:     []string{"ACTIVE"},
-			Pending:    []string{"PENDING"},
-			Refresh:    waitForDNSZone(dnsClient, d.Id()),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			Delay:      5 * time.Second,
-			MinTimeout: 3 * time.Second,
-		}
-
-		_, err = stateConf.WaitForState()
-		if err != nil {
-			return fmtp.Errorf(
-				"Error waiting for DNS Zone (%s) to become ACTIVE for update: %s",
-				d.Id(), err)
+		if err := updateDNSZone(ctx, d, dnsClient); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("router") {
-		// when updating private zone
-		if zoneType == "private" {
-			associateList, disassociateList, err := resourceGetDNSRouters(dnsClient, d, region)
-			if err != nil {
-				return fmtp.Errorf("Error getting HuaweiCloud DNS Zone Router: %s", err)
-			}
-			if len(associateList) > 0 {
-				// AssociateZone
-				for i := range associateList {
-					logp.Printf("[DEBUG] Updating AssociateZone Options: %#v", associateList[i])
-					_, err := zones.AssociateZone(dnsClient, d.Id(), associateList[i]).Extract()
-					if err != nil {
-						return fmtp.Errorf("Error AssociateZone: %s", err)
-					}
-
-					logp.Printf("[DEBUG] Waiting for AssociateZone (%s) to Router (%s) become ACTIVE",
-						d.Id(), associateList[i].RouterID)
-					stateRouterConf := &resource.StateChangeConf{
-						Target:     []string{"ACTIVE"},
-						Pending:    []string{"PENDING"},
-						Refresh:    waitForDNSZoneRouter(dnsClient, d.Id(), associateList[i].RouterID),
-						Timeout:    d.Timeout(schema.TimeoutUpdate),
-						Delay:      5 * time.Second,
-						MinTimeout: 3 * time.Second,
-					}
-
-					_, err = stateRouterConf.WaitForState()
-					if err != nil {
-						return fmtp.Errorf("Error waiting for AssociateZone (%s) to Router (%s) become ACTIVE: %s",
-							d.Id(), associateList[i].RouterID, err)
-					}
-				}
-			}
-			if len(disassociateList) > 0 {
-				// DisassociateZone
-				for j := range disassociateList {
-					logp.Printf("[DEBUG] Updating DisassociateZone Options: %#v", disassociateList[j])
-					_, err := zones.DisassociateZone(dnsClient, d.Id(), disassociateList[j]).Extract()
-					if err != nil {
-						return fmtp.Errorf("Error DisassociateZone: %s", err)
-					}
-
-					logp.Printf("[DEBUG] Waiting for DisassociateZone (%s) to Router (%s) become DELETED",
-						d.Id(), disassociateList[j].RouterID)
-					stateRouterConf := &resource.StateChangeConf{
-						Target:     []string{"DELETED"},
-						Pending:    []string{"ACTIVE", "PENDING", "ERROR"},
-						Refresh:    waitForDNSZoneRouter(dnsClient, d.Id(), disassociateList[j].RouterID),
-						Timeout:    d.Timeout(schema.TimeoutUpdate),
-						Delay:      5 * time.Second,
-						MinTimeout: 3 * time.Second,
-					}
-
-					_, err = stateRouterConf.WaitForState()
-					if err != nil {
-						return fmtp.Errorf("Error waiting for DisassociateZone (%s) to Router (%s) become DELETED: %s",
-							d.Id(), disassociateList[j].RouterID, err)
-					}
-				}
-			}
+	if d.HasChange("router") && zoneType == "private" {
+		if err := updateDNSZoneRouters(ctx, d, dnsClient, region); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
 	// update tags
 	resourceType, err := utils.GetDNSZoneTagType(zoneType)
 	if err != nil {
-		return fmtp.Errorf("Error getting resource type of DNS zone %s: %s", d.Id(), err)
+		return diag.Errorf("error getting resource type of DNS zone %s: %s", d.Id(), err)
 	}
 
 	tagErr := utils.UpdateResourceTags(dnsClient, d, resourceType, d.Id())
 	if tagErr != nil {
-		return fmtp.Errorf("Error updating tags of DNS zone %s: %s", d.Id(), tagErr)
+		return diag.Errorf("error updating tags of DNS zone %s: %s", d.Id(), tagErr)
 	}
 
-	return resourceDNSZoneV2Read(d, meta)
+	return resourceDNSZoneV2Read(ctx, d, meta)
 }
 
-func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
+func updateDNSZone(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	var updateOpts zones.UpdateOpts
+	if d.HasChange("email") {
+		updateOpts.Email = d.Get("email").(string)
+	}
+	if d.HasChange("ttl") {
+		updateOpts.TTL = d.Get("ttl").(int)
+	}
+	if d.HasChange("description") {
+		updateOpts.Description = d.Get("description").(string)
+	}
+
+	log.Printf("[DEBUG] Updating Zone %s with options: %#v", d.Id(), updateOpts)
+	_, err := zones.Update(client, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error updating HuaweiCloud DNS Zone: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for DNS Zone (%s) to update", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{"ACTIVE"},
+		Pending:    []string{"PENDING"},
+		Refresh:    waitForDNSZone(client, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for DNS Zone (%s) to become ACTIVE for update: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func updateDNSZoneRouters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	region string) error {
+	associateList, disassociateList, err := resourceGetDNSRouters(client, d, region)
+	if err != nil {
+		return fmt.Errorf("error getting HuaweiCloud DNS Zone Router: %s", err)
+	}
+	if len(associateList) > 0 {
+		// AssociateZone
+		for i := range associateList {
+			log.Printf("[DEBUG] Updating AssociateZone Options: %#v", associateList[i])
+			_, err := zones.AssociateZone(client, d.Id(), associateList[i]).Extract()
+			if err != nil {
+				return fmt.Errorf("error AssociateZone: %s", err)
+			}
+
+			log.Printf("[DEBUG] Waiting for AssociateZone (%s) to Router (%s) become ACTIVE",
+				d.Id(), associateList[i].RouterID)
+			stateRouterConf := &resource.StateChangeConf{
+				Target:     []string{"ACTIVE"},
+				Pending:    []string{"PENDING"},
+				Refresh:    waitForDNSZoneRouter(client, d.Id(), associateList[i].RouterID),
+				Timeout:    d.Timeout(schema.TimeoutUpdate),
+				Delay:      5 * time.Second,
+				MinTimeout: 3 * time.Second,
+			}
+
+			_, err = stateRouterConf.WaitForStateContext(ctx)
+			if err != nil {
+				return fmt.Errorf("error waiting for AssociateZone (%s) to Router (%s) become ACTIVE: %s",
+					d.Id(), associateList[i].RouterID, err)
+			}
+		}
+	}
+	if len(disassociateList) > 0 {
+		// DisassociateZone
+		for j := range disassociateList {
+			log.Printf("[DEBUG] Updating DisassociateZone Options: %#v", disassociateList[j])
+			_, err := zones.DisassociateZone(client, d.Id(), disassociateList[j]).Extract()
+			if err != nil {
+				return fmt.Errorf("error DisassociateZone: %s", err)
+			}
+
+			log.Printf("[DEBUG] Waiting for DisassociateZone (%s) to Router (%s) become DELETED",
+				d.Id(), disassociateList[j].RouterID)
+			stateRouterConf := &resource.StateChangeConf{
+				Target:     []string{"DELETED"},
+				Pending:    []string{"ACTIVE", "PENDING", "ERROR"},
+				Refresh:    waitForDNSZoneRouter(client, d.Id(), disassociateList[j].RouterID),
+				Timeout:    d.Timeout(schema.TimeoutUpdate),
+				Delay:      5 * time.Second,
+				MinTimeout: 3 * time.Second,
+			}
+
+			_, err = stateRouterConf.WaitForStateContext(ctx)
+			if err != nil {
+				return fmt.Errorf("error waiting for DisassociateZone (%s) to Router (%s) become DELETED: %s",
+					d.Id(), disassociateList[j].RouterID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceDNSZoneV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	var dnsClient *golangsdk.ServiceClient
 	var err error
@@ -442,15 +459,15 @@ func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 		dnsClient, err = conf.DnsV2Client(conf.GetRegion(d))
 	}
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud DNS client: %s", err)
+		return diag.Errorf("error creating HuaweiCloud DNS client: %s", err)
 	}
 
 	_, err = zones.Delete(dnsClient, d.Id()).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error deleting HuaweiCloud DNS Zone: %s", err)
+		return diag.Errorf("error deleting HuaweiCloud DNS Zone: %s", err)
 	}
 
-	logp.Printf("[DEBUG] Waiting for DNS Zone (%s) to become available", d.Id())
+	log.Printf("[DEBUG] Waiting for DNS Zone (%s) to become available", d.Id())
 	stateConf := &resource.StateChangeConf{
 		Target: []string{"DELETED"},
 		//we allow to try to delete ERROR zone
@@ -461,10 +478,10 @@ func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf(
-			"Error waiting for DNS Zone (%s) to delete: %s",
+		return diag.Errorf(
+			"error waiting for DNS Zone (%s) to delete: %s",
 			d.Id(), err)
 	}
 
@@ -483,7 +500,7 @@ func waitForDNSZone(dnsClient *golangsdk.ServiceClient, zoneId string) resource.
 			return nil, "", err
 		}
 
-		logp.Printf("[DEBUG] HuaweiCloud DNS Zone (%s) current status: %s", zone.ID, zone.Status)
+		log.Printf("[DEBUG] HuaweiCloud DNS Zone (%s) current status: %s", zone.ID, zone.Status)
 		return zone, parseStatus(zone.Status), nil
 	}
 }
@@ -520,7 +537,7 @@ func waitForDNSZoneRouter(dnsClient *golangsdk.ServiceClient, zoneId string, rou
 		}
 		for i := range zone.Routers {
 			if routerId == zone.Routers[i].RouterID {
-				logp.Printf("[DEBUG] HuaweiCloud DNS Zone (%s) Router (%s) current status: %s",
+				log.Printf("[DEBUG] HuaweiCloud DNS Zone (%s) Router (%s) current status: %s",
 					zoneId, routerId, zone.Routers[i].Status)
 				return zone, parseStatus(zone.Routers[i].Status), nil
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Move dns resources to service dir. 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSV2PtrRecord_'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSV2PtrRecord_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSV2PtrRecord_basic 
=== PAUSE TestAccDNSV2PtrRecord_basic
=== RUN   TestAccDNSV2PtrRecord_withEpsId
=== PAUSE TestAccDNSV2PtrRecord_withEpsId
=== CONT  TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2PtrRecord_withEpsId
--- PASS: TestAccDNSV2PtrRecord_withEpsId (36.20s) 
--- PASS: TestAccDNSV2PtrRecord_basic (52.34s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       52.418s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSV2RecordSet_'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSV2RecordSet_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSV2RecordSet_basic 
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_basic
=== CONT  TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (41.89s) 
--- PASS: TestAccDNSV2RecordSet_private (42.30s) 
--- PASS: TestAccDNSV2RecordSet_basic (70.75s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       70.826s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSV2Zone_'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSV2Zone_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSV2Zone_basic 
=== PAUSE TestAccDNSV2Zone_basic
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== RUN   TestAccDNSV2Zone_readTTL
=== PAUSE TestAccDNSV2Zone_readTTL
=== RUN   TestAccDNSV2Zone_withEpsId
=== PAUSE TestAccDNSV2Zone_withEpsId
=== CONT  TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2Zone_private
=== CONT  TestAccDNSV2Zone_withEpsId
--- PASS: TestAccDNSV2Zone_readTTL (26.06s) 
--- PASS: TestAccDNSV2Zone_private (26.74s) 
--- PASS: TestAccDNSV2Zone_withEpsId (26.96s) 
--- PASS: TestAccDNSV2Zone_basic (42.51s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       42.594s
```
