### PR TITLE
feat(cce): support security_groups in node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -244,6 +244,11 @@ extend_param = {
 * `priority` - (Optional, Int) Specifies the weight of the node pool.
   A node pool with a higher weight has a higher priority during scaling.
 
+* `security_groups` - (Optional, List, ForceNew) Specifies the list of custom security group IDs for the node pool.
+  If specified, the nodes will be put in these security groups. When specifying a security group, do not modify
+  the rules of the port on which CCE running depends. For details, see
+  [documentation](https://support.huaweicloud.com/intl/en-us/cce_faq/cce_faq_00265.html).
+
 * `pod_security_groups` - (Optional, List, ForceNew) Specifies the list of security group IDs for the pod.
   Only supported in CCE Turbo clusters of v1.19 and above. Changing this parameter will create a new resource.
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -118,8 +118,10 @@ type CreateSpec struct {
 	Autoscaling AutoscalingSpec `json:"autoscaling"`
 	// Node management parameters
 	NodeManagement NodeManagementSpec `json:"nodeManagement"`
-	// Security group configurations
+	// Pod security group configurations
 	PodSecurityGroups []PodSecurityGroupSpec `json:"podSecurityGroups,omitempty"`
+	// Node security group configurations
+	CustomSecurityGroups []string `json:"customSecurityGroups,omitempty"`
 }
 
 type PodSecurityGroupSpec struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/results.go
@@ -57,8 +57,10 @@ type Spec struct {
 	Autoscaling AutoscalingSpec `json:"autoscaling"`
 	// Node pool management parameters
 	NodeManagement NodeManagementSpec `json:"nodeManagement"`
-	// Security group configurations
+	// Pod security group configurations
 	PodSecurityGroups []PodSecurityGroupSpec `json:"podSecurityGroups"`
+	// Node security group configurations
+	CustomSecurityGroups []string `json:"customSecurityGroups"`
 }
 
 type AutoscalingSpec struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2779 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCENodePool_SecurityGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCENodePool_SecurityGroups -timeout 360m -parallel 4
=== RUN   TestAccCCENodePool_SecurityGroups
=== PAUSE TestAccCCENodePool_SecurityGroups
=== CONT  TestAccCCENodePool_SecurityGroups
--- PASS: TestAccCCENodePool_SecurityGroups (1032.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1032.789s
```
