### PR TITLE
fix(ces): add default value for alarm_type

### DIFF
--- a/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
+++ b/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
@@ -43,6 +43,7 @@ func TestAccCESAlarmRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "alarm_type", "MULTI_INSTANCE"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_level", "2"),
@@ -213,7 +214,6 @@ func testCESAlarmRule_basic(rName string) string {
 resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
   alarm_name           = "rule-%s"
   alarm_action_enabled = true
-  alarm_type           = "MULTI_INSTANCE"
 
   metric {
     namespace   = "SYS.ECS"

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
@@ -233,7 +233,7 @@ func ResourceAlarmRule() *schema.Resource {
 			"alarm_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
+				Default:      "MULTI_INSTANCE",
 				ValidateFunc: validation.StringInSlice([]string{"EVENT.SYS", "EVENT.CUSTOM", "MULTI_INSTANCE"}, false),
 			},
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The alarm_type is optional in v1 API, and the API provides a default value `MULTI_INSTANCE`
but it's required in v2 API, so we need to add a default value keep the resource behavior constant

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ces' TESTARGS='-run TestAccCESAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccCESAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_basic
=== PAUSE TestAccCESAlarmRule_basic
=== CONT  TestAccCESAlarmRule_basic
--- PASS: TestAccCESAlarmRule_basic (317.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       317.506s

make testacc TEST='./huaweicloud/services/acceptance/ces' TESTARGS='-run TestAccCESAlarmRule_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccCESAlarmRule_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_withEpsId
=== PAUSE TestAccCESAlarmRule_withEpsId
=== CONT  TestAccCESAlarmRule_withEpsId
--- PASS: TestAccCESAlarmRule_withEpsId (191.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       191.575s

make testacc TEST='./huaweicloud/services/acceptance/ces' TESTARGS='-run TestAccCESAlarmRule_sysEvent'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccCESAlarmRule_sysEvent -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_sysEvent
=== PAUSE TestAccCESAlarmRule_sysEvent
=== CONT  TestAccCESAlarmRule_sysEvent
--- PASS: TestAccCESAlarmRule_sysEvent (192.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       192.833s

make testacc TEST='./huaweicloud/services/acceptance/ces' TESTARGS='-run TestAccCESAlarmRule_multiConditions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccCESAlarmRule_multiConditions -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_multiConditions
=== PAUSE TestAccCESAlarmRule_multiConditions
=== CONT  TestAccCESAlarmRule_multiConditions
--- PASS: TestAccCESAlarmRule_multiConditions (210.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       210.334s
```
