### PR TITLE
fix(scripts): support plus sign as list index

### DIFF
--- a/scripts/markdown_check/main.go
+++ b/scripts/markdown_check/main.go
@@ -76,7 +76,7 @@ func checkMarkdownSchemas(res *schema.Resource, parent string, mdContent *string
 	for name, schemaObject := range res.Schema {
 		fieldPath := buildFieldPath(parent, name)
 
-		reg := fmt.Sprintf("\\* `%s` - ", name)
+		reg := fmt.Sprintf("[\\*|+] `%s` - ", name)
 		isExist := checkArgumentExist(*mdContent, reg)
 
 		extentStr, deprecated := buildAttributeString(schemaObject)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

 in some docs, some paraters list index are plus sign(+), let's support this format:
```
* `virtual_spaces` - (Required, List, ForceNew) Specifies the detailed management of space configuration in a group.
  Changing this parameter will create a new resource.

  + `name` - (Required, String, ForceNew) Specifies the virtual space name. Currently, only **kubernetes**, **runtime**,
    and **user** are supported. Changing this parameter will create a new resource.
  + `size` - (Required, String, ForceNew) Specifies the size of a virtual space. Only an integer percentage is supported.
    Example: 90%. Note that the total percentage of all virtual spaces in a group cannot exceed 100%.
    Changing this parameter will create a new resource.
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
