### PR TITLE
feat(nat/transitip): add new resource support

### DIFF
--- a/docs/resources/nat_private_transit_ip.md
+++ b/docs/resources/nat_private_transit_ip.md
@@ -1,0 +1,66 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# huaweicloud_nat_private_transit_ip
+
+Manages a transit IP resource of the **private** NAT within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "subnet_id" {}
+variable "ipv4_address" {}
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_nat_private_transit_ip" "test" {
+  subnet_id             = var.subnet_id
+  ip_address            = var.ipv4_address
+  enterprise_project_id = var.enterprise_project_id
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the transit IP is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the transit subnet ID to which the transit IP belongs.  
+  Changing this will create a new resource.
+
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address of the transit subnet.  
+  Changing this will create a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the transit
+  IP belongs.  
+  Changing this will create a new resource.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the transit IP.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `network_interface_id` - The network interface ID of the transit IP for private NAT.
+
+* `gateway_id` - The ID of the private NAT gateway to which the transit IP belongs.
+
+* `created_at` - The creation time of the transit IP for private NAT.
+
+* `updated_at` - The latest update time of the transit IP for private NAT.
+
+## Import
+
+Transit IPs can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_nat_private_transit_ip.test 5a1d921c-1df5-477d-8481-317b3fb47b5d
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230315022543-467196c2ec9c
+	github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chnsz/golangsdk v0.0.0-20230315022543-467196c2ec9c h1:fJdSir/UwbQNRGxlgeyv66S9kjLYgU5kUUOfoJpia8c=
 github.com/chnsz/golangsdk v0.0.0-20230315022543-467196c2ec9c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98 h1:Hh6M5GgAYTS0HGQk/GR+PlS8sh1QUeCcwWIgbBN3+HE=
+github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -634,6 +634,7 @@ func (c *Config) NatGatewayClient(region string) (*golangsdk.ServiceClient, erro
 	return c.NewServiceClient("nat", region)
 }
 
+// NatV3Client has the endpoint: https://nat.{{region}}/{{cloud}}/v3/
 func (c *Config) NatV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("natv3", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -258,6 +258,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version: "v2",
 		Product: "NAT",
 	},
+	"natv3": {
+		Name:    "nat",
+		Version: "v3",
+		Product: "NAT",
+	},
 	"elbv2": {
 		Name:             "elb",
 		Version:          "v2.0",
@@ -751,11 +756,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v2.0",
 		WithOutProjectID: true,
 		Product:          "NAT",
-	},
-	"natv3": {
-		Name:    "nat",
-		Version: "v3",
-		Product: "NAT",
 	},
 }
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -863,7 +863,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_gateway":   nat.ResourcePublicGateway(),
 			"huaweicloud_nat_snat_rule": nat.ResourcePublicSnatRule(),
 
-			"huaweicloud_nat_private_gateway": nat.ResourcePrivateGateway(),
+			"huaweicloud_nat_private_gateway":    nat.ResourcePrivateGateway(),
+			"huaweicloud_nat_private_transit_ip": nat.ResourcePrivateTransitIp(),
 
 			"huaweicloud_network_acl":              ResourceNetworkACL(),
 			"huaweicloud_network_acl_rule":         ResourceNetworkACLRule(),

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_transit_ip_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_transit_ip_test.go
@@ -1,0 +1,153 @@
+package nat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/transitips"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func getPrivateTransitIpResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	return transitips.Get(client, state.Primary.ID)
+}
+
+func TestAccPrivateTransitIp_basic(t *testing.T) {
+	var (
+		obj transitips.TransitIp
+
+		rName1 = "huaweicloud_nat_private_transit_ip.test"
+		rName2 = "huaweicloud_nat_private_transit_ip.random_ip_address"
+		name   = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc1 := acceptance.InitResourceCheck(
+		rName1,
+		&obj,
+		getPrivateTransitIpResourceFunc,
+	)
+	rc2 := acceptance.InitResourceCheck(
+		rName2,
+		&obj,
+		getPrivateTransitIpResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc1.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIp_basic_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName1, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.68"),
+					resource.TestCheckResourceAttr(rName1, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName1, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName1, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName1, "created_at"),
+					resource.TestCheckResourceAttrSet(rName1, "updated_at"),
+					resource.TestCheckResourceAttrPair(rName2, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName2, "ip_address"),
+					resource.TestCheckResourceAttr(rName2, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName2, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName2, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName2, "created_at"),
+					resource.TestCheckResourceAttrSet(rName2, "updated_at"),
+				),
+			},
+			{
+				Config: testAccPrivateTransitIp_basic_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.88"),
+					resource.TestCheckResourceAttr(rName1, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName1, "tags.newkey", "value"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName2, "tags.newkey", "value"),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateTransitIp_basic_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_transit_ip" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  ip_address            = "192.168.0.68"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_nat_private_transit_ip" "random_ip_address" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccPrivateTransitIp_basic_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_transit_ip" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  ip_address            = "192.168.0.88"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
+}
+
+resource "huaweicloud_nat_private_transit_ip" "random_ip_address" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_transit_ip.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_transit_ip.go
@@ -1,0 +1,166 @@
+package nat
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/transitips"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourcePrivateTransitIp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePrivateTransitIpCreate,
+		ReadContext:   resourcePrivateTransitIpRead,
+		UpdateContext: resourcePrivateTransitIpUpdate,
+		DeleteContext: resourcePrivateTransitIpDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the transit IP is located.",
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the transit subnet to which the transit IP belongs.",
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The IP address of the transit subnet.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The ID of the enterprise project to which the transit IP belongs.",
+			},
+			"tags": common.TagsSchema(),
+			"network_interface_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The network interface ID of the transit IP for private NAT.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the private NAT gateway to which the transit IP belongs.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the transit IP for private NAT.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the transit IP for private NAT.",
+			},
+		},
+	}
+}
+
+func resourcePrivateTransitIpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	opts := transitips.CreateOpts{
+		SubnetId:            d.Get("subnet_id").(string),
+		IpAddress:           d.Get("ip_address").(string),
+		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		Tags:                utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+	}
+
+	log.Printf("[DEBUG] The create options of the transit IP (Private NAT) is: %#v", opts)
+	resp, err := transitips.Create(client, opts)
+	if err != nil {
+		return diag.Errorf("error creating transit IP (Private NAT): %s", err)
+	}
+	d.SetId(resp.ID)
+
+	return resourcePrivateTransitIpRead(ctx, d, meta)
+}
+
+func resourcePrivateTransitIpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	natClient, err := cfg.NatV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	resp, err := transitips.Get(natClient, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Transit IP (Private NAT)")
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("subnet_id", resp.SubnetId),
+		d.Set("ip_address", resp.IpAddress),
+		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
+		d.Set("tags", utils.TagsToMap(resp.Tags)),
+		d.Set("gateway_id", resp.GatewayId),
+		d.Set("network_interface_id", resp.NetworkInterfaceId),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving transit IP (Private NAT) fields: %s", err)
+	}
+	return nil
+}
+
+func resourcePrivateTransitIpUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	natClient, err := cfg.NatV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	transitIpId := d.Id()
+	err = utils.UpdateResourceTags(natClient, d, "transit-ips", transitIpId)
+	if err != nil {
+		return diag.Errorf("error updating tags of the transit IP (Private NAT) (%s): %s", transitIpId, err)
+	}
+
+	return resourcePrivateTransitIpRead(ctx, d, meta)
+}
+
+func resourcePrivateTransitIpDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	transitIpId := d.Id()
+	err = transitips.Delete(client, transitIpId)
+	if err != nil {
+		return diag.Errorf("error deleting transit IP (Private NAT) (%s): %s", transitIpId, err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/transitips/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/transitips/requests.go
@@ -1,0 +1,53 @@
+package transitips
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+)
+
+// CreateOpts is the structure used to create a new transit IP.
+type CreateOpts struct {
+	// The ID of the subnet to which the transit IP belongs.
+	SubnetId string `json:"virsubnet_id" required:"true"`
+	// The IP address
+	IpAddress string `json:"ip_address,omitempty"`
+	// The ID of the enterprise project to which the transit IP belongs.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// The key/value pairs to associate with the transit IP.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method used to create a new transit IP using given parameters.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*TransitIp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "transit_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = c.Post(rootURL(c), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.TransitIp, err
+}
+
+// Get is a method used to obtain the transit IP detail by its ID.
+func Get(c *golangsdk.ServiceClient, transitIpId string) (*TransitIp, error) {
+	var r queryResp
+	_, err := c.Get(resourceURL(c, transitIpId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.TransitIp, err
+}
+
+// Delete is a method to remove the specified transit IP using its ID.
+func Delete(c *golangsdk.ServiceClient, transitIpId string) error {
+	_, err := c.Delete(resourceURL(c, transitIpId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/transitips/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/transitips/results.go
@@ -1,0 +1,41 @@
+package transitips
+
+import "github.com/chnsz/golangsdk/openstack/common/tags"
+
+// TransitIp is the structure that represents the detail of the transit IP for private NAT.
+type TransitIp struct {
+	// The transit IP ID.
+	ID string `json:"id"`
+	// The project ID to which the transit IP (private NAT) belongs.
+	ProjectId string `json:"project_id"`
+	// The network interface ID of the transit IP for private NAT.
+	NetworkInterfaceId string `json:"network_interface_id"`
+	// The IP address of the transit IP.
+	IpAddress string `json:"ip_address"`
+	// The creation time.
+	CreatedAt string `json:"created_at"`
+	// The latest update time.
+	UpdatedAt string `json:"updated_at"`
+	// The ID of the subnet to which the transit IP belongs.
+	SubnetId string `json:"virsubnet_id"`
+	// The key/value pairs to associate with the transit IP.
+	Tags []tags.ResourceTag `json:"tags"`
+	// The ID of the private NAT gateway to which the transit IP belongs.
+	GatewayId string `json:"gateway_id"`
+	// The ID of the enterprise project to which the transit IP belongs.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+}
+
+type createResp struct {
+	// The transit IP detail.
+	TransitIp TransitIp `json:"transit_ip"`
+	// Request ID.
+	RequestId string `json:"request_id"`
+}
+
+type queryResp struct {
+	// The transit IP detail.
+	TransitIp TransitIp `json:"transit_ip"`
+	// Request ID.
+	RequestId string `json:"request_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/transitips/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/transitips/urls.go
@@ -1,0 +1,13 @@
+package transitips
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "private-nat/transit-ips"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, transitIpId string) string {
+	return c.ServiceURL(rootPath, transitIpId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230315022543-467196c2ec9c
+# github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -226,6 +226,7 @@ github.com/chnsz/golangsdk/openstack/nat/v2/dnats
 github.com/chnsz/golangsdk/openstack/nat/v2/gateways
 github.com/chnsz/golangsdk/openstack/nat/v2/snats
 github.com/chnsz/golangsdk/openstack/nat/v3/gateways
+github.com/chnsz/golangsdk/openstack/nat/v3/transitips
 github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths
 github.com/chnsz/golangsdk/openstack/networking/v1/eips
 github.com/chnsz/golangsdk/openstack/networking/v1/flowlogs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource support for transit IP of private NAT.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/nat' TESTARGS='-run=TestAccPrivateTransitIp_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run=TestAccPrivateTransitIp_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateTransitIp_basic
=== PAUSE TestAccPrivateTransitIp_basic
=== CONT  TestAccPrivateTransitIp_basic
--- PASS: TestAccPrivateTransitIp_basic (64.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       64.989s
```
