### PR TITLE
feat(nat/dnat): add new private dnat resource

### DIFF
--- a/docs/resources/nat_private_dnat_rule.md
+++ b/docs/resources/nat_private_dnat_rule.md
@@ -1,0 +1,163 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# huaweicloud_nat_private_dnat_rule
+
+Manages a DNAT rule resource of the **private** NAT within HuaweiCloud.
+
+## Example Usage
+
+### DNAT rules forwarded with ECS instance as the backend
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "huaweicloud_compute_instance" "test" {
+  ...
+}
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_interface_id  = huaweicloud_compute_instance.test.network[0].port
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules forwarded with ELB loadbalancer as the backend
+
+```hcl
+variable "network_id" {}
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  ...
+}
+
+data "huaweicloud_networking_port" "test" {
+  network_id = var.network_id
+  fixed_ip   = huaweicloud_elb_loadbalancer.test.ipv4_address
+}
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_interface_id  = data.huaweicloud_networking_port.test.id
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules forwarded with VIP as the backend
+
+```hcl
+variable "network_id" {}
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "huaweicloud_networking_vip" "test" {
+  network_id = var.network_id
+}
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_interface_id  = huaweicloud_networking_vip.test.id
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules forwarded with a custom private IP address as the backend
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_private_ip    = "172.168.0.69"
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules for all ports
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id         = var.gateway_id
+  protocol           = "any"
+  transit_ip_id      = var.transit_ip_id
+  backend_private_ip = "172.168.0.69"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DNAT rule is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `gateway_id` - (Required, String, ForceNew) Specifies the private NAT gateway ID to which the DNAT rule belongs.  
+  Changing this will create a new resource.
+
+* `transit_ip_id` - (Required, String) Specifies the ID of the transit IP for private NAT.
+
+* `transit_service_port` - (Optional, Int) Specifies the port of the transit IP.  
+
+-> Defaults to `0` and the default port is only available for rules with the protocol **any**.
+
+* `protocol` - (Optional, String) Specifies the protocol type.  
+  The valid values are **tcp**, **udp** and **any**. Defaults to **any**.
+
+* `backend_interface_id` - (Optional, String) Specifies the network interface ID of the transit IP for private NAT.  
+  Exactly one of `backend_interface_id` and `backend_private_ip` must be set.
+
+* `backend_private_ip` - (Optional, String) Specifies the private IP address of the backend instance.
+
+* `internal_service_port` - (Optional, Int) Specifies the port of the backend instance.
+
+-> Defaults to `0` and the default port is only available for rules with the protocol **any**.
+
+* `description` - (Optional, String) Specifies the description of the DNAT rule, which contain maximum of `255`
+  characters, and angle brackets (< and >) are not allowed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `backend_type` - The type of backend instance.
+  The valid values are as follows:
+  + **COMPUTE**: ECS instance.
+  + **VIP**: VIP.
+  + **ELB**: ELB loadbalancer.
+  + **ELBv3**: ver.3 ELB loadbalancer.
+  + **CUSTOMIZE**: custom backend IP address.
+
+* `created_at` - The creation time of the DNAT rule.
+
+* `updated_at` - The latest update time of the DNAT rule.
+
+## Import
+
+DNAT rules can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_nat_private_dnat_rule.test 19e3f4ed-fde0-406a-828d-7e0482400da9
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98
+	github.com/chnsz/golangsdk v0.0.0-20230317105734-9707805af7da
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230315022543-467196c2ec9c h1:fJdSir/UwbQNRGxlgeyv66S9kjLYgU5kUUOfoJpia8c=
-github.com/chnsz/golangsdk v0.0.0-20230315022543-467196c2ec9c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98 h1:Hh6M5GgAYTS0HGQk/GR+PlS8sh1QUeCcwWIgbBN3+HE=
-github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230317105734-9707805af7da h1:sEeSch/VPSP1KKbGsV/LPe1j8vZ8zAW5aSuzuEnh98Y=
+github.com/chnsz/golangsdk v0.0.0-20230317105734-9707805af7da/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -865,6 +865,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_gateway":   nat.ResourcePublicGateway(),
 			"huaweicloud_nat_snat_rule": nat.ResourcePublicSnatRule(),
 
+			"huaweicloud_nat_private_dnat_rule":  nat.ResourcePrivateDnatRule(),
 			"huaweicloud_nat_private_gateway":    nat.ResourcePrivateGateway(),
 			"huaweicloud_nat_private_transit_ip": nat.ResourcePrivateTransitIp(),
 

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
@@ -1,0 +1,750 @@
+package nat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/dnats"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func getPrivateDnatRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	return dnats.Get(client, state.Primary.ID)
+}
+
+// The backend forwarding object is the ECS instance.
+func TestAccPrivateDnatRule_basic(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "huaweicloud_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_basic_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
+						"huaweicloud_compute_instance.test", "network.0.port"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+					resource.TestCheckResourceAttrSet(rName, "backend_type"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_basic_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_basic_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_transitIpConfig(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "transit_ip_used" {
+  name = "%[1]s-transit-ip"
+  cidr = "172.16.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "transit_ip_used" {
+  vpc_id     = huaweicloud_vpc.transit_ip_used.id
+  name       = "%[1]s-transit-ip"
+  cidr       = cidrsubnet(huaweicloud_vpc.transit_ip_used.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.transit_ip_used.cidr, 4, 1), 1)
+}
+
+resource "huaweicloud_nat_private_transit_ip" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.transit_ip_used.id
+  enterprise_project_id = "0"
+}
+`, name)
+}
+
+func testAccPrivateDnatRule_ecsPart(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  name              = "%[2]s"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  image_id          = data.huaweicloud_images_image.test.id
+  security_groups   = [huaweicloud_networking_secgroup.test.name]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  admin_pass        = "%[3]s"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "huaweicloud_nat_private_gateway" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
+}
+`, common.TestBaseComputeResources(name), name, acceptance.RandomPassword())
+}
+
+func testAccPrivateDnatRule_basic_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  transit_service_port  = 1000
+  backend_interface_id  = huaweicloud_compute_instance.test.network[0].port
+  internal_service_port = 2000
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name))
+}
+
+func testAccPrivateDnatRule_basic_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  protocol              = "udp"
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  transit_service_port  = 3000
+  backend_interface_id  = huaweicloud_compute_instance.test.network[0].port
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name))
+}
+
+func testAccPrivateDnatRule_basic_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id           = huaweicloud_nat_private_gateway.test.id
+  protocol             = "any"
+  transit_ip_id        = huaweicloud_nat_private_transit_ip.test.id
+  backend_interface_id = huaweicloud_compute_instance.test.network[0].port
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name))
+}
+
+// The backend forwarding object is the ELB loadbalancer.
+func TestAccPrivateDnatRule_elbBackend(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "huaweicloud_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_elbBackend_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
+						"data.huaweicloud_networking_port.test", "id"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_elbBackend_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_elbBackend_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_elbBackend_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_network_acl" "test" {
+  name = "%[3]s"
+
+  subnets = [
+    huaweicloud_vpc_subnet.test.id
+  ]
+
+  inbound_rules = [
+    huaweicloud_network_acl_rule.test.id
+  ]
+}
+
+resource "huaweicloud_network_acl_rule" "test" {
+  name                   = "%[3]s"
+  protocol               = "tcp"
+  action                 = "allow"
+  source_ip_address      = huaweicloud_vpc.test.cidr
+  source_port            = "8080"
+  destination_ip_address = "0.0.0.0/0"
+  destination_port       = "8081"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "in_v4_icmp_all" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "in_v4_elb_member" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "tcp"
+  ports             = "80,8081"
+  remote_ip_prefix  = huaweicloud_vpc.test.cidr
+}
+
+resource "huaweicloud_networking_secgroup_rule" "in_v4_all_group" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  remote_group_id   = huaweicloud_networking_secgroup.test.id
+}
+
+resource "huaweicloud_networking_secgroup_rule" "out_v4_all" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "egress"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[3]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_compute_eip_associate" "test" {
+  public_ip   = huaweicloud_vpc_eip.test.address
+  instance_id = huaweicloud_compute_instance.test.id
+}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name           = "%[3]s"
+  vpc_id         = huaweicloud_vpc.test.id
+  ipv4_subnet_id = huaweicloud_vpc_subnet.test.subnet_id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+}
+
+resource "huaweicloud_elb_listener" "test" {
+  name            = "%[3]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+
+  idle_timeout     = 60
+  request_timeout  = 60
+  response_timeout = 60
+}
+
+resource "huaweicloud_elb_pool" "test" {
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = huaweicloud_elb_listener.test.id
+
+  persistence {
+    type = "HTTP_COOKIE"
+  }
+}
+
+resource "huaweicloud_elb_monitor" "test" {
+  protocol    = "HTTP"
+  interval    = 20
+  timeout     = 15
+  max_retries = 10
+  url_path    = "/"
+  port        = 8080
+  pool_id     = huaweicloud_elb_pool.test.id
+}
+
+resource "huaweicloud_elb_member" "test" {
+  address       = huaweicloud_compute_instance.test.access_ip_v4
+  protocol_port = 8080
+  pool_id       = huaweicloud_elb_pool.test.id
+  subnet_id     = huaweicloud_vpc_subnet.test.subnet_id
+}
+
+data "huaweicloud_networking_port" "test" {
+  network_id = huaweicloud_vpc_subnet.test.id
+  fixed_ip   = huaweicloud_elb_loadbalancer.test.ipv4_address
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+}
+
+func testAccPrivateDnatRule_elbBackend_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  transit_service_port  = 1000
+  backend_interface_id  = data.huaweicloud_networking_port.test.id
+  internal_service_port = 2000
+}
+`, testAccPrivateDnatRule_elbBackend_base(name))
+}
+
+func testAccPrivateDnatRule_elbBackend_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  protocol              = "udp"
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  transit_service_port  = 3000
+  backend_interface_id  = data.huaweicloud_networking_port.test.id
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_elbBackend_base(name))
+}
+
+func testAccPrivateDnatRule_elbBackend_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id           = huaweicloud_nat_private_gateway.test.id
+  protocol             = "any"
+  transit_ip_id        = huaweicloud_nat_private_transit_ip.test.id
+  backend_interface_id = data.huaweicloud_networking_port.test.id
+}
+`, testAccPrivateDnatRule_elbBackend_base(name))
+}
+
+// The backend forwarding object is the VIP.
+func TestAccPrivateDnatRule_vipBackend(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "huaweicloud_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_vipBackend_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
+						"huaweicloud_networking_vip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_vipBackend_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_vipBackend_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_vipBackend_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_nat_private_gateway" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  name                  = "%[3]s"
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_networking_vip" "test" {
+  network_id = huaweicloud_vpc_subnet.test.id
+}
+`, common.TestBaseNetwork(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+}
+
+func testAccPrivateDnatRule_vipBackend_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_service_port  = 1000
+  backend_interface_id  = huaweicloud_networking_vip.test.id
+  internal_service_port = 2000
+}
+
+`, testAccPrivateDnatRule_vipBackend_base(name))
+}
+
+func testAccPrivateDnatRule_vipBackend_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  protocol              = "udp"
+  transit_service_port  = 3000
+  backend_interface_id  = huaweicloud_networking_vip.test.id
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_vipBackend_base(name))
+}
+
+func testAccPrivateDnatRule_vipBackend_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id           = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id        = huaweicloud_nat_private_transit_ip.test.id
+  protocol             = "any"
+  backend_interface_id = huaweicloud_networking_vip.test.id
+}
+`, testAccPrivateDnatRule_vipBackend_base(name))
+}
+
+func TestAccPrivateDnatRule_customIpAddress(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "huaweicloud_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"huaweicloud_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"huaweicloud_nat_private_transit_ip.test", "id"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "backend_private_ip", "172.168.0.69"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "backend_private_ip", "172.168.0.79"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_4(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_customIpAddress_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_nat_private_gateway" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  name                  = "%[3]s"
+  enterprise_project_id = "0"
+}
+
+`, common.TestBaseNetwork(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+}
+
+// Default protocol 'any'
+func testAccPrivateDnatRule_customIpAddress_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id         = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id      = huaweicloud_nat_private_transit_ip.test.id
+  backend_private_ip = "172.168.0.69"
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}
+
+func testAccPrivateDnatRule_customIpAddress_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_service_port  = 1000
+  backend_private_ip    = "172.168.0.69"
+  internal_service_port = 2000
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}
+
+func testAccPrivateDnatRule_customIpAddress_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id            = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id         = huaweicloud_nat_private_transit_ip.test.id
+  protocol              = "udp"
+  transit_service_port  = 3000
+  backend_private_ip    = "172.168.0.79"
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}
+
+func testAccPrivateDnatRule_customIpAddress_step_4(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_dnat_rule" "test" {
+  gateway_id         = huaweicloud_nat_private_gateway.test.id
+  transit_ip_id      = huaweicloud_nat_private_transit_ip.test.id
+  protocol           = "any"
+  backend_private_ip = "172.168.0.79"
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
@@ -1,0 +1,222 @@
+package nat
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/dnats"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourcePrivateDnatRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePrivateDnatRuleCreate,
+		ReadContext:   resourcePrivateDnatRuleRead,
+		UpdateContext: resourcePrivateDnatRuleUpdate,
+		DeleteContext: resourcePrivateDnatRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the DNAT rule is located.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The private NAT gateway ID to which the DNAT rule belongs.",
+			},
+			"transit_ip_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the transit IP for private NAT.",
+			},
+			"transit_service_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The port of the transit IP.",
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The protocol type.",
+			},
+			"backend_interface_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The network interface ID of the transit IP for private NAT.",
+				ExactlyOneOf: []string{"backend_private_ip"},
+			},
+			"backend_private_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The private IP address of the backend instance.",
+			},
+			"internal_service_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The port of the backend instance.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the DNAT rule.",
+			},
+			"backend_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of backend instance.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the DNAT rule.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the DNAT rule.",
+			},
+		},
+	}
+}
+
+func resourcePrivateDnatRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	opts := dnats.CreateOpts{
+		GatewayId:           d.Get("gateway_id").(string),
+		Protocol:            d.Get("protocol").(string),
+		Description:         d.Get("description").(string),
+		NetworkInterfaceId:  d.Get("backend_interface_id").(string),
+		PrivateIpAddress:    d.Get("backend_private_ip").(string),
+		InternalServicePort: strconv.Itoa(d.Get("internal_service_port").(int)),
+		TransitIpId:         d.Get("transit_ip_id").(string),
+		TransitServicePort:  strconv.Itoa(d.Get("transit_service_port").(int)),
+	}
+
+	log.Printf("[DEBUG] The create options of the DNAT rule (Private NAT) is: %#v", opts)
+	resp, err := dnats.Create(client, opts)
+	if err != nil {
+		return diag.Errorf("error creating DNAT rule (Private NAT): %s", err)
+	}
+	d.SetId(resp.ID)
+
+	return resourcePrivateDnatRuleRead(ctx, d, meta)
+}
+
+func resourcePrivateDnatRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NatV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	resp, err := dnats.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Private DNAT rule")
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("gateway_id", resp.GatewayId),
+		d.Set("transit_ip_id", resp.TransitIpId),
+		d.Set("description", resp.Description),
+		d.Set("backend_interface_id", resp.NetworkInterfaceId),
+		d.Set("protocol", resp.Protocol),
+		d.Set("backend_private_ip", resp.PrivateIpAddress),
+		d.Set("backend_type", resp.Type),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	// Parse the internal service port
+	if internalServicePort, err := strconv.Atoi(resp.InternalServicePort); err != nil {
+		mErr = multierror.Append(mErr, fmt.Errorf("invalid format for internal service port, want 'string', but '%T'",
+			resp.InternalServicePort))
+	} else if internalServicePort != 0 {
+		mErr = multierror.Append(mErr, d.Set("internal_service_port", internalServicePort))
+	}
+
+	// Parse the transit service port
+	if transitServicePort, err := strconv.Atoi(resp.TransitServicePort); err != nil {
+		mErr = multierror.Append(mErr, fmt.Errorf("invalid format for transit service port, want 'string', but '%T'",
+			resp.TransitServicePort))
+	} else if transitServicePort != 0 {
+		mErr = multierror.Append(mErr, d.Set("transit_service_port", transitServicePort))
+	}
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving resource fields of the DNAT rule (Private NAT): %s", err)
+	}
+	return nil
+}
+
+func resourcePrivateDnatRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NatV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	ruleId := d.Id()
+	opts := dnats.UpdateOpts{
+		Protocol:            d.Get("protocol").(string),
+		Description:         utils.String(d.Get("description").(string)),
+		InternalServicePort: strconv.Itoa(d.Get("internal_service_port").(int)),
+		TransitIpId:         d.Get("transit_ip_id").(string),
+		TransitServicePort:  strconv.Itoa(d.Get("transit_service_port").(int)),
+	}
+	if d.HasChange("backend_private_ip") {
+		opts.PrivateIpAddress = d.Get("backend_private_ip").(string)
+	} else if d.HasChange("backend_interface_id") {
+		opts.NetworkInterfaceId = d.Get("backend_interface_id").(string)
+	}
+
+	_, err = dnats.Update(client, ruleId, opts)
+	if err != nil {
+		return diag.Errorf("error updating DNAT rule (Private NAT) (%s): %s", ruleId, err)
+	}
+
+	return resourcePrivateDnatRuleRead(ctx, d, meta)
+}
+
+func resourcePrivateDnatRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NatV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	ruleId := d.Id()
+	err = dnats.Delete(client, ruleId)
+	if err != nil {
+		return diag.Errorf("error deleting DNAT rule (Private NAT) (%s): %s", ruleId, err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/dnats/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/dnats/requests.go
@@ -1,0 +1,94 @@
+package dnats
+
+import "github.com/chnsz/golangsdk"
+
+// CreateOpts is the structure used to create a new private DNAT rule.
+type CreateOpts struct {
+	// The ID of the gateway to which the private DNAT rule belongs.
+	GatewayId string `json:"gateway_id" required:"true"`
+	// The ID of the transit IP for private NAT.
+	TransitIpId string `json:"transit_ip_id" required:"true"`
+	// The description of the DNAT rule, which contain maximum of `255` characters, and angle brackets (< and >) are
+	// not allowed.
+	Description string `json:"description,omitempty"`
+	// The network interface ID of the transit IP for private NAT.
+	NetworkInterfaceId string `json:"network_interface_id,omitempty"`
+	// The protocol type of the private DNAT rule.
+	// The valid values (and the related protocol numbers) are 'UDP/udp (6)', 'TCP/tcp' (17) and 'ANY/any (0)'.
+	Protocol string `json:"protocol,omitempty"`
+	// The private IP address of the backend instance.
+	PrivateIpAddress string `json:"private_ip_address,omitempty"`
+	// The port of the backend instance.
+	InternalServicePort string `json:"internal_service_port,omitempty"`
+	// The port of the transit IP.
+	TransitServicePort string `json:"transit_service_port,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method used to create a private DNAT rule using given parameters.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*Rule, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "dnat_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = c.Post(rootURL(c), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Rule, err
+}
+
+// Get is a method used to obtain the private DNAT rule detail by its ID.
+func Get(c *golangsdk.ServiceClient, ruleId string) (*Rule, error) {
+	var r queryResp
+	_, err := c.Get(resourceURL(c, ruleId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Rule, err
+}
+
+// UpdateOpts is the structure used to modify an existing private DNAT rule.
+type UpdateOpts struct {
+	// The ID of the transit IP for private NAT.
+	TransitIpId string `json:"transit_ip_id,omitempty"`
+	// The description of the DNAT rule, which contain maximum of `255` characters, and angle brackets (< and >) are
+	// not allowed.
+	Description *string `json:"description,omitempty"`
+	// The network interface ID of the transit IP for private NAT.
+	NetworkInterfaceId string `json:"network_interface_id,omitempty"`
+	// The protocol type. The valid values (and the related protocol numbers) are 'UDP/udp (6)', 'TCP/tcp' (17) and
+	// 'ANY/any (0)'.
+	Protocol string `json:"protocol,omitempty"`
+	// The private IP address of the backend instance.
+	PrivateIpAddress string `json:"private_ip_address,omitempty"`
+	// The port of the backend instance.
+	InternalServicePort string `json:"internal_service_port,omitempty"`
+	// The port of the transit IP.
+	TransitServicePort string `json:"transit_service_port,omitempty"`
+}
+
+// Update is a method used to modify an existing DNAT rule using given parameters.
+func Update(c *golangsdk.ServiceClient, ruleId string, opts UpdateOpts) (*Rule, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "dnat_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	var r updateResp
+	_, err = c.Put(resourceURL(c, ruleId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Rule, err
+}
+
+// Delete is a method to remove the specified DNAT rule using its ID.
+func Delete(c *golangsdk.ServiceClient, ruleId string) error {
+	_, err := c.Delete(resourceURL(c, ruleId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/dnats/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/dnats/results.go
@@ -1,0 +1,62 @@
+package dnats
+
+// Rule is a struct that represents the private DNAT rule detail.
+type Rule struct {
+	// The ID of the DNAT rule.
+	ID string `json:"id"`
+	// The project ID.
+	ProjectId string `json:"project_id"`
+	// The description of the DNAT rule, which contain maximum of `255` characters, and angle brackets (< and >) are
+	// not allowed.
+	Description string `json:"description"`
+	// The ID of the transit IP.
+	TransitIpId string `json:"transit_ip_id"`
+	// The ID of the gateway to which the private DNAT rule belongs.
+	GatewayId string `json:"gateway_id"`
+	// The network interface ID of the transit IP for private NAT.
+	NetworkInterfaceId string `json:"network_interface_id"`
+	// The backend type of the DNAT rule.
+	// The values of the backend type are as follow:
+	// + COMPUTE
+	// + VIP
+	// + ELB
+	// + ELBv3
+	// + CUSTOMIZE
+	Type string `json:"type"`
+	// The protocol type. The valid values (and the related protocol numbers) are 'UDP/udp (6)', 'TCP/tcp' (17) and
+	// 'ANY/any (0)'.
+	Protocol string `json:"protocol"`
+	// The private IP address of the backend instance.
+	PrivateIpAddress string `json:"private_ip_address"`
+	// The port of the backend instance.
+	InternalServicePort string `json:"internal_service_port"`
+	// The port of the transit IP.
+	TransitServicePort string `json:"transit_service_port"`
+	// The ID of the enterprise project to which the private DNAT rule belongs.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// The creation time of the private DNAT rule.
+	CreatedAt string `json:"created_at"`
+	// The latest update time of the private DNAT rule.
+	UpdatedAt string `json:"updated_at"`
+}
+
+type createResp struct {
+	// The DNAT rule detail.
+	Rule Rule `json:"dnat_rule"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+type queryResp struct {
+	// The DNAT rule detail.
+	Rule Rule `json:"dnat_rule"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+type updateResp struct {
+	// The DNAT rule detail.
+	Rule Rule `json:"dnat_rule"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/dnats/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/dnats/urls.go
@@ -1,0 +1,13 @@
+package dnats
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "private-nat/dnat-rules"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, ruleId string) string {
+	return c.ServiceURL(rootPath, ruleId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230317071010-f12e0dd4db98
+# github.com/chnsz/golangsdk v0.0.0-20230317105734-9707805af7da
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -225,6 +225,7 @@ github.com/chnsz/golangsdk/openstack/mrs/v2/jobs
 github.com/chnsz/golangsdk/openstack/nat/v2/dnats
 github.com/chnsz/golangsdk/openstack/nat/v2/gateways
 github.com/chnsz/golangsdk/openstack/nat/v2/snats
+github.com/chnsz/golangsdk/openstack/nat/v3/dnats
 github.com/chnsz/golangsdk/openstack/nat/v3/gateways
 github.com/chnsz/golangsdk/openstack/nat/v3/transitips
 github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New resource support: private DNAT rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new private dnat resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/nat' TESTARGS='-run=TestAccPrivateDnatRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run=TestAccPrivateDnatRule_ -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_basic
=== PAUSE TestAccPrivateDnatRule_basic
=== RUN   TestAccPrivateDnatRule_elbBackend
=== PAUSE TestAccPrivateDnatRule_elbBackend
=== RUN   TestAccPrivateDnatRule_vipBackend
=== PAUSE TestAccPrivateDnatRule_vipBackend
=== RUN   TestAccPrivateDnatRule_customIpAddress
=== PAUSE TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_basic
=== CONT  TestAccPrivateDnatRule_vipBackend
=== CONT  TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_elbBackend
--- PASS: TestAccPrivateDnatRule_customIpAddress (87.42s)
--- PASS: TestAccPrivateDnatRule_vipBackend (87.80s)
--- PASS: TestAccPrivateDnatRule_basic (240.81s)
--- PASS: TestAccPrivateDnatRule_elbBackend (261.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       261.235s
```
