### PR TITLE
fix(workflow): only running the first basic test for each file

### DIFF
--- a/.github/workflows/cron-ci.yml
+++ b/.github/workflows/cron-ci.yml
@@ -100,11 +100,11 @@ jobs:
             test_file=$path/${org_file/%.go/_test.go}
 
             if [ -f "./${test_file}" ]; then
-              basic_cases=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk '{print $2}' | awk -F '(' '{print $1}')
-              if [ "X$basic_cases" != "X" ]; then
+              basic_case=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk 'NR==1{print $2}' | awk -F '(' '{print $1}')
+              if [ "X$basic_case" != "X" ]; then
                 total=`expr $total + 1`
-                echo -e "\nrun acceptance basic tests: $basic_cases"
-                make testacc TEST="./$path" TESTARGS="-run ${basic_cases}"
+                echo -e "\nrun acceptance basic test: $basic_case"
+                make testacc TEST="./$path" TESTARGS="-run ${basic_case}"
                 if [ $? -ne 0 ]; then
                   result=`expr $result + 1`
                 fi

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -202,11 +202,11 @@ jobs:
             test_file=$path/${org_file/%.go/_test.go}
 
             if [ -f "./${test_file}" ]; then
-              basic_cases=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk '{print $2}' | awk -F '(' '{print $1}')
-              if [ "X$basic_cases" != "X" ]; then
+              basic_case=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk 'NR==1{print $2}' | awk -F '(' '{print $1}')
+              if [ "X$basic_case" != "X" ]; then
                 total=`expr $total + 1`
-                echo -e "\n[$total] `date` run acceptance basic tests: $basic_cases"
-                make testacc TEST="./$path" TESTARGS="-run ${basic_cases}"
+                echo -e "\n[$total] `date` run acceptance basic test: $basic_case"
+                make testacc TEST="./$path" TESTARGS="-run ${basic_case}"
                 if [ $? -ne 0 ]; then
                   result=`expr $result + 1`
                 fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

if there are more than one test cases with **_basic**, it will get the following error:
```
[38] Fri Mar 17 13:04:35 UTC 2023 run acceptance basic tests: TestAccNetworkingV2RouterInterface_basic_subnet
TestAccNetworkingV2RouterInterface_basic_port
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccNetworkingV2RouterInterface_basic_subnet
=== RUN   TestAccNetworkingV2RouterInterface_basic_subnet
=== PAUSE TestAccNetworkingV2RouterInterface_basic_subnet
=== CONT  TestAccNetworkingV2RouterInterface_basic_subnet
    acceptance.go:177: This environment does not support deprecated tests
--- SKIP: TestAccNetworkingV2RouterInterface_basic_subnet (0.00s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated	0.026s
TestAccNetworkingV2RouterInterface_basic_port -timeout 360m -parallel 4
make: TestAccNetworkingV2RouterInterface_basic_port: No such file or directory
make: *** [GNUmakefile:21: testacc] Error 127
```

the reason is that `basic_cases` has multi-lines, then the command get an error.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ basic_cases=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk '{print $2}' | awk -F '(' '{print $1}')
$ echo $basic_cases
TestAccNetworkingV2RouterInterface_basic_subnet TestAccNetworkingV2RouterInterface_basic_port

$ basic_cases=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk 'NR==1{print $2}' | awk -F '(' '{print $1}')
$ echo $basic_cases
TestAccNetworkingV2RouterInterface_basic_subnet
```
