### PR TITLE
docs: fix documentation errors in RDS, VPC and VPCEP service

### DIFF
--- a/docs/data-sources/rds_storage_types.md
+++ b/docs/data-sources/rds_storage_types.md
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 * `db_type` - (Required, String) DB engine. The valid values are **MySQL**, **PostgreSQL**, **SQLServer**.
 
-* `db_version` - (Optional, String) DB version number.
+* `db_version` - (Required, String) DB version number.
 
 * `instance_mode` - (Optional, String) HA mode. The valid values are **single**, **ha**, **replica**.
 

--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -33,6 +33,8 @@ filters must match exactly one VPC whose data will be exported as attributes.
 
 * `cidr` - (Optional, String) Specifies the cidr block of the desired VPC.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID which the desired VPC belongs to.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/vpc_route_table.md
+++ b/docs/data-sources/vpc_route_table.md
@@ -30,28 +30,28 @@ The following arguments are supported:
 * `region` - (Optional, String) The region in which to query the vpc route table.
   If omitted, the provider-level region will be used.
 
-* `vpc_id` (Required, String) - Specifies the VPC ID where the route table resides.
+* `vpc_id` - (Required, String) Specifies the VPC ID where the route table resides.
 
-* `name` (Optional, String) - Specifies the name of the route table.
+* `name` - (Optional, String) Specifies the name of the route table.
 
-* `id` (Optional, String) - Specifies the ID of the route table.
+* `id` - (Optional, String) Specifies the ID of the route table.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `default` (Bool) - Whether the route table is default or not.
+* `default` - Whether the route table is default or not.
 
-* `description` (String) - The supplementary information about the route table.
+* `description` - The supplementary information about the route table.
 
-* `subnets` (List) - An array of one or more subnets associating with the route table.
+* `subnets` - An array of one or more subnets associating with the route table.
 
-* `route` (List) - The route object list. The [route object](#route_object) is documented below.
+* `route` - The route object list. The [route object](#route_object) is documented below.
 
 <a name="route_object"></a>
 The `route` block supports:
 
-* `type` (String) - The route type.
-* `destination` (String) - The destination address in the CIDR notation format
-* `nexthop` (String) - The next hop.
-* `description` (String) - The description about the route.
+* `type` - The route type.
+* `destination` - The destination address in the CIDR notation format
+* `nexthop` - The next hop.
+* `description` - The description about the route.

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -231,8 +231,8 @@ The `volume` block supports:
   Changing this parameter will create a new resource. For details about volume types, see
   [DB Instance Storage Types](https://support.huaweicloud.com/intl/en-us/productdesc-rds/rds_01_0020.html).
 
-* `disk_encryption_id` - (Optional) Specifies the key ID for disk encryption. Changing this parameter will create a new
-  resource.
+* `disk_encryption_id` - (Optional, String, ForceNew) Specifies the key ID for disk encryption.
+  Changing this parameter will create a new resource.
 
 The `backup_strategy` block supports:
 
@@ -255,6 +255,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Specifies a resource ID in UUID format.
 
 * `status` - Indicates the DB instance status.
+
+* `db/user_name` - Indicates the default user name of database.
 
 * `created` - Indicates the creation time.
 

--- a/docs/resources/rds_parametergroup.md
+++ b/docs/resources/rds_parametergroup.md
@@ -27,6 +27,9 @@ resource "huaweicloud_rds_parametergroup" "pg_1" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) The region in which to create the RDS parameter group. If omitted, the
+  provider-level region will be used. Changing this creates a new parameter group.
+
 * `name` - (Required, String) The parameter group name. It contains a maximum of 64 characters.
 
 * `description` - (Optional, String) The parameter group description. It contains a maximum of 256 characters and cannot

--- a/docs/resources/rds_read_replica_instance.md
+++ b/docs/resources/rds_read_replica_instance.md
@@ -122,6 +122,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `db` - Indicates the database information. Structure is documented below.
 
+* `volume/size` - Indicates the volume size which is the same as that of the primary DB instance.
+
 * `private_ips` - Indicates the private IP address list.
 
 * `public_ips` - Indicates the public IP address list.
@@ -134,13 +136,10 @@ In addition to all arguments above, the following attributes are exported:
 
 The `db` block supports:
 
-* `port` - Indicates the database port information.
-
 * `type` - Indicates the DB engine. Value: MySQL, PostgreSQL, SQLServer.
-
-* `user_name` - Indicates the default user name of database.
-
 * `version` - Indicates the database version.
+* `port` - Indicates the database port information.
+* `user_name` - Indicates the default user name of database.
 
 ## Timeouts
 

--- a/docs/resources/vpc_address_group.md
+++ b/docs/resources/vpc_address_group.md
@@ -38,7 +38,7 @@ resource "huaweicloud_vpc_address_group" "ipv6" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies tThe region in which to create the IP address group. If omitted, the
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the IP address group. If omitted, the
   provider-level region will be used. Changing this creates a new address group.
   
 * `name` - (Required, String) Specifies the IP address group name. The value is a string of 1 to 64 characters that can contain

--- a/docs/resources/vpc_flow_log.md
+++ b/docs/resources/vpc_flow_log.md
@@ -57,16 +57,16 @@ The following arguments are supported:
 * `log_stream_id` - (Required, String, ForceNew) Specifies the LTS log stream ID.
   Changing this creates a new VPC flow log.
 
-* `traffic_type` - (Optinal, String, ForceNew) Specifies the type of traffic to log. The value can be:
+* `traffic_type` - (Optional, String, ForceNew) Specifies the type of traffic to log. The value can be:
   + *all*: Specifies that both accepted and rejected traffic of the specified resource will be logged.
   + *accept*: Specifies that only accepted inbound and outbound traffic of the specified resource will be logged.
   + *reject*: Specifies that only rejected inbound and outbound traffic of the specified resource will be logged.
 
   Defauts to *all*. Changing this creates a new VPC flow log.
 
-* `enabled` - (Optinal, Bool) Specifies whether to enable the flow log function, the default value is *true*.
+* `enabled` - (Optional, Bool) Specifies whether to enable the flow log function, the default value is *true*.
 
-* `description` - (Optinal, String) Specifies description about the VPC flow log.
+* `description` - (Optional, String) Specifies description about the VPC flow log.
   The value can contain no more than 255 characters and cannot contain angle brackets (< or >).
 
 ## Attributes Reference

--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -27,16 +27,16 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the VPC peering connection. If omitted, the
   provider-level region will be used. Changing this creates a new VPC peering connection resource.
 
-* `name` (Required, String) - Specifies the name of the VPC peering connection. The value can contain 1 to 64
+* `name` - (Required, String) Specifies the name of the VPC peering connection. The value can contain 1 to 64
   characters.
 
-* `vpc_id` (Required, String, ForceNew) - Specifies the ID of a VPC involved in a VPC peering connection. Changing this
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC involved in a VPC peering connection. Changing this
   creates a new VPC peering connection.
 
-* `peer_vpc_id` (Required, String, ForceNew) - Specifies the VPC ID of the accepter tenant. Changing this creates a new
+* `peer_vpc_id` - (Required, String, ForceNew) Specifies the VPC ID of the accepter tenant. Changing this creates a new
   VPC peering connection.
 
-* `peer_tenant_id` (Optional, String, ForceNew) - Specified the Tenant Id of the accepter tenant. Changing this creates
+* `peer_tenant_id` - (Optional, String, ForceNew) Specifies the tenant ID of the accepter tenant. Changing this creates
   a new VPC peering connection.
 
 ## Attributes Reference

--- a/docs/resources/vpc_peering_connection_accepter.md
+++ b/docs/resources/vpc_peering_connection_accepter.md
@@ -60,10 +60,10 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the vpc peering connection accepter. If omitted,
   the provider-level region will be used. Changing this creates a new VPC peering connection accepter resource.
 
-* `vpc_peering_connection_id` (Required, String, ForceNew) - The VPC Peering Connection ID to manage. Changing this
+* `vpc_peering_connection_id` - (Required, String, ForceNew) The VPC Peering Connection ID to manage. Changing this
   creates a new VPC peering connection accepter.
 
-* `accept` (Optional, Bool)- Whether or not to accept the peering request. Defaults to `false`.
+* `accept` - (Optional, Bool) Whether or not to accept the peering request. Defaults to `false`.
 
 ## Removing huaweicloud_vpc_peering_connection_accepter from your configuration
 

--- a/docs/resources/vpc_route.md
+++ b/docs/resources/vpc_route.md
@@ -49,17 +49,17 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the VPC route. If omitted, the provider-level
   region will be used. Changing this creates a new resource.
 
-* `vpc_id` (Required, String, ForceNew) - Specifies the VPC for which a route is to be added. Changing this creates a
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC for which a route is to be added. Changing this creates a
   new resource.
 
-* `destination` (Required, String, ForceNew) - Specifies the destination address in the CIDR notation format,
+* `destination` - (Required, String, ForceNew) Specifies the destination address in the CIDR notation format,
   for example, 192.168.200.0/24. The destination of each route must be unique and cannot overlap with any
   subnet in the VPC. Changing this creates a new resource.
 
-* `type` (Required, String) - Specifies the route type. Currently, the value can be:
+* `type` - (Required, String) Specifies the route type. Currently, the value can be:
   **ecs**, **eni**, **vip**, **nat**, **peering**, **vpn**, **dc** and **cc**.
 
-* `nexthop` (Required, String) - Specifies the next hop.
+* `nexthop` - (Required, String) Specifies the next hop.
   + If the route type is **ecs**, the value is an ECS instance ID in the VPC.
   + If the route type is **eni**, the value is the extension NIC of an ECS in the VPC.
   + If the route type is **vip**, the value is a virtual IP address.
@@ -69,10 +69,10 @@ The following arguments are supported:
   + If the route type is **dc**, the value is a Direct Connect gateway ID.
   + If the route type is **cc**, the value is a Cloud Connection ID.
 
-* `description` (Optional, String) - Specifies the supplementary information about the route.
+* `description` - (Optional, String) Specifies the supplementary information about the route.
   The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
 
-* `route_table_id` (Optional, String, ForceNew) - Specifies the route table ID for which a route is to be added.
+* `route_table_id` - (Optional, String, ForceNew) Specifies the route table ID for which a route is to be added.
   If the value is not set, the route will be added to the *default* route table.
 
 ## Attributes Reference

--- a/docs/resources/vpc_route_table.md
+++ b/docs/resources/vpc_route_table.md
@@ -64,34 +64,34 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the vpc route table.
   If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `vpc_id` (Required, String, ForceNew) - Specifies the VPC ID for which a route table is to be added.
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID for which a route table is to be added.
   Changing this creates a new resource.
 
-* `name` (Required, String) - Specifies the route table name. The value is a string of no more than
+* `name` - (Required, String) Specifies the route table name. The value is a string of no more than
   64 characters that can contain letters, digits, underscores (_), hyphens (-), and periods (.).
 
-* `description` (Optional, String) - Specifies the supplementary information about the route table.
+* `description` - (Optional, String) Specifies the supplementary information about the route table.
   The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
 
-* `subnets` (Optional, List) - Specifies an array of one or more subnets associating with the route table.
+* `subnets` - (Optional, List) Specifies an array of one or more subnets associating with the route table.
 
   -> **NOTE:** The custom route table associated with a subnet affects only the outbound traffic.
   The default route table determines the inbound traffic.
 
-* `route` (Optional, List) - Specifies the route object list. The [route object](#route_object)
+* `route` - (Optional, List) Specifies the route object list. The [route object](#route_object)
   is documented below.
 
 <a name="route_object"></a>
 The `route` block supports:
 
-* `destination` (Required, String) - Specifies the destination address in the CIDR notation format,
+* `destination` - (Required, String) Specifies the destination address in the CIDR notation format,
   for example, 192.168.200.0/24. The destination of each route must be unique and cannot overlap
   with any subnet in the VPC.
 
-* `type` (Required, String) - Specifies the route type. Currently, the value can be:
+* `type` - (Required, String) Specifies the route type. Currently, the value can be:
   **ecs**, **eni**, **vip**, **nat**, **peering**, **vpn**, **dc** and **cc**.
 
-* `nexthop` (Required, String) - Specifies the next hop.
+* `nexthop` - (Required, String) Specifies the next hop.
   + If the route type is **ecs**, the value is an ECS instance ID in the VPC.
   + If the route type is **eni**, the value is the extension NIC of an ECS in the VPC.
   + If the route type is **vip**, the value is a virtual IP address.
@@ -101,7 +101,7 @@ The `route` block supports:
   + If the route type is **dc**, the value is a Direct Connect gateway ID.
   + If the route type is **cc**, the value is a Cloud Connection ID.
 
-* `description` (Optional, String) - Specifies the supplementary information about the route.
+* `description` - (Optional, String) Specifies the supplementary information about the route.
   The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
 
 ## Attributes Reference

--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -42,37 +42,37 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies tThe region in which to create the vpc subnet. If omitted, the
   provider-level region will be used. Changing this creates a new Subnet.
 
-* `name` (Required, String) - Specifies the subnet name. The value is a string of 1 to 64 characters that can contain
+* `name` - (Required, String) Specifies the subnet name. The value is a string of 1 to 64 characters that can contain
   letters, digits, underscores (_), and hyphens (-).
 
-* `cidr` (Required, String, ForceNew) - Specifies the network segment on which the subnet resides. The value must be in
+* `cidr` - (Required, String, ForceNew) Specifies the network segment on which the subnet resides. The value must be in
   CIDR format and within the CIDR block of the VPC. The subnet mask cannot be greater than 28. Changing this creates a
   new Subnet.
 
-* `gateway_ip` (Required, String, ForceNew) - Specifies the gateway of the subnet. The value must be a valid IP address
+* `gateway_ip` - (Required, String, ForceNew) Specifies the gateway of the subnet. The value must be a valid IP address
   in the subnet segment. Changing this creates a new Subnet.
 
-* `vpc_id` (Required, String, ForceNew) - Specifies the ID of the VPC to which the subnet belongs. Changing this creates
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC to which the subnet belongs. Changing this creates
   a new Subnet.
 
 * `description` - (Optional, String) Specifies supplementary information about the subnet. The value is a string of
   no more than 255 characters and cannot contain angle brackets (< or >).
 
-* `ipv6_enable` (Optional, Bool) - Specifies whether the IPv6 function is enabled for the subnet. Defaults to false.
+* `ipv6_enable` - (Optional, Bool) Specifies whether the IPv6 function is enabled for the subnet. Defaults to false.
 
-* `dhcp_enable` (Optional, Bool) - Specifies whether the DHCP function is enabled for the subnet. Defaults to true.
+* `dhcp_enable` - (Optional, Bool) Specifies whether the DHCP function is enabled for the subnet. Defaults to true.
 
-* `primary_dns` (Optional, String) - Specifies the IP address of DNS server 1 on the subnet. The value must be a valid
+* `primary_dns` - (Optional, String) Specifies the IP address of DNS server 1 on the subnet. The value must be a valid
   IP address.
 
-* `secondary_dns` (Optional, String) - Specifies the IP address of DNS server 2 on the subnet. The value must be a valid
+* `secondary_dns` - (Optional, String) Specifies the IP address of DNS server 2 on the subnet. The value must be a valid
   IP address.
 
-* `dns_list` (Optional, List) - Specifies the DNS server address list of a subnet. This field is required if you need to
+* `dns_list` - (Optional, List) Specifies the DNS server address list of a subnet. This field is required if you need to
   use more than two DNS servers. This parameter value is the superset of both DNS server address 1 and DNS server
   address 2.
 
-* `availability_zone` (Optional, String, ForceNew) - Specifies the availability zone (AZ) to which the subnet belongs.
+* `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone (AZ) to which the subnet belongs.
   The value must be an existing AZ in the system. Changing this creates a new Subnet.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the subnet.

--- a/docs/resources/vpcep_approval.md
+++ b/docs/resources/vpcep_approval.md
@@ -55,10 +55,10 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to obtain the VPC endpoint service. If omitted, the
   provider-level region will be used. Changing this creates a new resource.
 
-* `service_id` (Required, String, ForceNew) - Specifies the ID of the VPC endpoint service. Changing this creates a new
+* `service_id` - (Required, String, ForceNew) Specifies the ID of the VPC endpoint service. Changing this creates a new
   resource.
 
-* `endpoints` (Required, List) - Specifies the list of VPC endpoint IDs which accepted to connect to VPC endpoint
+* `endpoints` - (Required, List) Specifies the list of VPC endpoint IDs which accepted to connect to VPC endpoint
   service. The VPC endpoints will be rejected when the resource was destroyed.
 
 ## Attributes Reference

--- a/docs/resources/vpcep_endpoint.md
+++ b/docs/resources/vpcep_endpoint.md
@@ -63,25 +63,25 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the VPC endpoint. If omitted, the provider-level
   region will be used. Changing this creates a new VPC endpoint.
 
-* `service_id` (Required, String, ForceNew) - Specifies the ID of the VPC endpoint service. Changing this creates a new
+* `service_id` - (Required, String, ForceNew) Specifies the ID of the VPC endpoint service. Changing this creates a new
   VPC endpoint.
 
-* `vpc_id` (Required, String, ForceNew) - Specifies the ID of the VPC where the VPC endpoint is to be created. Changing
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC where the VPC endpoint is to be created. Changing
   this creates a new VPC endpoint.
 
-* `network_id` (Required, String, ForceNew) - Specifies the network ID of the subnet in the VPC specified by `vpc_id`.
+* `network_id` - (Required, String, ForceNew) Specifies the network ID of the subnet in the VPC specified by `vpc_id`.
   Changing this creates a new VPC endpoint.
 
-* `ip_address` (Optional, String, ForceNew) - Specifies the IP address for accessing the associated VPC endpoint
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address for accessing the associated VPC endpoint
   service. Only IPv4 addresses are supported. Changing this creates a new VPC endpoint.
 
-* `enable_dns` (Optional, Bool, ForceNew) - Specifies whether to create a private domain name. The default value is
+* `enable_dns` - (Optional, Bool, ForceNew) Specifies whether to create a private domain name. The default value is
   true. Changing this creates a new VPC endpoint.
 
-* `enable_whitelist` (Optional, Bool, ForceNew) - Specifies whether to enable access control. The default value is
+* `enable_whitelist` - (Optional, Bool, ForceNew) Specifies whether to enable access control. The default value is
   false. Changing this creates a new VPC endpoint.
 
-* `whitelist` (Optional, List, ForceNew) - Specifies the list of IP address or CIDR block which can be accessed to the
+* `whitelist` - (Optional, List, ForceNew) Specifies the list of IP address or CIDR block which can be accessed to the
   VPC endpoint. Changing this creates a new VPC endpoint.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the VPC endpoint.

--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -32,29 +32,28 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the VPC endpoint service. If omitted, the
   provider-level region will be used. Changing this creates a new VPC endpoint service resource.
 
-* `name` (Optional, String) - Specifies the name of the VPC endpoint service. The value contains a maximum of 16
+* `name` - (Optional, String) Specifies the name of the VPC endpoint service. The value contains a maximum of 16
   characters, including letters, digits, underscores (_), and hyphens (-).
 
-* `vpc_id` (Required, String, ForceNew) - Specifies the ID of the VPC to which the backend resource of the VPC endpoint
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC to which the backend resource of the VPC endpoint
   service belongs. Changing this creates a new VPC endpoint service.
 
-* `server_type` (Required, String, ForceNew) - Specifies the backend resource type. The value can be **VM**, **VIP**
-  or **LB**.
+* `server_type` - (Required, String, ForceNew) Specifies the backend resource type. The value can be **VM**, **VIP**
+  or **LB**. Changing this creates a new VPC endpoint service.
 
-* `port_id` (Required, String, ForceNew) - Specifies the ID for identifying the backend resource of the VPC endpoint
-  service.
+* `port_id` - (Required, String) Specifies the ID for identifying the backend resource of the VPC endpoint service.
   + If the `server_type` is **VM**, the value is the NIC ID of the ECS where the VPC endpoint service is deployed.
   + If the `server_type` is **VIP**, the value is the NIC ID of the physical server where virtual resources are
       created.
   + If the `server_type` is **LB**, the value is the ID of the port bound to the private IP address of the load
       balancer.
 
-* `port_mapping` (Required, String) - Specified the port mappings opened to the VPC endpoint service. Structure is
+* `port_mapping` - (Required, List) Specifies the port mappings opened to the VPC endpoint service. Structure is
   documented below.
 
-* `approval` (Optional, Bool) - Specifies whether connection approval is required. The default value is false.
+* `approval` - (Optional, Bool) Specifies whether connection approval is required. The default value is false.
 
-* `permissions` (Optional, List) - Specifies the list of accounts to access the VPC endpoint service. The record is in
+* `permissions` - (Optional, List) Specifies the list of accounts to access the VPC endpoint service. The record is in
   the `iam:domain::domain_id` format, while `*` allows all users to access the VPC endpoint service.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the VPC endpoint service.

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_engine_versions.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_engine_versions.go
@@ -33,7 +33,7 @@ func DataSourceRdsEngineVersionsV3() *schema.Resource {
 			},
 			"versions": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -71,11 +71,6 @@ func ResourceRdsReadReplicaInstance() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -85,6 +80,12 @@ func ResourceRdsReadReplicaInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: "schema: Computed",
 						},
 					},
 				},

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
@@ -92,6 +92,7 @@ func ResourceVPCEndpointService() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "interface",
+				Description:  "schema: Computed",
 				ValidateFunc: validation.StringInSlice([]string{"interface"}, false),
 			},
 			"approval": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes the following error for **RDS** service

```
====== Checking for resources huaweicloud_rds_instance =====
the format of `volume.disk_encryption_id` is not correct, should be (Optional, String, ForceNew)
can not find `db.user_name`, please check it

====== Checking for resources huaweicloud_rds_read_replica_instance =====
can not find `volume.size`, please check it

====== Checking for resources huaweicloud_rds_parametergroup =====
can not find `region`, please check it

====== Checking for data-sources huaweicloud_rds_storage_types =====
the format of `db_version` is not correct, should be (Required, String)

====== Checking for data-sources huaweicloud_rds_engine_versions =====
the format of `versions` is not correct, should be (Optional, List)

====== Checking for resources huaweicloud_vpc_route_table =====
can not find `vpc_id`, please check it
can not find `name`, please check it
can not find `description`, please check it
can not find `subnets`, please check it
can not find `route`, please check it
can not find `route.destination`, please check it
can not find `route.type`, please check it
can not find `route.nexthop`, please check it
can not find `route.description`, please check it

====== Checking for resources huaweicloud_vpcep_endpoint =====
can not find `network_id`, please check it
can not find `enable_dns`, please check it
can not find `vpc_id`, please check it
can not find `whitelist`, please check it
can not find `ip_address`, please check it
can not find `enable_whitelist`, please check it
can not find `service_id`, please check it

...
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
