### PR TITLE
feat(as): add source_dest_check for as group

### DIFF
--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -225,6 +225,9 @@ The `networks` block supports:
 
 * `ipv6_bandwidth_id` - (Optional, String) Specifies the ID of the shared bandwidth of an IPv6 address.
 
+* `source_dest_check` - (Optional, Bool) Specifies whether processesing only traffic that is destined specifically
+  for it. Defaults to true.
+
 <a name="group_security_group_object"></a>
 The `security_groups` block supports:
 

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -135,6 +135,11 @@ func ResourceASGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"source_dest_check": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
 					},
 				},
 			},
@@ -271,6 +276,18 @@ func buildNetworksOpts(networks []interface{}) []groups.NetworkOpts {
 			res[i].IPv6BandWidth = &groups.BandWidthOpts{
 				ID: id.(string),
 			}
+		}
+
+		if item["source_dest_check"].(bool) {
+			// Cancle all allowed-address-pairs to enable the source/destination check
+			res[i].AllowedAddressPairs = make([]groups.AddressPairOpts, 0)
+		} else {
+			// Update the allowed-address-pairs to 1.1.1.1/0
+			// to disable the source/destination check
+			addressPairs := groups.AddressPairOpts{
+				IpAddress: "1.1.1.1/0",
+			}
+			res[i].AllowedAddressPairs = []groups.AddressPairOpts{addressPairs}
 		}
 	}
 
@@ -614,6 +631,7 @@ func flattenNetworks(networks []groups.Network) []map[string]interface{} {
 			"id":                item.ID,
 			"ipv6_enable":       item.IPv6Enable,
 			"ipv6_bandwidth_id": item.IPv6BandWidth.ID,
+			"source_dest_check": len(item.AllowedAddressPairs) == 0,
 		}
 	}
 	return res


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #2792 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/as TESTARGS='-run=TestAccASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run=TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (248.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        248.717s

make testacc TEST=./huaweicloud/services/acceptance/as/ TESTARGS='-run=TestAccASGroup_sourceDestCheck'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as/ -v -run=TestAccASGroup_sourceDestCheck -timeout 360m -parallel 4
=== RUN   TestAccASGroup_sourceDestCheck
=== PAUSE TestAccASGroup_sourceDestCheck
=== CONT  TestAccASGroup_sourceDestCheck
--- PASS: TestAccASGroup_sourceDestCheck (161.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        161.099s
```