### PR TITLE
feat(DLI): add a new resource to manage authentication

### DIFF
--- a/docs/resources/dli_datasource_auth.md
+++ b/docs/resources/dli_datasource_auth.md
@@ -1,0 +1,153 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# huaweicloud_dli_datasource_auth
+
+Manages a DLI datasource authentication resource within HuaweiCloud.  
+
+## Example Usage
+
+### Create a datasource Password authentication
+
+```hcl
+  variable "username" {}
+  variable "password" {}
+  
+  resource "huaweicloud_dli_datasource_auth" "test" {
+    type     = "passwd"
+    name     = "demo"
+    username = var.username
+    password = var.password
+  }
+```
+
+### Create a datasource CSS authentication
+
+```hcl
+  variable "username" {}
+  variable "password" {}
+  variable "certificate_location" {}
+  
+  resource "huaweicloud_dli_datasource_auth" "test" {
+    type                 = "CSS"
+    name                 = "demo"
+    username             = var.username
+    password             = var.password
+    certificate_location = var.certificate_location
+  }
+```
+
+### Create a datasource Kafka_SSL authentication
+
+```hcl
+  variable "truststore_location" {}
+  variable "truststore_password" {}
+  variable "keystore_location" {}
+  variable "keystore_password" {}
+  variable "key_password" {}
+  
+  resource "huaweicloud_dli_datasource_auth" "test" {
+    type                = "Kafka_SSL"
+    name                = "demo"
+    truststore_location = var.truststore_location
+    truststore_password = var.truststore_password
+    keystore_location   = var.keystore_location
+    keystore_password   = var.keystore_password
+    key_password        = var.key_password
+  }
+```
+
+### Create a datasource Kerberos authentication
+
+```hcl
+  variable "username" {}
+  variable "krb5_conf" {}
+  variable "keytab" {}
+  
+  resource "huaweicloud_dli_datasource_auth" "test" {
+    type      = "KRB"
+    name      = "demo"
+    username  = var.username
+    krb5_conf = var.krb5_conf
+    keytab    = var.keytab
+  }
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) The name of a datasource authentication.
+
+* `type` - (Required, String, ForceNew) Data source type.  
+  The options are as follows:
+    + **passwd**: Password.
+    + **CSS**: CSS.
+    + **KRB**: Kafka_SSL.
+    + **Kafka_SSL**: Kafka_SSL.
+
+  Changing this parameter will create a new resource.
+
+* `username` - (Optional, String) Username for accessing the security cluster or datasource.
+
+* `password` - (Optional, String) The password for accessing the security cluster or datasource.
+
+* `certificate_location` - (Optional, String, ForceNew) Path of the security cluster certificate.  
+ Currently, only OBS paths and CER files are supported.
+
+  Changing this parameter will create a new resource.
+
+* `truststore_location` - (Optional, String) The OBS path of the **truststore** configuration file.
+
+* `truststore_password` - (Optional, String) The password of the **truststore** configuration file.
+
+* `keystore_location` - (Optional, String) The OBS path of the **keystore** configuration file.
+
+* `keystore_password` - (Optional, String) The password of the **keystore** configuration file.
+
+* `key_password` - (Optional, String, ForceNew) The key password.
+
+  Changing this parameter will create a new resource.
+
+* `krb5_conf` - (Optional, String) The OBS path of the **krb5** configuration file.
+
+* `keytab` - (Optional, String) The OBS path of the **keytab** configuration file.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the `name`.
+
+* `owner` - The user name of owner.
+
+## Import
+
+The DLI datasource authentication can be imported using `id` which equals the `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_dli_datasource_auth.test <name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include:
+`password`, `truststore_password`, `keystore_password`, `key_password`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dli_datasource_auth" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      password, truststore_password, keystore_password, key_password
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -724,6 +724,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_flinkjar_job":          dli.ResourceFlinkJarJob(),
 			"huaweicloud_dli_permission":            dli.ResourceDliPermission(),
 			"huaweicloud_dli_datasource_connection": dli.ResourceDatasourceConnection(),
+			"huaweicloud_dli_datasource_auth":       dli.ResourceDatasourceAuth(),
 
 			"huaweicloud_dms_kafka_user":        dms.ResourceDmsKafkaUser(),
 			"huaweicloud_dms_kafka_permissions": dms.ResourceDmsKafkaPermissions(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -60,7 +60,12 @@ var (
 	HW_SMS_SOURCE_SERVER            = os.Getenv("HW_SMS_SOURCE_SERVER")
 	HW_CFW_ENVIRONMENT              = os.Getenv("HW_CFW_ENVIRONMENT")
 
-	HW_DLI_FLINK_JAR_OBS_PATH = os.Getenv("HW_DLI_FLINK_JAR_OBS_PATH")
+	HW_DLI_FLINK_JAR_OBS_PATH           = os.Getenv("HW_DLI_FLINK_JAR_OBS_PATH")
+	HW_DLI_DS_AUTH_CSS_OBS_PATH         = os.Getenv("HW_DLI_DS_AUTH_CSS_OBS_PATH")
+	HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH = os.Getenv("HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH")
+	HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH   = os.Getenv("HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH")
+	HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH    = os.Getenv("HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH")
+	HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH     = os.Getenv("HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH")
 
 	HW_GITHUB_REPO_HOST      = os.Getenv("HW_GITHUB_REPO_HOST")      // Repository host (Github, Gitlab, Gitee)
 	HW_GITHUB_PERSONAL_TOKEN = os.Getenv("HW_GITHUB_PERSONAL_TOKEN") // Personal access token (Github, Gitlab, Gitee)
@@ -348,6 +353,27 @@ func TestAccPreCheckDms(t *testing.T) {
 func TestAccPreCheckDliJarPath(t *testing.T) {
 	if HW_DLI_FLINK_JAR_OBS_PATH == "" {
 		t.Skip("HW_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliDsAuthCss(t *testing.T) {
+	if HW_DLI_DS_AUTH_CSS_OBS_PATH == "" {
+		t.Skip("HW_DLI_DS_AUTH_CSS_OBS_PATH must be set for DLI datasource CSS Auth acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliDsAuthKafka(t *testing.T) {
+	if HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH == "" || HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH == "" {
+		t.Skip("HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH,HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH must be set for DLI datasource Kafka Auth acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliDsAuthKrb(t *testing.T) {
+	if HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH == "" || HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH == "" {
+		t.Skip("HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH,HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH must be set for DLI datasource Kafka Auth acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
@@ -1,0 +1,338 @@
+package dli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDatasourceAuthResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getDatasourceAuth: Query the DLI datasource authentication.
+	var (
+		getDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+		getDatasourceAuthProduct = "dli"
+	)
+	getDatasourceAuthClient, err := cfg.NewServiceClient(getDatasourceAuthProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DLI Client: %s", err)
+	}
+
+	getDatasourceAuthPath := getDatasourceAuthClient.Endpoint + getDatasourceAuthHttpUrl
+	getDatasourceAuthPath = strings.ReplaceAll(getDatasourceAuthPath, "{project_id}", getDatasourceAuthClient.ProjectID)
+
+	getDatasourceAuthPath += "?auth_info_name=" + state.Primary.ID
+
+	getDatasourceAuthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getDatasourceAuthResp, err := getDatasourceAuthClient.Request("GET", getDatasourceAuthPath, &getDatasourceAuthOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DatasourceAuth: %s", err)
+	}
+	getDatasourceAuthRespBody, err := utils.FlattenResponse(getDatasourceAuthResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DatasourceAuth: %s", err)
+	}
+	v := utils.PathSearch("auth_infos[0]", getDatasourceAuthRespBody, nil)
+	if v == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return v, nil
+}
+
+func TestAccDatasourceAuth_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dli_datasource_auth.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDatasourceAuthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDatasourceAuth_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "passwd"),
+					resource.TestCheckResourceAttr(rName, "username", "test"),
+					resource.TestCheckResourceAttrSet(rName, "owner"),
+				),
+			},
+			{
+				Config: testDatasourceAuth_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "username", "test123"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"truststore_password",
+					"keystore_password",
+					"key_password",
+				},
+			},
+		},
+	})
+}
+
+func testDatasourceAuth_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name     = "%s"
+  type     = "passwd"
+  username = "test"
+  password = "Huawei12!"
+}
+`, name)
+}
+
+func testDatasourceAuth_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name     = "%s"
+  type     = "passwd"
+  username = "test123"
+  password = "Huawei12!"
+}
+`, name)
+}
+
+func TestAccDatasourceAuth_css(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dli_datasource_auth.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDatasourceAuthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliDsAuthCss(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDatasourceAuth_css(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "CSS"),
+					resource.TestCheckResourceAttr(rName, "username", "test"),
+					resource.TestCheckResourceAttrSet(rName, "owner"),
+				),
+			},
+			{
+				Config: testDatasourceAuth_css_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "username", "test_update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"truststore_password",
+					"keystore_password",
+					"key_password",
+				},
+			},
+		},
+	})
+}
+
+func testDatasourceAuth_css(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name                 = "%s"
+  type                 = "CSS"
+  username             = "test"
+  password             = "Huawei12!"
+  certificate_location = "%s"
+}
+`, name, acceptance.HW_DLI_DS_AUTH_CSS_OBS_PATH)
+}
+
+func testDatasourceAuth_css_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name                 = "%s"
+  type                 = "CSS"
+  username             = "test_update"
+  password             = "Huawei12!"
+  certificate_location = "%s"
+}
+`, name, acceptance.HW_DLI_DS_AUTH_CSS_OBS_PATH)
+}
+
+func TestAccDatasourceAuth_Kafka_SSL(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dli_datasource_auth.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDatasourceAuthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliDsAuthKafka(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDatasourceAuth_Kafka_SSL(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "Kafka_SSL"),
+					resource.TestCheckResourceAttrSet(rName, "owner"),
+				),
+			},
+			{
+				Config: testDatasourceAuth_Kafka_SSL_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"truststore_password",
+					"keystore_password",
+					"key_password",
+				},
+			},
+		},
+	})
+}
+
+func testDatasourceAuth_Kafka_SSL(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name                = "%s"
+  type                = "Kafka_SSL"
+  truststore_location = "%s"
+  truststore_password = "Huawei12!"
+  keystore_location   = "%s"
+  keystore_password   = "Huawei12!"
+  key_password        = "Huawei12!"
+}
+`, name, acceptance.HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH, acceptance.HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH)
+}
+
+func testDatasourceAuth_Kafka_SSL_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name                = "%s"
+  type                = "Kafka_SSL"
+  truststore_location = "%s"
+  truststore_password = "Huawei123!"
+  keystore_location   = "%s"
+  keystore_password   = "Huawei123!"
+  key_password        = "Huawei123!"
+}
+`, name, acceptance.HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH, acceptance.HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH)
+}
+
+func TestAccDatasourceAuth_KRB(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dli_datasource_auth.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDatasourceAuthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliDsAuthKrb(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDatasourceAuth_KRB(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "KRB"),
+					resource.TestCheckResourceAttrSet(rName, "owner"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"truststore_password",
+					"keystore_password",
+					"key_password",
+				},
+			},
+		},
+	})
+}
+
+func testDatasourceAuth_KRB(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_datasource_auth" "test" {
+  name      = "%s"
+  type      = "KRB"
+  username  = "test"
+  krb5_conf = "%s"
+  keytab    = "%s"
+}
+`, name, acceptance.HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH, acceptance.HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH)
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
@@ -1,0 +1,360 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DLI
+// ---------------------------------------------------------------
+
+package dli
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDatasourceAuth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatasourceAuthCreate,
+		UpdateContext: resourceDatasourceAuthUpdate,
+		ReadContext:   resourceDatasourceAuthRead,
+		DeleteContext: resourceDatasourceAuthDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of a datasource authentication.`,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9][\w]*$`),
+						"Only letters, digits and underscores (_) are allowed."),
+					validation.StringDoesNotMatch(regexp.MustCompile(`^[0-9]*$`), "The name cannot be all digits."),
+				),
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Data source type.`,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Username for accessing the security cluster or datasource.`,
+				ConflictsWith: []string{
+					"truststore_location",
+				},
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The password for accessing the security cluster or datasource.`,
+				RequiredWith: []string{
+					"username",
+				},
+			},
+			"certificate_location": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The OBS path of the security cluster certificate.`,
+				ConflictsWith: []string{
+					"truststore_location", "krb5_conf",
+				},
+			},
+			"truststore_location": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The OBS path of the **truststore** configuration file.`,
+				RequiredWith: []string{
+					"truststore_password", "keystore_location", "keystore_password", "key_password",
+				},
+			},
+			"truststore_password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Computed:    true,
+				Description: `The password of the **truststore** configuration file.`,
+			},
+			"keystore_location": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The OBS path of the **keystore** configuration file.`,
+			},
+			"keystore_password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Computed:    true,
+				Description: `The password of the **keystore ** configuration file.`,
+			},
+			"key_password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The key password.`,
+			},
+			"krb5_conf": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The OBS path of the **krb5** configuration file.`,
+				RequiredWith: []string{
+					"keytab",
+				},
+			},
+			"keytab": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The OBS path of the **keytab** configuration file.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user name of owner.`,
+			},
+		},
+	}
+}
+
+func resourceDatasourceAuthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createDatasourceAuth: create a DLI datasource authentication.
+	var (
+		createDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+		createDatasourceAuthProduct = "dli"
+	)
+	createDatasourceAuthClient, err := cfg.NewServiceClient(createDatasourceAuthProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DLI Client: %s", err)
+	}
+
+	createDatasourceAuthPath := createDatasourceAuthClient.Endpoint + createDatasourceAuthHttpUrl
+	createDatasourceAuthPath = strings.ReplaceAll(createDatasourceAuthPath, "{project_id}", createDatasourceAuthClient.ProjectID)
+
+	createDatasourceAuthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			201,
+		},
+	}
+	createDatasourceAuthOpt.JSONBody = utils.RemoveNil(buildCreateDatasourceAuthBodyParams(d, cfg))
+	_, err = createDatasourceAuthClient.Request("POST", createDatasourceAuthPath, &createDatasourceAuthOpt)
+	if err != nil {
+		return diag.Errorf("error creating DatasourceAuth: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceDatasourceAuthRead(ctx, d, meta)
+}
+
+func buildCreateDatasourceAuthBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"auth_info_name":       utils.ValueIngoreEmpty(d.Get("name")),
+		"datasource_type":      utils.ValueIngoreEmpty(d.Get("type")),
+		"username":             utils.ValueIngoreEmpty(d.Get("username")),
+		"password":             utils.ValueIngoreEmpty(d.Get("password")),
+		"certificate_location": utils.ValueIngoreEmpty(d.Get("certificate_location")),
+		"truststore_location":  utils.ValueIngoreEmpty(d.Get("truststore_location")),
+		"truststore_password":  utils.ValueIngoreEmpty(d.Get("truststore_password")),
+		"keystore_location":    utils.ValueIngoreEmpty(d.Get("keystore_location")),
+		"keystore_password":    utils.ValueIngoreEmpty(d.Get("keystore_password")),
+		"key_password":         utils.ValueIngoreEmpty(d.Get("key_password")),
+		"krb5_conf":            utils.ValueIngoreEmpty(d.Get("krb5_conf")),
+		"keytab":               utils.ValueIngoreEmpty(d.Get("keytab")),
+	}
+	return bodyParams
+}
+
+func resourceDatasourceAuthRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getDatasourceAuth: Query the DLI datasource authentication.
+	var (
+		getDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+		getDatasourceAuthProduct = "dli"
+	)
+	getDatasourceAuthClient, err := cfg.NewServiceClient(getDatasourceAuthProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DLI Client: %s", err)
+	}
+
+	getDatasourceAuthPath := getDatasourceAuthClient.Endpoint + getDatasourceAuthHttpUrl
+	getDatasourceAuthPath = strings.ReplaceAll(getDatasourceAuthPath, "{project_id}", getDatasourceAuthClient.ProjectID)
+
+	getDatasourceAuthqueryParams := buildGetDatasourceAuthQueryParams(d)
+	getDatasourceAuthPath += getDatasourceAuthqueryParams
+
+	getDatasourceAuthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getDatasourceAuthResp, err := getDatasourceAuthClient.Request("GET", getDatasourceAuthPath, &getDatasourceAuthOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DatasourceAuth")
+	}
+
+	getDatasourceAuthRespBody, err := utils.FlattenResponse(getDatasourceAuthResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	v := utils.PathSearch("auth_infos[0]", getDatasourceAuthRespBody, nil)
+	if v == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving DatasourceAuth")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("auth_infos[0].auth_info_name", getDatasourceAuthRespBody, nil)),
+		d.Set("type", utils.PathSearch("auth_infos[0].datasource_type", getDatasourceAuthRespBody, nil)),
+		d.Set("username", utils.PathSearch("auth_infos[0].username", getDatasourceAuthRespBody, nil)),
+		d.Set("certificate_location", utils.PathSearch("auth_infos[0].certificate_location", getDatasourceAuthRespBody, nil)),
+		d.Set("truststore_location", utils.PathSearch("auth_infos[0].truststore_location", getDatasourceAuthRespBody, nil)),
+		d.Set("keystore_location", utils.PathSearch("auth_infos[0].keystore_location", getDatasourceAuthRespBody, nil)),
+		d.Set("krb5_conf", utils.PathSearch("auth_infos[0].krb5_conf", getDatasourceAuthRespBody, nil)),
+		d.Set("keytab", utils.PathSearch("auth_infos[0].keytab", getDatasourceAuthRespBody, nil)),
+		d.Set("owner", utils.PathSearch("auth_infos[0].owner", getDatasourceAuthRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetDatasourceAuthQueryParams(d *schema.ResourceData) string {
+	res := ""
+	res = fmt.Sprintf("%s&auth_info_name=%v", res, d.Id())
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+func resourceDatasourceAuthUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateDatasourceAuthChanges := []string{
+		"name",
+		"username",
+		"password",
+		"truststore_location",
+		"truststore_password",
+		"keystore_location",
+		"keystore_password",
+		"krb5_conf",
+		"keytab",
+	}
+
+	if d.HasChanges(updateDatasourceAuthChanges...) {
+		var (
+			updateDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+			updateDatasourceAuthProduct = "dli"
+		)
+		updateDatasourceAuthClient, err := cfg.NewServiceClient(updateDatasourceAuthProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating DLI Client: %s", err)
+		}
+
+		updateDatasourceAuthPath := updateDatasourceAuthClient.Endpoint + updateDatasourceAuthHttpUrl
+		updateDatasourceAuthPath = strings.ReplaceAll(updateDatasourceAuthPath, "{project_id}", updateDatasourceAuthClient.ProjectID)
+
+		updateDatasourceAuthOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateDatasourceAuthOpt.JSONBody = utils.RemoveNil(buildUpdateDatasourceAuthBodyParams(d, cfg))
+		_, err = updateDatasourceAuthClient.Request("PUT", updateDatasourceAuthPath, &updateDatasourceAuthOpt)
+		if err != nil {
+			return diag.Errorf("error updating DatasourceAuth: %s", err)
+		}
+	}
+	return resourceDatasourceAuthRead(ctx, d, meta)
+}
+
+func buildUpdateDatasourceAuthBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"auth_info_name":      utils.ValueIngoreEmpty(d.Get("name")),
+		"username":            utils.ValueIngoreEmpty(d.Get("username")),
+		"password":            utils.ValueIngoreEmpty(d.Get("password")),
+		"truststore_location": utils.ValueIngoreEmpty(d.Get("truststore_location")),
+		"truststore_password": utils.ValueIngoreEmpty(d.Get("truststore_password")),
+		"keystore_location":   utils.ValueIngoreEmpty(d.Get("keystore_location")),
+		"keystore_password":   utils.ValueIngoreEmpty(d.Get("keystore_password")),
+		"krb5_conf":           utils.ValueIngoreEmpty(d.Get("krb5_conf")),
+		"keytab":              utils.ValueIngoreEmpty(d.Get("keytab")),
+	}
+	return bodyParams
+}
+
+func resourceDatasourceAuthDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteDatasourceAuth: missing operation notes
+	var (
+		deleteDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos/{id}"
+		deleteDatasourceAuthProduct = "dli"
+	)
+	deleteDatasourceAuthClient, err := cfg.NewServiceClient(deleteDatasourceAuthProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DLI Client: %s", err)
+	}
+
+	deleteDatasourceAuthPath := deleteDatasourceAuthClient.Endpoint + deleteDatasourceAuthHttpUrl
+	deleteDatasourceAuthPath = strings.ReplaceAll(deleteDatasourceAuthPath, "{project_id}", deleteDatasourceAuthClient.ProjectID)
+	deleteDatasourceAuthPath = strings.ReplaceAll(deleteDatasourceAuthPath, "{id}", d.Id())
+
+	deleteDatasourceAuthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	_, err = deleteDatasourceAuthClient.Request("DELETE", deleteDatasourceAuthPath, &deleteDatasourceAuthOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DatasourceAuth: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1670 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatasourceAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatasourceAuth -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== RUN   TestAccDatasourceAuth_css
=== PAUSE TestAccDatasourceAuth_css
=== RUN   TestAccDatasourceAuth_Kafka_SSL
=== PAUSE TestAccDatasourceAuth_Kafka_SSL
=== RUN   TestAccDatasourceAuth_KRB
=== PAUSE TestAccDatasourceAuth_KRB
=== CONT  TestAccDatasourceAuth_basic
=== CONT  TestAccDatasourceAuth_Kafka_SSL
=== CONT  TestAccDatasourceAuth_css
=== CONT  TestAccDatasourceAuth_KRB
--- PASS: TestAccDatasourceAuth_KRB (10.42s)
--- PASS: TestAccDatasourceAuth_basic (13.54s)
--- PASS: TestAccDatasourceAuth_css (16.21s)
--- PASS: TestAccDatasourceAuth_Kafka_SSL (18.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       18.738s
```
