### PR TITLE
chore(rfs): rename rf to rfs as service name changed

### DIFF
--- a/docs/resources/rfs_stack.md
+++ b/docs/resources/rfs_stack.md
@@ -2,13 +2,13 @@
 subcategory: "Application Orchestration Service (AOS)"
 ---
 
-# huaweicloud_rf_stack
+# huaweicloud_rfs_stack
 
-Provides an RF resource stack.
+Provides an RFS resource stack.
 
 ## Example Usage
 
-### Create an RF resource stack with resource deployment (using OBS URIs)
+### Create an RFS resource stack with resource deployment (using OBS URIs)
 
 ```hcl
 variable "stack_name" {}
@@ -16,7 +16,7 @@ variable "agency_name" {}
 variable "template_obs_uri" {}
 variable "variable_obs_uri" {}
 
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name = var.stack_name
 
   agency {
@@ -28,7 +28,7 @@ resource "huaweicloud_rf_stack" "test" {
   vars_uri     = var.variable_obs_uri
 ```
 
-### Create an RF resource stack with VPC deployment (using template and variable files)
+### Create an RFS resource stack with VPC deployment (using template and variable files)
 
 ```hcl
 variable "stack_name" {}
@@ -36,7 +36,7 @@ variable "agency_name" {}
 variable "template_path" {}
 variable "variable_path" {}
 
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name = var.stack_name
 
   agency {
@@ -110,7 +110,7 @@ subnet_name = "tf-example-vpc-subnet"
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region where the RF resource stack is located.  
+* `region` - (Optional, String, ForceNew) Specifies the region where the RFS resource stack is located.  
   If omitted, the provider-level region will be used. Change this parameter will create a new resource.
 
 * `name` - (Required, String, ForceNew) Specifies the name of the resource stack.  
@@ -178,10 +178,10 @@ This resource provides the following timeouts configuration options:
 * `delete` - Default is 5 minutes.
 
 For most HCL templates, the timeout parameters needs to be manually configured by the user to ensure that resources can
-be deployed successfully on the RF resource stack, e.g.
+be deployed successfully on the RFS resource stack, e.g.
 
 ```hcl
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   ...
 
   timeouts {
@@ -196,7 +196,7 @@ resource "huaweicloud_rf_stack" "test" {
 Stacks can be imported using their `id`, e.g.
 
 ```
-$ terraform import huaweicloud_rf_stack.test edd2f099-e1ac-4bd0-be32-8b2185620a90
+$ terraform import huaweicloud_rfs_stack.test edd2f099-e1ac-4bd0-be32-8b2185620a90
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
@@ -206,7 +206,7 @@ importing a stack. You can keep the resource the same with its definition bo cho
 Also you can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   ...
 
   lifecycle {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -75,7 +75,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/oms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/projectman"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rf"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rfs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/scm"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
@@ -612,7 +612,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_alarm_rule":             aom.ResourceAlarmRule(),
 			"huaweicloud_aom_service_discovery_rule": aom.ResourceServiceDiscoveryRule(),
 
-			"huaweicloud_rf_stack": rf.ResourceStack(),
+			"huaweicloud_rfs_stack": rfs.ResourceStack(),
 
 			"huaweicloud_api_gateway_api":   ResourceAPIGatewayAPI(),
 			"huaweicloud_api_gateway_group": ResourceAPIGatewayGroup(),
@@ -1019,6 +1019,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_rds_instance_v3":       rds.ResourceRdsInstance(),
 			"huaweicloud_rds_parametergroup_v3": rds.ResourceRdsConfiguration(),
+
+			"huaweicloud_rf_stack": rfs.ResourceStack(),
 
 			"huaweicloud_nat_dnat_rule_v2": nat.ResourcePublicDnatRule(),
 			"huaweicloud_nat_gateway_v2":   nat.ResourcePublicGateway(),

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_stack_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_stack_test.go
@@ -1,4 +1,4 @@
-package rf
+package rfs
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rf"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rfs"
 )
 
 func getStackesourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -19,14 +19,14 @@ func getStackesourceFunc(config *config.Config, state *terraform.ResourceState) 
 		return nil, fmt.Errorf("error creating AOS v3 client: %s", err)
 	}
 
-	return rf.QueryStackById(client, state.Primary.ID)
+	return rfs.QueryStackById(client, state.Primary.ID)
 }
 
 func TestAccStack_basic(t *testing.T) { // the template file is json format.
 	var (
 		obj stacks.Stack
 
-		rName = "huaweicloud_rf_stack.test"
+		rName = "huaweicloud_rfs_stack.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
 
@@ -82,7 +82,7 @@ func TestAccStack_basic(t *testing.T) { // the template file is json format.
 
 func testAccStack_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name        = "%[1]s"
   description = "Create by acc test"
 }
@@ -91,7 +91,7 @@ resource "huaweicloud_rf_stack" "test" {
 
 func testAccStack_withBody_step1(name, template string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name        = "%[1]s"
   description = "Create by acc test"
 
@@ -107,7 +107,7 @@ resource "huaweicloud_rf_stack" "test" {
 
 func testAccStack_withBody_step2(name, template, vars string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name        = "%[1]s"
   description = "Create by acc test"
 
@@ -126,7 +126,7 @@ func TestAccStack_withBody_HCL(t *testing.T) {
 	var (
 		obj stacks.Stack
 
-		rName = "huaweicloud_rf_stack.test"
+		rName = "huaweicloud_rfs_stack.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
 
@@ -184,7 +184,7 @@ func TestAccStack_withUri_JSON(t *testing.T) {
 	var (
 		obj stacks.Stack
 
-		rName = "huaweicloud_rf_stack.test"
+		rName = "huaweicloud_rfs_stack.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
 
@@ -288,7 +288,7 @@ func testAccStack_withUri_step1(name, template, vars string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name = "%[2]s"
 
   agency {
@@ -305,7 +305,7 @@ func testAccStack_withUri_step2(name, template, vars string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name = "%[2]s"
 
   agency {
@@ -323,7 +323,7 @@ func TestAccStack_withUri_HCL(t *testing.T) {
 	var (
 		obj stacks.Stack
 
-		rName = "huaweicloud_rf_stack.test"
+		rName = "huaweicloud_rfs_stack.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
 
@@ -380,7 +380,7 @@ func TestAccStack_archive(t *testing.T) {
 	var (
 		obj stacks.Stack
 
-		rName = "huaweicloud_rf_stack.test"
+		rName = "huaweicloud_rfs_stack.test"
 		name  = acceptance.RandomAccResourceNameWithDash()
 	)
 
@@ -436,7 +436,7 @@ func TestAccStack_archive(t *testing.T) {
 
 func testAccStack_archive_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name = "%[1]s"
 
   agency {
@@ -451,7 +451,7 @@ resource "huaweicloud_rf_stack" "test" {
 
 func testAccStack_archive_step2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_rf_stack" "test" {
+resource "huaweicloud_rfs_stack" "test" {
   name = "%[1]s"
 
   agency {

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_stack.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_stack.go
@@ -1,4 +1,4 @@
-package rf
+package rfs
 
 import (
 	"context"
@@ -43,7 +43,7 @@ func ResourceStack() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
-				Description: "The region where the RF resource stack is located.",
+				Description: "The region where the RFS resource stack is located.",
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -333,7 +333,7 @@ func resourceStackRead(_ context.Context, d *schema.ResourceData, meta interface
 	stackId := d.Id()
 	resp, err := QueryStackById(client, stackId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "RF resource stack")
+		return common.CheckDeletedDiag(d, err, "RFS resource stack")
 	}
 
 	mErr := multierror.Append(nil,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rfs TESTARGS='-run=TestAccStack'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run=TestAccStack -timeout 360m -parallel 4
=== RUN   TestAccStack_basic
=== PAUSE TestAccStack_basic
=== RUN   TestAccStack_withBody_HCL
=== PAUSE TestAccStack_withBody_HCL
=== RUN   TestAccStack_withUri_JSON
=== PAUSE TestAccStack_withUri_JSON
=== RUN   TestAccStack_withUri_HCL
=== PAUSE TestAccStack_withUri_HCL
=== RUN   TestAccStack_archive
=== PAUSE TestAccStack_archive
=== CONT  TestAccStack_basic
=== CONT  TestAccStack_withUri_HCL
=== CONT  TestAccStack_archive
    acceptance.go:474: Skip the archive URI parameters acceptance test for RF resource stack.
--- SKIP: TestAccStack_archive (0.00s)
=== CONT  TestAccStack_withUri_JSON
=== CONT  TestAccStack_withBody_HCL
--- PASS: TestAccStack_withUri_JSON (115.94s)
--- PASS: TestAccStack_withBody_HCL (126.09s)
--- PASS: TestAccStack_basic (128.84s)
--- PASS: TestAccStack_withUri_HCL (184.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       184.422s
```
