### PR TITLE
feat: dns support custom line resource

### DIFF
--- a/docs/resources/dns_custom_line.md
+++ b/docs/resources/dns_custom_line.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Domain Name Service (DNS)"
+---
+
+# huaweicloud_dns_custom_line
+
+Manages a DNS custom line resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "description" {}
+variable "ip_segments" {
+  type = list(string)
+}
+
+resource "huaweicloud_dns_custom_line" "test" {
+  name        = var.name
+  description = var.description
+  ip_segments = var.ip_segments
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the custom line name.
+  The value consists of 1 to 80 characters including chinese and english letters, digits, hyphens (-), underscores (_),
+  and periods (.). The name of each resolution line set by one account must be unique.
+
+* `ip_segments` - (Required, List) Specifies the IP address range.
+  The start IP address is separated from the end IP address with a hyphen (-). The IP address ranges cannot overlap.
+  If the start and end IP addresses are the same, there is only one IP address in the range. Set the value to
+  IP1-IP1. Currently, only IPv4 addresses are supported. You can specify a maximum of 50 IP address ranges.
+
+* `description` - (Optional, String) Specifies the custom line description. A maximum of 255 characters are allowed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The resource status.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+The DNS custom line can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_custom_line.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -735,9 +735,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
 			"huaweicloud_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),
 
-			"huaweicloud_dns_ptrrecord": dns.ResourceDNSPtrRecord(),
-			"huaweicloud_dns_recordset": dns.ResourceDNSRecordset(),
-			"huaweicloud_dns_zone":      dns.ResourceDNSZone(),
+			"huaweicloud_dns_custom_line": dns.ResourceDNSCustomLine(),
+			"huaweicloud_dns_ptrrecord":   dns.ResourceDNSPtrRecord(),
+			"huaweicloud_dns_recordset":   dns.ResourceDNSRecordset(),
+			"huaweicloud_dns_zone":        dns.ResourceDNSZone(),
 
 			"huaweicloud_drs_job":     drs.ResourceDrsJob(),
 			"huaweicloud_dws_cluster": dws.ResourceDwsCluster(),

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_custom_line_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_custom_line_test.go
@@ -1,0 +1,129 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDNSCustomLineResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getDNSCustomLine: Query DNS custom line
+	var (
+		getDNSCustomLineHttpUrl = "v2.1/customlines"
+		getDNSCustomLineProduct = "dns"
+	)
+	getDNSCustomLineClient, err := cfg.NewServiceClient(getDNSCustomLineProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DNS Client: %s", err)
+	}
+
+	getDNSCustomLinePath := getDNSCustomLineClient.Endpoint + getDNSCustomLineHttpUrl
+	getDNSCustomLinePath += fmt.Sprintf("?line_id=%s", state.Primary.ID)
+
+	getDNSCustomLineOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getDNSCustomLineResp, err := getDNSCustomLineClient.Request("GET", getDNSCustomLinePath, &getDNSCustomLineOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DNS custom line: %s", err)
+	}
+
+	getDNSCustomLineRespBody, err := utils.FlattenResponse(getDNSCustomLineResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flatten DNS custom line response: %s", err)
+	}
+	return flattenCustomLineResponseBody(getDNSCustomLineRespBody, state.Primary.ID)
+}
+
+func flattenCustomLineResponseBody(resp interface{}, id string) (interface{}, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("custom line response is empty")
+	}
+	curJson := utils.PathSearch("lines", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	for _, v := range curArray {
+		lineId := utils.PathSearch("line_id", v, "")
+		if id == lineId.(string) {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("the target custom line (%s) not exist", id)
+}
+
+func TestAccDNSCustomLine_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dns_custom_line.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDNSCustomLineResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSCustomLine_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "ip_segments.0", "100.100.100.100-100.100.100.100"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: testDNSCustomLine_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "ip_segments.0", "100.100.100.101-100.100.100.101"),
+					resource.TestCheckResourceAttr(rName, "ip_segments.1", "100.100.100.102-100.100.100.102"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDNSCustomLine_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_custom_line" "test" {
+  name        = "%s"
+  description = "test description"
+  ip_segments = ["100.100.100.100-100.100.100.100"]
+}
+`, name)
+}
+
+func testDNSCustomLine_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_custom_line" "test" {
+  name        = "%s_update"
+  description = "test description update"
+  ip_segments = ["100.100.100.101-100.100.100.101", "100.100.100.102-100.100.100.102"]
+}
+`, name)
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
@@ -1,0 +1,380 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DNS
+// ---------------------------------------------------------------
+
+package dns
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDNSCustomLine() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDNSCustomLineCreate,
+		UpdateContext: resourceDNSCustomLineUpdate,
+		ReadContext:   resourceDNSCustomLineRead,
+		DeleteContext: resourceDNSCustomLineDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 80),
+					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa5A-Za-z]([\u4e00-\u9fa5\\w-.]*)?$"),
+						"Only chinese and english letters, digits, hyphens (-), underscores (_), and periods"+
+							" (.) are allowed"),
+				),
+				Description: `Specifies the custom line name.`,
+			},
+			"ip_segments": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				MinItems:    1,
+				MaxItems:    50,
+				Description: `Specifies the IP address range.`,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringLenBetween(0, 255),
+				Description:  `Specifies the custom line description. A maximum of 255 characters are allowed.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource status.`,
+			},
+		},
+	}
+}
+
+func resourceDNSCustomLineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	createDNSCustomLineClient, err := cfg.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS Client: %s", err)
+	}
+
+	// createDNSCustomLine: create DNS custom line.
+	if err := createDNSCustomLine(createDNSCustomLineClient, d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	timeout := d.Timeout(schema.TimeoutCreate)
+	if err := waitForDNSCustomLineCreateOrUpdate(ctx, createDNSCustomLineClient, d, timeout); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceDNSCustomLineRead(ctx, d, meta)
+}
+
+func createDNSCustomLine(customLineClient *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		createDNSCustomLineHttpUrl = "v2.1/customlines"
+	)
+
+	createDNSCustomLinePath := customLineClient.Endpoint + createDNSCustomLineHttpUrl
+	createDNSCustomLineOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			202,
+		},
+	}
+	createDNSCustomLineOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateDNSCustomLineBodyParams(d))
+	createDNSCustomLineResp, err := customLineClient.Request("POST", createDNSCustomLinePath,
+		&createDNSCustomLineOpt)
+	if err != nil {
+		return fmt.Errorf("error creating DNS custom line: %s", err)
+	}
+
+	createDNSCustomLineRespBody, err := utils.FlattenResponse(createDNSCustomLineResp)
+	if err != nil {
+		return err
+	}
+
+	id, err := jmespath.Search("line_id", createDNSCustomLineRespBody)
+	if err != nil {
+		return fmt.Errorf("error creating DNS custom line: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+	return nil
+}
+
+func waitForDNSCustomLineCreateOrUpdate(ctx context.Context, customLineClient *golangsdk.ServiceClient,
+	d *schema.ResourceData, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"ACTIVE"},
+		Pending:      []string{"PENDING"},
+		Refresh:      dnsCustomLineStatusRefreshFunc(d, customLineClient),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for DNS custom line (%s) to be ACTIVE : %s", d.Id(), err)
+	}
+	return nil
+}
+
+func buildCreateOrUpdateDNSCustomLineBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        utils.ValueIngoreEmpty(d.Get("name")),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"ip_segments": utils.ValueIngoreEmpty(d.Get("ip_segments")),
+	}
+	return bodyParams
+}
+
+func resourceDNSCustomLineRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getDNSCustomLine: Query DNS custom line
+	var (
+		getDNSCustomLineHttpUrl = "v2.1/customlines"
+		getDNSCustomLineProduct = "dns"
+	)
+	getDNSCustomLineClient, err := cfg.NewServiceClient(getDNSCustomLineProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DNS Client: %s", err)
+	}
+
+	getDNSCustomLinePath := getDNSCustomLineClient.Endpoint + getDNSCustomLineHttpUrl
+	getDNSCustomLinePath += buildGetDNSCustomLineQueryParams(d)
+
+	getDNSCustomLineOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getDNSCustomLineResp, err := getDNSCustomLineClient.Request("GET", getDNSCustomLinePath,
+		&getDNSCustomLineOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS custom line")
+	}
+
+	getDNSCustomLineRespBody, err := utils.FlattenResponse(getDNSCustomLineResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	customLineMap, err := flattenCustomLineResponseBody(getDNSCustomLineRespBody, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS custom line")
+	}
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", customLineMap["name"]),
+		d.Set("ip_segments", customLineMap["ip_segments"]),
+		d.Set("status", customLineMap["status"]),
+		d.Set("description", customLineMap["description"]),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCustomLineResponseBody(resp interface{}, d *schema.ResourceData) (map[string]interface{}, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("the custom line response is empty")
+	}
+
+	curJson := utils.PathSearch("lines", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	for _, v := range curArray {
+		lineId := utils.PathSearch("line_id", v, "")
+		if d.Id() == lineId.(string) {
+			return map[string]interface{}{
+				"name":        utils.PathSearch("name", v, nil),
+				"ip_segments": utils.PathSearch("ip_segments", v, nil),
+				"status":      utils.PathSearch("status", v, nil),
+				"description": utils.PathSearch("description", v, nil),
+			}, nil
+		}
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func buildGetDNSCustomLineQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?line_id=%s", d.Id())
+}
+
+func resourceDNSCustomLineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	updateDNSCustomLineClient, err := cfg.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS Client: %s", err)
+	}
+
+	updateDNSCustomLineChanges := []string{
+		"name",
+		"description",
+		"ip_segments",
+	}
+
+	if d.HasChanges(updateDNSCustomLineChanges...) {
+		// updateDNSCustomLine: Update DNS custom line
+		if err := updateDNSCustomLine(updateDNSCustomLineClient, d); err != nil {
+			return diag.FromErr(err)
+		}
+
+		timeout := d.Timeout(schema.TimeoutUpdate)
+		if err := waitForDNSCustomLineCreateOrUpdate(ctx, updateDNSCustomLineClient, d, timeout); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return resourceDNSCustomLineRead(ctx, d, meta)
+}
+
+func updateDNSCustomLine(customLineClient *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		updateDNSCustomLineHttpUrl = "v2.1/customlines/{line_id}"
+	)
+
+	updateDNSCustomLinePath := customLineClient.Endpoint + updateDNSCustomLineHttpUrl
+	updateDNSCustomLinePath = strings.ReplaceAll(updateDNSCustomLinePath, "{line_id}", d.Id())
+
+	updateDNSCustomLineOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			202,
+		},
+	}
+	updateDNSCustomLineOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateDNSCustomLineBodyParams(d))
+	_, err := customLineClient.Request("PUT", updateDNSCustomLinePath,
+		&updateDNSCustomLineOpt)
+	if err != nil {
+		return fmt.Errorf("error updating DNS custom line: %s", err)
+	}
+	return nil
+}
+
+func resourceDNSCustomLineDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteDNSCustomLine: Delete DNS custom line
+	var (
+		deleteDNSCustomLineHttpUrl = "v2.1/customlines/{line_id}"
+		deleteDNSCustomLineProduct = "dns"
+	)
+	deleteDNSCustomLineClient, err := cfg.NewServiceClient(deleteDNSCustomLineProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DNS Client: %s", err)
+	}
+
+	deleteDNSCustomLinePath := deleteDNSCustomLineClient.Endpoint + deleteDNSCustomLineHttpUrl
+	deleteDNSCustomLinePath = strings.ReplaceAll(deleteDNSCustomLinePath, "{line_id}", d.Id())
+
+	deleteDNSCustomLineOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			202,
+		},
+	}
+	_, err = deleteDNSCustomLineClient.Request("DELETE", deleteDNSCustomLinePath, &deleteDNSCustomLineOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DNS custom line: %s", err)
+	}
+
+	if err := waitForDNSCustomLineDeleted(ctx, deleteDNSCustomLineClient, d); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func waitForDNSCustomLineDeleted(ctx context.Context, customLineClient *golangsdk.ServiceClient,
+	d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"DELETED"},
+		Pending:      []string{"ACTIVE", "PENDING", "ERROR"},
+		Refresh:      dnsCustomLineStatusRefreshFunc(d, customLineClient),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for DNS custom line (%s) to be DELETED: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func dnsCustomLineStatusRefreshFunc(d *schema.ResourceData, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			getDNSCustomLineHttpUrl = "v2.1/customlines"
+		)
+
+		getDNSCustomLinePath := client.Endpoint + getDNSCustomLineHttpUrl
+		getDNSCustomLinePath += buildGetDNSCustomLineQueryParams(d)
+		getDNSCustomLineOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+
+		getDNSCustomLineResp, err := client.Request("GET", getDNSCustomLinePath, &getDNSCustomLineOpt)
+		if err != nil {
+			return nil, "", err
+		}
+
+		getDNSCustomLineRespBody, err := utils.FlattenResponse(getDNSCustomLineResp)
+		if err != nil {
+			return nil, "", err
+		}
+		customLineMap, err := flattenCustomLineResponseBody(getDNSCustomLineRespBody, d)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return customLineMap, "DELETED", nil
+			}
+			return customLineMap, "", err
+		}
+
+		status := customLineMap["status"]
+		return getDNSCustomLineRespBody, parseStatus(status.(string)), nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
DNS support custom line resource.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSCustomLine_basic'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSCustomLine_basic -timeout 360m -parallel 4 
=== RUN   TestAccDNSCustomLine_basic 
=== PAUSE TestAccDNSCustomLine_basic
=== CONT  TestAccDNSCustomLine_basic
--- PASS: TestAccDNSCustomLine_basic (32.65s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       32.707s
```
