### PR TITLE
docs(cse/engine): new parameter enterprise project id support

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -83,6 +83,10 @@ The following arguments are supported:
   This parameter will be affected by these parameters and will appear when `terraform plan` or `terraform apply`.
   If it is inconsistent with the script configuration, it can be ignored by `ignore_changes` in non-change scenarios.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the dedicated
+  microservice engine belongs.  
+  Changing this will create a new engine.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -117,7 +121,7 @@ This resource provides the following timeouts configuration options:
 
 Engines can be imported using their `id`, e.g.
 
-```
+```bash
 $ terraform import huaweicloud_cse_microservice_engine.test eddc5d42-f9d5-4f8e-984b-d6f3e088561c
 ```
 
@@ -137,4 +141,11 @@ resource "huaweicloud_cse_microservice_engine" "test" {
     ]
   }
 }
+```
+
+For the engine created with the `enterprise_project_id`, its enterprise project ID needs to be specified additionally
+when importing, the format is `<id>/<enterprise_project_id>`, e.g.
+
+```bash
+$ terraform import huaweicloud_cse_microservice_engine.test eddc5d42-f9d5-4f8e-984b-d6f3e088561c/ef101e1a-990c-42cd-bb99-a4474e41e461
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support new parameter 'enterprise_project_id' to the CSE engine document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new parameter 'enterprise_project_id'.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
PENDING
```
