### PR TITLE
refactor(IMS): fix ims data source lint issues

### DIFF
--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccImsImageDataSource_basic(t *testing.T) {
@@ -156,7 +156,7 @@ resource "huaweicloud_compute_instance" "test" {
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
-    uuid = data.huaweicloud_vpc_subnet.test.id
+    uuid = huaweicloud_vpc_subnet.test.id
   }
 }
 

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccImsImagesDataSource_basic(t *testing.T) {
@@ -96,8 +96,8 @@ func TestAccImsImagesDataSource_testQueries(t *testing.T) {
 func testAccImsImagesDataSource_publicName(imageName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_images_images" "test" {
-  name        = "%s"
-  visibility  = "public"
+  name       = "%s"
+  visibility = "public"
 }
 `, imageName)
 }
@@ -125,8 +125,8 @@ data "huaweicloud_images_images" "test" {
 func testAccImsImagesDataSource_market() string {
 	return `
 data "huaweicloud_images_images" "test" {
-  os          = "CentOS"
-  visibility  = "market"
+  os         = "CentOS"
+  visibility = "market"
 }
 `
 }
@@ -145,15 +145,18 @@ data "huaweicloud_compute_flavors" "test" {
 }
 
 resource "huaweicloud_compute_instance" "test" {
-  name               = "%[2]s"
-  image_name         = "Ubuntu 18.04 server 64bit"
-  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  name       = "%[2]s"
+  image_name = "Ubuntu 18.04 server 64bit"
+  flavor_id  = data.huaweicloud_compute_flavors.test.ids[0]
+
   security_group_ids = [
     huaweicloud_networking_secgroup.test.id
   ]
-  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+
   network {
-    uuid = data.huaweicloud_vpc_subnet.test.id
+    uuid = huaweicloud_vpc_subnet.test.id
   }
 }
 
@@ -161,6 +164,7 @@ resource "huaweicloud_images_image" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_compute_instance.test.id
   description = "created by Terraform AccTest"
+
   tags = {
     foo = "bar"
     key = "value"
@@ -183,8 +187,8 @@ func testAccImsImagesDataSource_queryTag(rName string) string {
 	return fmt.Sprintf(`
 %s
 data "huaweicloud_images_images" "test" {
-  visibility  = "private"
-  tag         = "foo=bar"
+  visibility = "private"
+  tag        = "foo=bar"
 }
 `, testAccImsImagesDataSource_base(rName))
 }

--- a/huaweicloud/services/ims/data_source_huaweicloud_images_image.go
+++ b/huaweicloud/services/ims/data_source_huaweicloud_images_image.go
@@ -2,29 +2,22 @@ package ims
 
 import (
 	"context"
+	"log"
 	"regexp"
 	"sort"
 	"strconv"
 	"time"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
-
-	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
-
-var imageValidSortKeys = []string{
-	"name", "container_format", "disk_format", "status", "id", "size",
-}
-var imageValidVisibilities = []string{
-	"public", "private", "community", "shared", "market",
-}
 
 func DataSourceImagesImageV2() *schema.Resource {
 	return &schema.Resource{
@@ -51,10 +44,9 @@ func DataSourceImagesImageV2() *schema.Resource {
 			},
 
 			"visibility": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(imageValidVisibilities, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 
 			"owner": {
@@ -64,19 +56,15 @@ func DataSourceImagesImageV2() *schema.Resource {
 			},
 
 			"sort_key": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "name",
-				ValidateFunc: validation.StringInSlice(imageValidSortKeys, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "name",
 			},
 
 			"sort_direction": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "asc",
-				ValidateFunc: validation.StringInSlice([]string{
-					"asc", "desc",
-				}, false),
 			},
 
 			"tag": {
@@ -93,9 +81,6 @@ func DataSourceImagesImageV2() *schema.Resource {
 			"architecture": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"x86", "arm",
-				}, false),
 			},
 			"os": {
 				Type:     schema.TypeString,
@@ -195,10 +180,12 @@ func DataSourceImagesImageV2() *schema.Resource {
 
 // dataSourceImagesImageV2Read performs the image lookup.
 func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	imageClient, err := config.ImageV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	imageClient, err := cfg.ImageV2Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud image client: %s", err)
+		return diag.Errorf("error creating IMS client: %s", err)
 	}
 
 	imageType := d.Get("visibility").(string)
@@ -221,27 +208,26 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 		Status:         "active",
 	}
 
-	if epsId := common.GetEnterpriseProjectID(d, config); epsId != "" {
+	if epsId := common.GetEnterpriseProjectID(d, cfg); epsId != "" {
 		listOpts.EnterpriseProjectID = epsId
 	} else {
 		listOpts.EnterpriseProjectID = "all_granted_eps"
 	}
 
-	logp.Printf("[DEBUG] List Options: %#v", listOpts)
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
 
-	var image cloudimages.Image
 	allPages, err := cloudimages.List(imageClient, listOpts).AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to query images: %s", err)
+		return diag.Errorf("unable to query images: %s", err)
 	}
 
 	allImages, err := cloudimages.ExtractImages(allPages)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve images: %s", err)
+		return diag.Errorf("unable to retrieve images: %s", err)
 	}
 
 	if len(allImages) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. " +
+		return diag.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
@@ -250,7 +236,7 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 	if nameRegex, ok := d.GetOk("name_regex"); ok {
 		r, err := regexp.Compile(nameRegex.(string))
 		if err != nil {
-			return fmtp.DiagErrorf("name_regex format error: %s", err)
+			return diag.Errorf("name_regex format error: %s", err)
 		}
 
 		for _, image := range allImages {
@@ -259,34 +245,34 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 	} else {
-		filteredImages = allImages[:]
+		filteredImages = allImages
 	}
 
 	if len(filteredImages) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. " +
+		return diag.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
+	var image cloudimages.Image
 	if len(filteredImages) > 1 {
 		recent := d.Get("most_recent").(bool)
-		logp.Printf("[DEBUG] Multiple images %d found and `most_recent` is set to: %t", len(filteredImages), recent)
-		if recent {
-			image = mostRecentImage(filteredImages)
-		} else {
-			return fmtp.DiagErrorf("Your query returned more than one result. Please try a more " +
+		log.Printf("[DEBUG] Multiple images %d found and `most_recent` is set to: %t", len(filteredImages), recent)
+		if !recent {
+			return diag.Errorf("Your query returned more than one result. Please try a more " +
 				"specific search criteria, or set `most_recent` attribute to true.")
 		}
+		image = mostRecentImage(filteredImages)
 	} else {
 		image = filteredImages[0]
 	}
 
-	logp.Printf("[DEBUG] Single Image found: %s", image.ID)
+	log.Printf("[DEBUG] Single Image found: %s", image.ID)
 	return dataSourceImagesImageV2Attributes(ctx, d, &image)
 }
 
 // dataSourceImagesImageV2Attributes populates the fields of an Image resource.
 func dataSourceImagesImageV2Attributes(_ context.Context, d *schema.ResourceData, image *cloudimages.Image) diag.Diagnostics {
-	logp.Printf("[DEBUG] huaweicloud_images_image details: %#v", image)
+	log.Printf("[DEBUG] Get IMS image details: %#v", image)
 	d.SetId(image.ID)
 
 	imageType := image.Imagetype
@@ -318,11 +304,7 @@ func dataSourceImagesImageV2Attributes(_ context.Context, d *schema.ResourceData
 		mErr = multierror.Append(mErr, d.Set("size_bytes", size))
 	}
 
-	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("Error setting IMS image fields: %s", err)
-	}
-
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 type imageSort []cloudimages.Image
@@ -330,9 +312,9 @@ type imageSort []cloudimages.Image
 func (a imageSort) Len() int      { return len(a) }
 func (a imageSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a imageSort) Less(i, j int) bool {
-	itime := a[i].UpdatedAt
-	jtime := a[j].UpdatedAt
-	return itime.Unix() < jtime.Unix()
+	iTime := a[i].UpdatedAt
+	jTime := a[j].UpdatedAt
+	return iTime.Unix() < jTime.Unix()
 }
 
 // Returns the most recent Image out of a slice of images.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix ims data source lint issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix ims data source lint issues
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go -v  -timeout 360m -parallel 4
=== RUN   TestAccImsImageDataSource_basic
=== PAUSE TestAccImsImageDataSource_basic
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_basic
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_basic (53.42s)
--- PASS: TestAccImsImageDataSource_testQueries (440.91s) 
PASS
ok      command-line-arguments  440.948s

make testacc TEST='./huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go -v  -timeout 360m -parallel 4
=== RUN   TestAccImsImagesDataSource_basic
=== PAUSE TestAccImsImagesDataSource_basic
=== RUN   TestAccImsImagesDataSource_testQueries
=== PAUSE TestAccImsImagesDataSource_testQueries
=== CONT  TestAccImsImagesDataSource_basic
=== CONT  TestAccImsImagesDataSource_testQueries
--- PASS: TestAccImsImagesDataSource_basic (57.22s)
--- PASS: TestAccImsImagesDataSource_testQueries (431.35s) 
PASS
ok      command-line-arguments  431.392s
```
