### PR TITLE
feat(cfw): add service group and member

### DIFF
--- a/docs/resources/cfw_service_group.md
+++ b/docs/resources/cfw_service_group.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+---
+
+# huaweicloud_cfw_service_group
+
+Manages a CFW service group resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "description" {}
+
+data "huaweicloud_cfw_firewalls" "test" {}
+
+resource "huaweicloud_cfw_service_group" "test" {
+  object_id   = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  name        = var.name
+  description = var.description
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `object_id` - (Required, String, ForceNew) Specifies the protected object ID.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the service group name.
+
+* `description` - (Optional, String) Specifies the service group description.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The service group can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_cfw_service_group.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/docs/resources/cfw_service_group_member.md
+++ b/docs/resources/cfw_service_group_member.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+---
+
+# huaweicloud_cfw_service_group_member
+
+Manages a CFW service group member resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "group_id" {}
+variable "protocol" {}
+variable "source_port" {}
+variable "dest_port" {}
+
+resource "huaweicloud_cfw_service_group" "test" {
+  group_id    = var.group_id
+  protocol    = var.protocol
+  source_port = var.source_port
+  dest_port   = var.dest_port
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the service group.
+
+  Changing this parameter will create a new resource.
+
+* `protocol` - (Required, Int, ForceNew) Specifies the protocol type.
+  The valid values are:
+    + **6**: indicates TCP;
+    + **17**: indicates UDP;
+    + **1**: indicates ICMP;
+    + **58**: indicates ICMPv6;
+    + **-1**: indicates any protocol.
+
+  Changing this parameter will create a new resource.
+
+* `source_port` - (Required, String, ForceNew) Specifies the source port.source_port
+
+  Changing this parameter will create a new resource.
+
+* `dest_port` - (Required, String, ForceNew) Specifies the destination port.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Optional, String, ForceNew) Specifies the service member name
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the service member description.
+
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The service group member can be imported using service group ID and member ID, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cfw_service_group_member.test <group_id>/<member_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -676,6 +676,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_protection_rule":      cfw.ResourceProtectionRule(),
 			"huaweicloud_cfw_address_group":        cfw.ResourceAddressGroup(),
 			"huaweicloud_cfw_address_group_member": cfw.ResourceAddressGroupMember(),
+			"huaweicloud_cfw_service_group":        cfw.ResourceServiceGroup(),
+			"huaweicloud_cfw_service_group_member": cfw.ResourceServiceGroupMember(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go
@@ -1,0 +1,134 @@
+package cfw
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cfw"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getServiceGroupMemberResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getServiceGroupMember: Query the CFW service group member detail
+	var (
+		getServiceGroupMemberHttpUrl = "v1/{project_id}/service-items"
+		getServiceGroupMemberProduct = "cfw"
+	)
+	getServiceGroupMemberClient, err := cfg.NewServiceClient(getServiceGroupMemberProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CFW Client: %s", err)
+	}
+
+	getServiceGroupMemberPath := getServiceGroupMemberClient.Endpoint + getServiceGroupMemberHttpUrl
+	getServiceGroupMemberPath = strings.ReplaceAll(getServiceGroupMemberPath, "{project_id}", getServiceGroupMemberClient.ProjectID)
+
+	getServiceGroupMemberqueryParams := buildGetServiceGroupMemberQueryParams(state)
+	getServiceGroupMemberPath += getServiceGroupMemberqueryParams
+
+	getServiceGroupMemberOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getServiceGroupMemberResp, err := getServiceGroupMemberClient.Request("GET", getServiceGroupMemberPath, &getServiceGroupMemberOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving ServiceGroupMember: %s", err)
+	}
+
+	getServiceGroupMemberRespBody, err := utils.FlattenResponse(getServiceGroupMemberResp)
+	if err != nil {
+		return nil, err
+	}
+
+	members, err := jmespath.Search("data.records", getServiceGroupMemberRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing data.records from response= %#v", getServiceGroupMemberRespBody)
+	}
+
+	return cfw.FilterServiceGroupMembers(members.([]interface{}), state.Primary.ID)
+}
+
+func TestAccServiceGroupMember_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cfw_service_group_member.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getServiceGroupMemberResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testServiceGroupMember_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_cfw_service_group.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "6"),
+					resource.TestCheckResourceAttr(rName, "source_port", "80"),
+					resource.TestCheckResourceAttr(rName, "dest_port", "22"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testServiceGroupMemberImportState(rName),
+			},
+		},
+	})
+}
+
+func testServiceGroupMember_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cfw_service_group_member" "test" {
+  group_id    = huaweicloud_cfw_service_group.test.id
+  protocol    = 6
+  source_port = "80"
+  dest_port   = "22"
+}
+`, testServiceGroup_basic(name))
+}
+
+func buildGetServiceGroupMemberQueryParams(state *terraform.ResourceState) string {
+	res := "?offset=0&limit=1024"
+	res = fmt.Sprintf("%s&set_id=%v", res, state.Primary.Attributes["group_id"])
+
+	return res
+}
+
+func testServiceGroupMemberImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["group_id"] == "" {
+			return "", fmt.Errorf("attribute (group_id) of Resource (%s) not found: %s", name, rs)
+		}
+
+		return rs.Primary.Attributes["group_id"] + "/" + rs.Primary.ID, nil
+	}
+}

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_test.go
@@ -1,0 +1,115 @@
+package cfw
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getServiceGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getServiceGroup: Query the CFW service group detail
+	var (
+		getServiceGroupHttpUrl = "v1/{project_id}/service-sets/{id}"
+		getServiceGroupProduct = "cfw"
+	)
+	getServiceGroupClient, err := cfg.NewServiceClient(getServiceGroupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CFW Client: %s", err)
+	}
+
+	getServiceGroupPath := getServiceGroupClient.Endpoint + getServiceGroupHttpUrl
+	getServiceGroupPath = strings.ReplaceAll(getServiceGroupPath, "{project_id}", getServiceGroupClient.ProjectID)
+	getServiceGroupPath = strings.ReplaceAll(getServiceGroupPath, "{id}", state.Primary.ID)
+
+	getServiceGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getServiceGroupResp, err := getServiceGroupClient.Request("GET", getServiceGroupPath, &getServiceGroupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving ServiceGroup: %s", err)
+	}
+	return utils.FlattenResponse(getServiceGroupResp)
+}
+
+func TestAccServiceGroup_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cfw_service_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getServiceGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testServiceGroup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test"),
+				),
+			},
+			{
+				Config: testServiceGroup_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test update"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"object_id"},
+			},
+		},
+	})
+}
+
+func testServiceGroup_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cfw_service_group" "test" {
+  object_id   = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  name        = "%s"
+  description = "terraform test"
+}
+`, testAccDatasourceFirewalls_basic(), name)
+}
+
+func testServiceGroup_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cfw_service_group" "test" {
+  object_id   = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  name        = "%s-update"
+  description = "terraform test update"
+}
+`, testAccDatasourceFirewalls_basic(), name)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group.go
@@ -1,0 +1,244 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CFW
+// ---------------------------------------------------------------
+
+package cfw
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceServiceGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServiceGroupCreate,
+		UpdateContext: resourceServiceGroupUpdate,
+		ReadContext:   resourceServiceGroupRead,
+		DeleteContext: resourceServiceGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"object_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the protected object ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the service group name.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the service group description.`,
+			},
+		},
+	}
+}
+
+func resourceServiceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createServiceGroup: Create a CFW service group.
+	var (
+		createServiceGroupHttpUrl = "v1/{project_id}/service-set"
+		createServiceGroupProduct = "cfw"
+	)
+	createServiceGroupClient, err := cfg.NewServiceClient(createServiceGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW Client: %s", err)
+	}
+
+	createServiceGroupPath := createServiceGroupClient.Endpoint + createServiceGroupHttpUrl
+	createServiceGroupPath = strings.ReplaceAll(createServiceGroupPath, "{project_id}",
+		createServiceGroupClient.ProjectID)
+
+	createServiceGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createServiceGroupOpt.JSONBody = utils.RemoveNil(buildCreateServiceGroupBodyParams(d))
+	createServiceGroupResp, err := createServiceGroupClient.Request("POST", createServiceGroupPath,
+		&createServiceGroupOpt)
+	if err != nil {
+		return diag.Errorf("error creating ServiceGroup: %s", err)
+	}
+
+	createServiceGroupRespBody, err := utils.FlattenResponse(createServiceGroupResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("data.id", createServiceGroupRespBody)
+	if err != nil {
+		return diag.Errorf("error creating ServiceGroup: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceServiceGroupRead(ctx, d, meta)
+}
+
+func buildCreateServiceGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"object_id":   utils.ValueIngoreEmpty(d.Get("object_id")),
+		"name":        utils.ValueIngoreEmpty(d.Get("name")),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourceServiceGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getServiceGroup: Query the CFW service group detail
+	var (
+		getServiceGroupHttpUrl = "v1/{project_id}/service-sets/{id}"
+		getServiceGroupProduct = "cfw"
+	)
+	getServiceGroupClient, err := cfg.NewServiceClient(getServiceGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW Client: %s", err)
+	}
+
+	getServiceGroupPath := getServiceGroupClient.Endpoint + getServiceGroupHttpUrl
+	getServiceGroupPath = strings.ReplaceAll(getServiceGroupPath, "{project_id}",
+		getServiceGroupClient.ProjectID)
+	getServiceGroupPath = strings.ReplaceAll(getServiceGroupPath, "{id}", d.Id())
+
+	getServiceGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getServiceGroupResp, err := getServiceGroupClient.Request("GET", getServiceGroupPath,
+		&getServiceGroupOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ServiceGroup")
+	}
+
+	getServiceGroupRespBody, err := utils.FlattenResponse(getServiceGroupResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("data.name", getServiceGroupRespBody, nil)),
+		d.Set("description", utils.PathSearch("data.description", getServiceGroupRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceServiceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateServiceGroupChanges := []string{
+		"name",
+		"description",
+	}
+
+	if d.HasChanges(updateServiceGroupChanges...) {
+		// updateServiceGroup: Update the configuration of CFW service group
+		var (
+			updateServiceGroupHttpUrl = "v1/{project_id}/service-sets/{id}"
+			updateServiceGroupProduct = "cfw"
+		)
+		updateServiceGroupClient, err := cfg.NewServiceClient(updateServiceGroupProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating CFW Client: %s", err)
+		}
+
+		updateServiceGroupPath := updateServiceGroupClient.Endpoint + updateServiceGroupHttpUrl
+		updateServiceGroupPath = strings.ReplaceAll(updateServiceGroupPath, "{project_id}",
+			updateServiceGroupClient.ProjectID)
+		updateServiceGroupPath = strings.ReplaceAll(updateServiceGroupPath, "{id}", d.Id())
+
+		updateServiceGroupOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateServiceGroupOpt.JSONBody = utils.RemoveNil(buildUpdateServiceGroupBodyParams(d))
+		_, err = updateServiceGroupClient.Request("PUT", updateServiceGroupPath, &updateServiceGroupOpt)
+		if err != nil {
+			return diag.Errorf("error updating ServiceGroup: %s", err)
+		}
+	}
+	return resourceServiceGroupRead(ctx, d, meta)
+}
+
+func buildUpdateServiceGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        utils.ValueIngoreEmpty(d.Get("name")),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourceServiceGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteServiceGroup: Delete an existing CFW service group
+	var (
+		deleteServiceGroupHttpUrl = "v1/{project_id}/service-sets/{id}"
+		deleteServiceGroupProduct = "cfw"
+	)
+	deleteServiceGroupClient, err := cfg.NewServiceClient(deleteServiceGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW Client: %s", err)
+	}
+
+	deleteServiceGroupPath := deleteServiceGroupClient.Endpoint + deleteServiceGroupHttpUrl
+	deleteServiceGroupPath = strings.ReplaceAll(deleteServiceGroupPath, "{project_id}",
+		deleteServiceGroupClient.ProjectID)
+	deleteServiceGroupPath = strings.ReplaceAll(deleteServiceGroupPath, "{id}", d.Id())
+
+	deleteServiceGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	_, err = deleteServiceGroupClient.Request("DELETE", deleteServiceGroupPath, &deleteServiceGroupOpt)
+	if err != nil {
+		return diag.Errorf("error deleting ServiceGroup: %s", err)
+	}
+
+	return nil
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group_member.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group_member.go
@@ -1,0 +1,273 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CFW
+// ---------------------------------------------------------------
+
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceServiceGroupMember() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServiceGroupMemberCreate,
+		ReadContext:   resourceServiceGroupMemberRead,
+		DeleteContext: resourceServiceGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceServiceGroupMemberImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the service group.`,
+			},
+			"protocol": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the protocol type.`,
+			},
+			"source_port": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the source port.source_port`,
+			},
+			"dest_port": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the destination port.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the service member name`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the service member description.`,
+			},
+		},
+	}
+}
+
+func resourceServiceGroupMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createServiceGroupMember: Create a CFW service group member.
+	var (
+		createServiceGroupMemberHttpUrl = "v1/{project_id}/service-items"
+		createServiceGroupMemberProduct = "cfw"
+	)
+	createServiceGroupMemberClient, err := cfg.NewServiceClient(createServiceGroupMemberProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW Client: %s", err)
+	}
+
+	createServiceGroupMemberPath := createServiceGroupMemberClient.Endpoint + createServiceGroupMemberHttpUrl
+	createServiceGroupMemberPath = strings.ReplaceAll(createServiceGroupMemberPath, "{project_id}",
+		createServiceGroupMemberClient.ProjectID)
+
+	createServiceGroupMemberOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createServiceGroupMemberOpt.JSONBody = utils.RemoveNil(buildCreateServiceGroupMemberBodyParams(d))
+	createServiceGroupMemberResp, err := createServiceGroupMemberClient.Request("POST", createServiceGroupMemberPath,
+		&createServiceGroupMemberOpt)
+	if err != nil {
+		return diag.Errorf("error creating ServiceGroupMember: %s", err)
+	}
+
+	createServiceGroupMemberRespBody, err := utils.FlattenResponse(createServiceGroupMemberResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("data.items[0].id", createServiceGroupMemberRespBody)
+	if err != nil {
+		return diag.Errorf("error creating ServiceGroupMember: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceServiceGroupMemberRead(ctx, d, meta)
+}
+
+func buildCreateServiceGroupMemberBodyParams(d *schema.ResourceData) map[string]interface{} {
+	item := map[string]interface{}{
+		"protocol":    utils.ValueIngoreEmpty(d.Get("protocol")),
+		"source_port": utils.ValueIngoreEmpty(d.Get("source_port")),
+		"dest_port":   utils.ValueIngoreEmpty(d.Get("dest_port")),
+		"name":        utils.ValueIngoreEmpty(d.Get("name")),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+
+	bodyParams := map[string]interface{}{
+		"set_id":        utils.ValueIngoreEmpty(d.Get("group_id")),
+		"service_items": []map[string]interface{}{item},
+	}
+	return bodyParams
+}
+
+func resourceServiceGroupMemberRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getServiceGroupMember: Query the CFW service group member detail
+	var (
+		getServiceGroupMemberHttpUrl = "v1/{project_id}/service-items"
+		getServiceGroupMemberProduct = "cfw"
+	)
+	getServiceGroupMemberClient, err := cfg.NewServiceClient(getServiceGroupMemberProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW Client: %s", err)
+	}
+
+	getServiceGroupMemberPath := getServiceGroupMemberClient.Endpoint + getServiceGroupMemberHttpUrl
+	getServiceGroupMemberPath = strings.ReplaceAll(getServiceGroupMemberPath, "{project_id}",
+		getServiceGroupMemberClient.ProjectID)
+
+	getServiceGroupMemberqueryParams := buildGetServiceGroupMemberQueryParams(d)
+	getServiceGroupMemberPath += getServiceGroupMemberqueryParams
+
+	getServiceGroupMemberOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getServiceGroupMemberResp, err := getServiceGroupMemberClient.Request("GET", getServiceGroupMemberPath,
+		&getServiceGroupMemberOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ServiceGroupMember")
+	}
+
+	getServiceGroupMemberRespBody, err := utils.FlattenResponse(getServiceGroupMemberResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	members, err := jmespath.Search("data.records", getServiceGroupMemberRespBody)
+	if err != nil {
+		diag.Errorf("error parsing data.records from response= %#v", getServiceGroupMemberRespBody)
+	}
+
+	member, err := FilterServiceGroupMembers(members.([]interface{}), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ServiceGroupMember")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("group_id", utils.PathSearch("data.set_id", getServiceGroupMemberRespBody, nil)),
+		d.Set("protocol", utils.PathSearch("protocol", member, nil)),
+		d.Set("source_port", utils.PathSearch("source_port", member, nil)),
+		d.Set("dest_port", utils.PathSearch("dest_port", member, nil)),
+		d.Set("name", utils.PathSearch("name", member, nil)),
+		d.Set("description", utils.PathSearch("description", member, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func FilterServiceGroupMembers(members []interface{}, id string) (interface{}, error) {
+	if len(members) != 0 {
+		for _, v := range members {
+			member := v.(map[string]interface{})
+			if member["item_id"] == id {
+				return v, nil
+			}
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func buildGetServiceGroupMemberQueryParams(d *schema.ResourceData) string {
+	res := "?offset=0&limit=1024"
+	res = fmt.Sprintf("%s&set_id=%v", res, d.Get("group_id"))
+
+	return res
+}
+
+func resourceServiceGroupMemberDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteServiceGroupMember: Delete an existing CFW service group member
+	var (
+		deleteServiceGroupMemberHttpUrl = "v1/{project_id}/service-items/{id}"
+		deleteServiceGroupMemberProduct = "cfw"
+	)
+	deleteServiceGroupMemberClient, err := cfg.NewServiceClient(deleteServiceGroupMemberProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW Client: %s", err)
+	}
+
+	deleteServiceGroupMemberPath := deleteServiceGroupMemberClient.Endpoint + deleteServiceGroupMemberHttpUrl
+	deleteServiceGroupMemberPath = strings.ReplaceAll(deleteServiceGroupMemberPath, "{project_id}",
+		deleteServiceGroupMemberClient.ProjectID)
+	deleteServiceGroupMemberPath = strings.ReplaceAll(deleteServiceGroupMemberPath, "{id}", d.Id())
+
+	deleteServiceGroupMemberOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	_, err = deleteServiceGroupMemberClient.Request("DELETE", deleteServiceGroupMemberPath,
+		&deleteServiceGroupMemberOpt)
+	if err != nil {
+		return diag.Errorf("error deleting ServiceGroupMember: %s", err)
+	}
+
+	return nil
+}
+
+func resourceServiceGroupMemberImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be <group_id>/<member_id>")
+	}
+
+	d.Set("group_id", parts[0])
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resources huaweicloud_cfw_service_group and huaweicloud_cfw_service_group_member
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cfw' TESTARGS='-run TestAccServiceGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccServiceGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccServiceGroup_basic
=== PAUSE TestAccServiceGroup_basic
=== CONT  TestAccServiceGroup_basic
--- PASS: TestAccServiceGroup_basic (26.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       26.738s

make testacc TEST='./huaweicloud/services/acceptance/cfw' TESTARGS='-run TestAccServiceGroupMember_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccServiceGroupMember_basic -timeout 360m -parallel 4
=== RUN   TestAccServiceGroupMember_basic
=== PAUSE TestAccServiceGroupMember_basic
=== CONT  TestAccServiceGroupMember_basic
--- PASS: TestAccServiceGroupMember_basic (30.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       30.480s
```
