### PR TITLE
feat(secgroups): add id to secgroups data source

### DIFF
--- a/docs/data-sources/networking_secgroups.md
+++ b/docs/data-sources/networking_secgroups.md
@@ -23,6 +23,8 @@ data "huaweicloud_networking_secgroups" "test" {
 * `region` - (Optional, String) Specifies the region in which to obtain the security group list.
   If omitted, the provider-level region will be used.
 
+* `id` - (Optional, String) Specifies the id of the desired security group.
+
 * `name` - (Optional, String) Specifies the name of the security group.
 
 * `description` - (Optional, String) Specifies the description of the security group. The security groups can be

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
@@ -66,6 +66,35 @@ func TestAccNetworkingSecGroupsDataSource_description(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingSecGroupsDataSource_id(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_networking_secgroups.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupsDataSource_id(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
+						"[Acc Test] The security group created by Terraform."),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
+						"huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNetworkingSecGroupsDataSource_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_networking_secgroup" "test" {
@@ -91,6 +120,16 @@ func testAccNetworkingSecGroupV3DataSource_description(rName string) string {
 
 data "huaweicloud_networking_secgroups" "test" {
   description = "[Acc Test]"
+}
+`, testAccNetworkingSecGroupsDataSource_base(rName))
+}
+
+func testAccNetworkingSecGroupsDataSource_id(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_networking_secgroups" "test" {
+  id = huaweicloud_networking_secgroup.test.id
 }
 `, testAccNetworkingSecGroupsDataSource_base(rName))
 }

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_secgroups.go
@@ -27,6 +27,12 @@ func DataSourceNetworkingSecGroups() *schema.Resource {
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -172,6 +178,7 @@ func dataSourceNetworkingSecGroupsRead(ctx context.Context, d *schema.ResourceDa
 	// The List method currently does not support filtering by keyword in the description. Therefore, keyword filtering
 	// is implemented by manually filtering the description value of the List method return.
 	listOpts := v3groups.ListOpts{
+		ID:                  d.Get("id").(string),
 		Name:                d.Get("name").(string),
 		EnterpriseProjectId: config.DataGetEnterpriseProjectID(d),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/vpc TESTARGS='-run=TestAccNetworkingSecGroupsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccNetworkingSecGroupsDataSource -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupsDataSource_basic
=== PAUSE TestAccNetworkingSecGroupsDataSource_basic
=== RUN   TestAccNetworkingSecGroupsDataSource_description
=== PAUSE TestAccNetworkingSecGroupsDataSource_description
=== RUN   TestAccNetworkingSecGroupsDataSource_id
=== PAUSE TestAccNetworkingSecGroupsDataSource_id
=== CONT  TestAccNetworkingSecGroupsDataSource_basic
=== CONT  TestAccNetworkingSecGroupsDataSource_id
=== CONT  TestAccNetworkingSecGroupsDataSource_description
--- PASS: TestAccNetworkingSecGroupsDataSource_id (28.53s)
--- PASS: TestAccNetworkingSecGroupsDataSource_basic (28.71s)
--- PASS: TestAccNetworkingSecGroupsDataSource_description (31.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       31.320s
```
