### PR TITLE
docs: fix documention errors for vpc networking

### DIFF
--- a/docs/data-sources/networking_port.md
+++ b/docs/data-sources/networking_port.md
@@ -30,7 +30,7 @@ data "huaweicloud_networking_port" "port_1" {
 
 * `status` - (Optional, String) Specifies the status of the port.
 
-* `security_group_ids` - (Optional, String) The list of port security group IDs to filter.
+* `security_group_ids` - (Optional, List) The list of port security group IDs to filter.
 
 ## Attributes Reference
 

--- a/docs/data-sources/networking_secgroup.md
+++ b/docs/data-sources/networking_secgroup.md
@@ -23,6 +23,8 @@ data "huaweicloud_networking_secgroup" "secgroup" {
 
 * `name` - (Optional, String) Specifies the name of the security group.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the security group.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/networking_vip.md
+++ b/docs/resources/networking_vip.md
@@ -48,8 +48,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `device_owner` - The device owner of the VIP.
 
-* `subnet_id` - The subnet ID in which to allocate IP address for this VIP.
-
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/resource_huaweicloud_networking_secgroup.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup.go
@@ -41,14 +41,6 @@ var securityGroupRuleSchema = &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"port_range_min": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"port_range_max": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"ports": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -80,6 +72,16 @@ var securityGroupRuleSchema = &schema.Schema{
 			"priority": {
 				Type:     schema.TypeInt,
 				Computed: true,
+			},
+			"port_range_min": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "schema: Deprecated",
+			},
+			"port_range_max": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "schema: Deprecated",
 			},
 		},
 	},

--- a/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_networking_port_v2.go
@@ -49,41 +49,31 @@ func DataSourceNetworkingPortV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
-			// will be deprecated or change to computed
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"device_owner": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"device_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"security_group_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
+			},
+
+			// marked as computed
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "schema: Computed",
+			},
+			"device_owner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "schema: Computed",
+			},
+			"device_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "schema: Computed",
 			},
 
 			// Computed
@@ -101,6 +91,24 @@ func DataSourceNetworkingPortV2() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			// marked as deprecated
+			"admin_state_up": {
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "this field is deprecated",
+			},
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "this field is deprecated",
+			},
+			"project_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "this field is deprecated",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fix the following error:

```
====== Checking for resources huaweicloud_networking_vip =====
`subnet_id` was deprecated, should be deleted in Markdown

====== Checking for resources huaweicloud_networking_secgroup =====
can not find `rules.port_range_min`, please check it
can not find `rules.port_range_max`, please check it

====== Checking for data-sources huaweicloud_networking_port =====
the format of `security_group_ids` is not correct, should be (Optional, List)
can not find `project_id`, please check it
the format of `name` is not correct, should be (Optional, String)
the format of `device_owner` is not correct, should be (Optional, String)
the format of `device_id` is not correct, should be (Optional, String)

====== Checking for data-sources huaweicloud_networking_secgroup =====
can not find `enterprise_project_id`, please check it
can not find `rules.port_range_min`, please check it
can not find `rules.port_range_max`, please check it
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccNetworkingV2PortDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingV2PortDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (6.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       7.005s
```
