### PR TITLE
fix(dns): dns multi recordset line id change to forceNew

### DIFF
--- a/docs/resources/dns_recordset.md
+++ b/docs/resources/dns_recordset.md
@@ -107,7 +107,7 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the record set.
 
-* `line_id` - (Optional, String) Specifies the resolution line ID.
+* `line_id` - (Optional, String, ForceNew) Specifies the resolution line ID.
   Changing this parameter will create a new resource.
 
 -> **NOTE:** Only public zone support. You can use custom line or get more information about default resolution lines

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -214,6 +215,14 @@ func TestAccDNSRecordset_privateZone(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "tags.key", "value_private_update"),
 				),
 			},
+			{
+				Config:      testDNSRecordset_privateZone_updateWeight(name),
+				ExpectError: regexp.MustCompile(`private zone do not support.`),
+			},
+			{
+				Config:      testDNSRecordset_privateZone_updateLineID(name),
+				ExpectError: regexp.MustCompile(`private zone do not support.`),
+			},
 		},
 	})
 }
@@ -339,6 +348,50 @@ resource "huaweicloud_dns_recordset" "test" {
   status      = "ENABLE"
   ttl         = 900
   records     = ["\"test records\""]
+
+  tags = {
+    foo = "bar_private_update"
+    key = "value_private_update"
+  }
+}
+`, testAccDNSZone_private(name), name)
+}
+
+func testDNSRecordset_privateZone_updateWeight(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dns_recordset" "test" {
+  zone_id     = huaweicloud_dns_zone.zone_1.id
+  name        = "update.%s"
+  type        = "TXT"
+  description = "a private record set update"
+  status      = "ENABLE"
+  ttl         = 900
+  records     = ["\"test records\""]
+  weight      = 3
+
+  tags = {
+    foo = "bar_private_update"
+    key = "value_private_update"
+  }
+}
+`, testAccDNSZone_private(name), name)
+}
+
+func testDNSRecordset_privateZone_updateLineID(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dns_recordset" "test" {
+  zone_id     = huaweicloud_dns_zone.zone_1.id
+  name        = "update.%s"
+  type        = "TXT"
+  description = "a private record set update"
+  status      = "ENABLE"
+  ttl         = 900
+  records     = ["\"test records\""]
+  line_id     = "Dianxin_Shanxi"
 
   tags = {
     foo = "bar_private_update"

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
@@ -87,6 +87,7 @@ complete host name ended with a dot.`,
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: `Specifies the resolution line ID.`,
 			},
 			"status": {
@@ -341,6 +342,12 @@ func resourceDNSRecordsetUpdate(ctx context.Context, d *schema.ResourceData, met
 	zoneType, err := getDNSZoneType(recordsetClient, zoneID)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if zoneType == "private" {
+		if _, ok := d.GetOk("weight"); ok {
+			return diag.Errorf("private zone do not support weight.")
+		}
 	}
 
 	updateDNSRecordsetChanges := []string{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
dns multi recordset line id change to forceNew.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSRecordset_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSRecordset_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSRecordset_basic 
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_basic
=== CONT  TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDNSRecordset_publicZone (49.80s) 
--- PASS: TestAccDNSRecordset_basic (52.04s) 
--- PASS: TestAccDNSRecordset_privateZone (57.78s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       57.838s
```
