### PR TITLE
refactor(obs): remove some ValidateFunc in obs bucket and object

### DIFF
--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -44,18 +44,12 @@ func ResourceObsBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "STANDARD",
-				ValidateFunc: validation.StringInSlice([]string{
-					"STANDARD", "WARM", "COLD",
-				}, true),
 			},
 
 			"acl": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "private",
-				ValidateFunc: validation.StringInSlice([]string{
-					"private", "public-read", "public-read-write", "log-delivery-write",
-				}, true),
 			},
 
 			"policy": {
@@ -161,9 +155,6 @@ func ResourceObsBucket() *schema.Resource {
 									"storage_class": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"WARM", "COLD",
-										}, true),
 									},
 								},
 							},
@@ -192,9 +183,6 @@ func ResourceObsBucket() *schema.Resource {
 									"storage_class": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"WARM", "COLD",
-										}, true),
 									},
 								},
 							},

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -61,17 +60,11 @@ func ResourceObsBucketObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"STANDARD", "WARM", "COLD",
-				}, true),
 			},
 
 			"acl": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"private", "public-read", "public-read-write",
-				}, true),
 			},
 
 			"encryption": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_basic -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (38.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       38.311s

make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucketObject_source -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (27.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       28.094s
```
