### PR TITLE
refactor(ELB/loadbalancer): fix lb loadbalancer lint issues

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -844,7 +844,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),
 			"huaweicloud_lb_l7rule":       lb.ResourceL7RuleV2(),
 			"huaweicloud_lb_listener":     lb.ResourceListenerV2(),
-			"huaweicloud_lb_loadbalancer": lb.ResourceLoadBalancerV2(),
+			"huaweicloud_lb_loadbalancer": lb.ResourceLoadBalancer(),
 			"huaweicloud_lb_member":       lb.ResourceMemberV2(),
 			"huaweicloud_lb_monitor":      lb.ResourceMonitorV2(),
 			"huaweicloud_lb_pool":         lb.ResourcePoolV2(),
@@ -1023,7 +1023,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_key_v1": dew.ResourceKmsKey(),
 
 			"huaweicloud_lb_certificate_v2":  lb.ResourceCertificateV2(),
-			"huaweicloud_lb_loadbalancer_v2": lb.ResourceLoadBalancerV2(),
+			"huaweicloud_lb_loadbalancer_v2": lb.ResourceLoadBalancer(),
 			"huaweicloud_lb_listener_v2":     lb.ResourceListenerV2(),
 			"huaweicloud_lb_pool_v2":         lb.ResourcePoolV2(),
 			"huaweicloud_lb_member_v2":       lb.ResourceMemberV2(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix lb loadbalancer lint issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix lb loadbalancer lint issues
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go -v  -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== RUN   TestAccLBV2LoadBalancer_secGroup
=== PAUSE TestAccLBV2LoadBalancer_secGroup
=== RUN   TestAccLBV2LoadBalancer_withEpsId
=== PAUSE TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_withEpsId (70.22s) 
--- PASS: TestAccLBV2LoadBalancer_basic (97.55s) 
--- PASS: TestAccLBV2LoadBalancer_secGroup (105.50s) 
PASS
ok      command-line-arguments  105.553s
```
