### PR TITLE
refactor(ELB/listener): fix lb listener lint issues

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -843,8 +843,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),
 			"huaweicloud_lb_l7rule":       lb.ResourceL7RuleV2(),
-			"huaweicloud_lb_listener":     lb.ResourceListenerV2(),
 			"huaweicloud_lb_loadbalancer": lb.ResourceLoadBalancer(),
+			"huaweicloud_lb_listener":     lb.ResourceListener(),
 			"huaweicloud_lb_member":       lb.ResourceMemberV2(),
 			"huaweicloud_lb_monitor":      lb.ResourceMonitorV2(),
 			"huaweicloud_lb_pool":         lb.ResourcePoolV2(),
@@ -1024,7 +1024,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_lb_certificate_v2":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_loadbalancer_v2": lb.ResourceLoadBalancer(),
-			"huaweicloud_lb_listener_v2":     lb.ResourceListenerV2(),
+			"huaweicloud_lb_listener_v2":     lb.ResourceListener(),
 			"huaweicloud_lb_pool_v2":         lb.ResourcePoolV2(),
 			"huaweicloud_lb_member_v2":       lb.ResourceMemberV2(),
 			"huaweicloud_lb_monitor_v2":      lb.ResourceMonitorV2(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 fix lb listener lint issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix lb listener lint issues
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/lb/' TESTARGS='-run TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccLBV2Listener_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== CONT  TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (128.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        128.089s
```
