### PR TITLE
chore(dns): fix cli lint and log message

### DIFF
--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
@@ -104,14 +104,14 @@ func resourceDNSPtrRecordCreate(ctx context.Context, d *schema.ResourceData, met
 		EnterpriseProjectID: common.GetEnterpriseProjectID(d, conf),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	fip_id := d.Get("floatingip_id").(string)
-	n, err := ptrrecords.Create(dnsClient, region, fip_id, createOpts).Extract()
+	log.Printf("[DEBUG] Create options: %#v", createOpts)
+	fipId := d.Get("floatingip_id").(string)
+	n, err := ptrrecords.Create(dnsClient, region, fipId, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating DNS PTR record: %s", err)
 	}
 
-	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become ACTIVE", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"ACTIVE"},
 		Pending:    []string{"PENDING_CREATE"},
@@ -170,10 +170,10 @@ func resourceDNSPtrRecordRead(_ context.Context, d *schema.ResourceData, meta in
 	if resourceTags, err := tags.Get(dnsClient, "DNS-ptr_record", d.Id()).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return diag.Errorf("error saving tags to state for DNS ptr record (%s): %s", d.Id(), err)
+			return diag.Errorf("error saving tags to state for DNS PTR record (%s): %s", d.Id(), err)
 		}
 	} else {
-		log.Printf("[WARN] Error fetching tags of DNS ptr record (%s): %s", d.Id(), err)
+		log.Printf("[WARN] Error fetching tags of DNS PTR record (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -194,14 +194,14 @@ func resourceDNSPtrRecordUpdate(ctx context.Context, d *schema.ResourceData, met
 			TTL:         d.Get("ttl").(int),
 		}
 
-		log.Printf("[DEBUG] Update Options: %#v", updateOpts)
-		fip_id := d.Get("floatingip_id").(string)
-		n, err := ptrrecords.Create(dnsClient, region, fip_id, updateOpts).Extract()
+		log.Printf("[DEBUG] Update options: %#v", updateOpts)
+		fipId := d.Get("floatingip_id").(string)
+		n, err := ptrrecords.Create(dnsClient, region, fipId, updateOpts).Extract()
 		if err != nil {
 			return diag.Errorf("error updating DNS PTR record: %s", err)
 		}
 
-		log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
+		log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become ACTIVE", n.ID)
 		stateConf := &resource.StateChangeConf{
 			Target:     []string{"ACTIVE"},
 			Pending:    []string{"PENDING_CREATE"},

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -107,7 +107,7 @@ func resourceDNSRecordSetV2Create(ctx context.Context, d *schema.ResourceData, m
 		Type:        d.Get("type").(string),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] Create options: %#v", createOpts)
 	n, err := recordsets.Create(dnsClient, zoneID, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating DNS record set: %s", err)
@@ -116,7 +116,7 @@ func resourceDNSRecordSetV2Create(ctx context.Context, d *schema.ResourceData, m
 	id := fmt.Sprintf("%s/%s", zoneID, n.ID)
 	d.SetId(id)
 
-	log.Printf("[DEBUG] Waiting for DNS record set (%s) to become available", n.ID)
+	log.Printf("[DEBUG] Waiting for DNS record set (%s) to become ACTIVE", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"ACTIVE"},
 		Pending:    []string{"PENDING"},
@@ -331,16 +331,16 @@ func waitForDNSRecordSet(dnsClient *golangsdk.ServiceClient, zoneID, recordsetId
 	}
 }
 
-func parseDNSV2RecordSetID(id string) (string, string, error) {
+func parseDNSV2RecordSetID(id string) (zoneID string, recordsetID string, err error) {
 	idParts := strings.Split(id, "/")
 	if len(idParts) != 2 {
-		return "", "", fmt.Errorf("unable to determine DNS record set ID from raw ID: %s", id)
+		err = fmt.Errorf("unable to determine DNS record set ID from raw ID: %s", id)
+		return
 	}
 
-	zoneID := idParts[0]
-	recordsetID := idParts[1]
-
-	return zoneID, recordsetID, nil
+	zoneID = idParts[0]
+	recordsetID = idParts[1]
+	return
 }
 
 func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interface{}) (*golangsdk.ServiceClient, string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
fix dns cli lint and log message.
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSZone_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSZone_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSZone_basic 
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private 
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL 
=== RUN   TestAccDNSZone_withEpsId 
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_basic
=== CONT  TestAccDNSZone_readTTL 
=== CONT  TestAccDNSZone_private 
=== CONT  TestAccDNSZone_withEpsId
--- PASS: TestAccDNSZone_readTTL (28.21s) 
--- PASS: TestAccDNSZone_private (30.54s) 
--- PASS: TestAccDNSZone_withEpsId (31.86s) 
--- PASS: TestAccDNSZone_basic (44.41s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       44.543s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSV2RecordSet_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSV2RecordSet_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSV2RecordSet_basic 
=== PAUSE TestAccDNSV2RecordSet_basic 
=== RUN   TestAccDNSV2RecordSet_readTTL 
=== PAUSE TestAccDNSV2RecordSet_readTTL 
=== RUN   TestAccDNSV2RecordSet_private 
=== PAUSE TestAccDNSV2RecordSet_private 
=== CONT  TestAccDNSV2RecordSet_basic 
=== CONT  TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_readTTL 
--- PASS: TestAccDNSV2RecordSet_readTTL (37.27s) 
--- PASS: TestAccDNSV2RecordSet_private (40.15s) 
--- PASS: TestAccDNSV2RecordSet_basic (60.97s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       61.372s
```

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSPtrRecord_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSPtrRecord_ -timeout 360m -parallel 4 
=== RUN   TestAccDNSPtrRecord_basic 
=== PAUSE TestAccDNSPtrRecord_basic
=== RUN   TestAccDNSPtrRecord_withEpsId
=== PAUSE TestAccDNSPtrRecord_withEpsId
=== CONT  TestAccDNSPtrRecord_basic
=== CONT  TestAccDNSPtrRecord_withEpsId
--- PASS: TestAccDNSPtrRecord_withEpsId (35.19s) 
--- PASS: TestAccDNSPtrRecord_basic (49.47s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       49.521s
```
