### PR TITLE
docs: fix documentation errors in WAF,CPH,DMS,DDS,DLI

### DIFF
--- a/docs/resources/cph_server.md
+++ b/docs/resources/cph_server.md
@@ -72,7 +72,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `availability_zone` - (Required, String, ForceNew) The name of the AZ where the cloud server is located.
+* `availability_zone` - (Optional, String, ForceNew) The name of the AZ where the cloud server is located.
 
   Changing this parameter will create a new resource.
 

--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `password` - (Required, String) Specifies the Administrator password of the database instance.
 
-* `disk_encryption_id` - (Required, String, ForceNew) Specifies the disk encryption ID of the instance. Changing this
+* `disk_encryption_id` - (Optional, String, ForceNew) Specifies the disk encryption ID of the instance. Changing this
   creates a new instance.
 
 * `mode` - (Required, String, ForceNew) Specifies the mode of the database instance. Changing this creates a new
@@ -139,8 +139,9 @@ The following arguments are supported:
   This parameter is mandatory if `charging_mode` is set to *prePaid*.
   Changing this creates a new instance.
 
-* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto-renew is enabled.
   Valid values are `true` and `false`, defaults to `false`.
+  Changing this creates a new instance.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the DDS instance.
 
@@ -191,7 +192,7 @@ The `backup_strategy` block supports:
   + The HH value must be 1 greater than the hh value.
   + The values from mm and MM must be the same and must be set to any of the following 00, 15, 30, or 45.
 
-* `keep_days` - (Optional, Int) Specifies the number of days to retain the generated backup files. The value range is
+* `keep_days` - (Required, Int) Specifies the number of days to retain the generated backup files. The value range is
   from 0 to 732.
   + If this parameter is set to 0, the automated backup policy is not set.
   + If this parameter is not transferred, the automated backup policy is enabled by default. Backup files are stored

--- a/docs/resources/dli_flinkjar_job.md
+++ b/docs/resources/dli_flinkjar_job.md
@@ -134,6 +134,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Job ID in Int format.
 
+* `status` - The Job status.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/docs/resources/dli_flinksql_job.md
+++ b/docs/resources/dli_flinksql_job.md
@@ -60,11 +60,11 @@ The following arguments are supported:
 
   Default value: false
 
-* `checkpoint_mode` - (Optional, Int) Specifies snapshot mode. There are two options:
+* `checkpoint_mode` - (Optional, String) Specifies snapshot mode. There are two options:
   + **exactly_once**: indicates that data is processed only once.
   + **at_least_once**: indicates that data is processed at least once.
 
-  The default value is 1.
+  The default value is `exactly_once`.
 
 * `checkpoint_interval` - (Optional, Int) Specifies snapshot interval. The unit is second.
   The default value is 10.
@@ -82,7 +82,7 @@ The following arguments are supported:
 * `restart_when_exception` - (Optional, Bool) Specifies whether to enable the function of automatically
  restarting a job upon job exceptions. The default value is false.
   
-* `idle_state_retention` - (Optional, String) Specifies retention time of the idle state. The unit is hour.
+* `idle_state_retention` - (Optional, Int) Specifies retention time of the idle state. The unit is hour.
  The default value is 1.
 
 * `edge_group_ids` - (Optional, List) Specifies edge computing group IDs.
@@ -122,6 +122,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Job ID in Int format.
+
+* `status` - The Job status.
 
 ## Timeouts
 

--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -70,7 +70,7 @@ The following arguments are supported:
   + x86_64 : default value
   + aarch64
 
-* `resource_mode` - (Optional, String, ForceNew) Queue resource mode. Changing this parameter will create a new
+* `resource_mode` - (Optional, Int, ForceNew) Queue resource mode. Changing this parameter will create a new
   resource. The options are as follows:
   + 0: indicates the shared resource mode.
   + 1: indicates the exclusive resource mode.

--- a/docs/resources/dli_spark_job.md
+++ b/docs/resources/dli_spark_job.md
@@ -124,6 +124,16 @@ The following arguments are supported:
 
 The `dependent_packages` block supports:
 
+* `group_name` - (Required, String, ForceNew) Specifies the user group name.
+  Changing this parameter will submit a new spark job.
+
+* `packages` - (Required, List, ForceNew) Specifies the user group resource for details.
+  Changing this parameter will submit a new spark job.
+  The [object](#dependent_packages_packages) structure is documented below.
+
+<a name="dependent_packages_packages"></a>
+The `packages` block supports:
+
 * `type` - (Required, String, ForceNew) Specifies the resource type of the package.
   Changing this parameter will submit a new spark job.
 

--- a/docs/resources/dli_sql_job.md
+++ b/docs/resources/dli_sql_job.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `sql` - (Required, String, ForceNew) Specifies SQL statement that you want to execute.
   Changing this parameter will create a new resource.
 
-* `database_name` - (Required, String, ForceNew) Specifies the database where the SQL is executed. This argument does
+* `database_name` - (Optional, String, ForceNew) Specifies the database where the SQL is executed. This argument does
  not need to be configured during database creation. Changing this parameter will create a new resource.
 
 * `queue_name` - (Optional, String, ForceNew) Specifies queue which this job to be submitted belongs.

--- a/docs/resources/dli_table.md
+++ b/docs/resources/dli_table.md
@@ -98,7 +98,7 @@ The `column` block supports:
    resource.
   * `description` - (Required, String, ForceNew) Specifies the description of column. Changing this parameter will
    create a new resource.
-  * `is_partition` - (Required, Bool, ForceNew) Specifies whether the column is a partition column. The value
+  * `is_partition` - (Optional, Bool, ForceNew) Specifies whether the column is a partition column. The value
     `true` indicates a partition column, and the value false indicates a non-partition column. The default value
      is false. Changing this parameter will create a new resource.
   

--- a/docs/resources/dms_kafka_permissions.md
+++ b/docs/resources/dms_kafka_permissions.md
@@ -48,9 +48,9 @@ The following arguments are supported:
 <a name="dms_kafka_policies"></a>
 The `policies` block supports:
 
-* `user_name` -(Required, String) Specifies the user name.
+* `user_name` - (Required, String) Specifies the username.
 
-* `access_policy` -(Required, String) Specifies the permissions type. The value can be:
+* `access_policy` - (Required, String) Specifies the permissions type. The value can be:
   + **all**: publish and subscribe permissions.
   + **pub**: publish permissions.
   + **sub**: subscribe permissions.

--- a/docs/resources/waf_cloud_instance.md
+++ b/docs/resources/waf_cloud_instance.md
@@ -57,7 +57,7 @@ The following arguments are supported:
   If `period_unit` is set to **year**, the value ranges from `1` to `3`.  
   Changing this will create a new resource.
 
-* `auto_renew` - (Required, String) Specifies whether auto renew is enabled.
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
   Valid values are **true** and **false**.
 
 * `bandwidth_expack_product` - (Optional, List) Specifies the configuration of the bandwidth extended packages.

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -60,10 +60,10 @@ The following arguments are supported:
 
 * `server` - (Required, List) Specifies an array of origin web servers. The object structure is documented below.
 
-* `certificate_id` - (Required, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
+* `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
   is set to HTTPS.
 
-* `certificate_name` - (Required, String) Specifies the certificate name. This parameter is mandatory
+* `certificate_name` - (Optional, String) Specifies the certificate name. This parameter is mandatory
   when `client_protocol` is set to HTTPS.
 
 * `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain. If not specified, a new

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_topic.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_topic.go
@@ -57,7 +57,7 @@ func ResourceDmsRocketMQTopic() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: `Specifies the list of associated brokers of the topic.`,
+				Description: "schema: Required; Specifies the list of associated brokers of the topic.",
 			},
 			"queue_num": {
 				Type:         schema.TypeInt,

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -97,14 +97,23 @@ func ResourceCloudInstance() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"prePaid",
 				}, false),
-				RequiredWith: []string{
-					"period_unit", "auto_renew",
-				},
 				Description: "The charging mode of the cloud WAF.",
 			},
-			"period_unit": common.SchemaPeriodUnit(nil),
-			"period":      common.SchemaPeriod(nil),
-			"auto_renew":  common.SchemaAutoRenewUpdatable(nil),
+			"period_unit": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"month", "year",
+				}, false),
+			},
+			"period": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 9),
+			},
+			"auto_renew": common.SchemaAutoRenewUpdatable(nil),
 			"bandwidth_expack_product": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
@@ -56,6 +56,7 @@ func ResourceWafReferenceTableV1() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringLenBetween(1, 2048),
 				},
+				Description: "schema: Required",
 			},
 			"description": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix documentation errors in WAF,CPH,DMS,DDS,DLI
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

```
====== Checking for resources huaweicloud_waf_domain =====
the format of `certificate_id` is not correct, should be (Optional, String)
the format of `certificate_name` is not correct, should be (Optional, String)

====== Checking for resources huaweicloud_waf_reference_table =====
the format of `conditions` is not correct, should be (Optional, List)

====== Checking for resources huaweicloud_waf_cloud_instance =====
the format of `period_unit` is not correct, should be (Optional, String, ForceNew)
the format of `auto_renew` is not correct, should be (Optional, String)
the format of `period` is not correct, should be (Optional, Int, ForceNew)

====== Checking for resources huaweicloud_cph_server =====
the format of `availability_zone` is not correct, should be (Optional, String, ForceNew)

====== Checking for resources huaweicloud_dms_rocketmq_topic =====
the format of `brokers` is not correct, should be (Optional, List, ForceNew)

====== Checking for resources huaweicloud_dms_kafka_permissions =====
can not find `policies.user_name`, please check it
can not find `policies.access_policy`, please check it

====== Checking for resources huaweicloud_dds_instance =====
the format of `disk_encryption_id` is not correct, should be (Optional, String, ForceNew)
the format of `backup_strategy.keep_days` is not correct, should be (Required, Int)
the format of `auto_renew` is not correct, should be (Optional, String, ForceNew)

====== Checking for resources huaweicloud_dli_table =====
the format of `columns.is_partition` is not correct, should be (Optional, Bool, ForceNew)

====== Checking for resources huaweicloud_dli_flinkjar_job =====
can not find `status`, please check it

====== Checking for resources huaweicloud_dli_sql_job =====
the format of `database_name` is not correct, should be (Optional, String, ForceNew)

====== Checking for resources huaweicloud_dli_queue =====
the format of `resource_mode` is not correct, should be (Optional, Int, ForceNew)

====== Checking for resources huaweicloud_dli_flinksql_job =====
can not find `status`, please check it
the format of `checkpoint_mode` is not correct, should be (Optional, String)
the format of `idle_state_retention` is not correct, should be (Optional, Int)

====== Checking for resources huaweicloud_dli_spark_job =====
can not find `dependent_packages.group_name`, please check it
can not find `dependent_packages.packages`, please check it


```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccCloudInstance_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCloudInstance_basic -timeout 360m -parallel 4 
=== RUN   TestAccCloudInstance_basic 
=== PAUSE TestAccCloudInstance_basic
=== CONT  TestAccCloudInstance_basic
--- PASS: TestAccCloudInstance_basic (125.97s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       126.037s

```
