### PR TITLE
fix(nat): fix nat private snat rule error

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_snat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_snat_rule.go
@@ -126,7 +126,7 @@ func resourcePrivateSnatRuleRead(_ context.Context, d *schema.ResourceData, meta
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("gateway_id", resp.GatewayId),
-		d.Set("transit_ip_id", utils.PathSearch("[0].TransitIpId", resp.TransitIpAssociations, nil)),
+		d.Set("transit_ip_id", utils.PathSearch("[0].ID", resp.TransitIpAssociations, nil)),
 		d.Set("description", resp.Description),
 		d.Set("subnet_id", resp.SubnetId),
 		d.Set("cidr", resp.Cidr),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix nat private snat rule set transit_ip_id error
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/nat' TESTARGS='-run TestAccPrivateSnatRule_'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_ -timeout 360m -parallel 4 
=== RUN   TestAccPrivateSnatRule_basic 
=== PAUSE TestAccPrivateSnatRule_basic
=== RUN   TestAccPrivateSnatRule_cidr
=== PAUSE TestAccPrivateSnatRule_cidr
=== CONT  TestAccPrivateSnatRule_basic
=== CONT  TestAccPrivateSnatRule_cidr
--- PASS: TestAccPrivateSnatRule_cidr (67.98s) 
--- PASS: TestAccPrivateSnatRule_basic (76.49s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       76.566s
```
