### PR TITLE
fix(test): fix semantic error in test

### DIFF
--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
@@ -140,7 +140,7 @@ resource "huaweicloud_vpc_eip" "test" {
   bandwidth {
     share_type  = "PER"
     size        = 5
-    name        = "%[1]s"
+    name        = "%s"
     charge_mode = "traffic"
   }
 }`, common.TestVpc(rName), rName)

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_instance_groups_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_instance_groups_test.go
@@ -37,7 +37,7 @@ func testAccWafInstanceGroups_conf(name string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_compute_flavors" "flavors" {
-  availability_zone = data.huaweicloud_availability_zones.zones.names[1]
+  availability_zone = data.huaweicloud_availability_zones.test.names[1]
   performance_type  = "normal"
   cpu_core_count    = 2
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceWafInstanceGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafInstanceGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafInstanceGroups_basic
=== PAUSE TestAccDataSourceWafInstanceGroups_basic
=== CONT  TestAccDataSourceWafInstanceGroups_basic
--- PASS: TestAccDataSourceWafInstanceGroups_basic (455.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       455.977s

$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccEIPAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== CONT  TestAccEIPAssociate_basic
--- PASS: TestAccEIPAssociate_basic (204.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       204.907s
```
