### PR TITLE
feat(IMS): add ims image share resource

### DIFF
--- a/docs/resources/images_image_share.md
+++ b/docs/resources/images_image_share.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# huaweicloud_images_image_share
+
+Manages an IMS image share resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "source_image_id" {}
+variable "target_project_ids" {}
+
+resource "resource_huaweicloud_images_image_share" "test" {
+  source_image_id    = var.source_image_id
+  target_project_ids = var.target_project_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `source_image_id` - (Required, String, ForceNew) Specifies the ID of the source image.
+
+  Changing this parameter will create a new resource.
+
+* `target_project_ids` - (Optional, List) Specifies the IDs of the target projects.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.

--- a/docs/resources/images_image_share_accepter.md
+++ b/docs/resources/images_image_share_accepter.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# huaweicloud_images_image_share_accepter
+
+Manages an IMS image share accepter resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "image_id" {}
+
+resource "resource_huaweicloud_images_image_share_accepter" "test" {
+  image_id   = var.image_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `image_id` - (Required, String, ForceNew) Specifies the ID of the image.
+
+  Changing this parameter will create a new resource.
+
+* `vault_id` - (Optional, String, ForceNew) Specifies the ID of a vault. This parameter is mandatory if you want
+  to accept a shared full-ECS image created from a CBR backup.
+
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -826,8 +826,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_vpc":                 ResourceIecVpc(),
 			"huaweicloud_iec_vpc_subnet":          resourceIecSubnet(),
 
-			"huaweicloud_images_image":      ims.ResourceImsImage(),
-			"huaweicloud_images_image_copy": ims.ResourceImsImageCopy(),
+			"huaweicloud_images_image":                ims.ResourceImsImage(),
+			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),
+			"huaweicloud_images_image_share":          ims.ResourceImsImageShare(),
+			"huaweicloud_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
 
 			"huaweicloud_iotda_space":               iotda.ResourceSpace(),
 			"huaweicloud_iotda_product":             iotda.ResourceProduct(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -43,11 +43,12 @@ var (
 
 	HW_WAF_ENABLE_FLAG = os.Getenv("HW_WAF_ENABLE_FLAG")
 
-	HW_DEST_REGION         = os.Getenv("HW_DEST_REGION")
-	HW_DEST_PROJECT_ID     = os.Getenv("HW_DEST_PROJECT_ID")
-	HW_CHARGING_MODE       = os.Getenv("HW_CHARGING_MODE")
-	HW_HIGH_COST_ALLOW     = os.Getenv("HW_HIGH_COST_ALLOW")
-	HW_SWR_SHARING_ACCOUNT = os.Getenv("HW_SWR_SHARING_ACCOUNT")
+	HW_DEST_REGION          = os.Getenv("HW_DEST_REGION")
+	HW_DEST_PROJECT_ID      = os.Getenv("HW_DEST_PROJECT_ID")
+	HW_DEST_PROJECT_ID_TEST = os.Getenv("HW_DEST_PROJECT_ID_TEST")
+	HW_CHARGING_MODE        = os.Getenv("HW_CHARGING_MODE")
+	HW_HIGH_COST_ALLOW      = os.Getenv("HW_HIGH_COST_ALLOW")
+	HW_SWR_SHARING_ACCOUNT  = os.Getenv("HW_SWR_SHARING_ACCOUNT")
 
 	HW_CERTIFICATE_KEY_PATH         = os.Getenv("HW_CERTIFICATE_KEY_PATH")
 	HW_CERTIFICATE_CHAIN_PATH       = os.Getenv("HW_CERTIFICATE_CHAIN_PATH")
@@ -119,6 +120,8 @@ var (
 	HW_SRC_SECRET_KEY = os.Getenv("HW_SRC_SECRET_KEY")
 	HW_EXTGW_ID       = os.Getenv("HW_EXTGW_ID")
 	HW_POOL_NAME      = os.Getenv("HW_POOL_NAME")
+
+	HW_IMAGE_SHARE_SOURCE_IMAGE_ID = os.Getenv("HW_IMAGE_SHARE_SOURCE_IMAGE_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -288,6 +291,13 @@ func TestAccPreCheckAdminOnly(t *testing.T) {
 func TestAccPreCheckReplication(t *testing.T) {
 	if HW_DEST_REGION == "" || HW_DEST_PROJECT_ID == "" {
 		t.Skip("Jump the replication policy acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckProjectId(t *testing.T) {
+	if HW_DEST_PROJECT_ID_TEST == "" {
+		t.Skip("Skipping test because it requires the test project id.")
 	}
 }
 
@@ -522,5 +532,12 @@ func TestAccPreCheckDcDirectConnection(t *testing.T) {
 func TestAccPreCheckCfw(t *testing.T) {
 	if HW_CFW_INSTANCE_ID == "" {
 		t.Skip("HW_CFW_INSTANCE_ID must be set for CFW acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSourceImage(t *testing.T) {
+	if HW_IMAGE_SHARE_SOURCE_IMAGE_ID == "" {
+		t.Skip("Skip the interface acceptance test because of the source image ID is missing.")
 	}
 }

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_share_accepter_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_share_accepter_test.go
@@ -1,0 +1,97 @@
+package ims
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getImsImageShareAccepterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getImage: Query IMS image
+	var (
+		getImageHttpUrl = "v2/cloudimages"
+		getImageProduct = "ims"
+	)
+	getImageClient, err := cfg.NewServiceClient(getImageProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS Client: %s", err)
+	}
+
+	getImagePath := getImageClient.Endpoint + getImageHttpUrl
+	getImagePath = strings.ReplaceAll(getImagePath, "{project_id}", getImageClient.ProjectID)
+
+	imageId := state.Primary.Attributes["image_id"]
+	getImageQueryParams := buildGetImageQueryParams(imageId)
+	getImagePath += getImageQueryParams
+
+	getImageOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getImageResp, err := getImageClient.Request("GET", getImagePath, &getImageOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS image: %s", err)
+	}
+
+	getImageRespBody, err := utils.FlattenResponse(getImageResp)
+	if err != nil {
+		return nil, err
+	}
+
+	images := utils.PathSearch("images", getImageRespBody, nil)
+	if images == nil || len(images.([]interface{})) == 0 {
+		return nil, fmt.Errorf("error get IMS share image")
+	}
+
+	return make(map[string]interface{}), nil
+}
+
+func TestAccImsImageShareAccepter_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_images_image_share_accepter.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getImsImageShareAccepterResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheckSourceImage(t)
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testImsImageShareAccepter_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "image_id", acceptance.HW_IMAGE_SHARE_SOURCE_IMAGE_ID),
+				),
+			},
+		},
+	})
+}
+
+func testImsImageShareAccepter_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_images_image_share_accepter" "test" {
+ image_id = "%s"
+}
+`, acceptance.HW_IMAGE_SHARE_SOURCE_IMAGE_ID)
+}

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_share_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_share_test.go
@@ -1,0 +1,128 @@
+package ims
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getImsImageShareResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getImage: Query IMS image
+	var (
+		getImageHttpUrl = "v2/cloudimages"
+		getImageProduct = "ims"
+	)
+	getImageClient, err := cfg.NewServiceClient(getImageProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS Client: %s", err)
+	}
+
+	getImagePath := getImageClient.Endpoint + getImageHttpUrl
+	getImagePath = strings.ReplaceAll(getImagePath, "{project_id}", getImageClient.ProjectID)
+
+	getImageQueryParams := buildGetImageQueryParams(state.Primary.ID)
+	getImagePath += getImageQueryParams
+
+	getImageOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getImageResp, err := getImageClient.Request("GET", getImagePath, &getImageOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS image: %s", err)
+	}
+
+	getImageRespBody, err := utils.FlattenResponse(getImageResp)
+	if err != nil {
+		return nil, err
+	}
+
+	images := utils.PathSearch("images", getImageRespBody, nil)
+	if images == nil || len(images.([]interface{})) == 0 {
+		return nil, fmt.Errorf("error get IMS share image")
+	}
+
+	return make(map[string]interface{}), nil
+}
+
+func buildGetImageQueryParams(id string) string {
+	res := ""
+	res = fmt.Sprintf("%s?id=%v", res, id)
+	res = fmt.Sprintf("%s&__imagetype=%v", res, "shared")
+	return res
+}
+
+func TestAccImsImageShare_basic(t *testing.T) {
+	var obj interface{}
+
+	imageName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_images_image_share.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getImsImageShareResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheckReplication(t)
+			acceptance.TestAccPreCheckProjectId(t)
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testImsImageShare_basic(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "source_image_id",
+						"huaweicloud_images_image.test", "id"),
+				),
+			},
+			{
+				Config: testImsImageShare_update(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "source_image_id",
+						"huaweicloud_images_image.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testImsImageShare_basic(imageName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_images_image_share" "test" {
+ source_image_id    = huaweicloud_images_image.test.id
+ target_project_ids = ["%[2]s"]
+}
+`, testAccImsImage_basic(imageName), acceptance.HW_DEST_PROJECT_ID)
+}
+
+func testImsImageShare_update(imageName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_images_image_share" "test" {
+ source_image_id    = huaweicloud_images_image.test.id
+ target_project_ids = ["%[2]s"]
+}
+`, testAccImsImage_basic(imageName), acceptance.HW_DEST_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image_share.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image_share.go
@@ -1,0 +1,221 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product IMS
+// ---------------------------------------------------------------
+
+package ims
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceImsImageShare() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceImsImageShareCreate,
+		UpdateContext: resourceImsImageShareUpdate,
+		ReadContext:   resourceImsImageShareRead,
+		DeleteContext: resourceImsImageShareDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"source_image_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the source image.`,
+			},
+			"target_project_ids": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: `Specifies the IDs of the target projects.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceImsImageShareCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+
+	projectIds := d.Get("target_project_ids")
+	err := dealImageMembers(ctx, d, cfg, "POST", schema.TimeoutCreate, projectIds.(*schema.Set).List())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	sourceImageId := d.Get("source_image_id")
+	d.SetId(sourceImageId.(string))
+
+	return resourceImsImageShareRead(ctx, d, meta)
+}
+
+func resourceImsImageShareUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+
+	if d.HasChange("target_project_ids") {
+		oProjectIdsRaw, nProjectIdsRaw := d.GetChange("target_project_ids")
+		shareProjectIds := nProjectIdsRaw.(*schema.Set).Difference(oProjectIdsRaw.(*schema.Set))
+		unShareProjectIds := oProjectIdsRaw.(*schema.Set).Difference(nProjectIdsRaw.(*schema.Set))
+		if shareProjectIds.Len() > 0 {
+			err := dealImageMembers(ctx, d, cfg, "POST", schema.TimeoutCreate, shareProjectIds.List())
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+		if unShareProjectIds.Len() > 0 {
+			err := dealImageMembers(ctx, d, cfg, "DELETE", schema.TimeoutDelete, unShareProjectIds.List())
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return resourceImsImageShareRead(ctx, d, meta)
+}
+
+func resourceImsImageShareRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceImsImageShareDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+
+	projectIds := d.Get("target_project_ids")
+	err := dealImageMembers(ctx, d, cfg, "DELETE", schema.TimeoutDelete, projectIds.(*schema.Set).List())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func dealImageMembers(ctx context.Context, d *schema.ResourceData, cfg *config.Config, requestMethod,
+	timeout string, projectIds []interface{}) error {
+	region := cfg.GetRegion(d)
+	var (
+		imageMemberHttpUrl = "v1/cloudimages/members"
+		imageMemberProduct = "ims"
+	)
+
+	imageMemberClient, err := cfg.NewServiceClient(imageMemberProduct, region)
+	if err != nil {
+		return fmt.Errorf("error creating IMS Client: %s", err)
+	}
+
+	imageMemberPath := imageMemberClient.Endpoint + imageMemberHttpUrl
+
+	imageMemberOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	imageMemberOpt.JSONBody = utils.RemoveNil(buildImageMemberBodyParams(d, projectIds))
+	imageMemberResp, err := imageMemberClient.Request(requestMethod, imageMemberPath, &imageMemberOpt)
+	operateMethod := "creating"
+	if requestMethod == "DELETE" {
+		operateMethod = "deleting"
+	}
+	if err != nil {
+		return fmt.Errorf("error %s IMS image share: %s", operateMethod, err)
+	}
+
+	imageMemberRespBody, err := utils.FlattenResponse(imageMemberResp)
+	if err != nil {
+		return err
+	}
+
+	jobId, err := jmespath.Search("job_id", imageMemberRespBody)
+	if err != nil {
+		return fmt.Errorf("error %s IMS image share: job_id is not found in API response", operateMethod)
+	}
+
+	err = waitForJobSuccess(ctx, d, imageMemberClient, jobId.(string), timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildImageMemberBodyParams(d *schema.ResourceData, projectIds []interface{}) map[string]interface{} {
+	imagesParams := []interface{}{
+		utils.ValueIngoreEmpty(d.Id()),
+	}
+	bodyParams := map[string]interface{}{
+		"images":   imagesParams,
+		"projects": projectIds,
+	}
+	return bodyParams
+}
+
+func waitForJobSuccess(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	jobId, timeout string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"INIT", "RUNNING"},
+		Target:     []string{"SUCCESS"},
+		Refresh:    imsJobStatusRefreshFunc(jobId, client),
+		Timeout:    d.Timeout(timeout),
+		Delay:      1 * time.Second,
+		MinTimeout: 1 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for job (%s) success: %s", jobId, err)
+	}
+	return nil
+}
+
+func imsJobStatusRefreshFunc(jobId string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			getJobStatusHttpUrl = "v1/{project_id}/jobs/{job_id}"
+		)
+
+		getJobStatusPath := client.Endpoint + getJobStatusHttpUrl
+		getJobStatusPath = strings.ReplaceAll(getJobStatusPath, "{project_id}", client.ProjectID)
+		getJobStatusPath = strings.ReplaceAll(getJobStatusPath, "{job_id}", fmt.Sprintf("%v", jobId))
+
+		getJobStatusOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		getJobStatusResp, err := client.Request("GET", getJobStatusPath, &getJobStatusOpt)
+		if err != nil {
+			return getJobStatusResp, "FAIL", nil
+		}
+
+		getJobStatusRespBody, err := utils.FlattenResponse(getJobStatusResp)
+		if err != nil {
+			return nil, "", err
+		}
+
+		status := utils.PathSearch("status", getJobStatusRespBody, "")
+		return getJobStatusRespBody, status.(string), nil
+	}
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image_share_accepter.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image_share_accepter.go
@@ -1,0 +1,188 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product IMS
+// ---------------------------------------------------------------
+
+package ims
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceImsImageShareAccepter() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceImsImageShareAccepterCreate,
+		ReadContext:   resourceImsImageShareAccepterRead,
+		DeleteContext: resourceImsImageShareAccepterDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the image.`,
+			},
+			"vault_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of a vault.`,
+			},
+		},
+	}
+}
+
+func resourceImsImageShareAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createImageShareAccepter: create IMS image share accepter
+	var (
+		createImageShareAccepterHttpUrl = "v1/cloudimages/members"
+		createImageShareAccepterProduct = "ims"
+	)
+	createImageShareAccepterClient, err := cfg.NewServiceClient(createImageShareAccepterProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS Client: %s", err)
+	}
+
+	createImageShareAccepterPath := createImageShareAccepterClient.Endpoint + createImageShareAccepterHttpUrl
+
+	createImageShareAccepterOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createImageShareAccepterOpt.JSONBody = utils.RemoveNil(buildCreateImageShareAccepterBodyParams(d,
+		createImageShareAccepterClient.ProjectID))
+
+	createImageShareAccepterResp, err := createImageShareAccepterClient.Request("PUT",
+		createImageShareAccepterPath, &createImageShareAccepterOpt)
+	if err != nil {
+		return diag.Errorf("error creating IMS image share accepter: %s", err)
+	}
+
+	createImageShareAccepterRespBody, err := utils.FlattenResponse(createImageShareAccepterResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId, err := jmespath.Search("job_id", createImageShareAccepterRespBody)
+	if err != nil {
+		return diag.Errorf("error creating IMS image share accepter: job_id is not found in API response")
+	}
+
+	err = waitForJobSuccess(ctx, d, createImageShareAccepterClient, jobId.(string), schema.TimeoutCreate)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId)
+
+	return resourceImsImageShareAccepterRead(ctx, d, meta)
+}
+
+func buildCreateImageShareAccepterBodyParams(d *schema.ResourceData, projectId string) map[string]interface{} {
+	imagesParams := []interface{}{
+		utils.ValueIngoreEmpty(d.Get("image_id")),
+	}
+	bodyParams := map[string]interface{}{
+		"images":     imagesParams,
+		"project_id": projectId,
+		"status":     "accepted",
+		"vault_id":   utils.ValueIngoreEmpty(d.Get("vault_id")),
+	}
+	return bodyParams
+}
+
+func resourceImsImageShareAccepterRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceImsImageShareAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteImageShareAccepter: delete IMS image share accepter
+	var (
+		deleteImageShareAccepterHttpUrl = "v1/cloudimages/members"
+		deleteImageShareAccepterProduct = "ims"
+	)
+	deleteImageShareAccepterClient, err := cfg.NewServiceClient(deleteImageShareAccepterProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS Client: %s", err)
+	}
+
+	deleteImageShareAccepterPath := deleteImageShareAccepterClient.Endpoint + deleteImageShareAccepterHttpUrl
+
+	deleteImageShareAccepterOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	deleteImageShareAccepterOpt.JSONBody = utils.RemoveNil(buildDeleteImageShareAccepterBodyParams(d,
+		deleteImageShareAccepterClient.ProjectID))
+	deleteImageShareAccepterResp, err := deleteImageShareAccepterClient.Request("PUT",
+		deleteImageShareAccepterPath, &deleteImageShareAccepterOpt)
+	if err != nil {
+		return diag.Errorf("error deleting IMS image share accepter: %s", err)
+	}
+
+	deleteImageShareAccepterRespBody, err := utils.FlattenResponse(deleteImageShareAccepterResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId, err := jmespath.Search("job_id", deleteImageShareAccepterRespBody)
+	if err != nil {
+		return diag.Errorf("error deleting IMS image share accepter: job_id is not found in API response")
+	}
+
+	err = waitForJobSuccess(ctx, d, deleteImageShareAccepterClient, jobId.(string), schema.TimeoutDelete)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func buildDeleteImageShareAccepterBodyParams(d *schema.ResourceData, projectId string) map[string]interface{} {
+	imagesParams := []interface{}{
+		utils.ValueIngoreEmpty(d.Get("image_id")),
+	}
+	bodyParams := map[string]interface{}{
+		"images":     imagesParams,
+		"project_id": projectId,
+		"status":     "rejected",
+	}
+	return bodyParams
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add ims image share resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add ims image share resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ims/' TESTARGS='-run TestAccImsImageShare_basic' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims/ -v -run TestAccImsImageShare_basic -timeout 360m -parallel 4 
=== RUN   TestAccImsImageShare_basic 
=== PAUSE TestAccImsImageShare_basic
=== CONT  TestAccImsImageShare_basic
--- PASS: TestAccImsImageShare_basic (437.43s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       437.480s

make testacc TEST='./huaweicloud/services/acceptance/ims/' TESTARGS='-run TestAccImsImageShareAccepter_basic'           
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims/ -v -run TestAccImsImageShareAccepter_basic -timeout 360m -parallel 4 
=== RUN   TestAccImsImageShareAccepter_basic 
=== PAUSE TestAccImsImageShareAccepter_basic
=== CONT  TestAccImsImageShareAccepter_basic
--- PASS: TestAccImsImageShareAccepter_basic (15.28s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       15.347s
```
