### PR TITLE
fix(dcs): only config whitelist when the function is enabled during c…

### DIFF
--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -601,8 +601,9 @@ func resourceDcsInstancesCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	// create whiteList if configured.
-	if d.Get("whitelists").(*schema.Set).Len() > 0 {
+	// create whitelist when the function is enabled and configured
+	enabled := d.Get("whitelist_enable").(bool)
+	if enabled && d.Get("whitelists").(*schema.Set).Len() > 0 {
 		whitelistOpts := buildWhiteListParams(d)
 		logp.Printf("[DEBUG] Create whitelist options: %#v", whitelistOpts)
 


### PR DESCRIPTION
…reating

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/dcs" TESTARGS="-run TestAccDcsInstances_whitelists"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs -v -run TestAccDcsInstances_whitelists -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_whitelists
--- PASS: TestAccDcsInstances_whitelists (83.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       83.970s
```
