### PR TITLE
fix(apig/routes): rename the next-hop list parameter

### DIFF
--- a/docs/resources/apig_instance_routes.md
+++ b/docs/resources/apig_instance_routes.md
@@ -13,7 +13,7 @@ variable "instance_id" {}
 
 resource "huaweicloud_apig_instance_routes" "test" {
   instance_id = var.instance_id
-  next_hops   = ["172.16.3.0/24", "172.16.7.0/24"]
+  nexthops    = ["172.16.3.0/24", "172.16.7.0/24"]
 }
 ```
 
@@ -27,7 +27,7 @@ The following arguments are supported:
 * `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the routes belong.
   Changing this will create a new resource.
 
-* `next_hops` - (Required, List) Specifies the configuration of the next hop routes.
+* `nexthops` - (Required, List) Specifies the configuration of the next-hop routes.
 
 -> The network segment of the next hop cannot overlap with the network segment of the APIG instance.
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go
@@ -65,14 +65,14 @@ func TestAccInstanceRoutes_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_apig_instance.test", "id"),
-					resource.TestCheckResourceAttr(rName, "next_hops.#", "2"),
+					resource.TestCheckResourceAttr(rName, "nexthops.#", "2"),
 				),
 			},
 			{
 				Config: testAccInstanceRoutes_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "next_hops.#", "2"),
+					resource.TestCheckResourceAttr(rName, "nexthops.#", "2"),
 				),
 			},
 			{
@@ -110,7 +110,7 @@ func testAccInstanceRoutes_basic_step1(name string) string {
 
 resource "huaweicloud_apig_instance_routes" "test" {
   instance_id = huaweicloud_apig_instance.test.id
-  next_hops   = ["172.16.128.0/20","172.16.0.0/20"]
+  nexthops    = ["172.16.128.0/20","172.16.0.0/20"]
 }
 `, testAccInstanceRoutes_base(name))
 }
@@ -121,7 +121,7 @@ func testAccInstanceRoutes_basic_step2(name string) string {
 
 resource "huaweicloud_apig_instance_routes" "test" {
   instance_id = huaweicloud_apig_instance.test.id
-  next_hops   = ["172.16.64.0/20","172.16.192.0/20"]
+  nexthops    = ["172.16.64.0/20","172.16.192.0/20"]
 }
 `, testAccInstanceRoutes_base(name))
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
@@ -46,7 +46,7 @@ func ResourceInstanceRoutes() *schema.Resource {
 				ForceNew:    true,
 				Description: "The ID of the dedicated instance to which the routes belong.",
 			},
-			"next_hops": {
+			"nexthops": {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -86,7 +86,7 @@ func resourceInstanceRoutesCreate(ctx context.Context, d *schema.ResourceData, m
 
 	var (
 		instanceId = d.Get("instance_id").(string)
-		routes     = d.Get("next_hops").(*schema.Set)
+		routes     = d.Get("nexthops").(*schema.Set)
 	)
 	if err := modifyInstanceRoutes(client, instanceId, routes.List()); err != nil {
 		return diag.Errorf("error creating instance routes: %v", err)
@@ -131,7 +131,7 @@ func resourceInstanceRoutesRead(_ context.Context, d *schema.ResourceData, meta 
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "Instance routes")
 	}
 
-	return diag.FromErr(d.Set("next_hops", result.UserRoutes))
+	return diag.FromErr(d.Set("nexthops", result.UserRoutes))
 }
 
 func resourceInstanceRoutesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -143,7 +143,7 @@ func resourceInstanceRoutesUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	var (
 		instanceId = d.Get("instance_id").(string)
-		routes     = d.Get("next_hops").(*schema.Set)
+		routes     = d.Get("nexthops").(*schema.Set)
 	)
 	if err := modifyInstanceRoutes(client, instanceId, routes.List()); err != nil {
 		return diag.Errorf("error updating instance routes: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
rename the next-hop list parameter

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
