### PR TITLE
fix(CPH): use the datasrouce to get image_id

### DIFF
--- a/huaweicloud/services/acceptance/cph/resource_huaweicloud_cph_server_test.go
+++ b/huaweicloud/services/acceptance/cph/resource_huaweicloud_cph_server_test.go
@@ -120,6 +120,10 @@ resource "huaweicloud_kps_keypair" "test" {
   name        = "%s"
   description = "%s"
 }
+
+data "huaweicloud_cph_phone_images" "test" {
+  image_label = "cloud_phone"
+}
 `, name, name, name, name)
 }
 
@@ -131,7 +135,7 @@ resource "huaweicloud_cph_server" "test" {
   name          = "%s"
   server_flavor = "physical.rx1.xlarge"
   phone_flavor  = "rx1.cp.c15.d46.e1v1"
-  image_id      = "22110120221209e101210a3000000b02"
+  image_id      = data.huaweicloud_cph_phone_images.test.images[0].id
   keypair_name  = huaweicloud_kps_keypair.test.name
 
   vpc_id    = huaweicloud_vpc.test.id
@@ -165,7 +169,7 @@ resource "huaweicloud_cph_server" "test" {
   name          = "%s"
   server_flavor = "physical.rx1.xlarge"
   phone_flavor  = "rx1.cp.c15.d46.e1v1"
-  image_id      = "22110120221209e101210a3000000b02"
+  image_id      = data.huaweicloud_cph_phone_images.test.images[0].id
   keypair_name  = huaweicloud_kps_keypair.test.name
 
   vpc_id    = huaweicloud_vpc.test.id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cph' TESTARGS='-run=TestAccCphServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run=TestAccCphServer -timeout 360m -parallel 4
=== RUN   TestAccCphServer_basic
=== PAUSE TestAccCphServer_basic
=== CONT  TestAccCphServer_basic
--- PASS: TestAccCphServer_basic (1979.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       1979.861s
```
