### PR TITLE
fix(DMS): fix dms rabbitmq test

### DIFF
--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getDmsRabitMqInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getDmsRabbitMqInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.DmsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HuaweiCloud DMS client(V2): %s", err)
@@ -30,7 +30,7 @@ func TestAccDmsRabbitmqInstances_basic(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&instance,
-		getDmsRabitMqInstanceFunc,
+		getDmsRabbitMqInstanceFunc,
 	)
 
 	// DMS instances use the tenant-level shared lock, the instances cannot be created or modified in parallel.
@@ -79,7 +79,7 @@ func TestAccDmsRabbitmqInstances_withEpsId(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&instance,
-		getDmsRabitMqInstanceFunc,
+		getDmsRabbitMqInstanceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -109,7 +109,7 @@ func TestAccDmsRabbitmqInstances_compatible(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&instance,
-		getDmsRabitMqInstanceFunc,
+		getDmsRabbitMqInstanceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -146,7 +146,7 @@ func TestAccDmsRabbitmqInstances_single(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&instance,
-		getDmsRabitMqInstanceFunc,
+		getDmsRabbitMqInstanceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -173,18 +173,16 @@ data "huaweicloud_availability_zones" "test" {}
 data "huaweicloud_dms_product" "test1" {
   engine        = "rabbitmq"
   instance_type = "cluster"
-  version       = "3.7.17"
+  version       = "3.8.35"
   node_num      = 3
 }
 
 data "huaweicloud_dms_product" "test2" {
   engine        = "rabbitmq"
   instance_type = "cluster"
-  version       = "3.7.17"
+  version       = "3.8.35"
   node_num      = 5
 }
-
-data "huaweicloud_availability_zones" "test" {}
 `, common.TestBaseNetwork(rName))
 }
 
@@ -320,7 +318,7 @@ func testAccDmsRabbitmqInstance_single(rName string) string {
 data "huaweicloud_dms_product" "single" {
   engine           = "rabbitmq"
   instance_type    = "single"
-  version          = "3.7.17"
+  version          = "3.8.35"
   node_num         = 1
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dms rabbitmq test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dms rabbitmq test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go -v  -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (1260.39s)
--- PASS: TestAccDmsRabbitmqInstances_compatible (1835.32s)
--- PASS: TestAccDmsRabbitmqInstances_single (2117.97s)
--- PASS: TestAccDmsRabbitmqInstances_basic (2469.60s)
PASS
ok      command-line-arguments  2469.640s
```
