### PR TITLE
feat(mrs): support setting component configurations during cluster cr…

### DIFF
--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -424,6 +424,10 @@ The EIP must have been created and must be in the same region as the cluster.
   The `nodes` object structure of the `custom_nodes` is documented below.
   `Unlike other nodes, it needs to specify group_name`
 
+* `component_configs` - (Optional, List, ForceNew) Specifies the component configurations of the cluster.
+  The [object](#component_configurations) structure is documented below.
+  Changing this will create a new MapReduce cluster resource.
+
 * `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the cluster.
 
 The `nodes` block supports:
@@ -485,6 +489,27 @@ The `nodes` block supports:
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
 
+<a name="component_configurations"></a>
+The `component_configs` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the component name of the cluster which has installed.
+  Changing this will create a new MapReduce cluster resource.
+
+* `configs` - (Required, List, ForceNew) Specifies the configuration of component installed.
+  The [object](#component_configuration) structure is documented below.
+
+<a name="component_configuration"></a>
+The `configs` block supports:
+
+* `key` - (Required, String, ForceNew) Specifies the configuration item key of component installed.
+  Changing this will create a new MapReduce cluster resource.
+
+* `value` - (Required, String, ForceNew) Specifies the configuration item value of component installed.
+  Changing this will create a new MapReduce cluster resource.
+
+* `config_file_name` - (Required, String, ForceNew) Specifies the configuration file name of component installed.
+  Changing this will create a new MapReduce cluster resource.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -519,7 +544,7 @@ terraform import huaweicloud_mapreduce_cluster.test b11b407c-e604-4e8d-8bc4-9239
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`manager_admin_pass`, `node_admin_pass`,`template_id` and `assigned_roles`.
+`manager_admin_pass`, `node_admin_pass`,`template_id`, `assigned_roles` and `component_configs`.
 It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230330124331-45e8b29b9330
+	github.com/chnsz/golangsdk v0.0.0-20230407023207-7e6ac8e50517
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chnsz/golangsdk v0.0.0-20230330124331-45e8b29b9330 h1:pOKXNGskAcwpjvZkXPQG6M4yi7ZO7238lX7XHsyrMYw=
 github.com/chnsz/golangsdk v0.0.0-20230330124331-45e8b29b9330/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230407023207-7e6ac8e50517 h1:VSt6yBVGuRe/Dq8OVUrqtuIkn2/KQEM9F6ALqn81U74=
+github.com/chnsz/golangsdk v0.0.0-20230407023207-7e6ac8e50517/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/requests.go
@@ -116,6 +116,8 @@ type CreateOpts struct {
 	// Cluster tag For more parameter description, see Table 4.
 	// A maximum of 10 tags can be added to a cluster.
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
+	// the component configurations of MRS cluster.
+	ComponentConfigs []ComponentConfigOpts `json:"component_configs,omitempty"`
 }
 
 // ChargeInfo is a structure representing billing information.
@@ -268,6 +270,20 @@ type ScriptOpts struct {
 	// Time when the bootstrap action script is executed. Currently, the following two options are available: Before component start and After component start
 	// The default value is false, indicating that the bootstrap action script is executed after the component is started.
 	BeforeComponentStart *bool `json:"before_component_start,omitempty"`
+}
+
+type ComponentConfigOpts struct {
+	// The component name of MRS cluster which has installed.
+	Name    string       `json:"component_name" required:"true"`
+	Configs []ConfigOpts `json:"configs" required:"true"`
+}
+type ConfigOpts struct {
+	// The configuration item key of component installed.
+	Key string `json:"key" required:"true"`
+	// The configuration item value of component installed.
+	Value string `json:"value" required:"true"`
+	// The configuration file name of component installed.
+	ConfigFileName string `json:"config_file_name" required:"true"`
 }
 
 // JobOpts is a structure representing the job which to execution.

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/requests.go
@@ -5,6 +5,7 @@
 package whiteblackip_rules
 
 import (
+	"fmt"
 	"github.com/chnsz/golangsdk"
 )
 
@@ -20,8 +21,11 @@ type CreateOptsBuilder interface {
 
 // CreateOpts contains all the values needed to create a new whiteblackip rule.
 type CreateOpts struct {
-	Addr  string `json:"addr" required:"true"`
-	White int    `json:"white,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Addr        string `json:"addr,omitempty"`
+	White       int    `json:"white"`
+	Description string `json:"description,omitempty"`
+	IPGroupID   string `json:"ip_group_id,omitempty"`
 }
 
 // ToWhiteBlackIPCreateMap builds a create request body from CreateOpts.
@@ -31,13 +35,17 @@ func (opts CreateOpts) ToWhiteBlackIPCreateMap() (map[string]interface{}, error)
 
 // Create will create a new whiteblackip rule based on the values in CreateOpts.
 func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	return CreateWithEpsId(c, opts, policyID, "")
+}
+
+func CreateWithEpsId(c *golangsdk.ServiceClient, opts CreateOptsBuilder, policyID, epsID string) (r CreateResult) {
 	b, err := opts.ToWhiteBlackIPCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
-	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	_, r.Err = c.Post(rootURL(c, policyID)+generateEpsIdQuery(epsID), b, &r.Body, reqOpt)
 	return
 }
 
@@ -49,8 +57,11 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains all the values needed to update a whiteblackip rule.
 type UpdateOpts struct {
-	Addr  string `json:"addr" required:"true"`
-	White *int   `json:"white" required:"true"`
+	Name        string `json:"name,omitempty"`
+	Addr        string `json:"addr,omitempty"`
+	White       *int   `json:"white" required:"true"`
+	Description string `json:"description,omitempty"`
+	IPGroupID   string `json:"ip_group_id,omitempty"`
 }
 
 // ToWhiteBlackIPUpdateMap builds a update request body from UpdateOpts.
@@ -60,30 +71,50 @@ func (opts UpdateOpts) ToWhiteBlackIPUpdateMap() (map[string]interface{}, error)
 
 // Update accepts a UpdateOpts struct and uses the values to update a rule.The response code from api is 200
 func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	return UpdateWithEpsId(c, opts, policyID, ruleID, "")
+}
+
+func UpdateWithEpsId(c *golangsdk.ServiceClient, opts UpdateOptsBuilder,
+	policyID, ruleID, epsID string) (r UpdateResult) {
 	b, err := opts.ToWhiteBlackIPUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
-	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, nil, reqOpt)
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID)+generateEpsIdQuery(epsID), b, nil, reqOpt)
 	return
 }
 
 // Get retrieves a particular whiteblackip rule based on its unique ID.
 func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	return GetWithEpsId(c, policyID, ruleID, "")
+}
+
+func GetWithEpsId(c *golangsdk.ServiceClient, policyID, ruleID, epsID string) (r GetResult) {
 	reqOpt := &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders,
 	}
-	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID)+generateEpsIdQuery(epsID), &r.Body, reqOpt)
 	return
 }
 
 // Delete will permanently delete a particular whiteblackip rule based on its unique ID.
 func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	return DeleteWithEpsId(c, policyID, ruleID, "")
+}
+
+func DeleteWithEpsId(c *golangsdk.ServiceClient, policyID, ruleID, epsID string) (r DeleteResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders}
-	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID)+generateEpsIdQuery(epsID), reqOpt)
 	return
+}
+
+func generateEpsIdQuery(epsID string) string {
+	if len(epsID) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsID)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/whiteblackip_rules/results.go
@@ -17,6 +17,17 @@ type WhiteBlackIP struct {
 	White int `json:"white"`
 	// Policy ID
 	PolicyID string `json:"policyid"`
+
+	Name        string   `json:"name"`
+	Status      int      `json:"status"`
+	Description string   `json:"description"`
+	IPGroup     *IPGroup `json:"ip_group"`
+}
+
+type IPGroup struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Size int    `json:"size"`
 }
 
 type commonResult struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230330124331-45e8b29b9330
+# github.com/chnsz/golangsdk v0.0.0-20230407023207-7e6ac8e50517
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
…eation

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- support setting component configurations during cluster creation
- CheckDeleted when the cluster is terminated

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/mrs" TESTARGS="-run TestAccMrsMapReduceCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_basic
=== PAUSE TestAccMrsMapReduceCluster_basic
=== CONT  TestAccMrsMapReduceCluster_basic
--- PASS: TestAccMrsMapReduceCluster_basic (686.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       686.404s
```
