### PR TITLE
chore: add deprecated warning to compute_keypair

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -11,7 +11,7 @@ Add a node to a CCE cluster.
 ```hcl
 data "huaweicloud_availability_zones" "myaz" {}
 
-resource "huaweicloud_compute_keypair" "mykp" {
+resource "huaweicloud_kps_keypair" "mykp" {
   name       = "mykp"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
@@ -30,7 +30,7 @@ resource "huaweicloud_cce_node" "node" {
   name              = "node"
   flavor_id         = "s3.large.2"
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-  key_pair          = huaweicloud_compute_keypair.mykp.name
+  key_pair          = huaweicloud_kps_keypair.mykp.name
 
   root_volume {
     size       = 40
@@ -51,7 +51,7 @@ resource "huaweicloud_cce_node" "mynode" {
   name              = "mynode"
   flavor_id         = "s3.large.2"
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-  key_pair          = huaweicloud_compute_keypair.mykp.name
+  key_pair          = huaweicloud_kps_keypair.mykp.name
 
   root_volume {
     size       = 40
@@ -90,7 +90,7 @@ resource "huaweicloud_cce_node" "mynode" {
   name              = "mynode"
   flavor_id         = "s3.large.2"
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-  key_pair          = huaweicloud_compute_keypair.mykp.name
+  key_pair          = huaweicloud_kps_keypair.mykp.name
 
   root_volume {
     size       = 40
@@ -114,7 +114,7 @@ resource "huaweicloud_cce_node" "mynode" {
   name              = "mynode"
   flavor_id         = "s3.large.2"
   availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
-  key_pair          = huaweicloud_compute_keypair.mykp.name
+  key_pair          = huaweicloud_kps_keypair.mykp.name
 
   root_volume {
     size       = 40

--- a/docs/resources/compute_keypair.md
+++ b/docs/resources/compute_keypair.md
@@ -4,6 +4,8 @@ subcategory: "Elastic Cloud Server (ECS)"
 
 # huaweicloud_compute_keypair
 
+-> **DEPRECATED:**  This resource  has been deprecated. Please use [huaweicloud_kps_keypair](https://www.terraform.io/docs/providers/huaweicloud/r/kps_keypair).
+
 Manages a keypair resource within HuaweiCloud.
 
 ## Example Usage


### PR DESCRIPTION
Adds deprecated warning on docs and link to recomended resource

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
