### PR TITLE
fix(RDS): fix rds database privilege users type

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
@@ -43,7 +43,7 @@ func ResourceRdsDatabasePrivilege() *schema.Resource {
 				ForceNew: true,
 			},
 			"users": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
 				MaxItems: 50,
@@ -57,6 +57,7 @@ func ResourceRdsDatabasePrivilege() *schema.Resource {
 						"readonly": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},
@@ -108,7 +109,7 @@ func resourceRdsDatabasePrivilegeCreate(ctx context.Context, d *schema.ResourceD
 	dbName := d.Get("db_name").(string)
 	createOpts := rds.GrantRequest{
 		DbName: d.Get("db_name").(string),
-		Users:  buildUserOpts(d.Get("users").([]interface{})),
+		Users:  buildUserOpts(d.Get("users").(*schema.Set).List()),
 	}
 	log.Printf("[DEBUG] Create RDS database privilege options: %#v", createOpts)
 
@@ -168,7 +169,7 @@ func resourceRdsDatabasePrivilegeDelete(_ context.Context, d *schema.ResourceDat
 
 	deleteOpts := rds.RevokeRequestBody{
 		DbName: d.Get("db_name").(string),
-		Users:  buildRevokeUserOpts(d.Get("users").([]interface{})),
+		Users:  buildRevokeUserOpts(d.Get("users").(*schema.Set).List()),
 	}
 	log.Printf("[DEBUG] Delete RDS database privilege options: %#v", deleteOpts)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds database privilege users type
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds database privilege users type
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsDatabasePrivilege_basic' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsDatabasePrivilege_basic -timeout 360m -parallel 4 
=== RUN   TestAccRdsDatabasePrivilege_basic 
=== PAUSE TestAccRdsDatabasePrivilege_basic
=== CONT  TestAccRdsDatabasePrivilege_basic
--- PASS: TestAccRdsDatabasePrivilege_basic (803.55s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       803.597s
```
