### PR TITLE
docs: Fix documentation for port of dcs instance

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -134,6 +134,7 @@ The following arguments are supported:
   Changing this creates a new instance resource.
 
 * `port` - (Optional, Int) Port customization, which is supported only by Redis 4.0 and Redis 5.0 instances.
+  Redis instance defaults to 6379. Memcached instance does not use this argument.
 
 * `password` - (Optional, String, ForceNew) Specifies the password of a DCS instance.
   Changing this creates a new instance.
@@ -142,7 +143,6 @@ The following arguments are supported:
   + Must contain three combinations of the following four characters: Lower case letters, uppercase letter, digital,
     Special characters include (`~!@#$^&*()-_=+\\|{}:,<.>/?).
   + The new password cannot be the same as the old password.
-    Redis instance defaults to 6379. Memcached instance does not use this argument.
 
 * `whitelists` - (Optional, List) Specifies the IP addresses which can access the instance.
   This parameter is valid for Redis 4.0 and 5.0 versions. The structure is described below.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In the documentation a description of the DCS port argument is in incorrect place, this pr is fixed it.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
docs: Fix documentation for port of dcs instance
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
