### PR TITLE
chore(SMN): fix lint issues

### DIFF
--- a/docs/resources/smn_subscription.md
+++ b/docs/resources/smn_subscription.md
@@ -47,12 +47,12 @@ The following arguments are supported:
   + **For an HTTPS subscription**, the endpoint starts with `https://`.
   + **For an email subscription**, the endpoint is an mail address.
   + **For an SMS message subscription**, the endpoint is a phone number,
-  the format is \[+\]\[country code\]\[phone number\], e.g. +86185xxxx0000.
+    the format is \[+\]\[country code\]\[phone number\], e.g. +86185xxxx0000.
   + **For a functionstage subscription**, the endpoint is a function urn.
   + **For a functiongraph subscription**, the endpoint is a workflow ID.
 
 * `remark` - (Optional, String, ForceNew) Remark information. The remarks must be a UTF-8-coded character string
-  containing 128 bytes.
+  containing 128 bytes. Changing this parameter will create a new resource.
 
 ## Attributes Reference
 
@@ -64,8 +64,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `owner` - Project ID of the topic creator.
 
-* `status` - Subscription status. 0 indicates that the subscription is not confirmed. 1 indicates that the subscription
-  is confirmed. 3 indicates that the subscription is canceled.
+* `status` - Subscription status.
+  + **0**: indicates that the subscription is not confirmed.
+  + **1**: indicates that the subscription is confirmed.
+  + **3**: indicates that the subscription is canceled.
 
 ## Import
 

--- a/docs/resources/smn_topic.md
+++ b/docs/resources/smn_topic.md
@@ -4,7 +4,7 @@ subcategory: "Simple Message Notification (SMN)"
 
 # huaweicloud_smn_topic
 
-Manages an SMN Topic resource within HuaweiCloud.
+Manages an SMN topic resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -42,8 +42,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `topic_urn` - Resource identifier of a topic, which is unique.
 
-* `push_policy` - Message pushing policy. 0 indicates that the message sending fails and the message is cached in the
-  queue. 1 indicates that the failed message is discarded.
+* `push_policy` - Message pushing policy.
+  + **0**: indicates that the message sending fails and the message is cached in the queue.
+  + **1**: indicates that the failed message is discarded.
 
 * `create_time` - Time when the topic was created.
 

--- a/huaweicloud/services/acceptance/smn/data_source_huaweicloud_smn_topics_test.go
+++ b/huaweicloud/services/acceptance/smn/data_source_huaweicloud_smn_topics_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccDataTopics_basic(t *testing.T) {
 	dataSourceName := "data.huaweicloud_smn_topics.test"
+	resourcerName := "huaweicloud_smn_topic.topic_1"
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
 	rName := acceptance.RandomAccResourceNameWithDash()
 
@@ -22,18 +24,13 @@ func TestAccDataTopics_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.id",
-						"huaweicloud_smn_topic.topic_1", "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.topic_urn",
-						"huaweicloud_smn_topic.topic_1", "topic_urn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.display_name",
-						"huaweicloud_smn_topic.topic_1", "display_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.id", resourcerName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.topic_urn", resourcerName, "topic_urn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.display_name", resourcerName, "display_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.tags.foo", resourcerName, "tags.foo"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.tags.key", resourcerName, "tags.key"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.enterprise_project_id",
-						"huaweicloud_smn_topic.topic_1", "enterprise_project_id"),
-					resource.TestCheckResourceAttrPair(
-						dataSourceName, "topics.0.tags.foo", "huaweicloud_smn_topic.topic_1", "tags.foo"),
-					resource.TestCheckResourceAttrPair(
-						dataSourceName, "topics.0.tags.key", "huaweicloud_smn_topic.topic_1", "tags.key"),
+						resourcerName, "enterprise_project_id"),
 				),
 			},
 		},

--- a/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_test.go
+++ b/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/smn/v2/topics"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/smn/v2/topics"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -14,7 +16,7 @@ import (
 func getResourceSMNTopic(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	smnClient, err := conf.SmnV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating smn: %s", err)
+		return nil, fmt.Errorf("error creating SMN client: %s", err)
 	}
 
 	return topics.Get(smnClient, state.Primary.ID).Extract()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes the following golang-ci lint:
```
==> Checking for golangci-lint...
huaweicloud/services/smn/resource_huaweicloud_smn_topic.go:17: File is not `gci`-ed with -s standard,default,prefix(github.com/chnsz/golangsdk),prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3),prefix(github.com/huaweicloud/terraform-provider-huaweicloud),blank,dot (gci)
        "github.com/chnsz/golangsdk/openstack/smn/v2/topics"
huaweicloud/services/smn/data_source_huaweicloud_smn_topics.go:12: File is not `gci`-ed with -s standard,default,prefix(github.com/chnsz/golangsdk),prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3),prefix(github.com/huaweicloud/terraform-provider-huaweicloud),blank,dot (gci)
        "github.com/chnsz/golangsdk/openstack/smn/v2/topics"
huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go:13: File is not `gci`-ed with -s standard,default,prefix(github.com/chnsz/golangsdk),prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3),prefix(github.com/huaweicloud/terraform-provider-huaweicloud),blank,dot (gci)
        "github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions"
huaweicloud/services/smn/resource_huaweicloud_smn_topic.go:106:2: commentFormatting: put a space between `//` and comment text (gocritic)
        //set tags
        ^
huaweicloud/services/smn/data_source_huaweicloud_smn_topics.go:86:2: import-shadowing: The name 'config' shadows an import name (revive)
        config := meta.(*config.Config)
        ^
huaweicloud/services/smn/resource_huaweicloud_smn_topic.go:85:2: import-shadowing: The name 'config' shadows an import name (revive)
        config := meta.(*config.Config)
        ^
huaweicloud/services/smn/resource_huaweicloud_smn_topic.go:126:2: import-shadowing: The name 'config' shadows an import name (revive)
        config := meta.(*config.Config)
        ^
huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go:175: line-length-limit: line is 156 characters, out of limit 150 (revive)
// urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:AUTO_ALARM_NOTIFY_TOPIC_MYSQL_mysql_0970dd7a1300f5672ff2c003c60ae115:a3ee64b608334ef2a47deef3b8454b14
huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go:144:33: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func resourceSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
                                ^
huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go:163:76: unused-parameter: parameter 'meta' seems to be unused, consider removing or renaming it as _ (revive)
func resourceSubscriptionImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

==> Checking for TF features in smn...
  -> resource_huaweicloud_smn_subscription.go: please use common.CheckDeletedDiag in ReadContext

  -> please use go-multierror package in data_source_huaweicloud_smn_topics.go


==> Checking for golangci-lint in ./huaweicloud/services/acceptance/smn...
huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_test.go:7: File is not `gci`-ed with -s standard,default,prefix(github.com/chnsz/golangsdk),prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3),prefix(github.com/huaweicloud/terraform-provider-huaweicloud),blank,dot (gci)
        "github.com/chnsz/golangsdk/openstack/smn/v2/topics"
huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_test.go:9: File is not `gci`-ed with -s standard,default,prefix(github.com/chnsz/golangsdk),prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3),prefix(github.com/huaweicloud/terraform-provider-huaweicloud),blank,dot (gci)
        "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_subscription_test.go:7: File is not `gci`-ed with -s standard,default,prefix(github.com/chnsz/golangsdk),prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3),prefix(github.com/huaweicloud/terraform-provider-huaweicloud),blank,dot (gci)
        "github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions"
huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_subscription_test.go:27:19: G601: Implicit memory aliasing in for loop. (gosec)
                        subscription = &subObject
                                       ^
huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_subscription_test.go:117:20: G601: Implicit memory aliasing in for loop. (gosec)
                                subscription = &subObject
                                               ^
huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_subscription_test.go:98:2: import-shadowing: The name 'config' shadows an import name (revive)
        config := acceptance.TestAccProvider.Meta().(*config.Config)
        ^
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/smn" TESTARGS="-run TestAcc"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/smn -v -run TestAcc -timeout 360m -parallel 4
=== RUN   TestAccDataTopics_basic
=== PAUSE TestAccDataTopics_basic
=== RUN   TestAccSmnMessageTemplate_basic
=== PAUSE TestAccSmnMessageTemplate_basic
=== RUN   TestAccSMNV2Subscription_basic
=== PAUSE TestAccSMNV2Subscription_basic
=== RUN   TestAccSMNV2Topic_basic
=== PAUSE TestAccSMNV2Topic_basic
=== RUN   TestAccSMNV2Topic_withEpsID
=== PAUSE TestAccSMNV2Topic_withEpsID
=== CONT  TestAccDataTopics_basic
=== CONT  TestAccSMNV2Topic_basic
=== CONT  TestAccSMNV2Subscription_basic
=== CONT  TestAccSMNV2Topic_withEpsID
--- PASS: TestAccSMNV2Topic_withEpsID (12.51s)
=== CONT  TestAccSmnMessageTemplate_basic
--- PASS: TestAccDataTopics_basic (14.69s)
--- PASS: TestAccSMNV2Subscription_basic (17.40s)
--- PASS: TestAccSMNV2Topic_basic (19.40s)
--- PASS: TestAccSmnMessageTemplate_basic (11.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       24.507s
```
