### PR TITLE
feat(WAF): waf resource and datasource support epsID

### DIFF
--- a/docs/data-sources/waf_certificate.md
+++ b/docs/data-sources/waf_certificate.md
@@ -9,23 +9,11 @@ Get the certificate in the WAF, including the one pushed from SCM.
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 data "huaweicloud_waf_certificate" "certificate_1" {
-  name = "certificate name"
-}
-
-resource "huaweicloud_waf_domain" "domain_1" {
-  domain           = "www.domainname.com"
-  certificate_id   = data.huaweicloud_waf_certificate.certificate_1.id
-  certificate_name = data.huaweicloud_waf_certificate.certificate_1.name
-  keep_policy      = false
-  proxy            = false
-
-  server {
-    client_protocol = "HTTPS"
-    server_protocol = "HTTP"
-    address         = "192.168.10.1"
-    port            = 8080
-  }
+  name                  = "certificate name"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -44,6 +32,8 @@ The following arguments are supported:
   + `0`: not expire
   + `1`: has expired
   + `2`: wil expired soon
+
+* `enterprise_project_id` - (Optional, String) The enterprise project ID of WAF certificate.
 
 ## Attributes Reference
 

--- a/docs/data-sources/waf_policies.md
+++ b/docs/data-sources/waf_policies.md
@@ -10,8 +10,11 @@ Use this data source to get a list of WAF policies.
 
 ```hcl
 variable "policy_name" {}
+variable enterprise_project_id {}
+
 data "huaweicloud_waf_policies" "policies" {
-  name = var.policy_name
+  name                  = var.policy_name
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -23,6 +26,8 @@ The following arguments are supported:
   will be used.
 
 * `name` - (Optional, String) Policy name used for matching. The value is case sensitive and supports fuzzy matching.
+
+* `enterprise_project_id` - (Optional, String) The enterprise project ID of WAF policies.
 
 ## Attributes Reference
 

--- a/docs/data-sources/waf_reference_tables.md
+++ b/docs/data-sources/waf_reference_tables.md
@@ -9,8 +9,11 @@ Use this data source to get a list of WAF reference tables.
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 data "huaweicloud_waf_reference_tables" "reftables" {
-  name = "reference_table_name"
+  name                  = "reference_table_name"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -22,6 +25,8 @@ The following arguments are supported:
   If omitted, the provider-level region will be used.
 
 * `name` - (Optional, String) The name of the reference table. The value is case sensitive and matches exactly.
+
+* `enterprise_project_id` - (Optional, String) The enterprise project ID of WAF reference tables.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -12,8 +12,11 @@ used. The certificate resource can be used in Cloud Mode, Dedicated Mode and ELB
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 resource "huaweicloud_waf_certificate" "certificate_1" {
-  name        = "cert_1"
+  name                  = "cert_1"
+  enterprise_project_id = var.enterprise_project_id
   certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIFmQl5dh2QUAeo39TIKtadgAgh4zHx09kSgayS9Wph9LEqq7MA+2042L3J9aOa
@@ -48,6 +51,9 @@ The following arguments are supported:
   certificate.
 
 * `private_key` - (Required, String, ForceNew) Specifies the private key. Changing this creates a new certificate.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF certificate.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_cloud_instance.md
+++ b/docs/resources/waf_cloud_instance.md
@@ -9,6 +9,8 @@ Using this resource to manage a cloud WAF in HuaweiCloud.
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 resource "huaweicloud_waf_cloud_instance" "test" {
   resource_spec_code = "professional"
 
@@ -22,10 +24,11 @@ resource "huaweicloud_waf_cloud_instance" "test" {
     resource_size = 1
   }
 
-  charging_mode = "prePaid"
-  period_unit   = "month"
-  period        = 1
-  auto_renew    = "true"
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+  auto_renew            = "true"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 

--- a/docs/resources/waf_cloud_instance.md
+++ b/docs/resources/waf_cloud_instance.md
@@ -12,7 +12,8 @@ Using this resource to manage a cloud WAF in HuaweiCloud.
 variable enterprise_project_id {}
 
 resource "huaweicloud_waf_cloud_instance" "test" {
-  resource_spec_code = "professional"
+  resource_spec_code    = "professional"
+  enterprise_project_id = var.enterprise_project_id
 
   bandwidth_expack_product {
     resource_size = 1
@@ -24,11 +25,10 @@ resource "huaweicloud_waf_cloud_instance" "test" {
     resource_size = 1
   }
 
-  charging_mode         = "prePaid"
-  period_unit           = "month"
-  period                = 1
-  auto_renew            = "true"
-  enterprise_project_id = var.enterprise_project_id
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "true"
 }
 ```
 

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -15,10 +15,12 @@ used. The dedicated mode domain name resource can be used in Dedicated Mode and 
 variable certificated_id {}
 variable vpc_id {}
 variable dedicated_engine_id {}
+variable enterprise_project_id {}
 
 resource "huaweicloud_waf_dedicated_domain" "domain_1" {
-  domain         = "www.example.com"
-  certificate_id = huaweicloud_waf_certificate.certificate_1.id
+  domain                = "www.example.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  enterprise_project_id = var.enterprise_project_id
 
   server {
     client_protocol = "HTTPS"
@@ -43,6 +45,9 @@ The following arguments are supported:
 
 * `server` - (Required, List, ForceNew) The server configuration list of the domain. A maximum of 80 can be configured.
   The object structure is documented below.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF dedicated domain.
+  Changing this parameter will create a new resource.
 
 * `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
   is set to HTTPS.

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -12,8 +12,12 @@ used. The domain name resource can be used in Cloud Mode.
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 resource "huaweicloud_waf_certificate" "certificate_1" {
-  name        = "cert_1"
+  name                  = "cert_1"
+  enterprise_project_id = var.enterprise_project_id
+  
   certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIFmQl5dh2QUAeo39TIKtadgAgh4zHx09kSgayS9Wph9LEqq7MA+2042L3J9aOa
@@ -34,10 +38,11 @@ EOT
 }
 
 resource "huaweicloud_waf_domain" "domain_1" {
-  domain           = "www.example.com"
-  certificate_id   = huaweicloud_waf_certificate.certificate_1.id
-  certificate_name = huaweicloud_waf_certificate.certificate_1.name
-  proxy            = true
+  domain                = "www.example.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  certificate_name      = huaweicloud_waf_certificate.certificate_1.name
+  proxy                 = true
+  enterprise_project_id = var.enterprise_project_id
 
   server {
     client_protocol = "HTTPS"
@@ -76,6 +81,9 @@ The following arguments are supported:
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the domain. Valid values are *prePaid*
   and *postPaid*, defaults to *prePaid*. Changing this creates a new instance.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF domain.
+  Changing this parameter will create a new resource.
 
 The `server` block supports:
 

--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -12,10 +12,13 @@ used. The policy resource can be used in Cloud Mode, Dedicated Mode and ELB Mode
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 resource "huaweicloud_waf_policy" "policy_1" {
-  name            = "policy_1"
-  protection_mode = "log"
-  level           = 2
+  name                  = "policy_1"
+  protection_mode       = "log"
+  level                 = 2
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -38,6 +41,9 @@ The following arguments are supported:
   + `1`: low
   + `2`: medium
   + `3`: high
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF policy.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_reference_table.md
+++ b/docs/resources/waf_reference_table.md
@@ -12,9 +12,12 @@ used. The reference table resource can be used in Cloud Mode (professional versi
 ## Example Usage
 
 ```hcl
+variable enterprise_project_id {}
+
 resource "huaweicloud_waf_reference_table" "ref_table" {
-  name = "tf_ref_table_demo"
-  type = "url"
+  name                  = "tf_ref_table_demo"
+  type                  = "url"
+  enterprise_project_id = var.enterprise_project_id
 
   conditions = [
     "/admin",
@@ -40,6 +43,9 @@ The following arguments are supported:
   condition is 2048 characters.
 
 * `description` - (Optional, String) The description of the reference table. The maximum length is 128 characters.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF reference table.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -30,13 +30,15 @@ resource "huaweicloud_waf_rule_blacklist" "rule" {
 ```hcl
 variable "policy_id" {}
 variable "address_group_id" {}
+variable enterprise_project_id {}
 
 resource "huaweicloud_waf_rule_blacklist" "rule" {
-  policy_id        = var.policy_id
-  address_group_id = var.address_group_id
-  action           = 1
-  name             = "test_name"
-  description      = "test description"
+  policy_id             = var.policy_id
+  address_group_id      = var.address_group_id
+  action                = 1
+  name                  = "test_name"
+  description           = "test description"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -67,6 +69,9 @@ The following arguments are supported:
   + `0`: block the request.
   + `1`: allow the request.
   + `2`: log the request only.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF rule blacklist and whitelist.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -12,15 +12,15 @@ used. The data masking rule resource can be used in Cloud Mode, Dedicated Mode a
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_1"
-}
+variable enterprise_project_id {}
+variable policy_id {}
 
 resource "huaweicloud_waf_rule_data_masking" "rule_1" {
-  policy_id = huaweicloud_waf_policy.policy_1.id
-  path      = "/login"
-  field     = "params"
-  subfield  = "password"
+  policy_id             = var.policy_id
+  path                  = "/login"
+  field                 = "params"
+  subfield              = "password"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -42,6 +42,9 @@ The following arguments are supported:
   + `cookie`: The field in the cookie.
 
 * `subfield` - (Required, String) Specifies the name of the masked field, e.g.: password.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF data masking rule.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -12,14 +12,14 @@ used. The web tamper protection rule resource can be used in Cloud Mode, Dedicat
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_1"
-}
+variable enterprise_project_id {}
+variable policy_id {}
 
 resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
-  policy_id = huaweicloud_waf_policy.policy_1.id
-  domain    = "www.your-domain.com"
-  path      = "/payment"
+  policy_id             = var.policy_id
+  domain                = "www.your-domain.com"
+  path                  = "/payment"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -36,6 +36,9 @@ The following arguments are supported:
 
 * `path` - (Required, String, ForceNew) Specifies the URL protected by the web tamper protection rule, excluding a
   domain name. Changing this creates a new rule.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID of WAF tamper protection rule.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230417074828-f66d11d77512
+	github.com/chnsz/golangsdk v0.0.0-20230418111741-7328b2d40053
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230417074828-f66d11d77512 h1:c4j+T2KUZ5GacnGEhy4SOeg1lpA1VmBwEpB6wvw+F0o=
-github.com/chnsz/golangsdk v0.0.0-20230417074828-f66d11d77512/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230418111741-7328b2d40053 h1:BCI21yKhT3WEcEeDccRRYBvOfHktIq+FoBvWPYBkGtI=
+github.com/chnsz/golangsdk v0.0.0-20230418111741-7328b2d40053/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
@@ -26,6 +26,34 @@ func TestAccDataSourceWafCertificateV1_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWafCertDataSourceID(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "expire_status", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceWafCertificateV1_withEpsID(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_waf_certificate.cert_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafCertificateListV1_conf_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafCertDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "expire_status", "1"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
 				),
@@ -52,11 +80,28 @@ func testAccWafCertificateListV1_conf(name string) string {
 %s
 
 data "huaweicloud_waf_certificate" "cert_1" {
-  name = huaweicloud_waf_certificate.certificate_1.name
+  name          = huaweicloud_waf_certificate.certificate_1.name
+  expire_status = 1
 
   depends_on = [
     huaweicloud_waf_certificate.certificate_1
   ]
 }
 `, testAccWafCertificateV1_conf(name))
+}
+
+func testAccWafCertificateListV1_conf_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_certificate" "cert_1" {
+  name                  = huaweicloud_waf_certificate.certificate_1.name
+  enterprise_project_id = "%s"
+  expire_status         = 1
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), epsID)
 }

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_policies_test.go
@@ -35,6 +35,33 @@ func TestAccDataSourceWafPoliciesV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceWafPoliciesV1_withEpsID(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_waf_policies.policies_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPoliciesV1_conf_epsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPoliciesID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "policies.0.name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.options.0.blacklist"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafPoliciesID(r string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
@@ -60,4 +87,19 @@ data "huaweicloud_waf_policies" "policies_1" {
   ]
 }
 `, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafPoliciesV1_conf_epsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_policies" "policies_1" {
+  name                  = huaweicloud_waf_policy.policy_1.name
+  enterprise_project_id = "%s"
+
+  depends_on = [
+    huaweicloud_waf_policy.policy_1
+  ]
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), epsID)
 }

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
@@ -34,6 +34,33 @@ func TestAccDataSourceReferenceTablesV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceReferenceTablesV1_basic_epsID(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_waf_reference_tables.ref_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReferenceTablesV1_conf_epsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReferenceTablesId(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.conditions.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckReferenceTablesId(r string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
@@ -55,4 +82,15 @@ data "huaweicloud_waf_reference_tables" "ref_table" {
   depends_on = [huaweicloud_waf_reference_table.ref_table]
 }
 `, testAccWafReferenceTableV1_conf(name))
+}
+
+func testAccReferenceTablesV1_conf_epsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_reference_tables" "ref_table" {
+  depends_on            = [huaweicloud_waf_reference_table.ref_table]
+  enterprise_project_id = "%s"
+}
+`, testAccWafReferenceTableV1_conf_withEpsID(name, epsID), epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -16,7 +16,7 @@ func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (inter
 	if err != nil {
 		return nil, fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
-	return certificates.Get(client, state.Primary.ID).Extract()
+	return certificates.GetWithEpsID(client, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"]).Extract()
 }
 
 func TestAccWafCertificateV1_basic(t *testing.T) {
@@ -58,6 +58,47 @@ func TestAccWafCertificateV1_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"certificate", "private_key"},
+			},
+		},
+	})
+}
+
+func TestAccWafCertificateV1_withEpsID(t *testing.T) {
+	var certificate certificates.Certificate
+	resourceName := "huaweicloud_waf_certificate.certificate_1"
+	name := acceptance.RandomAccResourceName()
+	updateName := name + "_update"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&certificate,
+		getResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafCertificateV1_conf_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testAccWafCertificateV1_conf_withEpsID(updateName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+				),
 			},
 		},
 	})
@@ -130,4 +171,75 @@ EOT
   ]
 }
 `, testAccWafDedicatedInstanceV1_conf(name), name)
+}
+
+func testAccWafCertificateV1_conf_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_certificate" "certificate_1" {
+  name = "%s"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+
+  enterprise_project_id = "%s"
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstance_epsId(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -245,10 +245,6 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     type            = "ipv4"
     vpc_id          = huaweicloud_vpc.test.id
   }
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
 }
 `, testAccWafCertificateV1_conf(name), name)
 }
@@ -284,10 +280,6 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     type            = "ipv4"
     vpc_id          = huaweicloud_vpc.test.id
   }
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
 }
 `, testAccWafCertificateV1_conf(name), name)
 }
@@ -317,10 +309,6 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     type            = "ipv4"
     vpc_id          = huaweicloud_vpc.test.id
   }
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
 }
 `, testAccWafCertificateV1_conf(name), name, name)
 }
@@ -346,10 +334,6 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     type            = "ipv4"
     vpc_id          = huaweicloud_vpc.test.id
   }
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
 }
 `, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
 }
@@ -386,10 +370,6 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     type            = "ipv4"
     vpc_id          = huaweicloud_vpc.test.id
   }
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
 }
 `, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
 }
@@ -421,10 +401,6 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     type            = "ipv4"
     vpc_id          = huaweicloud_vpc.test.id
   }
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
 }
 `, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -96,6 +96,88 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafDedicateDomainV1_withEpsID(t *testing.T) {
+	var domain domains.PremiumHost
+	resourceName := "huaweicloud_waf_dedicated_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedDomainV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedDomainV1_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.1"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_1"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "server.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "protect_status"),
+					resource.TestCheckResourceAttrSet(resourceName, "protocol"),
+					resource.TestCheckResourceAttrSet(resourceName, "tls"),
+					resource.TestCheckResourceAttrSet(resourceName, "cipher"),
+					resource.TestCheckResourceAttrSet(resourceName, "alarm_page.template_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_3ds"),
+					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_dss"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_update_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_2"),
+					resource.TestCheckResourceAttr(resourceName, "pci_3ds", "true"),
+					resource.TestCheckResourceAttr(resourceName, "pci_dss", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.address", "119.8.0.15"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_policy_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "protect_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafDedicatedDomainV1Destroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	c, err := config.WafDedicatedV1Client(acceptance.HW_REGION_NAME)
@@ -108,7 +190,7 @@ func testAccCheckWafDedicatedDomainV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := domains.Get(c, rs.Primary.ID)
+		_, err := domains.GetWithEpsID(c, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err == nil {
 			return fmt.Errorf("WAF dedicated mode domain still exists")
 		}
@@ -131,7 +213,7 @@ func testAccCheckWafDedicatedDomainV1Exists(n string, domain *domains.PremiumHos
 		if err != nil {
 			return fmt.Errorf("error creating HuaweiCloud WAF dedicated client: %s", err)
 		}
-		found, err := domains.Get(c, rs.Primary.ID)
+		found, err := domains.GetWithEpsID(c, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err != nil {
 			return err
 		}
@@ -161,7 +243,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8080
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   depends_on = [
@@ -191,7 +273,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8443
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   server {
@@ -200,7 +282,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.15"
     port            = 8443
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   depends_on = [
@@ -233,7 +315,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8080
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   depends_on = [
@@ -241,4 +323,108 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   ]
 }
 `, testAccWafCertificateV1_conf(name), name, name)
+}
+
+func testAccWafDedicatedDomainV1_basic_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain                = "www.%s.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  keep_policy           = false
+  proxy                 = false
+  tls                   = "TLS v1.1"
+  cipher                = "cipher_1"
+  enterprise_project_id = "%s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
+}
+
+func testAccWafDedicatedDomainV1_update_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain                = "www.%s.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  keep_policy           = false
+  proxy                 = true
+  tls                   = "TLS v1.2"
+  cipher                = "cipher_2"
+  pci_3ds               = true
+  pci_dss               = true
+  enterprise_project_id = "%s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.15"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
+}
+
+func testAccWafDedicatedDomainV1_policy_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_policy" "policy_1" {
+  name                  = "%[2]s"
+  enterprise_project_id = "%[3]s"
+}
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain                = "www.%[2]s.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  keep_policy           = true
+  proxy                 = true
+  tls                   = "TLS v1.2"
+  protect_status        = 0
+  enterprise_project_id = "%[3]s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -17,7 +17,7 @@ func getResourceObj(conf *config.Config, state *terraform.ResourceState) (interf
 	if err != nil {
 		return nil, fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
-	return domains.Get(c, state.Primary.ID).Extract()
+	return domains.GetWithEpsID(c, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"]).Extract()
 }
 
 func TestAccWafDomainV1_basic(t *testing.T) {
@@ -71,7 +71,54 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 	})
 }
 
-func TestAccWafDomainV1_policy(t *testing.T) {
+func TestAccWafDomainV1_withEpsID(t *testing.T) {
+	var domain domains.Domain
+	resourceName := "huaweicloud_waf_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+	domainName := fmt.Sprintf("%s.huawei.com", randName)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&domain,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDomainV1_basic_withEpsID(randName, domainName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", domainName),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+				),
+			},
+			{
+				Config: testAccWafDomainV1_update_withEpsID(randName, domainName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccWafDomainV1_withPolicy(t *testing.T) {
 	var domain domains.Domain
 	resourceName := "huaweicloud_waf_domain.domain_1"
 	randName := acceptance.RandomAccResourceName()
@@ -205,6 +252,10 @@ x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
 X7ioLbTeWGBqFM+C80PkdBNp
 -----END PRIVATE KEY-----
 EOT
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
 }
 `, testAccCloudInstance_basic, randName)
 }
@@ -265,6 +316,10 @@ func testAccWafDomainV1_policy(randName, domainName string) string {
 
 resource "huaweicloud_waf_policy" "policy_1" {
   name = "%s"
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
 }
 
 resource "huaweicloud_waf_domain" "domain_1" {
@@ -365,4 +420,127 @@ resource "huaweicloud_waf_domain" "domain_1" {
   }
 }
 `, randName, domainName)
+}
+
+func testAccWafDomainV1_base_withEpsID(randName, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_certificate" "certificate_1" {
+  name                  = "%s"
+  enterprise_project_id = "%s"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
+
+}
+`, testAccCloudInstance_basic_withEpsID(epsID), randName, epsID)
+}
+
+func testAccWafDomainV1_basic_withEpsID(randName, domainName, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_domain" "domain_1" {
+  domain                = "%s"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  certificate_name      = huaweicloud_waf_certificate.certificate_1.name
+  keep_policy           = false
+  proxy                 = false
+  enterprise_project_id = "%s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+  }
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
+}
+`, testAccWafDomainV1_base_withEpsID(randName, epsID), domainName, epsID)
+}
+
+func testAccWafDomainV1_update_withEpsID(randName, domainName, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_domain" "domain_1" {
+  domain                = "%s"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  certificate_name      = huaweicloud_waf_certificate.certificate_1.name
+  keep_policy           = false
+  proxy                 = true
+  enterprise_project_id = "%s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+  }
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
+}
+`, testAccWafDomainV1_base_withEpsID(randName, epsID), domainName, epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
@@ -56,6 +56,48 @@ func TestAccWafReferenceTableV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafReferenceTableV1_withEpsID(t *testing.T) {
+	var referencTable valuelists.WafValueList
+	resourceName := "huaweicloud_waf_reference_table.ref_table"
+	name := acceptance.RandomAccResourceName()
+	updateName := name + "_update"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafReferenceTableV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafReferenceTableV1_conf_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafReferenceTableV1Exists(resourceName, &referencTable),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "tf acc"),
+					resource.TestCheckResourceAttr(resourceName, "type", "url"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+				),
+			},
+			{
+				Config: testAccWafReferenceTableV1_update_withEpsID(updateName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafReferenceTableV1Exists(resourceName, &referencTable),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "type", "url"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafReferenceTableV1Destroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
@@ -68,7 +110,7 @@ func testAccCheckWafReferenceTableV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := valuelists.Get(wafClient, rs.Primary.ID)
+		_, err := valuelists.GetWithEpsID(wafClient, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err == nil {
 			return fmt.Errorf("WAF reference table still exists")
 		}
@@ -94,7 +136,7 @@ func testAccCheckWafReferenceTableV1Exists(n string, valueList *valuelists.WafVa
 			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
 		}
 
-		found, err := valuelists.Get(wafClient, rs.Primary.ID)
+		found, err := valuelists.GetWithEpsID(wafClient, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err != nil {
 			return err
 		}
@@ -149,4 +191,48 @@ resource "huaweicloud_waf_reference_table" "ref_table" {
   ]
 }
 `, testAccWafDedicatedInstanceV1_conf(name), name)
+}
+
+func testAccWafReferenceTableV1_conf_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_reference_table" "ref_table" {
+  name                  = "%s"
+  type                  = "url"
+  description           = "tf acc"
+  enterprise_project_id = "%s"
+
+  conditions = [
+    "/admin",
+    "/manage"
+  ]
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstance_epsId(name, epsID), name, epsID)
+}
+
+func testAccWafReferenceTableV1_update_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_reference_table" "ref_table" {
+  name                  = "%s"
+  type                  = "url"
+  description           = ""
+  enterprise_project_id = "%s"
+
+  conditions = [
+    "/bill",
+    "/sql"
+  ]
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstance_epsId(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -24,6 +24,7 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckWafRuleBlackListDestroy,
@@ -76,6 +77,49 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafRuleBlackList_withEpsID(t *testing.T) {
+	var rule rules.WhiteBlackIP
+	randName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_blacklist.rule"
+	addressGroupResourceName := "huaweicloud_waf_address_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafRuleBlackListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleBlackList_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(rName, &rule),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "ip_address", "192.160.0.0/24"),
+					resource.TestCheckResourceAttr(rName, "action", "0"),
+					resource.TestCheckResourceAttr(rName, "name", randName),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+				),
+			},
+			{
+				Config: testAccWafRuleBlackList_update_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(rName, &rule),
+					resource.TestCheckResourceAttrPair(rName, "address_group_id", addressGroupResourceName, "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "action", "2"),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", randName)),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttrSet(rName, "address_group_name"),
+					resource.TestCheckResourceAttrSet(rName, "address_group_size"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafRuleBlackListDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
@@ -89,7 +133,7 @@ func testAccCheckWafRuleBlackListDestroy(s *terraform.State) error {
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		_, err := rules.GetWithEpsId(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err == nil {
 			return fmt.Errorf("Waf rule still exists")
 		}
@@ -116,7 +160,7 @@ func testAccCheckWafRuleBlackListExists(n string, rule *rules.WhiteBlackIP) reso
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		found, err := rules.GetWithEpsId(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err != nil {
 			return err
 		}
@@ -207,4 +251,42 @@ resource "huaweicloud_waf_rule_blacklist" "rule_3" {
   description      = ""
 }
 `, testAccWafPolicyV1_basic(name), name, name)
+}
+
+func testAccWafRuleBlackList_basic_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_blacklist" "rule" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  ip_address            = "192.160.0.0/24"
+  name                  = "%s"
+  description           = "test description"
+  enterprise_project_id = "%s"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), name, epsID)
+}
+
+func testAccWafRuleBlackList_update_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_address_group" "test" {
+  name                  = "%[2]s"
+  description           = "example_description"
+  ip_addresses          = ["192.168.1.0/24"]
+  enterprise_project_id = "%[3]s"
+
+  depends_on   = [huaweicloud_waf_dedicated_instance.instance_1]
+}
+
+resource "huaweicloud_waf_rule_blacklist" "rule" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  address_group_id      = huaweicloud_waf_address_group.test.id
+  action                = 2
+  name                  = "%[2]s_update"
+  description           = ""
+  enterprise_project_id = "%[3]s"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -48,6 +48,33 @@ func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafRuleWebTamperProtection_withEpsID(t *testing.T) {
+	var rule rules.WebTamper
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleWebTamperProtection_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
@@ -61,7 +88,7 @@ func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error 
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		_, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err == nil {
 			return fmt.Errorf("WAF rule still exists")
 		}
@@ -88,7 +115,7 @@ func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTampe
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		found, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err != nil {
 			return err
 		}
@@ -113,4 +140,17 @@ resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
   path      = "/a"
 }
 `, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafRuleWebTamperProtection_basic_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  domain                = "www.abc.com"
+  path                  = "/a"
+  enterprise_project_id = "%s"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), epsID)
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
@@ -1,6 +1,7 @@
 package waf
 
 import (
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"time"
 
 	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
@@ -46,6 +47,10 @@ func DataSourceWafCertificateV1() *schema.Resource {
 					EXP_STATUS_NOT_EXPIRED, EXP_STATUS_EXPIRED, EXP_STATUS_EXPIRED_SOON,
 				}),
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"expiration": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -63,10 +68,11 @@ func dataSourceWafCertificateV1Read(d *schema.ResourceData, meta interface{}) er
 
 	expStatus := d.Get("expire_status").(int)
 	listOpts := certificates.ListOpts{
-		Page:      DEFAULT_PAGE_NUM,
-		Pagesize:  DEFAULT_PAGE_SIZE,
-		Name:      d.Get("name").(string),
-		ExpStatus: &expStatus,
+		Page:                DEFAULT_PAGE_NUM,
+		Pagesize:            DEFAULT_PAGE_SIZE,
+		Name:                d.Get("name").(string),
+		ExpStatus:           &expStatus,
+		EnterpriseProjectID: common.GetEnterpriseProjectID(d, config),
 	}
 
 	page, err := certificates.List(wafClient, listOpts).AllPages()

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
@@ -1,7 +1,6 @@
 package waf
 
 import (
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"time"
 
 	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
@@ -72,7 +71,7 @@ func dataSourceWafCertificateV1Read(d *schema.ResourceData, meta interface{}) er
 		Pagesize:            DEFAULT_PAGE_SIZE,
 		Name:                d.Get("name").(string),
 		ExpStatus:           &expStatus,
-		EnterpriseProjectID: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectID: config.GetEnterpriseProjectID(d),
 	}
 
 	page, err := certificates.List(wafClient, listOpts).AllPages()

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
@@ -2,9 +2,9 @@ package waf
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 
 	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -135,7 +135,7 @@ func dataSourceWafPoliciesV1Read(d *schema.ResourceData, meta interface{}) error
 
 	listOpts := policies.ListPolicyOpts{
 		Name:                d.Get("name").(string),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	rst, err := policies.ListPolicy(wafClient, listOpts)
 	if err != nil {

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
@@ -2,6 +2,7 @@ package waf
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 
 	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -22,6 +23,10 @@ func DataSourceWafPoliciesV1() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -129,7 +134,8 @@ func dataSourceWafPoliciesV1Read(d *schema.ResourceData, meta interface{}) error
 	}
 
 	listOpts := policies.ListPolicyOpts{
-		Name: d.Get("name").(string),
+		Name:                d.Get("name").(string),
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
 	}
 	rst, err := policies.ListPolicy(wafClient, listOpts)
 	if err != nil {

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
@@ -28,6 +28,10 @@ func DataSourceWafReferenceTablesV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"tables": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -72,7 +76,10 @@ func dataSourceWafReferenceTablesRead(d *schema.ResourceData, meta interface{}) 
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	r, err := valuelists.List(client, valuelists.ListValueListOpts{})
+	opts := valuelists.ListValueListOpts{
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+	}
+	r, err := valuelists.List(client, opts)
 	if err != nil {
 		return common.CheckDeleted(d, err, "Error obtain WAF reference table information")
 	}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
@@ -77,7 +77,7 @@ func dataSourceWafReferenceTablesRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	opts := valuelists.ListValueListOpts{
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	r, err := valuelists.List(client, opts)
 	if err != nil {

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
@@ -76,7 +76,7 @@ func resourceWafCertificateV1Create(d *schema.ResourceData, meta interface{}) er
 		Name:                d.Get("name").(string),
 		Content:             strings.TrimSpace(d.Get("certificate").(string)),
 		Key:                 strings.TrimSpace(d.Get("private_key").(string)),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 
 	certificate, err := certificates.Create(wafClient, createOpts).Extract()
@@ -97,7 +97,7 @@ func resourceWafCertificateV1Read(d *schema.ResourceData, meta interface{}) erro
 		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
 	}
 
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	n, err := certificates.GetWithEpsID(wafClient, d.Id(), epsID).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "Error obtain WAF certificate information")
@@ -121,7 +121,7 @@ func resourceWafCertificateV1Update(d *schema.ResourceData, meta interface{}) er
 
 	updateOpts := certificates.UpdateOpts{
 		Name:                d.Get("name").(string),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 
 	_, err = certificates.Update(wafClient, d.Id(), updateOpts).Extract()
@@ -138,7 +138,7 @@ func resourceWafCertificateV1Delete(d *schema.ResourceData, meta interface{}) er
 		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
 	}
 
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	err = certificates.DeleteWithEpsID(wafClient, d.Id(), epsID).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting WAF Certificate: %s", err)

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -410,7 +410,7 @@ func resourceCloudInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 			opts = clouds.UpdateOpts{
 				ProjectId:           cfg.GetProjectID(region),
 				IsAutoPay:           utils.Bool(true),
-				EnterpriseProjectId: common.GetEnterpriseProjectID(d, cfg),
+				EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 			}
 		)
 

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -408,8 +408,9 @@ func resourceCloudInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("resource_spec_code") {
 		var (
 			opts = clouds.UpdateOpts{
-				ProjectId: cfg.GetProjectID(region),
-				IsAutoPay: utils.Bool(true),
+				ProjectId:           cfg.GetProjectID(region),
+				IsAutoPay:           utils.Bool(true),
+				EnterpriseProjectId: common.GetEnterpriseProjectID(d, cfg),
 			}
 		)
 

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -192,7 +192,7 @@ func getCertificateNameById(d *schema.ResourceData, meta interface{}) (string, e
 		return "", fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
 	}
 	if _, ok := d.GetOk("certificate_id"); ok {
-		epsID := common.GetEnterpriseProjectID(d, config)
+		epsID := config.GetEnterpriseProjectID(d)
 		certificateId := d.Get("certificate_id").(string)
 		r, err := certificates.GetWithEpsID(c, certificateId, epsID).Extract()
 		if err != nil {
@@ -248,7 +248,7 @@ func resourceWafDedicatedDomainV1Create(d *schema.ResourceData, meta interface{}
 	}
 
 	createOpts, err := buildCreatePremiumHostOpts(d, meta)
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	createOpts.EnterpriseProjectID = epsID
 	if err != nil {
 		return err
@@ -285,7 +285,7 @@ func updateWafDedicatedDomain(client *golangsdk.ServiceClient, meta interface{},
 	updateOpts := domains.UpdatePremiumHostOpts{
 		Tls:                 d.Get("tls").(string),
 		Cipher:              d.Get("cipher").(string),
-		EnterpriseProjectID: common.GetEnterpriseProjectID(d, conf),
+		EnterpriseProjectID: conf.GetEnterpriseProjectID(d),
 	}
 
 	if d.HasChange("proxy") && !d.IsNewResource() {
@@ -391,7 +391,7 @@ func resourceWafDedicatedDomainV1Read(d *schema.ResourceData, meta interface{}) 
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	dm, err := domains.GetWithEpsID(wafClient, d.Id(), epsID)
 	if err != nil {
 		return common.CheckDeleted(d, err, "Error obtain WAF dedicated domain information")
@@ -462,7 +462,7 @@ func resourceWafDedicatedDomainV1Update(d *schema.ResourceData, meta interface{}
 
 	if d.HasChanges("protect_status") {
 		protectStatus := d.Get("protect_status").(int)
-		epsID := common.GetEnterpriseProjectID(d, config)
+		epsID := config.GetEnterpriseProjectID(d)
 		_, err = domains.UpdateProtectStatusWithWpsID(wafDedicatedClient, protectStatus, d.Id(), epsID)
 		if err != nil {
 			return fmtp.Errorf("[ERROR] error change the protection status of WAF dedicate domain %s: %s",
@@ -473,7 +473,7 @@ func resourceWafDedicatedDomainV1Update(d *schema.ResourceData, meta interface{}
 	if d.HasChanges("policy_id") {
 		oVal, nVal := d.GetChange("policy_id")
 		policyId := nVal.(string)
-		epsID := common.GetEnterpriseProjectID(d, config)
+		epsID := config.GetEnterpriseProjectID(d)
 		updateHostsOpts := policies.UpdateHostsOpts{
 			Hosts:               []string{d.Id()},
 			EnterpriseProjectId: epsID,
@@ -505,7 +505,7 @@ func resourceWafDedicatedDomainV1Delete(d *schema.ResourceData, meta interface{}
 
 	logp.Printf("[DEBUG] Delete WAF dedicated domain(keep_policy: %v).", d.Get("keep_policy"))
 	keepPolicy := d.Get("keep_policy").(bool)
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	_, err = domains.DeleteWithEpsID(wafDedicatedClient, keepPolicy, d.Id(), epsID)
 	if err != nil {
 		return fmtp.Errorf("error deleting WAF dedicated domain: %s", err)

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
@@ -60,6 +60,11 @@ func ResourceWafPolicyV1() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(0, 3),
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"options": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -140,7 +145,8 @@ func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	createOpts := policies.CreateOpts{
-		Name: d.Get("name").(string),
+		Name:                d.Get("name").(string),
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
 	}
 	policy, err := policies.Create(wafClient, createOpts).Extract()
 	if err != nil {
@@ -159,7 +165,7 @@ func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	// If the vlaue of 'protection_mode' or 'level' is not equal to the value returned by the server,
 	// then update the policy.
-	err = checkAndUpdateDefaultVal(wafClient, d, protectionMode, level)
+	err = checkAndUpdateDefaultVal(wafClient, d, protectionMode, level, config)
 	if err != nil {
 		return fmtp.Errorf("the Waf Policy was created successfully, "+
 			"but failed to update protection_mode or level : %s", err)
@@ -175,10 +181,12 @@ func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 // the value returned by the server.
 // If the value is not equal to the value returned by the server, call the update API to make changes.
 func checkAndUpdateDefaultVal(wafClient *golangsdk.ServiceClient, d *schema.ResourceData,
-	protectionMode string, level int) error {
+	protectionMode string, level int, conf *config.Config) error {
 
 	needUpdate := false
-	updateOpts := policies.UpdateOpts{}
+	updateOpts := policies.UpdateOpts{
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, conf),
+	}
 
 	if strings.Compare(d.Get("protection_mode").(string), protectionMode) != 0 && len(protectionMode) != 0 {
 		needUpdate = true
@@ -206,7 +214,7 @@ func resourceWafPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	n, err := policies.Get(wafClient, d.Id()).Extract()
+	n, err := policies.GetWithEpsID(wafClient, d.Id(), common.GetEnterpriseProjectID(d, config)).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "Waf Policy")
 	}
@@ -253,6 +261,7 @@ func resourceWafPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
 			Action: &policies.Action{
 				Category: d.Get("protection_mode").(string),
 			},
+			EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
 		}
 
 		logp.Printf("[DEBUG] updateOpts: %#v", updateOpts)
@@ -271,7 +280,7 @@ func resourceWafPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	err = policies.Delete(wafClient, d.Id()).ExtractErr()
+	err = policies.DeleteWithEpsID(wafClient, d.Id(), common.GetEnterpriseProjectID(d, config)).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting WAF Policy: %s", err)
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
@@ -146,7 +146,7 @@ func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	createOpts := policies.CreateOpts{
 		Name:                d.Get("name").(string),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	policy, err := policies.Create(wafClient, createOpts).Extract()
 	if err != nil {
@@ -185,7 +185,7 @@ func checkAndUpdateDefaultVal(wafClient *golangsdk.ServiceClient, d *schema.Reso
 
 	needUpdate := false
 	updateOpts := policies.UpdateOpts{
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, conf),
+		EnterpriseProjectId: conf.GetEnterpriseProjectID(d),
 	}
 
 	if strings.Compare(d.Get("protection_mode").(string), protectionMode) != 0 && len(protectionMode) != 0 {
@@ -214,7 +214,7 @@ func resourceWafPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	n, err := policies.GetWithEpsID(wafClient, d.Id(), common.GetEnterpriseProjectID(d, config)).Extract()
+	n, err := policies.GetWithEpsID(wafClient, d.Id(), config.GetEnterpriseProjectID(d)).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "Waf Policy")
 	}
@@ -261,7 +261,7 @@ func resourceWafPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
 			Action: &policies.Action{
 				Category: d.Get("protection_mode").(string),
 			},
-			EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+			EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 		}
 
 		logp.Printf("[DEBUG] updateOpts: %#v", updateOpts)
@@ -280,7 +280,7 @@ func resourceWafPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	err = policies.DeleteWithEpsID(wafClient, d.Id(), common.GetEnterpriseProjectID(d, config)).ExtractErr()
+	err = policies.DeleteWithEpsID(wafClient, d.Id(), config.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting WAF Policy: %s", err)
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
@@ -89,7 +89,7 @@ func resourceWafReferenceTableCreate(d *schema.ResourceData, meta interface{}) e
 		Type:                d.Get("type").(string),
 		Values:              utils.ExpandToStringList(d.Get("conditions").([]interface{})),
 		Description:         d.Get("description").(string),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	logp.Printf("[DEBUG] Create WAF reference table options: %#v", opt)
 
@@ -111,7 +111,7 @@ func resourceWafReferenceTableRead(d *schema.ResourceData, meta interface{}) err
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	r, err := valuelists.GetWithEpsID(client, d.Id(), common.GetEnterpriseProjectID(d, config))
+	r, err := valuelists.GetWithEpsID(client, d.Id(), config.GetEnterpriseProjectID(d))
 	if err != nil {
 		return common.CheckDeleted(d, err, "Error obtain WAF reference table information")
 	}
@@ -147,7 +147,7 @@ func resourceWafReferenceTableUpdate(d *schema.ResourceData, meta interface{}) e
 		Type:                d.Get("type").(string),
 		Values:              utils.ExpandToStringList(d.Get("conditions").([]interface{})),
 		Description:         &desc,
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	logp.Printf("[DEBUG] Update WAF reference table options: %#v", opt)
 
@@ -167,7 +167,7 @@ func resourceWafReferenceTableDelete(d *schema.ResourceData, meta interface{}) e
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	_, err = valuelists.DeleteWithEpsID(client, d.Id(), common.GetEnterpriseProjectID(d, config))
+	_, err = valuelists.DeleteWithEpsID(client, d.Id(), config.GetEnterpriseProjectID(d))
 	if err != nil {
 		return fmtp.Errorf("error deleting WAF reference table: %s", err)
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
@@ -105,7 +105,7 @@ func resourceWafRuleBlackListCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	policyID := d.Get("policy_id").(string)
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	createOpts := rules.CreateOpts{
 		White: d.Get("action").(int),
 	}
@@ -142,7 +142,7 @@ func resourceWafRuleBlackListRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	policyID := d.Get("policy_id").(string)
-	n, err := rules.GetWithEpsId(wafClient, policyID, d.Id(), common.GetEnterpriseProjectID(d, config)).Extract()
+	n, err := rules.GetWithEpsId(wafClient, policyID, d.Id(), config.GetEnterpriseProjectID(d)).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "WAF Black List Rule")
 	}
@@ -200,7 +200,7 @@ func resourceWafRuleBlackListUpdate(d *schema.ResourceData, meta interface{}) er
 		logp.Printf("[DEBUG] updating blacklist and whitelist rule, updateOpts: %#v", updateOpts)
 
 		policyID := d.Get("policy_id").(string)
-		epsID := common.GetEnterpriseProjectID(d, config)
+		epsID := config.GetEnterpriseProjectID(d)
 		_, err = rules.UpdateWithEpsId(wafClient, updateOpts, policyID, d.Id(), epsID).Extract()
 		if err != nil {
 			return fmtp.Errorf("error updating HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
@@ -218,7 +218,7 @@ func resourceWafRuleBlackListDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	policyID := d.Get("policy_id").(string)
-	err = rules.DeleteWithEpsId(wafClient, policyID, d.Id(), common.GetEnterpriseProjectID(d, config)).ExtractErr()
+	err = rules.DeleteWithEpsId(wafClient, policyID, d.Id(), config.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
@@ -80,6 +80,11 @@ func ResourceWafRuleBlackListV1() *schema.Resource {
 					PROTECTION_ACTION_BLOCK, PROTECTION_ACTION_ALLOW, PROTECTION_ACTION_LOG,
 				}),
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"address_group_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -100,6 +105,7 @@ func resourceWafRuleBlackListCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	policyID := d.Get("policy_id").(string)
+	epsID := common.GetEnterpriseProjectID(d, config)
 	createOpts := rules.CreateOpts{
 		White: d.Get("action").(int),
 	}
@@ -117,7 +123,7 @@ func resourceWafRuleBlackListCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	logp.Printf("[DEBUG] WAF black list rule creating opts: %#v", createOpts)
-	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	rule, err := rules.CreateWithEpsId(wafClient, createOpts, policyID, epsID).Extract()
 	if err != nil {
 		return fmtp.Errorf("error creating WAF black list rule: %s", err)
 	}
@@ -136,7 +142,7 @@ func resourceWafRuleBlackListRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	policyID := d.Get("policy_id").(string)
-	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	n, err := rules.GetWithEpsId(wafClient, policyID, d.Id(), common.GetEnterpriseProjectID(d, config)).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "WAF Black List Rule")
 	}
@@ -194,7 +200,8 @@ func resourceWafRuleBlackListUpdate(d *schema.ResourceData, meta interface{}) er
 		logp.Printf("[DEBUG] updating blacklist and whitelist rule, updateOpts: %#v", updateOpts)
 
 		policyID := d.Get("policy_id").(string)
-		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+		epsID := common.GetEnterpriseProjectID(d, config)
+		_, err = rules.UpdateWithEpsId(wafClient, updateOpts, policyID, d.Id(), epsID).Extract()
 		if err != nil {
 			return fmtp.Errorf("error updating HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
 		}
@@ -211,7 +218,7 @@ func resourceWafRuleBlackListDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	policyID := d.Get("policy_id").(string)
-	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	err = rules.DeleteWithEpsId(wafClient, policyID, d.Id(), common.GetEnterpriseProjectID(d, config)).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
@@ -83,7 +83,7 @@ func resourceWafRuleDataMaskingCreate(d *schema.ResourceData, meta interface{}) 
 		Path:                d.Get("path").(string),
 		Category:            d.Get("field").(string),
 		Index:               d.Get("subfield").(string),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 
 	logp.Printf("[DEBUG] WAF Data Masking Rule creating opts: %#v", createOpts)
@@ -107,7 +107,7 @@ func resourceWafRuleDataMaskingRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	policyID := d.Get("policy_id").(string)
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	n, err := rules.GetWithEpsID(wafClient, policyID, d.Id(), epsID).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "WAF Data Masking Rule")
@@ -137,7 +137,7 @@ func resourceWafRuleDataMaskingUpdate(d *schema.ResourceData, meta interface{}) 
 			Path:                d.Get("path").(string),
 			Category:            d.Get("field").(string),
 			Index:               d.Get("subfield").(string),
-			EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+			EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 		}
 
 		logp.Printf("[DEBUG] WAF Data Masking Rule updating opts: %#v", updateOpts)
@@ -159,7 +159,7 @@ func resourceWafRuleDataMaskingDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	policyID := d.Get("policy_id").(string)
-	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), common.GetEnterpriseProjectID(d, config)).ExtractErr()
+	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), config.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting HuaweiCloud WAF Data Masking Rule: %s", err)
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
@@ -67,7 +67,7 @@ func resourceWafRuleWebTamperProtectionCreate(d *schema.ResourceData, meta inter
 	createOpts := rules.CreateOpts{
 		Hostname:            d.Get("domain").(string),
 		Url:                 d.Get("path").(string),
-		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 
 	policyID := d.Get("policy_id").(string)
@@ -91,7 +91,7 @@ func resourceWafRuleWebTamperProtectionRead(d *schema.ResourceData, meta interfa
 	}
 
 	policyID := d.Get("policy_id").(string)
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	n, err := rules.GetWithEpsID(wafClient, policyID, d.Id(), epsID).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "WAF Web Tamper Protection Rule")
@@ -119,7 +119,7 @@ func resourceWafRuleWebTamperProtectionDelete(d *schema.ResourceData, meta inter
 	}
 
 	policyID := d.Get("policy_id").(string)
-	epsID := common.GetEnterpriseProjectID(d, config)
+	epsID := config.GetEnterpriseProjectID(d)
 	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), epsID).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting HuaweiCloud WAF Web Tamper Protection Rule: %s", err)

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
@@ -47,6 +47,11 @@ func ResourceWafRuleWebTamperProtectionV1() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -60,8 +65,9 @@ func resourceWafRuleWebTamperProtectionCreate(d *schema.ResourceData, meta inter
 	}
 	// create options
 	createOpts := rules.CreateOpts{
-		Hostname: d.Get("domain").(string),
-		Url:      d.Get("path").(string),
+		Hostname:            d.Get("domain").(string),
+		Url:                 d.Get("path").(string),
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
 	}
 
 	policyID := d.Get("policy_id").(string)
@@ -85,7 +91,8 @@ func resourceWafRuleWebTamperProtectionRead(d *schema.ResourceData, meta interfa
 	}
 
 	policyID := d.Get("policy_id").(string)
-	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	epsID := common.GetEnterpriseProjectID(d, config)
+	n, err := rules.GetWithEpsID(wafClient, policyID, d.Id(), epsID).Extract()
 	if err != nil {
 		return common.CheckDeleted(d, err, "WAF Web Tamper Protection Rule")
 	}
@@ -112,7 +119,8 @@ func resourceWafRuleWebTamperProtectionDelete(d *schema.ResourceData, meta inter
 	}
 
 	policyID := d.Get("policy_id").(string)
-	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	epsID := common.GetEnterpriseProjectID(d, config)
+	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), epsID).ExtractErr()
 	if err != nil {
 		return fmtp.Errorf("error deleting HuaweiCloud WAF Web Tamper Protection Rule: %s", err)
 	}

--- a/vendor/github.com/chnsz/golangsdk/openstack/utils/utils.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/utils/utils.go
@@ -1,7 +1,17 @@
 package utils
 
+import "fmt"
+
 func DeleteNotPassParams(params *map[string]interface{}, not_pass_params []string) {
 	for _, i := range not_pass_params {
 		delete(*params, i)
 	}
+}
+
+// GenerateEpsIDQuery is used to generate a request URL with enterprise_project_id
+func GenerateEpsIDQuery(epsID string) string {
+	if len(epsID) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsID)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf/v1/clouds/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf/v1/clouds/requests.go
@@ -23,7 +23,7 @@ type CreateOpts struct {
 	// The configuration of the rule extended packages.
 	RuleExpackProductInfo *ExpackProductInfo `json:"rule_expack_product_info,omitempty"`
 	// The ID of the enterprise project to which the cloud WAF belongs.
-	EnterpriseProjectId string `q:"enterprise_project_id"`
+	EnterpriseProjectId string `q:"enterprise_project_id" json:"-"`
 }
 
 // ProductInfo is an object that represents the configuration of the cloud WAF.
@@ -90,7 +90,7 @@ type UpdateOpts struct {
 	// The configuration of the rule extended packages.
 	RuleExpackProductInfo *ExpackProductInfo `json:"rule_expack_product_info,omitempty"`
 	// The ID of the enterprise project to which the cloud WAF belongs.
-	EnterpriseProjectId string `q:"enterprise_project_id"`
+	EnterpriseProjectId string `q:"enterprise_project_id" json:"-"`
 }
 
 // UpdateProductInfo is an object that represents the update configuration of the cloud WAF.

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists/requests.go
@@ -4,7 +4,10 @@
 
 package valuelists
 
-import "github.com/chnsz/golangsdk"
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/utils"
+)
 
 var requestOpts = golangsdk.RequestOpts{
 	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
@@ -12,10 +15,11 @@ var requestOpts = golangsdk.RequestOpts{
 
 // CreateOpts the options to create reference table.
 type CreateOpts struct {
-	Name        string   `json:"name" required:"true"`
-	Type        string   `json:"type" required:"true"`
-	Values      []string `json:"values,omitempty"`
-	Description string   `json:"description,omitempty"`
+	Name                string   `json:"name" required:"true"`
+	Type                string   `json:"type" required:"true"`
+	Values              []string `json:"values,omitempty"`
+	Description         string   `json:"description,omitempty"`
+	EnterpriseProjectId string   `q:"enterprise_project_id" json:"-"`
 }
 
 // Create a reference table.
@@ -24,9 +28,13 @@ func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*WafValueList, error) 
 	if err != nil {
 		return nil, err
 	}
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	var rst golangsdk.Result
-	_, err = c.Post(rootURL(c), b, &rst.Body, &golangsdk.RequestOpts{
+	_, err = c.Post(rootURL(c)+query.String(), b, &rst.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -40,10 +48,11 @@ func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*WafValueList, error) 
 
 //UpdateValueListOpts the options to update reference table.
 type UpdateValueListOpts struct {
-	Name        string   `json:"name" required:"true"`
-	Values      []string `json:"values,omitempty"`
-	Type        string   `json:"type,omitempty"`
-	Description *string  `json:"description,omitempty"`
+	Name                string   `json:"name" required:"true"`
+	Values              []string `json:"values,omitempty"`
+	Type                string   `json:"type,omitempty"`
+	Description         *string  `json:"description,omitempty"`
+	EnterpriseProjectId string   `q:"enterprise_project_id" json:"-"`
 }
 
 // Update reference table according options and id.
@@ -52,9 +61,13 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateValueListOpts) (*W
 	if err != nil {
 		return nil, err
 	}
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	var rst golangsdk.Result
-	_, err = c.Put(resourceURL(c, id), b, &rst.Body, &golangsdk.RequestOpts{
+	_, err = c.Put(resourceURL(c, id)+query.String(), b, &rst.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -68,8 +81,12 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateValueListOpts) (*W
 
 // Get a reference table by id.
 func Get(c *golangsdk.ServiceClient, id string) (*WafValueList, error) {
+	return GetWithEpsID(c, id, "")
+}
+
+func GetWithEpsID(c *golangsdk.ServiceClient, id, epsID string) (*WafValueList, error) {
 	var rst golangsdk.Result
-	_, err := c.Get(resourceURL(c, id), &rst.Body, &golangsdk.RequestOpts{
+	_, err := c.Get(resourceURL(c, id)+utils.GenerateEpsIDQuery(epsID), &rst.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -83,8 +100,9 @@ func Get(c *golangsdk.ServiceClient, id string) (*WafValueList, error) {
 
 // ListValueListOpts the options to query a list of reference tables.
 type ListValueListOpts struct {
-	Page     int `q:"page"`
-	Pagesize int `q:"pagesize"`
+	Page                int    `q:"page"`
+	Pagesize            int    `q:"pagesize"`
+	EnterpriseProjectId string `q:"enterprise_project_id"`
 }
 
 // List : Query a list of reference tables according to the options.
@@ -111,8 +129,12 @@ func List(c *golangsdk.ServiceClient, opts ListValueListOpts) (*ListValueListRst
 
 // Delete reference table by id.
 func Delete(c *golangsdk.ServiceClient, id string) (*WafValueList, error) {
+	return DeleteWithEpsID(c, id, "")
+}
+
+func DeleteWithEpsID(c *golangsdk.ServiceClient, id, epsID string) (*WafValueList, error) {
 	var rst golangsdk.Result
-	_, err := c.DeleteWithResponse(resourceURL(c, id), &rst.Body, &golangsdk.RequestOpts{
+	_, err := c.DeleteWithResponse(resourceURL(c, id)+utils.GenerateEpsIDQuery(epsID), &rst.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules/requests.go
@@ -6,6 +6,7 @@ package webtamperprotection_rules
 
 import (
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/utils"
 )
 
 var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
@@ -20,9 +21,10 @@ type CreateOptsBuilder interface {
 
 // CreateOpts contains all the values needed to create a new web tamper protection rule.
 type CreateOpts struct {
-	Hostname    string `json:"hostname" required:"true"`
-	Url         string `json:"url" required:"true"`
-	Description string `json:"description,omitempty"`
+	Hostname            string `json:"hostname" required:"true"`
+	Url                 string `json:"url" required:"true"`
+	Description         string `json:"description,omitempty"`
+	EnterpriseProjectId string `q:"enterprise_project_id" json:"-"`
 }
 
 // ToWebTamperCreateMap builds a create request body from CreateOpts.
@@ -37,28 +39,42 @@ func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder)
 		r.Err = err
 		return
 	}
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
-	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	_, r.Err = c.Post(rootURL(c, policyID)+query.String(), b, &r.Body, reqOpt)
 	return
 }
 
 // Get retrieves a particular web tamper protection rule based on its unique ID.
 func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	return GetWithEpsID(c, policyID, ruleID, "")
+}
+
+func GetWithEpsID(c *golangsdk.ServiceClient, policyID, ruleID, epsID string) (r GetResult) {
 	reqOpt := &golangsdk.RequestOpts{
 		MoreHeaders: RequestOpts.MoreHeaders,
 	}
 
-	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID)+utils.GenerateEpsIDQuery(epsID), &r.Body, reqOpt)
 	return
 }
 
 // Delete will permanently delete a particular web tamper protection rule based on its unique ID.
 func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	return DeleteWithEpsID(c, policyID, ruleID, "")
+}
+
+func DeleteWithEpsID(c *golangsdk.ServiceClient, policyID, ruleID, epsID string) (r DeleteResult) {
 	reqOpt := &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders,
 	}
 
-	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID)+utils.GenerateEpsIDQuery(epsID), reqOpt)
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230417074828-f66d11d77512
+# github.com/chnsz/golangsdk v0.0.0-20230418111741-7328b2d40053
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -30,7 +30,6 @@ github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/responses
-github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/signs
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/throttles
 github.com/chnsz/golangsdk/openstack/apigw/shared/v1/apis
 github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
- waf certificate resource and datasource support epsID
- waf dedicated domain support epsID
- waf policy support epsID
- waf reference table support epsID
- waf rule(blacklist,dataMasking,webtamperProtection) support epsID
- waf cloud instance support epsID
- waf domain support epsID

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

### waf certificate
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafCertificateV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafCertificateV1_ -timeout 360m -parallel 4
=== RUN   TestAccWafCertificateV1_basic
=== PAUSE TestAccWafCertificateV1_basic
=== RUN   TestAccWafCertificateV1_withEpsID
=== PAUSE TestAccWafCertificateV1_withEpsID
=== CONT  TestAccWafCertificateV1_basic
=== CONT  TestAccWafCertificateV1_withEpsID
--- PASS: TestAccWafCertificateV1_basic (405.47s)
--- PASS: TestAccWafCertificateV1_withEpsID (410.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       410.320s

make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafCertificateV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafCertificateV1_ -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafCertificateV1_basic
=== PAUSE TestAccDataSourceWafCertificateV1_basic
=== RUN   TestAccDataSourceWafCertificateV1_withEpsID
=== PAUSE TestAccDataSourceWafCertificateV1_withEpsID
=== CONT  TestAccDataSourceWafCertificateV1_basic
=== CONT  TestAccDataSourceWafCertificateV1_withEpsID
--- PASS: TestAccDataSourceWafCertificateV1_withEpsID (320.02s)
--- PASS: TestAccDataSourceWafCertificateV1_basic (378.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       378.858s

```

### waf dedicated domain
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_ -timeout 360m -parallel 4
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== RUN   TestAccWafDedicateDomainV1_withEpsID
=== PAUSE TestAccWafDedicateDomainV1_withEpsID
=== CONT  TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_withEpsID
--- PASS: TestAccWafDedicateDomainV1_withEpsID (441.78s)
--- PASS: TestAccWafDedicateDomainV1_basic (444.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       444.695s
```

### waf policy
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1_ -timeout 360m -parallel 4
=== RUN   TestAccWafPolicyV1_basic
=== PAUSE TestAccWafPolicyV1_basic
=== RUN   TestAccWafPolicyV1_withEpsID
=== PAUSE TestAccWafPolicyV1_withEpsID
=== CONT  TestAccWafPolicyV1_basic
=== CONT  TestAccWafPolicyV1_withEpsID
--- PASS: TestAccWafPolicyV1_basic (369.77s)
--- PASS: TestAccWafPolicyV1_withEpsID (371.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       371.498s

make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafPoliciesV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafPoliciesV1_ -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafPoliciesV1_basic
=== PAUSE TestAccDataSourceWafPoliciesV1_basic
=== RUN   TestAccDataSourceWafPoliciesV1_basic_withEpsID
=== PAUSE TestAccDataSourceWafPoliciesV1_basic_withEpsID
=== CONT  TestAccDataSourceWafPoliciesV1_basic
=== CONT  TestAccDataSourceWafPoliciesV1_basic_withEpsID
--- PASS: TestAccDataSourceWafPoliciesV1_basic (375.40s)
--- PASS: TestAccDataSourceWafPoliciesV1_basic_withEpsID (377.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       377.974s
```

### waf reference table
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafReferenceTableV1_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafReferenceTableV1_ -timeout 360m -parallel 4 
=== RUN   TestAccWafReferenceTableV1_basic 
=== PAUSE TestAccWafReferenceTableV1_basic
=== RUN   TestAccWafReferenceTableV1_withEpsID
=== PAUSE TestAccWafReferenceTableV1_withEpsID
=== CONT  TestAccWafReferenceTableV1_basic
=== CONT  TestAccWafReferenceTableV1_withEpsID
--- PASS: TestAccWafReferenceTableV1_basic (380.98s) 
--- PASS: TestAccWafReferenceTableV1_withEpsID (442.26s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       442.320s


make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceReferenceTablesV1_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceReferenceTablesV1_ -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceReferenceTablesV1_basic 
--- PASS: TestAccDataSourceReferenceTablesV1_basic (391.15s) 
=== RUN   TestAccDataSourceReferenceTablesV1_basic_epsID
--- PASS: TestAccDataSourceReferenceTablesV1_basic_epsID (363.69s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       754.904s
```

### waf rule
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleBlackList_basic 
=== PAUSE TestAccWafRuleBlackList_basic
=== RUN   TestAccWafRuleBlackList_withEpsID
=== PAUSE TestAccWafRuleBlackList_withEpsID
=== CONT  TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_withEpsID
--- PASS: TestAccWafRuleBlackList_withEpsID (446.66s) 
--- PASS: TestAccWafRuleBlackList_basic (450.72s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       450.813s


make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleDataMasking_basic 
=== PAUSE TestAccWafRuleDataMasking_basic
=== RUN   TestAccWafRuleDataMasking_withEpsID
=== PAUSE TestAccWafRuleDataMasking_withEpsID
=== CONT  TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_withEpsID
--- PASS: TestAccWafRuleDataMasking_basic (344.14s) 
--- PASS: TestAccWafRuleDataMasking_withEpsID (413.48s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       413.588s


make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_ -timeout 360m -parallel 4
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== RUN   TestAccWafRuleWebTamperProtection_withEpsID
=== PAUSE TestAccWafRuleWebTamperProtection_withEpsID
=== CONT  TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_withEpsID
--- PASS: TestAccWafRuleWebTamperProtection_basic (353.73s)
--- PASS: TestAccWafRuleWebTamperProtection_withEpsID (365.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       365.107s

```

### waf cloud instance
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccCloudInstance_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCloudInstance_basic -timeout 360m -parallel 4 
=== RUN   TestAccCloudInstance_basic 
=== PAUSE TestAccCloudInstance_basic
=== CONT  TestAccCloudInstance_basic
--- PASS: TestAccCloudInstance_basic (119.58s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       119.638s


make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccCloudInstance_withEpsID'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCloudInstance_withEpsID -timeout 360m -parallel 4 
=== RUN   TestAccCloudInstance_withEpsID 
=== PAUSE TestAccCloudInstance_withEpsID
=== CONT  TestAccCloudInstance_withEpsID
--- PASS: TestAccCloudInstance_withEpsID (137.47s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       137.525s
```

waf domain
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4 
=== RUN   TestAccWafDomainV1_basic 
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (100.19s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       100.258s

make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4 
=== RUN   TestAccWafDomainV1_withEpsID 
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (101.30s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       101.354s

```



