### PR TITLE
fix(gaussdb): gaussdb support replica num

### DIFF
--- a/docs/resources/gaussdb_opengauss_instance.md
+++ b/docs/resources/gaussdb_opengauss_instance.md
@@ -136,15 +136,13 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `sharding_num` - (Optional, Int) Specifies the sharding number. The valid value is range form `1` to `9`.
-  The default value is 3. This parameter is valid only when the HA mode is set to **enterprise**.
+  The default value is 3.
 
 * `coordinator_num` - (Optional, Int) Specifies the coordinator number. Values: 1~9. The default value is 3.
   The value must not be greater than twice value of `sharding_num`.
-  This parameter is valid only when the HA mode is set to **enterprise**.
 
 * `replica_num` - (Optional, Int, ForceNew) The replica number. The valid values are **2** and **3**, defaults to **3**.
   Double replicas are only available for specific users and supports only instance versions are v1.3.0 or later.
-  This parameter is valid only when the HA mode is set to **centralization_standard**.
   Changing this parameter will create a new resource.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance.go
@@ -164,9 +164,6 @@ func ResourceOpenGaussInstance() *schema.Resource {
 					2, 3,
 				}),
 				Default: 3,
-				ConflictsWith: []string{
-					"sharding_num", "coordinator_num",
-				},
 			},
 			"security_group_id": {
 				Type:     schema.TypeString,
@@ -571,7 +568,7 @@ func setOpenGaussNodesAndRelatedNumbers(d *schema.ResourceData, instance instanc
 	}
 
 	if shardingNum > 0 && coordinatorNum > 0 {
-		*dnNum = shardingNum / 3
+		*dnNum = shardingNum / d.Get("replica_num").(int)
 		return multierror.Append(nil,
 			d.Set("nodes", nodesList),
 			d.Set("sharding_num", dnNum),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
gaussdb opengauss resource remove replica num ConflictsWith.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
I have checked resource `huaweicloud_gaussdb_opengauss_instance` when replicaNum is `2` and replicaNum is `3`. The resource can be successfully created.

However, due to issues with gaussdb, the security group cannot be deleted after deleting the newly created gaussdb resource, resulting in the inability of the test case to pass normally.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```

```
