### PR TITLE
feat(apig/signature): add new association resource

### DIFF
--- a/docs/resources/apig_signature_associate.md
+++ b/docs/resources/apig_signature_associate.md
@@ -1,0 +1,57 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_signature_associate
+
+Use this resource to bind the APIs to the signature within HuaweiCloud.
+
+-> A signature can only create one `huaweicloud_apig_signature_associate` resource.
+   And a published ID for API can only bind a signature.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "signature_id" {}
+variable "api_publish_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_apig_signature_associate" "test" {
+  instance_id  = var.instance_id
+  signature_id = var.signature_id
+  publish_ids  = var.api_publish_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the signature and the APIs are located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the APIs and the
+  signature belong.  
+  Changing this will create a new resource.
+
+* `signature_id` - (Required, String, ForceNew) Specifies the signature ID for APIs binding.  
+  Changing this will create a new resource.
+
+* `publish_ids` - (Required, List) Specifies the publish IDs corresponding to the APIs bound by the signature.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. The format is `<instance_id>/<signature_id>`.
+
+## Import
+
+Associate resources can be imported using their `signature_id` and the APIG dedicated instance ID to which the signature
+belongs, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_signature_associate.test <instance_id>/<signature_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -633,6 +633,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_routes":             apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                    apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_response":                    apig.ResourceApigResponseV2(),
+			"huaweicloud_apig_signature_associate":         apig.ResourceSignatureAssociate(),
 			"huaweicloud_apig_signature":                   apig.ResourceSignature(),
 			"huaweicloud_apig_throttling_policy_associate": apig.ResourceThrottlingPolicyAssociate(),
 			"huaweicloud_apig_throttling_policy":           apig.ResourceApigThrottlingPolicyV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_associate_test.go
@@ -1,0 +1,322 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/signs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func getSignatureAssociateFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+	}
+	opts := signs.ListBindOpts{
+		InstanceId:  state.Primary.Attributes["instance_id"],
+		SignatureId: state.Primary.Attributes["signature_id"],
+		Limit:       500,
+	}
+	resp, err := signs.ListBind(c, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return resp, nil
+}
+
+func TestAccSignatureAssociate_basic(t *testing.T) {
+	var (
+		apiDetails []signs.SignBindApiInfo
+
+		name   = acceptance.RandomAccResourceName()
+		rName1 = "huaweicloud_apig_signature_associate.basic_bind"
+		rName2 = "huaweicloud_apig_signature_associate.hmac_bind"
+		rName3 = "huaweicloud_apig_signature_associate.aes_bind"
+
+		rc1 = acceptance.InitResourceCheck(rName1, &apiDetails, getSignatureAssociateFunc)
+		rc2 = acceptance.InitResourceCheck(rName2, &apiDetails, getSignatureAssociateFunc)
+		rc3 = acceptance.InitResourceCheck(rName3, &apiDetails, getSignatureAssociateFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc1.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSignatureAssociate_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName1, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "signature_id",
+						"huaweicloud_apig_signature.basic", "id"),
+					resource.TestCheckResourceAttr(rName1, "publish_ids.#", "2"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName2, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "signature_id",
+						"huaweicloud_apig_signature.hmac", "id"),
+					resource.TestCheckResourceAttr(rName2, "publish_ids.#", "2"),
+					rc3.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName3, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "signature_id",
+						"huaweicloud_apig_signature.aes", "id"),
+					resource.TestCheckResourceAttr(rName3, "publish_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccSignatureAssociate_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName1, "publish_ids.#", "2"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "publish_ids.#", "2"),
+					rc3.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName3, "publish_ids.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSignatureAssociateImportStateFunc(rName1),
+			},
+			{
+				ResourceName:      rName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSignatureAssociateImportStateFunc(rName2),
+			},
+			{
+				ResourceName:      rName3,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSignatureAssociateImportStateFunc(rName3),
+			},
+		},
+	})
+}
+
+func testAccSignatureAssociateImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["signature_id"] == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<signature_id>', but got '%s/%s'",
+				rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["signature_id"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["signature_id"]), nil
+	}
+}
+
+func testAccSignatureAssociate_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_vpc_channel" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+  port        = 80
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    id = huaweicloud_compute_instance.test.id
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+  
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = "%[2]s_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  count = 6
+
+  name        = "%[2]s_${count.index}"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  count = 6
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[count.index].id
+}
+
+resource "huaweicloud_apig_signature" "basic" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_basic"
+  type        = "basic"
+}
+
+resource "huaweicloud_apig_signature" "hmac" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_hmac"
+  type        = "hmac"
+}
+
+resource "huaweicloud_apig_signature" "aes" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_aes"
+  type        = "aes"
+  algorithm   = "aes-128-cfb"
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testAccSignatureAssociate_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_signature_associate" "basic_bind" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  signature_id = huaweicloud_apig_signature.basic.id
+  publish_ids  = slice(huaweicloud_apig_api_publishment.test[*].publish_id, 0, 2)
+}
+
+resource "huaweicloud_apig_signature_associate" "hmac_bind" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  signature_id = huaweicloud_apig_signature.hmac.id
+  publish_ids  = slice(huaweicloud_apig_api_publishment.test[*].publish_id, 2, 4)
+}
+
+resource "huaweicloud_apig_signature_associate" "aes_bind" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  signature_id = huaweicloud_apig_signature.aes.id
+  publish_ids  = slice(huaweicloud_apig_api_publishment.test[*].publish_id, 4, 6)
+}
+`, testAccSignatureAssociate_base(name))
+}
+
+func testAccSignatureAssociate_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_signature_associate" "basic_bind" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  signature_id = huaweicloud_apig_signature.basic.id
+  publish_ids  = slice(huaweicloud_apig_api_publishment.test[*].publish_id, 1, 3)
+}
+
+resource "huaweicloud_apig_signature_associate" "hmac_bind" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  signature_id = huaweicloud_apig_signature.hmac.id
+  publish_ids  = slice(huaweicloud_apig_api_publishment.test[*].publish_id, 3, 5)
+}
+
+resource "huaweicloud_apig_signature_associate" "aes_bind" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  signature_id = huaweicloud_apig_signature.aes.id
+  publish_ids  = setunion(slice(huaweicloud_apig_api_publishment.test[*].publish_id, 0, 1),
+    slice(huaweicloud_apig_api_publishment.test[*].publish_id, 5, 6))
+}
+`, testAccSignatureAssociate_base(name))
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_signature_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_signature_associate.go
@@ -1,0 +1,314 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/signs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// ResourceSignatureAssociate is a provider resource of the API signature.
+func ResourceSignatureAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSignatureAssociateCreate,
+		ReadContext:   resourceSignatureAssociateRead,
+		UpdateContext: resourceSignatureAssociateUpdate,
+		DeleteContext: resourceSignatureAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSignatureAssociateImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the signature and the APIs are located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the dedicated instance to which the APIs and the signature belong.",
+			},
+			"signature_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The signature ID for APIs binding.",
+			},
+			"publish_ids": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The publish IDs corresponding to the APIs bound by the signature.",
+			},
+		},
+	}
+}
+
+func signatureBindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, signId string,
+	publishIds []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		opts := buildSignBindApiListOpts(instanceId, signId)
+		resp, err := signs.ListBind(client, opts)
+		if err != nil {
+			return resp, "", err
+		}
+		bindPublishIds := flattenApiPublishIdsForSignature(resp)
+		if utils.StrSliceContainsAnother(bindPublishIds, publishIds) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func bindSignatureToApis(ctx context.Context, client *golangsdk.ServiceClient, opts signs.BindOpts,
+	timeout time.Duration) error {
+	var (
+		instanceId = opts.InstanceId
+		signId     = opts.SignatureId
+		publishIds = opts.PublishIds
+	)
+
+	_, err := signs.Bind(client, opts)
+	if err != nil {
+		return fmt.Errorf("error binding signature to the APIs: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: signatureBindingRefreshFunc(client, instanceId, signId, publishIds),
+		Timeout: timeout,
+		// In most cases, the bind operation will be completed immediately, but in a few cases, it needs to wait
+		// for a short period of time, and the polling is performed by incrementing the time here.
+		MinTimeout: 2 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the binding completed: %s", err)
+	}
+	return nil
+}
+
+func resourceSignatureAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+	var (
+		instanceId = d.Get("instance_id").(string)
+		signId     = d.Get("signature_id").(string)
+		publishIds = d.Get("publish_ids").(*schema.Set)
+
+		opts = signs.BindOpts{
+			InstanceId:  instanceId,
+			SignatureId: signId,
+			PublishIds:  utils.ExpandToStringListBySet(publishIds),
+		}
+	)
+	err = bindSignatureToApis(ctx, client, opts, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		diag.FromErr(err)
+	}
+	d.SetId(fmt.Sprintf("%s/%s", instanceId, signId))
+
+	return resourceSignatureAssociateRead(ctx, d, meta)
+}
+
+func buildSignBindApiListOpts(instanceId, signId string) signs.ListBindOpts {
+	return signs.ListBindOpts{
+		InstanceId:  instanceId,
+		SignatureId: signId,
+		Limit:       500,
+	}
+}
+
+func flattenApiPublishIdsForSignature(apiList []signs.SignBindApiInfo) []string {
+	if len(apiList) < 1 {
+		return nil
+	}
+
+	result := make([]string, len(apiList))
+	for i, val := range apiList {
+		result[i] = val.PublishId
+	}
+	return result
+}
+
+func resourceSignatureAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		signId     = d.Get("signature_id").(string)
+		opts       = buildSignBindApiListOpts(instanceId, signId)
+	)
+
+	resp, err := signs.ListBind(client, opts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Signature association")
+	}
+	if len(resp) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	return diag.FromErr(d.Set("publish_ids", flattenApiPublishIdsForSignature(resp)))
+}
+
+func signatureUnbindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, signId, bandId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		opts := buildSignBindApiListOpts(instanceId, signId)
+		resp, err := signs.ListBind(client, opts)
+		if err != nil {
+			return resp, "", err
+		}
+		for _, val := range resp {
+			if val.BindId == bandId {
+				return resp, "PENDING", nil
+			}
+		}
+		return resp, "COMPLETED", nil
+	}
+}
+
+func unbindSignatureFromApis(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	rmList []string, timeout time.Duration) error {
+	var (
+		instanceId = d.Get("instance_id").(string)
+		signId     = d.Get("signature_id").(string)
+	)
+	opts := buildSignBindApiListOpts(instanceId, signId)
+	resp, err := signs.ListBind(client, opts)
+	if err != nil {
+		return fmt.Errorf("error getting binding APIs based on signature (%s): %s", signId, err)
+	}
+
+	bindIds := make([]string, 0, len(resp))
+	for _, val := range resp {
+		if utils.StrSliceContains(rmList, val.PublishId) {
+			bindIds = append(bindIds, val.BindId)
+		}
+	}
+
+	for _, bandId := range bindIds {
+		err = signs.Unbind(client, instanceId, bandId)
+		if err != nil {
+			return fmt.Errorf("an error occurred during unbind signature: %s", err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING"},
+			Target:  []string{"COMPLETED"},
+			Refresh: signatureUnbindingRefreshFunc(client, instanceId, signId, bandId),
+			Timeout: timeout,
+			// In most cases, the unbind operation will be completed immediately, but in a few cases, it needs to wait
+			// for a short period of time, and the polling is performed by incrementing the time here.
+			MinTimeout: 2 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return fmt.Errorf("error waiting for the unbind operation completed: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceSignatureAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId     = d.Get("instance_id").(string)
+		signId         = d.Get("signature_id").(string)
+		oldRaw, newRaw = d.GetChange("publish_ids")
+
+		addSet = newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
+		rmSet  = oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
+	)
+
+	if rmSet.Len() > 0 {
+		err = unbindSignatureFromApis(ctx, client, d, utils.ExpandToStringListBySet(rmSet),
+			d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if addSet.Len() > 0 {
+		opts := signs.BindOpts{
+			InstanceId:  instanceId,
+			SignatureId: signId,
+			PublishIds:  utils.ExpandToStringListBySet(addSet),
+		}
+		// If the target (published) API already has a signature, this update will replace the signature.
+		err = bindSignatureToApis(ctx, client, opts, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			diag.FromErr(err)
+		}
+	}
+
+	return resourceSignatureAssociateRead(ctx, d, meta)
+}
+
+func resourceSignatureAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	err = unbindSignatureFromApis(ctx, client, d, utils.ExpandToStringListBySet(d.Get("publish_ids").(*schema.Set)),
+		d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceSignatureAssociateImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<signature_id>', but got '%s'",
+			importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("signature_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new APIG resource to bind the signature to the published APIs.

Notes: A published API can only has one signature.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new APIG resource to bind the signature to the published APIs.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccSignatureAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccSignatureAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccSignatureAssociate_basic
=== PAUSE TestAccSignatureAssociate_basic
=== CONT  TestAccSignatureAssociate_basic
--- PASS: TestAccSignatureAssociate_basic (519.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      519.835s
```
