### PR TITLE
feat(cce/turbo): support enable distributed CCE-Turbo cluster Management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230423034158-1ac248916332
+	github.com/chnsz/golangsdk v0.0.0-20230424095004-c8c9d7bd00cf
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230423034158-1ac248916332 h1:+zhvHNGvJTfrDWVxhR94PLg+zqHpBeLLKTzYGaOI0I8=
-github.com/chnsz/golangsdk v0.0.0-20230423034158-1ac248916332/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230424095004-c8c9d7bd00cf h1:AVg6f22h/nppepWh3mnDUJghOULpUANlPJYDAb/cAMA=
+github.com/chnsz/golangsdk v0.0.0-20230424095004-c8c9d7bd00cf/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_v3.go
@@ -151,6 +151,13 @@ func ResourceCCEClusterV3() *schema.Resource {
 				Computed:     true,
 				RequiredWith: []string{"eni_subnet_id"},
 			},
+			"enable_distribute_management": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"eni_subnet_id", "eni_subnet_cidr"},
+				Description:  "schema: Internal",
+			},
 			"authentication_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -479,6 +486,10 @@ func resourceCCEClusterV3Create(ctx context.Context, d *schema.ResourceData, met
 			Cidr:     d.Get("eni_subnet_cidr").(string),
 		}
 		createOpts.Spec.EniNetwork = &eniNetwork
+	}
+
+	if _, ok := d.GetOk("enable_distribute_management"); ok {
+		createOpts.Spec.EnableDistMgt = d.Get("enable_distribute_management").(bool)
 	}
 
 	masters, err := resourceClusterMastersV3(d)

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
@@ -59,6 +59,8 @@ type Spec struct {
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
 	//ENI network parameters
 	EniNetwork *EniNetworkSpec `json:"eniNetwork,omitempty"`
+	// Enable Distributed Cluster Management
+	EnableDistMgt bool `json:"enableDistMgt,omitempty"`
 	//Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230423034158-1ac248916332
+# github.com/chnsz/golangsdk v0.0.0-20230424095004-c8c9d7bd00cf
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Related to PR: https://github.com/chnsz/golangsdk/pull/320

CCE Turbo supports the creation of distributed clusters, and it can manage remote clusters or nodes.
<img width="921" alt="截屏2023-04-24 15 32 48" src="https://user-images.githubusercontent.com/43004096/233929427-f0befddc-381e-4a55-a2e7-d50b856e522d.png">

And the v3 API of CCE has opened the creation parameter of this function: `"enableDistMgt"`
<img width="788" alt="截屏2023-04-24 15 37 12" src="https://user-images.githubusercontent.com/43004096/233930106-a526c705-fee7-4df1-935e-8415b7004873.png">

If we enable the parameter: `"enableDistMgt"`, we can create a distributed CCE Turbo cluster：
<img width="474" alt="截屏2023-04-24 15 40 04" src="https://user-images.githubusercontent.com/43004096/233930639-632c7138-8a55-43fa-a05f-17018685263a.png">

Current parameter: "enable_dist_mgt" is not yet stable, use "schema: Internal" to indicate that it is not stable yet. When it is stable, I will add the documentation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
