### PR TITLE
fix(WAF): waf policy support epsID

### DIFF
--- a/docs/data-sources/waf_policies.md
+++ b/docs/data-sources/waf_policies.md
@@ -10,8 +10,11 @@ Use this data source to get a list of WAF policies.
 
 ```hcl
 variable "policy_name" {}
+variable "enterprise_project_id" {}
+
 data "huaweicloud_waf_policies" "policies" {
-  name = var.policy_name
+  name                  = var.policy_name
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -23,6 +26,8 @@ The following arguments are supported:
   will be used.
 
 * `name` - (Optional, String) Policy name used for matching. The value is case sensitive and supports fuzzy matching.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of WAF policies.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -12,13 +12,14 @@ used. The dedicated mode domain name resource can be used in Dedicated Mode and 
 ## Example Usage
 
 ```hcl
-variable certificated_id {}
-variable vpc_id {}
-variable dedicated_engine_id {}
+variable "certificated_id" {}
+variable "vpc_id" {}
+variable "enterprise_project_id" {}
 
 resource "huaweicloud_waf_dedicated_domain" "domain_1" {
-  domain         = "www.example.com"
-  certificate_id = huaweicloud_waf_certificate.certificate_1.id
+  domain                = "www.example.com"
+  certificate_id        = var.certificated_id
+  enterprise_project_id = var.enterprise_project_id
 
   server {
     client_protocol = "HTTPS"
@@ -43,6 +44,9 @@ The following arguments are supported:
 
 * `server` - (Required, List, ForceNew) The server configuration list of the domain. A maximum of 80 can be configured.
   The object structure is documented below.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF dedicated domain.
+  Changing this parameter will create a new resource.
 
 * `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
   is set to HTTPS.

--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -12,10 +12,13 @@ used. The policy resource can be used in Cloud Mode, Dedicated Mode and ELB Mode
 ## Example Usage
 
 ```hcl
+variable "enterprise_project_id" {}
+
 resource "huaweicloud_waf_policy" "policy_1" {
-  name            = "policy_1"
-  protection_mode = "log"
-  level           = 2
+  name                  = "policy_1"
+  protection_mode       = "log"
+  level                 = 2
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -38,6 +41,9 @@ The following arguments are supported:
   + `1`: low
   + `2`: medium
   + `3`: high
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF policy.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -96,6 +96,88 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafDedicateDomainV1_withEpsID(t *testing.T) {
+	var domain domains.PremiumHost
+	resourceName := "huaweicloud_waf_dedicated_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedDomainV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedDomainV1_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.1"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_1"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "server.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "protect_status"),
+					resource.TestCheckResourceAttrSet(resourceName, "protocol"),
+					resource.TestCheckResourceAttrSet(resourceName, "tls"),
+					resource.TestCheckResourceAttrSet(resourceName, "cipher"),
+					resource.TestCheckResourceAttrSet(resourceName, "alarm_page.template_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_3ds"),
+					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_dss"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_update_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_2"),
+					resource.TestCheckResourceAttr(resourceName, "pci_3ds", "true"),
+					resource.TestCheckResourceAttr(resourceName, "pci_dss", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.1.address", "119.8.0.15"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_policy_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "protect_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafDedicatedDomainV1Destroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	c, err := config.WafDedicatedV1Client(acceptance.HW_REGION_NAME)
@@ -108,7 +190,7 @@ func testAccCheckWafDedicatedDomainV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := domains.Get(c, rs.Primary.ID)
+		_, err := domains.GetWithEpsID(c, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err == nil {
 			return fmt.Errorf("WAF dedicated mode domain still exists")
 		}
@@ -131,7 +213,7 @@ func testAccCheckWafDedicatedDomainV1Exists(n string, domain *domains.PremiumHos
 		if err != nil {
 			return fmt.Errorf("error creating HuaweiCloud WAF dedicated client: %s", err)
 		}
-		found, err := domains.Get(c, rs.Primary.ID)
+		found, err := domains.GetWithEpsID(c, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err != nil {
 			return err
 		}
@@ -161,7 +243,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8080
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   depends_on = [
@@ -191,7 +273,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8443
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   server {
@@ -200,7 +282,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.15"
     port            = 8443
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   depends_on = [
@@ -233,7 +315,7 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
     address         = "119.8.0.14"
     port            = 8080
     type            = "ipv4"
-    vpc_id          = huaweicloud_vpc.vpc_1.id
+    vpc_id          = huaweicloud_vpc.test.id
   }
 
   depends_on = [
@@ -241,4 +323,100 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   ]
 }
 `, testAccWafCertificateV1_conf(name), name, name)
+}
+
+func testAccWafDedicatedDomainV1_basic_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain                = "www.%s.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  keep_policy           = false
+  proxy                 = false
+  tls                   = "TLS v1.1"
+  cipher                = "cipher_1"
+  enterprise_project_id = "%s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
+}
+
+func testAccWafDedicatedDomainV1_update_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain                = "www.%s.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  keep_policy           = false
+  proxy                 = true
+  tls                   = "TLS v1.2"
+  cipher                = "cipher_2"
+  pci_3ds               = true
+  pci_dss               = true
+  enterprise_project_id = "%s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.15"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
+}
+
+func testAccWafDedicatedDomainV1_policy_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_policy" "policy_1" {
+  name                  = "%[2]s"
+  enterprise_project_id = "%[3]s"
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain                = "www.%[2]s.com"
+  certificate_id        = huaweicloud_waf_certificate.certificate_1.id
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  keep_policy           = true
+  proxy                 = true
+  tls                   = "TLS v1.2"
+  protect_status        = 0
+  enterprise_project_id = "%[3]s"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+}
+`, testAccWafCertificateV1_conf_withEpsID(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_policies.go
@@ -4,6 +4,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -22,6 +24,10 @@ func DataSourceWafPoliciesV1() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -129,7 +135,8 @@ func dataSourceWafPoliciesV1Read(d *schema.ResourceData, meta interface{}) error
 	}
 
 	listOpts := policies.ListPolicyOpts{
-		Name: d.Get("name").(string),
+		Name:                d.Get("name").(string),
+		EnterpriseProjectId: common.GetEnterpriseProjectID(d, config),
 	}
 	rst, err := policies.ListPolicy(wafClient, listOpts)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- waf policy support epsID
- waf domain support epsID

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1_ -timeout 360m -parallel 4 
=== RUN   TestAccWafPolicyV1_basic 
=== PAUSE TestAccWafPolicyV1_basic     
=== RUN   TestAccWafPolicyV1_withEpsID 
=== PAUSE TestAccWafPolicyV1_withEpsID 
=== CONT  TestAccWafPolicyV1_basic     
=== CONT  TestAccWafPolicyV1_withEpsID 
--- PASS: TestAccWafPolicyV1_basic (433.47s) 
--- PASS: TestAccWafPolicyV1_withEpsID (444.60s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       444.663s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafPoliciesV1_'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafPoliciesV1_ -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceWafPoliciesV1_basic 
=== PAUSE TestAccDataSourceWafPoliciesV1_basic
=== RUN   TestAccDataSourceWafPoliciesV1_withEpsID
=== PAUSE TestAccDataSourceWafPoliciesV1_withEpsID
=== CONT  TestAccDataSourceWafPoliciesV1_basic
=== CONT  TestAccDataSourceWafPoliciesV1_withEpsID
--- PASS: TestAccDataSourceWafPoliciesV1_withEpsID (396.44s) 
--- PASS: TestAccDataSourceWafPoliciesV1_basic (457.01s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       457.067s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_ -timeout 360m -parallel 4
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== RUN   TestAccWafDedicateDomainV1_withEpsID
=== PAUSE TestAccWafDedicateDomainV1_withEpsID
=== CONT  TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_withEpsID
--- PASS: TestAccWafDedicateDomainV1_withEpsID (435.32s)
--- PASS: TestAccWafDedicateDomainV1_basic (480.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       481.029s
```
