### PR TITLE
feat(cce/turbo): support CCE Turbo partition management

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -668,6 +668,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_node_pool":   cce.ResourceCCENodePool(),
 			"huaweicloud_cce_namespace":   cce.ResourceCCENamespaceV1(),
 			"huaweicloud_cce_pvc":         cce.ResourceCcePersistentVolumeClaimsV1(),
+			"huaweicloud_cce_partition":   cce.ResourcePartition(),
 
 			"huaweicloud_cts_tracker":      cts.ResourceCTSTracker(),
 			"huaweicloud_cts_data_tracker": cts.ResourceCTSDataTracker(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -122,6 +122,8 @@ var (
 
 	// The cluster ID of the CCE
 	HW_CCE_CLUSTER_ID = os.Getenv("HW_CCE_CLUSTER_ID")
+	// The partition az of the CCE
+	HW_CCE_PARTITION_AZ = os.Getenv("HW_CCE_PARTITION_AZ")
 	// The namespace of the workload is located
 	HW_WORKLOAD_NAMESPACE = os.Getenv("HW_WORKLOAD_NAMESPACE")
 	// The workload type deployed in CCE/CCI
@@ -630,5 +632,12 @@ func TestAccPreCheckSourceImage(t *testing.T) {
 func TestAccPreCheckSecMaster(t *testing.T) {
 	if HW_SECMASTER_WORKSPACE_ID == "" {
 		t.Skip("HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCcePartitionAz(t *testing.T) {
+	if HW_CCE_PARTITION_AZ == "" {
+		t.Skip("Skip the interface acceptance test because of the cce partition az is missing.")
 	}
 }

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_partition_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_partition_test.go
@@ -1,0 +1,140 @@
+package cce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v3/partitions"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getPartitionResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CceV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CCE v1 client: %s", err)
+	}
+	resp, err := partitions.Get(c, state.Primary.Attributes["cluster_id"],
+		state.Primary.ID).Extract()
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("unable to find the partition (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccCCEPartition_basic(t *testing.T) {
+	var partition partitions.Partitions
+	resourceName := "huaweicloud_cce_partition.test"
+	randName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	// The availability zone of IES edge partition, example: "cn-south-1-ies-fstxz"
+	azName := acceptance.HW_CCE_PARTITION_AZ
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&partition,
+		getPartitionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCcePartitionAz(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPartition_basic(randName, azName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_id",
+						"huaweicloud_cce_cluster.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", azName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPartitionImportStateIdFunc(azName),
+			},
+		},
+	})
+}
+
+func testAccPartitionImportStateIdFunc(azName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_cce_cluster" {
+				clusterID = rs.Primary.ID
+			}
+		}
+		if clusterID == "" || azName == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", clusterID, azName)
+		}
+		return fmt.Sprintf("%s/%s", clusterID, azName), nil
+	}
+}
+
+// testVpc vpc with center and edge zone
+func testVpc(name, azName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "subnet_center" {
+  name       = "subnet-center"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+resource "huaweicloud_vpc_subnet" "subnet_edge" {
+  name              = "subnet-edge"
+  vpc_id            = huaweicloud_vpc.test.id
+  cidr              = "192.168.1.0/24"
+  gateway_ip        = "192.168.1.1"
+  availability_zone = "%s"
+}
+`, name, azName)
+}
+
+func testAccPartition_Base(randName, azName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                         = "%s"
+  cluster_type                 = "VirtualMachine"
+  flavor_id                    = "cce.s1.small"
+  vpc_id                       = huaweicloud_vpc.test.id
+  subnet_id                    = huaweicloud_vpc_subnet.subnet_center.id
+  container_network_type       = "eni"
+  eni_subnet_id                = huaweicloud_vpc_subnet.subnet_center.ipv4_subnet_id
+  eni_subnet_cidr              = huaweicloud_vpc_subnet.subnet_center.cidr
+  enable_distribute_management = true
+}
+`, testVpc(randName, azName), randName)
+}
+
+func testAccPartition_basic(randName, azName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_cce_partition" "test" {
+  cluster_id           = huaweicloud_cce_cluster.test.id
+  category             = "IES"
+  availability_zone    = "%s"
+  partition_subnet_id  = huaweicloud_vpc_subnet.subnet_edge.id
+  container_subnet_ids = [huaweicloud_vpc_subnet.subnet_edge.ipv4_subnet_id]
+}
+`, testAccPartition_Base(randName, azName), azName)
+}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_v3.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_v3.go
@@ -490,6 +490,12 @@ func ResourceCCENodeV3() *schema.Resource {
 				ForceNew:   true,
 				Deprecated: "will be removed after v1.26.0",
 			},
+			"partition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "schema: Internal",
+			},
 		},
 	}
 }
@@ -826,6 +832,11 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 	createOpts.Spec.Login = loginSpec
+
+	// Create a node in the specified partition
+	if v, ok := d.GetOk("partition"); ok {
+		createOpts.Spec.Partition = v.(string)
+	}
 
 	s, err := nodes.Create(nodeClient, clusterid, createOpts).Extract()
 	if err != nil {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_partition.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_partition.go
@@ -1,0 +1,221 @@
+package cce
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/cce/v3/partitions"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourcePartition() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePartitionCreate,
+		ReadContext:   resourcePartitionRead,
+		UpdateContext: resourcePartitionUpdate,
+		DeleteContext: resourcePartitionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePartitionImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"partition_subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"container_subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func buildPartitionSubnetID(d *schema.ResourceData) partitions.HostNetwork {
+	return partitions.HostNetwork{
+		SubnetID: d.Get("partition_subnet_id").(string),
+	}
+}
+
+func buildContainerSubnetIDs(d *schema.ResourceData) []partitions.ContainerNetwork {
+	networkRaw := d.Get("container_subnet_ids").(*schema.Set)
+	containerNetwork := make([]partitions.ContainerNetwork, networkRaw.Len())
+	for i, raw := range networkRaw.List() {
+		containerNetwork[i] = partitions.ContainerNetwork{
+			SubnetID: raw.(string),
+		}
+	}
+	return containerNetwork
+}
+
+func resourcePartitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	cceClient, err := cfg.CceV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating CCE Partition client: %s", err)
+	}
+
+	// wait for the cce cluster to become available
+	clusterid := d.Get("cluster_id").(string)
+	stateCluster := &resource.StateChangeConf{
+		Target:       []string{"Available"},
+		Refresh:      waitForClusterAvailable(cceClient, clusterid),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err = stateCluster.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("Error waiting for CCE cluster to be Available: %s", err)
+	}
+
+	createOpts := partitions.CreateOpts{
+		Kind:       "Partition",
+		ApiVersion: "v3",
+		Metadata: partitions.CreateMetaData{
+			Name: d.Get("availability_zone").(string),
+		},
+		Spec: partitions.Spec{
+			Category:          d.Get("category").(string),
+			PublicBorderGroup: d.Get("availability_zone").(string),
+			HostNetwork:       buildPartitionSubnetID(d),
+			ContainerNetwork:  buildContainerSubnetIDs(d),
+		},
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+
+	s, err := partitions.Create(cceClient, clusterid, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("Error creating Partition: %s", err)
+	}
+	d.SetId(s.Metadata.Name)
+
+	return resourcePartitionRead(ctx, d, meta)
+}
+
+func resourcePartitionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	cceClient, err := cfg.CceV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating CCE client: %s", err)
+	}
+	clusterid := d.Get("cluster_id").(string)
+	s, err := partitions.Get(cceClient, clusterid, d.Id()).Extract()
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Error retrieving CCE Partition")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("name", s.Metadata.Name),
+		d.Set("category", s.Spec.Category),
+		d.Set("availability_zone", s.Spec.PublicBorderGroup),
+		d.Set("partition_subnet_id", s.Spec.HostNetwork.SubnetID),
+	)
+
+	var containerNetworkIDs []string
+	for _, network := range s.Spec.ContainerNetwork {
+		containerNetworkIDs = append(containerNetworkIDs, network.SubnetID)
+	}
+	mErr = multierror.Append(mErr, d.Set("container_subnet_ids", containerNetworkIDs))
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("Error setting CCE Partition fields: %s", err)
+	}
+	return nil
+}
+
+func resourcePartitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	cceClient, err := cfg.CceV3Client(region)
+	if err != nil {
+		return diag.Errorf("Error creating CCE client: %s", err)
+	}
+
+	if d.HasChange("container_subnet_ids") {
+		var updateOpts partitions.UpdateOpts
+		updateOpts.Metadata.ContainerNetwork = buildContainerSubnetIDs(d)
+
+		clusterid := d.Get("cluster_id").(string)
+		_, err = partitions.Update(cceClient, clusterid, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("Error updating cce partition: %s", err)
+		}
+	}
+
+	return resourceCCENodeV3Read(ctx, d, meta)
+}
+
+func resourcePartitionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	cceClient, err := cfg.CceV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating CCE client: %s", err)
+	}
+
+	clusterid := d.Get("cluster_id").(string)
+	err = partitions.Delete(cceClient, clusterid, d.Id()).ExtractErr()
+	if err != nil {
+		return diag.Errorf("Error deleting CCE partition: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePartitionImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		err := fmt.Errorf("invalid format specified for CCE Partition. Format must be <cluster id>/<partition name>")
+		return nil, err
+	}
+
+	clusterID := parts[0]
+	partitionName := parts[1]
+
+	d.SetId(partitionName)
+	d.Set("cluster_id", clusterID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/doc.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/doc.go
@@ -1,0 +1,9 @@
+// Package partitions is a new feature introduced by CCE Turbo remote distributed cluster management.
+// Currently, partitions are divided into three categories: Center, HomeZone, and IES.
+//   - Default: Indicates the availability zone resources of the HuaweiCloud data center
+//   - HomeZone: Indicates the edge computing area in the user's home, which is not currently supported
+//   - IES: IES is the edge station of HuaweiCloud, which deploys user-specific cloud resources to the
+//          local computer zone
+// The concept of partitions can support CCE Turbo to manage distributed nodes, which has
+// strong applicability in the field of edge computing.
+package partitions

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/requests.go
@@ -1,0 +1,176 @@
+package partitions
+
+import (
+	"reflect"
+
+	"github.com/chnsz/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json"},
+}
+
+// ListOpts allows the filtering of list data using given parameters.
+type ListOpts struct {
+	Name string `json:"name"`
+}
+
+// List returns collection of partitions.
+func List(client *golangsdk.ServiceClient, clusterID string, opts ListOpts) ([]Partitions, error) {
+	var r ListResult
+	_, r.Err = client.Get(rootURL(client, clusterID), &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+
+	allPartitions, err := r.ExtractPartitions()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return FilterPartitions(allPartitions, opts), nil
+}
+
+func FilterPartitions(partitions []Partitions, opts ListOpts) []Partitions {
+	var refinedPartitions []Partitions
+	var matched bool
+
+	m := map[string]FilterStruct{}
+
+	if opts.Name != "" {
+		m["Name"] = FilterStruct{Value: opts.Name, Driller: []string{"Metadata"}}
+	}
+
+	if len(m) > 0 && len(partitions) > 0 {
+		for _, partition := range partitions {
+			matched = true
+
+			for key, value := range m {
+				if sVal := GetStructNestedField(&partition, key, value.Driller); !(sVal == value.Value) {
+					matched = false
+				}
+			}
+			if matched {
+				refinedPartitions = append(refinedPartitions, partition)
+			}
+		}
+	} else {
+		refinedPartitions = partitions
+	}
+	return refinedPartitions
+}
+
+func GetStructNestedField(v *Partitions, field string, structDriller []string) string {
+	r := reflect.ValueOf(v)
+	for _, drillField := range structDriller {
+		f := reflect.Indirect(r).FieldByName(drillField).Interface()
+		r = reflect.ValueOf(f)
+	}
+	f1 := reflect.Indirect(r).FieldByName(field)
+	return string(f1.String())
+}
+
+type FilterStruct struct {
+	Value   string
+	Driller []string
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOpts struct {
+	// API type, fixed value Partition
+	Kind string `json:"kind" required:"true"`
+	// API version, fixed value v3
+	ApiVersion string `json:"apiversion" required:"true"`
+	// Metadata required to create a Partition
+	Metadata CreateMetaData `json:"metadata"`
+	// specifications to create a Partition
+	Spec Spec `json:"spec" required:"true"`
+}
+
+// Metadata required to create a Partition
+type CreateMetaData struct {
+	// Partition name
+	Name string `json:"name,omitempty"`
+	// Partition tag, key value pair format
+	Labels map[string]string `json:"labels,omitempty"`
+	// Partition annotation, key value pair format
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// logical Partition. When it is created, the Partition does not have an internal
+// interface
+type CreateOptsBuilder interface {
+	ToPartitionCreateMap() (map[string]interface{}, error)
+}
+
+// ToPartitionCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToPartitionCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// logical Partition.
+func Create(c *golangsdk.ServiceClient, clusterid string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPartitionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{201}}
+	_, r.Err = c.Post(rootURL(c, clusterid), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular partitions based on its unique ID and cluster ID.
+func Get(c *golangsdk.ServiceClient, clusterid, partitionName string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, clusterid, partitionName), &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPartitionUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a new partition
+type UpdateOpts struct {
+	Metadata UpdateMetadata `json:"metadata,omitempty"`
+}
+
+type UpdateMetadata struct {
+	ContainerNetwork []ContainerNetwork `json:"containerNetwork,omitempty"`
+}
+
+// ToPartitionUpdateMap builds an update body based on UpdateOpts.
+func (opts UpdateOpts) ToPartitionUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update allows partitions to be updated.
+func Update(c *golangsdk.ServiceClient, clusterid, partitionName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPartitionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, clusterid, partitionName), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular partition based on its unique Name and cluster ID.
+func Delete(c *golangsdk.ServiceClient, clusterid, partitionName string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, clusterid, partitionName), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/results.go
@@ -1,0 +1,110 @@
+package partitions
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Describes the Partition Structure of cluster
+type ListPartition struct {
+	// API type, fixed value "List"
+	Kind string `json:"kind"`
+	// API version, fixed value "v3"
+	Apiversion string `json:"apiVersion"`
+	// all Clusters
+	Partitions []Partitions `json:"items"`
+}
+
+// Individual partitions of the cluster
+type Partitions struct {
+	// API type, fixed value " Host "
+	Kind string `json:"kind"`
+	// API version, fixed value v3
+	Apiversion string `json:"apiVersion"`
+	// Partition metadata
+	Metadata Metadata `json:"metadata"`
+	// Partition detailed parameters
+	Spec Spec `json:"spec"`
+}
+
+// Metadata required to create a partition
+type Metadata struct {
+	// Partition name
+	Name string `json:"name"`
+}
+
+// Spec describes Partitions specification
+type Spec struct {
+	// The category of partition
+	Category string `json:"category,omitempty"`
+	// The availability zone name of the partition
+	PublicBorderGroup string `json:"publicBorderGroup,omitempty"`
+	// The default host network for the partition
+	HostNetwork HostNetwork `json:"hostNetwork,omitempty"`
+	// The default host network for the partition container
+	ContainerNetwork []ContainerNetwork `json:"containerNetwork,omitempty"`
+}
+
+// HostNetwork the default host network for the partition
+type HostNetwork struct {
+	// The default SubnetID for the partition
+	SubnetID string `json:"subnetID,omitempty"`
+}
+
+// ContainerNetwork the default host network for the partition container
+type ContainerNetwork struct {
+	// The default SubnetID for the partition container
+	SubnetID string `json:"subnetID,omitempty"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a partition.
+func (r commonResult) Extract() (*Partitions, error) {
+	var s Partitions
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractPartitions is a function that accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func (r commonResult) ExtractPartitions() ([]Partitions, error) {
+	var s ListPartition
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Partitions, nil
+}
+
+// ListResult represents the result of a list operation. Call its ExtractCluster
+// method to interpret it as a Cluster.
+type ListResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Cluster.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Cluster.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Cluster.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/partitions/urls.go
@@ -1,0 +1,16 @@
+package partitions
+
+import "github.com/chnsz/golangsdk"
+
+const (
+	rootPath     = "clusters"
+	resourcePath = "partitions"
+)
+
+func rootURL(c *golangsdk.ServiceClient, clusterid string) string {
+	return c.ServiceURL(rootPath, clusterid, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, clusterid, partitionName string) string {
+	return c.ServiceURL(rootPath, clusterid, resourcePath, partitionName)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -57,6 +57,7 @@ github.com/chnsz/golangsdk/openstack/cce/v3/addons
 github.com/chnsz/golangsdk/openstack/cce/v3/clusters
 github.com/chnsz/golangsdk/openstack/cce/v3/nodepools
 github.com/chnsz/golangsdk/openstack/cce/v3/nodes
+github.com/chnsz/golangsdk/openstack/cce/v3/partitions
 github.com/chnsz/golangsdk/openstack/cce/v3/templates
 github.com/chnsz/golangsdk/openstack/cci/v1/namespaces
 github.com/chnsz/golangsdk/openstack/cci/v1/networks


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Related to PR: https://github.com/chnsz/golangsdk/pull/323

The partitions is a new feature introduced by CCE Turbo remote distributed cluster management. Currently, partitions are divided into three categories: Center, HomeZone, and IES.
   - `Default`: Indicates the availability zone resources of the HuaweiCloud data center.
   - `HomeZone`: Indicates the edge computing area in the user's home, which is not currently supported.
   - `IES`: IES is the edge station of HuaweiCloud, which deploys user-specific cloud resources to the local computer zone.
The concept of partitions can support CCE Turbo to manage distributed nodes, which has strong applicability in the field of edge computing.

1. When we create a CCE Turbo and enable the CCE distributed management function (CCE Remote feature), then we can see the `partition management` in the CCE console
<img width="1920" alt="截屏2023-04-26 18 02 39" src="https://user-images.githubusercontent.com/43004096/234542674-2c76ba87-84c9-4412-8d6e-79034348c8d9.png">

2. Using partition management, we can create an IES availability zone located in the edge zone, which is a CCE remote zone
<img width="1918" alt="截屏2023-04-26 18 04 20" src="https://user-images.githubusercontent.com/43004096/234543084-0b632aa1-62c1-4458-a395-cae646806830.png">

3. When purchasing a CCE node, we can also choose resources in the IES availability zone and create it as a CCE working node
<img width="1871" alt="截屏2023-04-26 18 06 05" src="https://user-images.githubusercontent.com/43004096/234543388-5ff46a4e-a504-4cd2-baa6-870a185dc1c2.png">

Example:
```
Create vpc, subnet resource...

resource "huaweicloud_cce_cluster" "cce_test" {
  name                         = "cce-test"
  flavor_id                    = "cce.s2.medium"
  cluster_version              = "v1.23"
  vpc_id                       = huaweicloud_vpc.vpc_ldm.id
  subnet_id                    = huaweicloud_vpc_subnet.subnet_center.id
  container_network_type       = "eni" // 云原生容器网络2.0
  eni_subnet_id                = huaweicloud_vpc_subnet.subnet_center.ipv4_subnet_id
  eni_subnet_cidr              = huaweicloud_vpc_subnet.subnet_center.cidr
  enable_distribute_management = true
}

resource "huaweicloud_cce_partition" "edge_part" {
  cluster_id           = huaweicloud_cce_cluster.cce_test.id
  category             = "IES"
  availability_zone    = var.ies_zone
  partition_subnet_id  = huaweicloud_vpc_subnet.subnet_edge.id
  container_subnet_ids = [huaweicloud_vpc_subnet.subnet_edge.ipv4_subnet_id]
}

resource "huaweicloud_cce_node" "cce_ies_node" {
  count = 2

  cluster_id        = huaweicloud_cce_cluster.cce_test.id
  name              = "cce-ies-node-${count.index}"
  availability_zone = var.az_ies
  partition         = var.az_ies
  flavor_id         = var.ccenode_ies_flavor
  os                = "EulerOS 2.9"
  runtime           = "docker"
  password          = "******"

  root_volume {
    size       = 50
    volumetype = "SSD"
  }
  data_volumes {
    size       = 100
    volumetype = "SSD"
  }
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ export HW_ACCESS_KEY=xxx
$ export HW_SECRET_KEY=xxx
$ export HW_REGION_NAME=cn-south-1
$ export HW_CCE_PARTITION_AZ=cn-south-1-ies-fstxz
$ make testacc TEST='./huaweicloud/services/acceptance/cce/' TESTARGS='-run=TestAccCCEPartitionV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce/ -v -run=TestAccCCEPartitionV3_basic -timeout 360m -parallel 4
=== RUN   TestAccCCEPartitionV3_basic
=== PAUSE TestAccCCEPartitionV3_basic
=== CONT  TestAccCCEPartitionV3_basic
--- PASS: TestAccCCEPartitionV3_basic (557.98s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce	557.997s
```
