### PR TITLE
fix(OBS): add request id to obs bucket error info

### DIFF
--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -654,7 +654,7 @@ func resourceObsBucketPolicyUpdate(obsClient *obs.ObsClient, d *schema.ResourceD
 		log.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
 		_, err := obsClient.DeleteBucketPolicy(bucket)
 		if err != nil {
-			return getObsError("Error deleting policy of OBS bucket %s: %s", bucket, err)
+			return getObsError("Error deleting policy of OBS bucket", bucket, err)
 		}
 	}
 
@@ -1132,8 +1132,7 @@ func setObsBucketPolicy(obsClient *obs.ObsClient, d *schema.ResourceData) error 
 				}
 				return nil
 			}
-			return fmt.Errorf("Error getting policy of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+			return fmt.Errorf("error getting policy of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1184,8 +1183,7 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 				}
 				return nil
 			}
-			return fmt.Errorf("Error getting encryption configuration of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+			return fmt.Errorf("error getting encryption configuration of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1265,8 +1263,7 @@ func setObsBucketLifecycleConfiguration(obsClient *obs.ObsClient, d *schema.Reso
 				}
 				return nil
 			}
-			return fmt.Errorf("Error getting lifecycle configuration of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+			return fmt.Errorf("error getting lifecycle configuration of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1349,8 +1346,7 @@ func setObsBucketWebsiteConfiguration(obsClient *obs.ObsClient, d *schema.Resour
 				}
 				return nil
 			}
-			return fmt.Errorf("Error getting website configuration of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+			return fmt.Errorf("error getting website configuration of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1414,8 +1410,7 @@ func setObsBucketCorsRules(obsClient *obs.ObsClient, d *schema.ResourceData) err
 				}
 				return nil
 			}
-			return fmt.Errorf("Error getting CORS configuration of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+			return fmt.Errorf("error getting CORS configuration of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1458,8 +1453,7 @@ func setObsBucketTags(obsClient *obs.ObsClient, d *schema.ResourceData) error {
 				}
 				return nil
 			}
-			return fmt.Errorf("Error getting tags of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+			return fmt.Errorf("error getting tags of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1479,9 +1473,8 @@ func setObsBucketStorageInfo(obsClient *obs.ObsClient, d *schema.ResourceData) e
 	bucket := d.Id()
 	output, err := obsClient.GetBucketStorageInfo(bucket)
 	if err != nil {
-		if obsError, ok := err.(obs.ObsError); ok {
-			return fmt.Errorf("error getting storage info of OBS bucket %s: %s,\n Reason: %s",
-				bucket, obsError.Code, obsError.Message)
+		if _, ok := err.(obs.ObsError); ok {
+			return fmt.Errorf("error getting storage info of OBS bucket %s: %s", bucket, err)
 		}
 		return err
 	}
@@ -1543,8 +1536,8 @@ func expirationHash(v interface{}) int {
 }
 
 func getObsError(action string, bucket string, err error) error {
-	if obsError, ok := err.(obs.ObsError); ok {
-		return fmt.Errorf("%s %s: %s,\n Reason: %s", action, bucket, obsError.Code, obsError.Message)
+	if _, ok := err.(obs.ObsError); ok {
+		return fmt.Errorf("%s %s: %s", action, bucket, err)
 	}
 	return err
 }

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_policy.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_policy.go
@@ -141,7 +141,7 @@ func resourceObsBucketPolicyDelete(_ context.Context, d *schema.ResourceData, me
 	log.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
 	_, err = obsClient.DeleteBucketPolicy(bucket)
 	if err != nil {
-		return diag.FromErr(getObsError("Error deleting policy of OBS bucket %s: %s", bucket, err))
+		return diag.FromErr(getObsError("Error deleting policy of OBS bucket", bucket, err))
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
some error info do not contain request id, it will bring difficult when solving problem, so it is need to add thr request id to the error info
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add request id to obs bucket error info
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs/' TESTARGS='-run TestAccObsBucket_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs/ -v -run TestAccObsBucket_ -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic 
=== PAUSE TestAccObsBucket_basic     
=== RUN   TestAccObsBucket_withEpsId 
=== PAUSE TestAccObsBucket_withEpsId 
=== RUN   TestAccObsBucket_multiAZ   
=== PAUSE TestAccObsBucket_multiAZ   
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_basic
=== CONT  TestAccObsBucket_logging
=== CONT  TestAccObsBucket_parallelFS
=== CONT  TestAccObsBucket_multiAZ
--- PASS: TestAccObsBucket_multiAZ (15.03s) 
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_parallelFS (15.31s) 
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_logging (20.16s) 
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_basic (23.76s) 
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_website (11.76s) 
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_cors (11.90s) 
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucket_versioning (20.72s) 
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucket_lifecycle (12.80s) 
--- PASS: TestAccObsBucket_quota (11.78s) 
--- PASS: TestAccObsBucket_encryption (34.20s) 
--- PASS: TestAccObsBucket_withEpsId (28.27s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       63.994s


make testacc TEST='./huaweicloud/services/acceptance/obs/' TESTARGS='-run TestAccObsBucketPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs/ -v -run TestAccObsBucketPolicy_ -timeout 360m -parallel 4
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucketPolicy_basic
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucketPolicy_s3 (13.87s)
--- PASS: TestAccObsBucketPolicy_basic (15.58s)
--- PASS: TestAccObsBucketPolicy_update (23.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       23.769s
```
