### PR TITLE
fix(WAF): waf rule support epsID

### DIFF
--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -30,13 +30,15 @@ resource "huaweicloud_waf_rule_blacklist" "rule" {
 ```hcl
 variable "policy_id" {}
 variable "address_group_id" {}
+variable "enterprise_project_id" {}
 
 resource "huaweicloud_waf_rule_blacklist" "rule" {
-  policy_id        = var.policy_id
-  address_group_id = var.address_group_id
-  action           = 1
-  name             = "test_name"
-  description      = "test description"
+  policy_id             = var.policy_id
+  address_group_id      = var.address_group_id
+  enterprise_project_id = var.enterprise_project_id
+  action                = 1
+  name                  = "test_name"
+  description           = "test description"
 }
 ```
 
@@ -52,6 +54,9 @@ The following arguments are supported:
 
 * `name` - (Required, String) Specifies the Rule name. The value can contain a maximum of 64 characters.
   Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF rule blacklist
+  and whitelist. Changing this parameter will create a new resource.
 
 * `ip_address` - (Optional, String) Specifies the IP address or range. For example, 192.168.0.125 or 192.168.0.0/24.
   This parameter is required when `address_group_id` is not specified. The parameter `address_group_id` and `ip_address`

--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -12,15 +12,15 @@ used. The data masking rule resource can be used in Cloud Mode, Dedicated Mode a
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_1"
-}
+variable "enterprise_project_id" {}
+variable "policy_id" {}
 
 resource "huaweicloud_waf_rule_data_masking" "rule_1" {
-  policy_id = huaweicloud_waf_policy.policy_1.id
-  path      = "/login"
-  field     = "params"
-  subfield  = "password"
+  policy_id             = var.policy_id
+  enterprise_project_id = var.enterprise_project_id
+  path                  = "/login"
+  field                 = "params"
+  subfield              = "password"
 }
 ```
 
@@ -42,6 +42,9 @@ The following arguments are supported:
   + `cookie`: The field in the cookie.
 
 * `subfield` - (Required, String) Specifies the name of the masked field, e.g.: password.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF data masking rule.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -12,14 +12,14 @@ used. The web tamper protection rule resource can be used in Cloud Mode, Dedicat
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_waf_policy" "policy_1" {
-  name = "policy_1"
-}
+variable "enterprise_project_id" {}
+variable "policy_id" {}
 
 resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
-  policy_id = huaweicloud_waf_policy.policy_1.id
-  domain    = "www.your-domain.com"
-  path      = "/payment"
+  policy_id             = var.policy_id
+  enterprise_project_id = var.enterprise_project_id
+  domain                = "www.your-domain.com"
+  path                  = "/payment"
 }
 ```
 
@@ -36,6 +36,9 @@ The following arguments are supported:
 
 * `path` - (Required, String, ForceNew) Specifies the URL protected by the web tamper protection rule, excluding a
   domain name. Changing this creates a new rule.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF tamper protection
+  rule. Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	rules "github.com/chnsz/golangsdk/openstack/waf_hw/v1/datamasking_rules"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccWafRuleDataMasking_basic(t *testing.T) {
@@ -67,6 +67,44 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafRuleDataMasking_withEpsID(t *testing.T) {
+	var rule rules.DataMasking
+	policyName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_waf_rule_data_masking.rule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafRuleDataMaskingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleDataMasking_basic_withEpsID(policyName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "path", "/login"),
+					resource.TestCheckResourceAttr(resourceName, "subfield", "password"),
+					resource.TestCheckResourceAttr(resourceName, "field", "params"),
+				),
+			},
+			{
+				Config: testAccWafRuleDataMasking_update_withEpsID(policyName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "path", "/login_new"),
+					resource.TestCheckResourceAttr(resourceName, "subfield", "secret"),
+					resource.TestCheckResourceAttr(resourceName, "field", "params"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafRuleDataMaskingDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
@@ -79,7 +117,7 @@ func testAccCheckWafRuleDataMaskingDestroy(s *terraform.State) error {
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		_, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err == nil {
 			return fmt.Errorf("WAF data masking rule still exists")
 		}
@@ -106,7 +144,7 @@ func testAccCheckWafRuleDataMaskingExists(n string, rule *rules.DataMasking) res
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		found, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err != nil {
 			return err
 		}
@@ -181,4 +219,32 @@ resource "huaweicloud_waf_rule_data_masking" "rule_4" {
   subfield  = "secret"
 }
 `, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafRuleDataMasking_basic_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_data_masking" "rule" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  path                  = "/login"
+  field                 = "params"
+  subfield              = "password"
+  enterprise_project_id = "%s"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), epsID)
+}
+
+func testAccWafRuleDataMasking_update_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_data_masking" "rule" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  path                  = "/login_new"
+  field                 = "params"
+  subfield              = "secret"
+  enterprise_project_id = "%s"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	rules "github.com/chnsz/golangsdk/openstack/waf_hw/v1/webtamperprotection_rules"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
@@ -48,6 +48,33 @@ func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafRuleWebTamperProtection_withEpsID(t *testing.T) {
+	var rule rules.WebTamper
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleWebTamperProtection_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
@@ -61,7 +88,7 @@ func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error 
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		_, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err == nil {
 			return fmt.Errorf("WAF rule still exists")
 		}
@@ -88,7 +115,7 @@ func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTampe
 		}
 
 		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		found, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
 		if err != nil {
 			return err
 		}
@@ -113,4 +140,17 @@ resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
   path      = "/a"
 }
 `, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafRuleWebTamperProtection_basic_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  domain                = "www.abc.com"
+  path                  = "/a"
+  enterprise_project_id = "%s"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, epsID), epsID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- waf rule blacklist support epsid
- waf rule datamasking support epsid
- waf fule web tamper protection support epsid

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleBlackList_basic 
=== PAUSE TestAccWafRuleBlackList_basic
=== RUN   TestAccWafRuleBlackList_withEpsID
=== PAUSE TestAccWafRuleBlackList_withEpsID
=== CONT  TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_withEpsID
--- PASS: TestAccWafRuleBlackList_withEpsID (380.29s) 
--- PASS: TestAccWafRuleBlackList_basic (435.06s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       435.142s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleDataMasking_basic 
=== PAUSE TestAccWafRuleDataMasking_basic
=== RUN   TestAccWafRuleDataMasking_withEpsID
=== PAUSE TestAccWafRuleDataMasking_withEpsID
=== CONT  TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_withEpsID
--- PASS: TestAccWafRuleDataMasking_withEpsID (389.43s) 
--- PASS: TestAccWafRuleDataMasking_basic (451.53s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       451.671s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleWebTamperProtection_basic 
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== RUN   TestAccWafRuleWebTamperProtection_withEpsID
=== PAUSE TestAccWafRuleWebTamperProtection_withEpsID
=== CONT  TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_withEpsID
--- PASS: TestAccWafRuleWebTamperProtection_withEpsID (379.40s) 
--- PASS: TestAccWafRuleWebTamperProtection_basic (383.70s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       383.748s
```



