### PR TITLE
feat(WAF): waf reference table support epsID

### DIFF
--- a/docs/data-sources/waf_reference_tables.md
+++ b/docs/data-sources/waf_reference_tables.md
@@ -9,8 +9,11 @@ Use this data source to get a list of WAF reference tables.
 ## Example Usage
 
 ```hcl
+variable "enterprise_project_id" {}
+
 data "huaweicloud_waf_reference_tables" "reftables" {
-  name = "reference_table_name"
+  name                  = "reference_table_name"
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -22,6 +25,8 @@ The following arguments are supported:
   If omitted, the provider-level region will be used.
 
 * `name` - (Optional, String) The name of the reference table. The value is case sensitive and matches exactly.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of WAF reference tables.
 
 ## Attributes Reference
 

--- a/docs/resources/waf_reference_table.md
+++ b/docs/resources/waf_reference_table.md
@@ -12,9 +12,12 @@ used. The reference table resource can be used in Cloud Mode (professional versi
 ## Example Usage
 
 ```hcl
+variable "enterprise_project_id" {}
+
 resource "huaweicloud_waf_reference_table" "ref_table" {
-  name = "tf_ref_table_demo"
-  type = "url"
+  name                  = "tf_ref_table_demo"
+  type                  = "url"
+  enterprise_project_id = var.enterprise_project_id
 
   conditions = [
     "/admin",
@@ -40,6 +43,9 @@ The following arguments are supported:
   condition is 2048 characters.
 
 * `description` - (Optional, String) The description of the reference table. The maximum length is 128 characters.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF reference table.
+  Changing this parameter will create a new resource.
 
 ## Attributes Reference
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_reference_table_test.go
@@ -34,6 +34,33 @@ func TestAccDataSourceReferenceTablesV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceReferenceTablesV1_withEpsID(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_waf_reference_tables.ref_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReferenceTablesV1_conf_epsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReferenceTablesId(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.conditions.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tables.0.creation_time"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckReferenceTablesId(r string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
@@ -55,4 +82,15 @@ data "huaweicloud_waf_reference_tables" "ref_table" {
   depends_on = [huaweicloud_waf_reference_table.ref_table]
 }
 `, testAccWafReferenceTableV1_conf(name))
+}
+
+func testAccReferenceTablesV1_conf_epsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_reference_tables" "ref_table" {
+  depends_on            = [huaweicloud_waf_reference_table.ref_table]
+  enterprise_project_id = "%s"
+}
+`, testAccWafReferenceTableV1_conf_withEpsID(name, epsID), epsID)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -56,6 +58,48 @@ func TestAccWafReferenceTableV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafReferenceTableV1_withEpsID(t *testing.T) {
+	var referencTable valuelists.WafValueList
+	resourceName := "huaweicloud_waf_reference_table.ref_table"
+	name := acceptance.RandomAccResourceName()
+	updateName := name + "_update"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafReferenceTableV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafReferenceTableV1_conf_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafReferenceTableV1Exists(resourceName, &referencTable),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "tf acc"),
+					resource.TestCheckResourceAttr(resourceName, "type", "url"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+				),
+			},
+			{
+				Config: testAccWafReferenceTableV1_update_withEpsID(updateName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafReferenceTableV1Exists(resourceName, &referencTable),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "type", "url"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafReferenceTableV1Destroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
@@ -68,7 +112,7 @@ func testAccCheckWafReferenceTableV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := valuelists.Get(wafClient, rs.Primary.ID)
+		_, err := valuelists.GetWithEpsID(wafClient, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err == nil {
 			return fmt.Errorf("WAF reference table still exists")
 		}
@@ -94,7 +138,7 @@ func testAccCheckWafReferenceTableV1Exists(n string, valueList *valuelists.WafVa
 			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
 		}
 
-		found, err := valuelists.Get(wafClient, rs.Primary.ID)
+		found, err := valuelists.GetWithEpsID(wafClient, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])
 		if err != nil {
 			return err
 		}
@@ -149,4 +193,48 @@ resource "huaweicloud_waf_reference_table" "ref_table" {
   ]
 }
 `, testAccWafDedicatedInstanceV1_conf(name), name)
+}
+
+func testAccWafReferenceTableV1_conf_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_reference_table" "ref_table" {
+  name                  = "%s"
+  type                  = "url"
+  description           = "tf acc"
+  enterprise_project_id = "%s"
+
+  conditions = [
+    "/admin",
+    "/manage"
+  ]
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstance_epsId(name, epsID), name, epsID)
+}
+
+func testAccWafReferenceTableV1_update_withEpsID(name, epsID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_reference_table" "ref_table" {
+  name                  = "%s"
+  type                  = "url"
+  description           = ""
+  enterprise_project_id = "%s"
+
+  conditions = [
+    "/bill",
+    "/sql"
+  ]
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstance_epsId(name, epsID), name, epsID)
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
@@ -3,8 +3,9 @@ package waf
 import (
 	"time"
 
-	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -25,6 +26,10 @@ func DataSourceWafReferenceTablesV1() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -72,7 +77,10 @@ func dataSourceWafReferenceTablesRead(d *schema.ResourceData, meta interface{}) 
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	r, err := valuelists.List(client, valuelists.ListValueListOpts{})
+	opts := valuelists.ListValueListOpts{
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+	}
+	r, err := valuelists.List(client, opts)
 	if err != nil {
 		return common.CheckDeleted(d, err, "Error obtain WAF reference table information")
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
@@ -4,10 +4,12 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -58,12 +60,16 @@ func ResourceWafReferenceTableV1() *schema.Resource {
 				},
 				Description: "schema: Required",
 			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 128),
 			},
-
 			"creation_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -81,10 +87,11 @@ func resourceWafReferenceTableCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	opt := valuelists.CreateOpts{
-		Name:        d.Get("name").(string),
-		Type:        d.Get("type").(string),
-		Values:      utils.ExpandToStringList(d.Get("conditions").([]interface{})),
-		Description: d.Get("description").(string),
+		Name:                d.Get("name").(string),
+		Type:                d.Get("type").(string),
+		Values:              utils.ExpandToStringList(d.Get("conditions").([]interface{})),
+		Description:         d.Get("description").(string),
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	logp.Printf("[DEBUG] Create WAF reference table options: %#v", opt)
 
@@ -106,7 +113,7 @@ func resourceWafReferenceTableRead(d *schema.ResourceData, meta interface{}) err
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	r, err := valuelists.Get(client, d.Id())
+	r, err := valuelists.GetWithEpsID(client, d.Id(), config.GetEnterpriseProjectID(d))
 	if err != nil {
 		return common.CheckDeleted(d, err, "Error obtain WAF reference table information")
 	}
@@ -139,9 +146,10 @@ func resourceWafReferenceTableUpdate(d *schema.ResourceData, meta interface{}) e
 	opt := valuelists.UpdateValueListOpts{
 		Name: d.Get("name").(string),
 		// Type is required, but it cannot be changed.
-		Type:        d.Get("type").(string),
-		Values:      utils.ExpandToStringList(d.Get("conditions").([]interface{})),
-		Description: &desc,
+		Type:                d.Get("type").(string),
+		Values:              utils.ExpandToStringList(d.Get("conditions").([]interface{})),
+		Description:         &desc,
+		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
 	logp.Printf("[DEBUG] Update WAF reference table options: %#v", opt)
 
@@ -161,7 +169,7 @@ func resourceWafReferenceTableDelete(d *schema.ResourceData, meta interface{}) e
 		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
 	}
 
-	_, err = valuelists.Delete(client, d.Id())
+	_, err = valuelists.DeleteWithEpsID(client, d.Id(), config.GetEnterpriseProjectID(d))
 	if err != nil {
 		return fmtp.Errorf("error deleting WAF reference table: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- waf reference support epsid
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafReferenceTableV1_'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafReferenceTableV1_ -timeout 360m -parallel 4 
=== RUN   TestAccWafReferenceTableV1_basic 
=== PAUSE TestAccWafReferenceTableV1_basic 
=== RUN   TestAccWafReferenceTableV1_withEpsID
=== PAUSE TestAccWafReferenceTableV1_withEpsID
=== CONT  TestAccWafReferenceTableV1_basic
=== CONT  TestAccWafReferenceTableV1_withEpsID 
--- PASS: TestAccWafReferenceTableV1_basic (361.38s) 
--- PASS: TestAccWafReferenceTableV1_withEpsID (369.74s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       370.030s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceReferenceTablesV1_'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceReferenceTablesV1_ -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceReferenceTablesV1_basic 
--- PASS: TestAccDataSourceReferenceTablesV1_basic (357.52s) 
=== RUN   TestAccDataSourceReferenceTablesV1_withEpsID
--- PASS: TestAccDataSourceReferenceTablesV1_withEpsID (364.06s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       721.721s
```


