### PR TITLE
fix(ECS): fix compute instance agency_name and agent_list attribute

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -318,11 +318,11 @@ The following arguments are supported:
 * `user_id` - (Optional, String, ForceNew) Specifies a user ID, required when using key_pair in prePaid charging mode.
   Changing this creates a new instance.
 
-* `agency_name` - (Optional, String, ForceNew) Specifies the IAM agency name which is created on IAM to provide
-  temporary credentials for ECS to access cloud services. Changing this creates a new instance.
+* `agency_name` - (Optional, String) Specifies the IAM agency name which is created on IAM to provide
+  temporary credentials for ECS to access cloud services.
 
-* `agent_list` - (Optional, String, ForceNew) Specifies the agent list in comma-separated string.
-  Changing this creates a new instance. Available agents are:
+* `agent_list` - (Optional, String) Specifies the agent list in comma-separated string.
+  Available agents are:
   + `ces`: enable cloud eye monitoring(free).
   + `hss`: enable host security basic(free).
   + `hss,hss-ent`: enable host security enterprise edition.

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -44,6 +44,8 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "delete_eip_on_termination", "true"),
 					resource.TestCheckResourceAttr(resourceName, "agent_list", "hss"),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "agency_name", "test111"),
+					resource.TestCheckResourceAttr(resourceName, "agent_list", "hss"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -55,6 +57,8 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform test update"),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "60"),
+					resource.TestCheckResourceAttr(resourceName, "agency_name", "test222"),
+					resource.TestCheckResourceAttr(resourceName, "agent_list", "ces"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -325,6 +329,7 @@ resource "huaweicloud_compute_instance" "test" {
   flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
   stop_before_destroy = true
+  agency_name         = "test111"
   agent_list          = "hss"
 
   network {
@@ -359,7 +364,8 @@ resource "huaweicloud_compute_instance" "test" {
   flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
   stop_before_destroy = true
-  agent_list          = "hss"
+  agency_name         = "test222"
+  agent_list          = "ces"
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -399,12 +399,12 @@ func ResourceComputeInstance() *schema.Resource {
 			"agency_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 			"agent_list": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 			"tags": {
 				Type:     schema.TypeMap,
@@ -1100,6 +1100,20 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, err := servers.UpdateMetadata(computeClient, d.Id(), metadataOpts).Extract()
 		if err != nil {
 			return diag.Errorf("error updating server (%s) metadata: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChanges("agency_name", "agent_list ") {
+		metadataOpts := make(servers.MetadataOpts)
+		if d.HasChange("agency_name") {
+			metadataOpts["agency_name"] = d.Get("agency_name").(string)
+		}
+		if d.HasChange("agent_list") {
+			metadataOpts["__support_agent_list"] = d.Get("agent_list").(string)
+		}
+		_, err = servers.UpdateMetadata(computeClient, d.Id(), metadataOpts).Extract()
+		if err != nil {
+			return diag.Errorf("error updating server (%s) metadata(agency_name, agent_list) : %s", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  remove the forcenew attribute of agency_name and agent_list, so that these two params support update
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix compute instance agency_name and agent_list attribute
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ecs/' TESTARGS='-run TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs/ -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (260.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       260.199s
```
