### PR TITLE
fix(rms/assign): the name cannot update now

### DIFF
--- a/docs/resources/rms_policy_assignment.md
+++ b/docs/resources/rms_policy_assignment.md
@@ -95,9 +95,10 @@ resource "huaweicloud_rms_policy_assignment" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required, String) Specifies the name of the policy assignment.  
+* `name` - (Required, String, ForceNew) Specifies the name of the policy assignment.  
   The valid length is limited from `1` to `64`, only letters, digits, hyphens (-) and underscores (_) are allowed.  
   The name must start with a letter.
+  Change this parameter will create a new resource.
 
 * `description` - (Optional, String) Specifies the description of the policy assignment, which contain maximum of
   `512` characters.

--- a/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_policy_assignment_test.go
+++ b/huaweicloud/services/acceptance/rms/resource_huaweicloud_rms_policy_assignment_test.go
@@ -30,7 +30,6 @@ func TestAccPolicyAssignment_basic(t *testing.T) {
 
 		rName       = "huaweicloud_rms_policy_assignment.test"
 		name        = acceptance.RandomAccResourceNameWithDash()
-		updateName  = acceptance.RandomAccResourceNameWithDash()
 		basicConfig = testAccPolicyAssignment_ecsConfig(name)
 	)
 
@@ -78,13 +77,13 @@ func TestAccPolicyAssignment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPolicyAssignment_basicUpdate(basicConfig, updateName, "Enabled"),
+				Config: testAccPolicyAssignment_basicUpdate(basicConfig, name, "Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeBuiltin),
 					resource.TestCheckResourceAttr(rName, "description", "An ECS is noncompliant if its flavor is "+
 						"not in the specified flavor list (filter by resource tag)."),
-					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "policy_definition_id",
 						"data.huaweicloud_rms_policy_definitions.test", "definitions.0.id"),
 					resource.TestCheckResourceAttr(rName, "policy_filter.0.region", acceptance.HW_REGION_NAME),
@@ -229,7 +228,6 @@ func TestAccPolicyAssignment_period(t *testing.T) {
 
 		rName       = "huaweicloud_rms_policy_assignment.test"
 		name        = acceptance.RandomAccResourceNameWithDash()
-		updateName  = acceptance.RandomAccResourceNameWithDash()
 		basicConfig = testAccPolicyAssignment_periodConfig(name)
 	)
 
@@ -273,12 +271,12 @@ func TestAccPolicyAssignment_period(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPolicyAssignment_periodUpdate(basicConfig, updateName, "Enabled"),
+				Config: testAccPolicyAssignment_periodUpdate(basicConfig, name, "Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "type", rms.AssignmentTypeBuiltin),
 					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "policy_definition_id",
 						"data.huaweicloud_rms_policy_definitions.test", "definitions.0.id"),
 					resource.TestCheckResourceAttr(rName, "period", "Six_Hours"),
@@ -380,7 +378,6 @@ func TestAccPolicyAssignment_custom(t *testing.T) {
 
 		rName        = "huaweicloud_rms_policy_assignment.test"
 		name         = acceptance.RandomAccResourceNameWithDash()
-		updateName   = acceptance.RandomAccResourceNameWithDash()
 		customConfig = testAccPolicyAssignment_customConfig(name)
 	)
 
@@ -422,10 +419,10 @@ func TestAccPolicyAssignment_custom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPolicyAssignment_customUpdate(customConfig, updateName, "Enabled"),
+				Config: testAccPolicyAssignment_customUpdate(customConfig, name, "Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "status", "Enabled"),
 					resource.TestCheckResourceAttr(rName, "parameters.string_test", "\"update_string_value\""),
 					resource.TestCheckResourceAttr(rName, "parameters.update_array_test", "[\"array_element\"]"),

--- a/huaweicloud/services/rms/resource_huaweicloud_rms_policy_assignment.go
+++ b/huaweicloud/services/rms/resource_huaweicloud_rms_policy_assignment.go
@@ -53,6 +53,7 @@ func ResourcePolicyAssignment() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringMatch(regexp.MustCompile(`^[A-Za-z][\w-]*$`),
 						"Only letters, digits, hyphens and underscores are allowed, and must start with a letter."),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Now, the forceNew behavior of the parameter 'name' is true.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. append the forceNew behavior to the resource RMS assignment.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rms' TESTARGS='-run=TestAccPolicyAssignment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rms -v -run=TestAccPolicyAssignment_ -timeout 360m -parallel 4
=== RUN   TestAccPolicyAssignment_basic
=== PAUSE TestAccPolicyAssignment_basic
=== RUN   TestAccPolicyAssignment_period
=== PAUSE TestAccPolicyAssignment_period
=== RUN   TestAccPolicyAssignment_custom
=== PAUSE TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_basic
=== CONT  TestAccPolicyAssignment_custom
=== CONT  TestAccPolicyAssignment_period
--- PASS: TestAccPolicyAssignment_period (96.48s)
--- PASS: TestAccPolicyAssignment_custom (274.53s)
--- PASS: TestAccPolicyAssignment_basic (274.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rms       274.763s
```
