### PR TITLE
docs(ces): update doc and test of ces alarm rule

### DIFF
--- a/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
+++ b/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go
@@ -25,7 +25,7 @@ func getAlarmRuleResourceFunc(conf *config.Config, state *terraform.ResourceStat
 func TestAccCESAlarmRule_basic(t *testing.T) {
 	var ar alarmrule.AlarmRule
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ces_alarmrule.alarmrule_1"
+	resourceName := "huaweicloud_ces_alarmrule.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -43,12 +43,16 @@ func TestAccCESAlarmRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "alarm_type", "MULTI_INSTANCE"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_level", "2"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.alarm_level", "3"),
 					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6.5"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.suppress_duration", "300"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.period", "300"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.metric_name", "network_incoming_bytes_rate_inband"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.alarm_level", "3"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.value", "6.5"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.period", "300"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.metric_name", "network_outgoing_bytes_rate_inband"),
 				),
 			},
 			{
@@ -61,8 +65,14 @@ func TestAccCESAlarmRule_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s-update", rName)),
 					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_level", "3"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "60"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.alarm_level", "4"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6.5"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.period", "1200"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.metric_name", "network_outgoing_bytes_rate_inband"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.alarm_level", "4"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.value", "20"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.period", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "condition.1.metric_name", "network_outgoing_bytes_rate_inband"),
 				),
 			},
 		},
@@ -72,7 +82,7 @@ func TestAccCESAlarmRule_basic(t *testing.T) {
 func TestAccCESAlarmRule_withEpsId(t *testing.T) {
 	var ar alarmrule.AlarmRule
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ces_alarmrule.alarmrule_1"
+	resourceName := "huaweicloud_ces_alarmrule.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -81,7 +91,10 @@ func TestAccCESAlarmRule_withEpsId(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -92,8 +105,10 @@ func TestAccCESAlarmRule_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_level", "2"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.alarm_level", "3"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6.5"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.period", "300"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.metric_name", "network_incoming_bytes_rate_inband"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
@@ -104,7 +119,7 @@ func TestAccCESAlarmRule_withEpsId(t *testing.T) {
 func TestAccCESAlarmRule_sysEvent(t *testing.T) {
 	var ar alarmrule.AlarmRule
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ces_alarmrule.alarmrule_1"
+	resourceName := "huaweicloud_ces_alarmrule.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -124,60 +139,8 @@ func TestAccCESAlarmRule_sysEvent(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_level", "2"),
 					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCESAlarmRule_multiConditions(t *testing.T) {
-	var ar alarmrule.AlarmRule
-	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ces_alarmrule.alarmrule_1"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&ar,
-		getAlarmRuleResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testCESAlarmRule_multiConditions(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.alarm_level", "3"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6.5"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.period", "300"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.metric_name", "network_incoming_bytes_rate_inband"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.alarm_level", "3"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.value", "6.5"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.period", "300"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.metric_name", "network_outgoing_bytes_rate_inband"),
-				),
-			},
-			{
-				Config: testCESAlarmRule_multiConditions_update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s-update", rName)),
-					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.alarm_level", "4"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6.5"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.period", "1200"),
-					resource.TestCheckResourceAttr(resourceName, "condition.0.metric_name", "network_outgoing_bytes_rate_inband"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.alarm_level", "4"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.value", "20"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.period", "3600"),
-					resource.TestCheckResourceAttr(resourceName, "condition.1.metric_name", "network_outgoing_bytes_rate_inband"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.alarm_level", "2"),
 				),
 			},
 		},
@@ -187,7 +150,7 @@ func TestAccCESAlarmRule_multiConditions(t *testing.T) {
 func TestAccCESAlarmRule_allInstance(t *testing.T) {
 	var ar alarmrule.AlarmRule
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ces_alarmrule.alarmrule_1"
+	resourceName := "huaweicloud_ces_alarmrule.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -221,7 +184,7 @@ func TestAccCESAlarmRule_allInstance(t *testing.T) {
 func TestAccCESAlarmRule_withResourceGroup(t *testing.T) {
 	var ar alarmrule.AlarmRule
 	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ces_alarmrule.alarmrule_1"
+	resourceName := "huaweicloud_ces_alarmrule.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -257,11 +220,60 @@ func TestAccCESAlarmRule_withResourceGroup(t *testing.T) {
 	})
 }
 
+func TestAccCESAlarmRule_old(t *testing.T) {
+	var ar alarmrule.AlarmRule
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_ces_alarmrule.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&ar,
+		getAlarmRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRule_old(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "alarm_type", "MULTI_INSTANCE"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_action_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_level", "2"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "6.5"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.suppress_duration", "300"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testCESAlarmRule_old_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "alarm_name", fmt.Sprintf("rule-%s-update", rName)),
+					resource.TestCheckResourceAttr(resourceName, "alarm_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_level", "3"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "60"),
+				),
+			},
+		},
+	})
+}
+
 func testCESAlarmRule_instanceBase(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_compute_instance" "vm_1" {
+resource "huaweicloud_compute_instance" "test" {
+  count = 2
+
   name               = "ecs-%[2]s"
   image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
@@ -277,7 +289,7 @@ resource "huaweicloud_compute_instance" "vm_1" {
 
 func testCESAlarmRule_topicBase(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_smn_topic" "topic_1" {
+resource "huaweicloud_smn_topic" "test" {
   name         = "smn-%s"
   display_name = "The display name of smn topic"
 }
@@ -290,174 +302,19 @@ func testCESAlarmRule_basic(rName string) string {
 
 %s
 
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
-  alarm_name           = "rule-%s"
-  alarm_action_enabled = true
-
-  metric {
-    namespace   = "SYS.ECS"
-    metric_name = "network_outgoing_bytes_rate_inband"
-
-    dimensions {
-      name  = "instance_id"
-      value = huaweicloud_compute_instance.vm_1.id
-    }
-  }
-
-  condition  {
-    period              = 300
-    filter              = "average"
-    comparison_operator = ">"
-    value               = 6.5
-    unit                = "B/s"
-    count               = 1
-    suppress_duration   = 300
-  }
-
-  alarm_actions {
-    type              = "notification"
-    notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
-    ]
-  }
-}
-`, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName)
-}
-
-func testCESAlarmRule_update(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-%s
-
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
-  alarm_name           = "rule-%s-update"
-  alarm_action_enabled = true
-  alarm_enabled        = false
-  alarm_level          = 3
-
-  metric {
-    namespace   = "SYS.ECS"
-    metric_name = "network_outgoing_bytes_rate_inband"
-
-    dimensions {
-      name  = "instance_id"
-      value = huaweicloud_compute_instance.vm_1.id
-    }
-  }
-
-  condition  {
-    period              = 300
-    filter              = "average"
-    comparison_operator = ">"
-    value               = 60
-    unit                = "B/s"
-    count               = 1
-    suppress_duration   = 300
-  }
-
-  alarm_actions {
-    type              = "notification"
-    notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
-    ]
-  }
-}
-`, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName)
-}
-
-func testCESAlarmRule_withEpsId(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-%s
-
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
-  alarm_name            = "rule-%s"
-  alarm_action_enabled  = true
-  enterprise_project_id = "%s"
-
-  metric {
-    namespace   = "SYS.ECS"
-    metric_name = "network_outgoing_bytes_rate_inband"
-	
-    dimensions {
-      name  = "instance_id"
-      value = huaweicloud_compute_instance.vm_1.id
-    }
-  }
-  
-  condition  {
-    period              = 300
-    filter              = "average"
-    comparison_operator = ">"
-    value               = 6
-    unit                = "B/s"
-    count               = 1
-    suppress_duration   = 300
-  }
-
-  alarm_actions {
-    type              = "notification"
-    notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
-    ]
-  }
-}
-`, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
-}
-
-func testCESAlarmRule_sysEvent(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
-  alarm_name           = "rule-%s"
-  alarm_action_enabled = true
-  alarm_type           = "EVENT.SYS"
-
-  metric {
-    namespace   = "SYS.ECS"
-    metric_name = "stopServer"
-  }
-  
-  condition  {
-    period              = 0
-    filter              = "average"
-    comparison_operator = ">="
-    value               = 1
-    unit                = "count"
-    count               = 1
-    suppress_duration   = 0
-  }
-
-  alarm_actions {
-    type              = "notification"
-    notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
-    ]
-  }
-}
-`, testCESAlarmRule_topicBase(rName), rName)
-}
-
-func testCESAlarmRule_multiConditions(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-%s
-
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
+resource "huaweicloud_ces_alarmrule" "test" {
   alarm_name           = "rule-%s"
   alarm_action_enabled = true
   alarm_type           = "MULTI_INSTANCE"
 
   metric {
-    namespace   = "SYS.ECS"
+    namespace = "SYS.ECS"
+  }
 
+  resources {
     dimensions {
       name  = "instance_id"
-      value = huaweicloud_compute_instance.vm_1.id
+      value = huaweicloud_compute_instance.test[0].id
     }
   }
 
@@ -488,31 +345,40 @@ resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
   alarm_actions {
     type              = "notification"
     notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
+      huaweicloud_smn_topic.test.topic_urn
     ]
   }
 }
 `, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName)
 }
 
-func testCESAlarmRule_multiConditions_update(rName string) string {
+func testCESAlarmRule_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
 %s
 
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
+resource "huaweicloud_ces_alarmrule" "test" {
   alarm_name           = "rule-%s-update"
   alarm_action_enabled = true
   alarm_enabled        = false
   alarm_type           = "MULTI_INSTANCE"
 
   metric {
-    namespace   = "SYS.ECS"
+    namespace = "SYS.ECS"
+  }
 
+  resources {
     dimensions {
       name  = "instance_id"
-      value = huaweicloud_compute_instance.vm_1.id
+      value = huaweicloud_compute_instance.test[0].id
+    }
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = huaweicloud_compute_instance.test[1].id
     }
   }
 
@@ -543,24 +409,104 @@ resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
   alarm_actions {
     type              = "notification"
     notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
+      huaweicloud_smn_topic.test.topic_urn
     ]
   }
 }
 `, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName)
 }
 
+func testCESAlarmRule_withEpsId(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "huaweicloud_ces_alarmrule" "test" {
+  alarm_name            = "rule-%s"
+  alarm_action_enabled  = true
+  alarm_type            = "MULTI_INSTANCE"
+  enterprise_project_id = "%s"
+
+  metric {
+    namespace = "SYS.ECS"
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = huaweicloud_compute_instance.test[0].id
+    }
+  }
+
+  condition  {
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    metric_name         = "network_incoming_bytes_rate_inband"
+    alarm_level         = 3
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
+    ]
+  }
+}
+`, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testCESAlarmRule_sysEvent(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_ces_alarmrule" "test" {
+  alarm_name           = "rule-%s"
+  alarm_action_enabled = true
+  alarm_type           = "EVENT.SYS"
+
+  metric {
+    namespace = "SYS.ECS"
+  }
+  
+  condition  {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 1
+    unit                = "count"
+    count               = 1
+    suppress_duration   = 0
+    alarm_level         = 2
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
+    ]
+  }
+}
+`, testCESAlarmRule_topicBase(rName), rName)
+}
+
 func testCESAlarmRule_allInstance(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
+resource "huaweicloud_ces_alarmrule" "test" {
   alarm_name           = "rule-%s"
   alarm_action_enabled = true
   alarm_type           = "ALL_INSTANCE"
 
   metric {
-    namespace   = "AGT.ECS"
+    namespace = "AGT.ECS"
   }
 
   resources {
@@ -587,7 +533,7 @@ resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
   alarm_actions {
     type              = "notification"
     notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
+      huaweicloud_smn_topic.test.topic_urn
     ]
   }
 }
@@ -607,12 +553,12 @@ resource "huaweicloud_ces_resource_group" "test" {
     namespace = "SYS.ECS"
     dimensions {
       name  = "instance_id"
-      value = huaweicloud_compute_instance.vm_1.id
+      value = huaweicloud_compute_instance.test[0].id
     }
   }
 }
 
-resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
+resource "huaweicloud_ces_alarmrule" "test" {
   alarm_name           = "rule-%s"
   alarm_action_enabled = true
   alarm_type           = "RESOURCE_GROUP"
@@ -655,13 +601,95 @@ resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
   alarm_actions {
     type              = "notification"
     notification_list = [
-      huaweicloud_smn_topic.topic_1.topic_urn
+      huaweicloud_smn_topic.test.topic_urn
     ]
   }
 
   lifecycle {
     ignore_changes = [
       resources
+    ]
+  }
+}
+`, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName)
+}
+
+func testCESAlarmRule_old(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "huaweicloud_ces_alarmrule" "test" {
+  alarm_name           = "rule-%s"
+  alarm_action_enabled = true
+
+  metric {
+    namespace   = "SYS.ECS"
+    metric_name = "network_outgoing_bytes_rate_inband"
+
+    dimensions {
+      name  = "instance_id"
+      value = huaweicloud_compute_instance.test[0].id
+    }
+  }
+
+  condition  {
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
+    ]
+  }
+}
+`, testCESAlarmRule_instanceBase(rName), testCESAlarmRule_topicBase(rName), rName)
+}
+
+func testCESAlarmRule_old_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "huaweicloud_ces_alarmrule" "test" {
+  alarm_name           = "rule-%s-update"
+  alarm_action_enabled = true
+  alarm_enabled        = false
+  alarm_level          = 3
+
+  metric {
+    namespace   = "SYS.ECS"
+    metric_name = "network_outgoing_bytes_rate_inband"
+
+    dimensions {
+      name  = "instance_id"
+      value = huaweicloud_compute_instance.test[0].id
+    }
+  }
+
+  condition  {
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 60
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
     ]
   }
 }

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
@@ -111,6 +111,7 @@ func ResourceAlarmRule() *schema.Resource {
 							Computed:      true,
 							Set:           resourceDimensionsHash,
 							ConflictsWith: []string{"resources"},
+							Description:   "schema: Deprecated",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {
@@ -247,9 +248,10 @@ func ResourceAlarmRule() *schema.Resource {
 			},
 
 			"alarm_level": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "schema: Deprecated",
 			},
 
 			"alarm_type": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ces' TESTARGS='-run TestAccCESAlarmRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccCESAlarmRule -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_basic
=== PAUSE TestAccCESAlarmRule_basic
=== RUN   TestAccCESAlarmRule_withEpsId
=== PAUSE TestAccCESAlarmRule_withEpsId
=== RUN   TestAccCESAlarmRule_sysEvent
=== PAUSE TestAccCESAlarmRule_sysEvent
=== RUN   TestAccCESAlarmRule_allInstance
=== PAUSE TestAccCESAlarmRule_allInstance
=== RUN   TestAccCESAlarmRule_withResourceGroup
=== PAUSE TestAccCESAlarmRule_withResourceGroup
=== RUN   TestAccCESAlarmRule_old
=== PAUSE TestAccCESAlarmRule_old
=== CONT  TestAccCESAlarmRule_basic
=== CONT  TestAccCESAlarmRule_allInstance
=== CONT  TestAccCESAlarmRule_old
=== CONT  TestAccCESAlarmRule_withResourceGroup
--- PASS: TestAccCESAlarmRule_allInstance (15.12s)
=== CONT  TestAccCESAlarmRule_sysEvent
--- PASS: TestAccCESAlarmRule_sysEvent (13.73s)
=== CONT  TestAccCESAlarmRule_withEpsId
--- PASS: TestAccCESAlarmRule_withResourceGroup (192.63s)
--- PASS: TestAccCESAlarmRule_old (206.27s)
--- PASS: TestAccCESAlarmRule_basic (209.11s)
--- PASS: TestAccCESAlarmRule_withEpsId (180.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       209.291s
```
