### PR TITLE
test(aom): fix the test case of aom service discovery rule

### DIFF
--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_service_discovery_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_service_discovery_rule_test.go
@@ -3,6 +3,7 @@ package aom
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	aomservice "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
@@ -19,6 +20,10 @@ func getServiceDiscoveryRuleResourceFunc(conf *config.Config, state *terraform.R
 	if err != nil {
 		return nil, fmt.Errorf("error creating AOM client: %s", err)
 	}
+
+	// wait 30 seconds before listing the rule, to avoid error
+	// lintignore:R018
+	time.Sleep(30 * time.Second)
 
 	response, err := c.ListServiceDiscoveryRules(&aom.ListServiceDiscoveryRulesRequest{})
 	if err != nil {

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
@@ -281,6 +281,10 @@ func resourceServiceDiscoveryRuleCreateOrUpdate(ctx context.Context, d *schema.R
 
 	d.SetId(createOpts.Name)
 
+	// wait for the configuration to take effect
+	// lintignore:R018
+	time.Sleep(30 * time.Second)
+
 	return resourceServiceDiscoveryRuleRead(ctx, d, meta)
 }
 
@@ -344,6 +348,7 @@ func resourceServiceDiscoveryRuleDelete(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.Errorf("error deleting AOM service discovery rule %s: %s", d.Id(), err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAOMServiceDiscoveryRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAOMServiceDiscoveryRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAOMServiceDiscoveryRule_basic
=== PAUSE TestAccAOMServiceDiscoveryRule_basic
=== CONT  TestAccAOMServiceDiscoveryRule_basic
--- PASS: TestAccAOMServiceDiscoveryRule_basic (112.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       112.483s
```
