### PR TITLE
chore(vpc/peering): fix lint issues

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -16,7 +16,7 @@
     },
     "MD033": {
         "allowed_elements": [
-            "a"
+            "a", "br"
         ]
     },
     "MD040": false,

--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -6,9 +6,11 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 Provides a resource to manage a VPC Peering Connection resource.
 
--> **NOTE:** For cross-tenant (requester's tenant differs from the accepter's tenant) VPC Peering Connections, use
-the `huaweicloud_vpc_peering_connection` resource to manage the requester's side of the connection and use
-the `huaweicloud_vpc_peering_connection_accepter` resource to manage the accepter's side of the connection.
+-> **NOTE:** For cross-tenant (requester's tenant differs from the accepter's tenant) VPC Peering Connections,
+  use the `huaweicloud_vpc_peering_connection` resource to manage the requester's side of the connection and
+  use the `huaweicloud_vpc_peering_connection_accepter` resource to manage the accepter's side of the connection.
+  <br/>If you create a VPC peering connection with another VPC of your own, the connection is created without the need
+  for you to accept the connection.
 
 ## Example Usage
 
@@ -48,17 +50,12 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The VPC peering connection status. The value can be PENDING_ACCEPTANCE, REJECTED, EXPIRED, DELETED, or
   ACTIVE.
 
-## Notes
-
-If you create a VPC peering connection with another VPC of your own, the connection is created without the need for you
-to accept the connection.
-
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/vpc_peering_connection_accepter.md
+++ b/docs/resources/vpc_peering_connection_accepter.md
@@ -93,5 +93,5 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection_accepter_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection_accepter_test.go
@@ -19,14 +19,15 @@ func TestAccVpcPeeringConnectionAccepter_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVpcPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVpcPeeringConnectionAccepter_basic(randName), //TODO: Research why normal scenario with peer tenant id is not working in acceptance tests
-				ExpectError: regexp.MustCompile(`VPC peering action not permitted: Can not accept/reject peering request not in PENDING_ACCEPTANCE state.`),
+				Config: testAccVpcPeeringConnectionAccepter_basic(randName),
+				ExpectError: regexp.MustCompile(
+					`VPC peering action not permitted: Can not accept/reject peering request not in PENDING_ACCEPTANCE state.`),
 			},
 		},
 	})
 }
 
-func testAccCheckVpcPeeringConnectionAccepterDestroy(s *terraform.State) error {
+func testAccCheckVpcPeeringConnectionAccepterDestroy(_ *terraform.State) error {
 	// We don't destroy the underlying VPC Peering Connection.
 	return nil
 }

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -15,7 +16,7 @@ import (
 func getPeeringConnectionResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	c, err := conf.NetworkingV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud Network client: %s", err)
+		return nil, fmt.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 	return peerings.Get(c, state.Primary.ID).Extract()
 }
@@ -44,10 +45,8 @@ func TestAccVpcPeeringConnection_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "vpc_id",
-						"${huaweicloud_vpc.test1.id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "peer_vpc_id",
-						"${huaweicloud_vpc.test2.id}"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "peer_vpc_id", "huaweicloud_vpc.test2", "id"),
 				),
 			},
 			{
@@ -55,10 +54,8 @@ func TestAccVpcPeeringConnection_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "vpc_id",
-						"${huaweicloud_vpc.test1.id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "peer_vpc_id",
-						"${huaweicloud_vpc.test2.id}"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "peer_vpc_id", "huaweicloud_vpc.test2", "id"),
 				),
 			},
 			{

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"log"
 
-	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -57,10 +60,11 @@ func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 }
 
 func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating Vpc client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
 	listOpts := peerings.ListOpts{
@@ -74,7 +78,7 @@ func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceD
 
 	refinedPeering, err := peerings.List(peeringClient, listOpts)
 	if err != nil {
-		return diag.Errorf("unable to retrieve vpc peering connections: %s", err)
+		return diag.Errorf("unable to retrieve VPC Peering Connections: %s", err)
 	}
 
 	if len(refinedPeering) < 1 {
@@ -83,22 +87,23 @@ func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceD
 	}
 
 	if len(refinedPeering) > 1 {
-		return diag.Errorf("multiple VPC peering connections matched." +
-			" Use additional constraints to reduce matches to a single VPC peering connection")
+		return diag.Errorf("multiple VPC Peering Connections matched." +
+			" Use additional constraints to reduce matches to a single VPC Peering Connection")
 	}
 
-	Peering := refinedPeering[0]
+	item := refinedPeering[0]
 
-	log.Printf("[INFO] Retrieved Vpc peering Connections using given filter %s: %+v", Peering.ID, Peering)
-	d.SetId(Peering.ID)
+	log.Printf("[INFO] Retrieved Vpc peering Connections using given filter %s: %+v", item.ID, item)
+	d.SetId(item.ID)
 
-	d.Set("id", Peering.ID)
-	d.Set("name", Peering.Name)
-	d.Set("status", Peering.Status)
-	d.Set("vpc_id", Peering.RequestVpcInfo.VpcId)
-	d.Set("peer_vpc_id", Peering.AcceptVpcInfo.VpcId)
-	d.Set("peer_tenant_id", Peering.AcceptVpcInfo.TenantId)
-	d.Set("region", config.GetRegion(d))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", item.Name),
+		d.Set("status", item.Status),
+		d.Set("vpc_id", item.RequestVpcInfo.VpcId),
+		d.Set("peer_vpc_id", item.AcceptVpcInfo.VpcId),
+		d.Set("peer_tenant_id", item.AcceptVpcInfo.TenantId),
+	)
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -5,21 +5,25 @@ import (
 	"log"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func ResourceVpcPeeringConnectionV2() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVPCPeeringV2Create,
-		ReadContext:   resourceVPCPeeringV2Read,
-		UpdateContext: resourceVPCPeeringV2Update,
-		DeleteContext: resourceVPCPeeringV2Delete,
+		CreateContext: resourceVPCPeeringCreate,
+		ReadContext:   resourceVPCPeeringRead,
+		UpdateContext: resourceVPCPeeringUpdate,
+		DeleteContext: resourceVPCPeeringDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -65,12 +69,12 @@ func ResourceVpcPeeringConnectionV2() *schema.Resource {
 	}
 }
 
-func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
-
+func resourceVPCPeeringCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
 	requestvpcinfo := peerings.VpcInfo{
@@ -89,15 +93,12 @@ func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	n, err := peerings.Create(peeringClient, createOpts).Extract()
-
 	if err != nil {
-		return diag.Errorf("error creating Vpc Peering Connection: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection: %s", err)
 	}
 
-	log.Printf("[INFO] Vpc Peering Connection ID: %s", n.ID)
-
-	log.Printf("[INFO] Waiting for Vpc Peering Connection(%s) to become available", n.ID)
-
+	d.SetId(n.ID)
+	log.Printf("[DEBUG] Waiting for VPC Peering Connection(%s) to become available", n.ID)
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"CREATING"},
 		Target:     []string{"PENDING_ACCEPTANCE", "ACTIVE"},
@@ -109,66 +110,67 @@ func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, met
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		log.Printf("Error creating Vpc Peering Connection: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection: %s", err)
 	}
-	d.SetId(n.ID)
 
-	return resourceVPCPeeringV2Read(ctx, d, meta)
-
+	return resourceVPCPeeringRead(ctx, d, meta)
 }
 
-func resourceVPCPeeringV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
+func resourceVPCPeeringRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
 	n, err := peerings.Get(peeringClient, d.Id()).Extract()
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			d.SetId("")
-			return nil
-		}
-
-		return diag.Errorf("error retrieving Vpc Peering Connection: %s", err)
+		return common.CheckDeletedDiag(d, err, "error retrieving VPC Peering Connection")
 	}
 
-	d.Set("name", n.Name)
-	d.Set("status", n.Status)
-	d.Set("vpc_id", n.RequestVpcInfo.VpcId)
-	d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId)
-	d.Set("peer_tenant_id", n.AcceptVpcInfo.TenantId)
-	d.Set("region", config.GetRegion(d))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", n.Name),
+		d.Set("status", n.Status),
+		d.Set("vpc_id", n.RequestVpcInfo.VpcId),
+		d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId),
+		d.Set("peer_tenant_id", n.AcceptVpcInfo.TenantId),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting VPC Peering Connection fields: %s", err)
+	}
 
 	return nil
 }
 
-func resourceVPCPeeringV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
+func resourceVPCPeeringUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
-	var updateOpts peerings.UpdateOpts
-
-	updateOpts.Name = d.Get("name").(string)
+	updateOpts := peerings.UpdateOpts{
+		Name: d.Get("name").(string),
+	}
 
 	_, err = peerings.Update(peeringClient, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return diag.Errorf("error updating Vpc Peering Connection: %s", err)
+		return diag.Errorf("error updating VPC Peering Connection: %s", err)
 	}
 
-	return resourceVPCPeeringV2Read(ctx, d, meta)
+	return resourceVPCPeeringRead(ctx, d, meta)
 }
 
-func resourceVPCPeeringV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
-	config := meta.(*config.Config)
-	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
+func resourceVPCPeeringDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating Vpc Peering Connection Client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -182,10 +184,9 @@ func resourceVPCPeeringV2Delete(ctx context.Context, d *schema.ResourceData, met
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error deleting Vpc Peering Connection: %s", err)
+		return diag.Errorf("error deleting VPC Peering Connection: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 
@@ -206,7 +207,6 @@ func waitForVpcPeeringActive(peeringClient *golangsdk.ServiceClient, peeringId s
 
 func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
 		r, err := peerings.Get(peeringClient, peeringId).Extract()
 
 		if err != nil {
@@ -218,7 +218,6 @@ func waitForVpcPeeringDelete(peeringClient *golangsdk.ServiceClient, peeringId s
 		}
 
 		err = peerings.Delete(peeringClient, peeringId).ExtractErr()
-
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[INFO] Successfully deleted vpc peering connection %s", peeringId)

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
@@ -5,17 +5,21 @@ import (
 	"log"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/networking/v2/peerings"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVPCPeeringAccepterV2Create,
+		CreateContext: resourceVPCPeeringAccepterCreate,
 		ReadContext:   resourceVpcPeeringAccepterRead,
 		UpdateContext: resourceVPCPeeringAccepterUpdate,
 		DeleteContext: resourceVPCPeeringAccepterDelete,
@@ -68,16 +72,15 @@ func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 	}
 }
 
-func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	peeringClient, err := config.NetworkingV2Client(config.GetRegion(d))
-
+func resourceVPCPeeringAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating Peering client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
 	id := d.Get("vpc_peering_connection_id").(string)
-
 	n, err := peerings.Get(peeringClient, id).Extract()
 	if err != nil {
 		return diag.Errorf("error retrieving Vpc Peering Connection: %s", err)
@@ -90,19 +93,16 @@ func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceD
 	var expectedStatus string
 
 	if _, ok := d.GetOk("accept"); ok {
-
 		expectedStatus = "ACTIVE"
-		_, err := peerings.Accept(peeringClient, id).ExtractResult()
 
+		_, err := peerings.Accept(peeringClient, id).ExtractResult()
 		if err != nil {
 			return diag.Errorf("unable to accept VPC Peering Connection: %s", err)
 		}
-
 	} else {
 		expectedStatus = "REJECTED"
 
 		_, err := peerings.Reject(peeringClient, id).ExtractResult()
-
 		if err != nil {
 			return diag.Errorf("unable to reject VPC Peering Connection: %s", err)
 		}
@@ -119,53 +119,52 @@ func resourceVPCPeeringAccepterV2Create(ctx context.Context, d *schema.ResourceD
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		log.Printf("[ERROR] Error deleting VPC Peering Connection: %s", err)
+		return diag.Errorf("error waiting for the VPC Peering Connection: %s", err)
 	}
+
 	d.SetId(n.ID)
-	log.Printf("[INFO] VPC Peering Connection status: %s", expectedStatus)
-
 	return resourceVpcPeeringAccepterRead(ctx, d, meta)
-
 }
 
 func resourceVpcPeeringAccepterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	peeringclient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	peeringClient, err := cfg.NetworkingV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating peering client: %s", err)
+		return diag.Errorf("error creating VPC Peering Connection client: %s", err)
 	}
 
-	n, err := peerings.Get(peeringclient, d.Id()).Extract()
+	n, err := peerings.Get(peeringClient, d.Id()).Extract()
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			d.SetId("")
-			return nil
-		}
-
-		return diag.Errorf("error retrieving Vpc Peering Connection: %s", err)
+		return common.CheckDeletedDiag(d, err, "error retrieving VPC Peering Connection")
 	}
 
-	d.Set("name", n.Name)
-	d.Set("status", n.Status)
-	d.Set("vpc_id", n.RequestVpcInfo.VpcId)
-	d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId)
-	d.Set("peer_tenant_id", n.AcceptVpcInfo.TenantId)
-	d.Set("region", config.GetRegion(d))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", n.Name),
+		d.Set("status", n.Status),
+		d.Set("vpc_id", n.RequestVpcInfo.VpcId),
+		d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId),
+		d.Set("peer_tenant_id", n.AcceptVpcInfo.TenantId),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting VPC Peering Connection fields: %s", err)
+	}
 
 	return nil
 }
 
 func resourceVPCPeeringAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	if d.HasChange("accept") {
-		return diag.Errorf("VPC peering action not permitted: Can not accept/reject peering request not in pending_acceptance state.'")
+		return diag.Errorf("VPC peering action not permitted: Can not accept/reject peering request not in pending_acceptance state.")
 	}
 
 	return resourceVpcPeeringAccepterRead(ctx, d, meta)
 }
 
-func resourceVPCPeeringAccepterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[WARN] Will not delete VPC peering connection. Terraform will remove this resource from the state file, however resources may remain.")
+func resourceVPCPeeringAccepterDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	log.Printf("[WARN] Will not delete VPC peering connection. Terraform will remove this resource from the state file, resources may remain.")
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes lint issues

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcPeeringConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcPeeringConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnection_basic
=== PAUSE TestAccVpcPeeringConnection_basic
=== CONT  TestAccVpcPeeringConnection_basic
--- PASS: TestAccVpcPeeringConnection_basic (53.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       53.202s

$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcPeeringConnectionAccepter_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcPeeringConnectionAccepter_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnectionAccepter_basic
=== PAUSE TestAccVpcPeeringConnectionAccepter_basic
=== CONT  TestAccVpcPeeringConnectionAccepter_basic
--- PASS: TestAccVpcPeeringConnectionAccepter_basic (37.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       37.616s

$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcPeeringConnectionDataSource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcPeeringConnectionDataSource -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnectionDataSource_basic
=== PAUSE TestAccVpcPeeringConnectionDataSource_basic
=== RUN   TestAccVpcPeeringConnectionDataSource_byVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byVpcId
=== RUN   TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== RUN   TestAccVpcPeeringConnectionDataSource_byVpcIds
=== PAUSE TestAccVpcPeeringConnectionDataSource_byVpcIds
=== CONT  TestAccVpcPeeringConnectionDataSource_basic
=== CONT  TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== CONT  TestAccVpcPeeringConnectionDataSource_byVpcId
=== CONT  TestAccVpcPeeringConnectionDataSource_byVpcIds
--- PASS: TestAccVpcPeeringConnectionDataSource_basic (45.99s)
--- PASS: TestAccVpcPeeringConnectionDataSource_byVpcId (52.74s)
--- PASS: TestAccVpcPeeringConnectionDataSource_byPeerVpcId (52.85s)
--- PASS: TestAccVpcPeeringConnectionDataSource_byVpcIds (61.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       61.467s
```
