### PR TITLE
test(cce): fix test cases of cluster and addon

### DIFF
--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_v3_test.go
@@ -184,7 +184,7 @@ func testAccCCEAddonV3_basic(rName string) string {
 
 resource "huaweicloud_cce_addon" "test" {
   cluster_id    = huaweicloud_cce_cluster.test.id
-  version       = "1.2.1"
+  version       = "1.3.6"
   template_name = "metrics-server"
   depends_on    = [huaweicloud_cce_node.test]
 }
@@ -222,27 +222,29 @@ resource "huaweicloud_cce_node_pool" "test" {
 data "huaweicloud_cce_addon_template" "test" {
   cluster_id = huaweicloud_cce_cluster.test.id
   name       = "autoscaler"
-  version    = "1.21.1"
+  version    = "1.25.21"
 }
 
 resource "huaweicloud_cce_addon" "test" {
   cluster_id    = huaweicloud_cce_cluster.test.id
   template_name = "autoscaler"
-  version       = "1.21.1"
+  version       = "1.25.21"
 
   values {
-    basic  = jsondecode(data.huaweicloud_cce_addon_template.test.spec).basic
-    custom = merge(
+    basic       = jsondecode(data.huaweicloud_cce_addon_template.test.spec).basic
+    custom_json = jsonencode(merge(
       jsondecode(data.huaweicloud_cce_addon_template.test.spec).parameters.custom,
       {
         cluster_id = huaweicloud_cce_cluster.test.id
         tenant_id  = "%s"
       }
-    )
+    ))
     flavor_json = jsonencode(jsondecode(data.huaweicloud_cce_addon_template.test.spec).parameters.flavor2)
   }
   
-  depends_on = [huaweicloud_cce_node_pool.test]
+  depends_on = [
+    huaweicloud_cce_node_pool.test,
+  ]
 }
 `, testAccCCENodePool_Base(rName), rName, acceptance.HW_PROJECT_ID)
 }

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_v3_test.go
@@ -44,6 +44,9 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"certificate_users.0.client_certificate_data", "kube_config_raw",
+				},
 			},
 			{
 				Config: testAccCCEClusterV3_update(rName),
@@ -121,7 +124,7 @@ func TestAccCCEClusterV3_withEip(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"eip",
+					"eip", "certificate_users.0.client_certificate_data", "kube_config_raw",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEClusterV3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEClusterV3 -timeout 360m -parallel 4
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== RUN   TestAccCCEClusterV3_prePaid
=== PAUSE TestAccCCEClusterV3_prePaid
=== RUN   TestAccCCEClusterV3_withEip
=== PAUSE TestAccCCEClusterV3_withEip
=== RUN   TestAccCCEClusterV3_withEpsId
=== PAUSE TestAccCCEClusterV3_withEpsId
=== RUN   TestAccCCEClusterV3_turbo
=== PAUSE TestAccCCEClusterV3_turbo
=== RUN   TestAccCCEClusterV3_HibernateAndAwake
=== PAUSE TestAccCCEClusterV3_HibernateAndAwake
=== CONT  TestAccCCEClusterV3DataSource_basic
=== CONT  TestAccCCEClusterV3_withEpsId
=== CONT  TestAccCCEClusterV3_prePaid
=== CONT  TestAccCCEClusterV3_HibernateAndAwake
--- PASS: TestAccCCEClusterV3_withEpsId (555.78s)
=== CONT  TestAccCCEClusterV3_withEip
--- PASS: TestAccCCEClusterV3DataSource_basic (561.15s)
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_prePaid (719.86s)
=== CONT  TestAccCCEClusterV3_turbo
--- PASS: TestAccCCEClusterV3_basic (522.08s)
--- PASS: TestAccCCEClusterV3_withEip (573.22s)
--- PASS: TestAccCCEClusterV3_HibernateAndAwake (1243.86s)
--- PASS: TestAccCCEClusterV3_turbo (526.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1246.597s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCCEAddonV3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEAddonV3 -timeout 360m -parallel 4
=== RUN   TestAccCCEAddonV3_basic
=== PAUSE TestAccCCEAddonV3_basic
=== RUN   TestAccCCEAddonV3_values
=== PAUSE TestAccCCEAddonV3_values
=== CONT  TestAccCCEAddonV3_basic
=== CONT  TestAccCCEAddonV3_values
--- PASS: TestAccCCEAddonV3_basic (942.40s)
--- PASS: TestAccCCEAddonV3_values (992.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       993.056s
```
