### PR TITLE
chore(ecs): fix golang-ci lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,14 +97,14 @@ linters-settings:
       - name: var-naming
         disabled: false
         arguments:
-          - ["API", "ID", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL"] # AllowList
+          - ["API", "ID", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL", "CPU"] # AllowList
           - [] # DenyList
       - name: argument-limit
         disabled: false
         arguments: [6]
       - name: function-result-limit
         disabled: false
-        arguments: [3]
+        arguments: [4]
       - name: line-length-limit
         disabled: false
         arguments: [150]

--- a/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_flavors_test.go
+++ b/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_flavors_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 

--- a/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_instance_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -29,7 +29,7 @@ func getEcsInstanceResourceFunc(conf *config.Config, state *terraform.ResourceSt
 }
 
 func TestAccComputeInstanceDataSource_basic(t *testing.T) {
-	rName := fmt.Sprintf("ecs-data-test-%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 	dataSourceName := "data.huaweicloud_compute_instance.this"
 	var instance cloudservers.CloudServer
 

--- a/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_instances_test.go
+++ b/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_instances_test.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccComputeInstancesDataSource_basic(t *testing.T) {
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 	dataSourceName := "data.huaweicloud_compute_instances.test"
 	var instance cloudservers.CloudServer
 

--- a/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_servergroups_test.go
+++ b/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_servergroups_test.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccComputeServerGroupsDataSource_basic(t *testing.T) {
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 	dataSourceName := "data.huaweicloud_compute_servergroups.test"
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
 

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_interface_attach_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_interface_attach_test.go
@@ -43,7 +43,7 @@ func TestAccComputeInterfaceAttach_Basic(t *testing.T) {
 	})
 }
 
-func computeInterfaceAttachParseID(id string) (instanceID string, portID string, err error) {
+func computeInterfaceAttachParseID(id string) (instanceID, portID string, err error) {
 	idParts := strings.Split(id, "/")
 	if len(idParts) < 2 {
 		err = fmt.Errorf("unable to parse the resource ID, must be <instance_id>/<port_id> format")
@@ -107,8 +107,6 @@ func testAccCheckComputeInterfaceAttachExists(n string, ai *attachinterfaces.Int
 		if err != nil {
 			return err
 		}
-
-		//if found.instanceID != instanceID || found.PortID != portId {
 		if found.PortID != portId {
 			return fmt.Errorf("interface attachment not found")
 		}
@@ -128,7 +126,6 @@ func testAccCheckComputeInterfaceAttachIP(
 			}
 		}
 		return fmt.Errorf("requested ip (%s) does not exist on port", ip)
-
 	}
 }
 

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_servergroup_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_servergroup_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -17,7 +16,7 @@ import (
 
 func TestAccComputeServerGroup_basic(t *testing.T) {
 	var sg servergroups.ServerGroup
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_compute_servergroup.sg_1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -44,7 +43,7 @@ func TestAccComputeServerGroup_basic(t *testing.T) {
 func TestAccComputeServerGroup_scheduler(t *testing.T) {
 	var instance cloudservers.CloudServer
 	var sg servergroups.ServerGroup
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_compute_servergroup.sg_1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -68,7 +67,7 @@ func TestAccComputeServerGroup_scheduler(t *testing.T) {
 func TestAccComputeServerGroup_members(t *testing.T) {
 	var instance cloudservers.CloudServer
 	var sg servergroups.ServerGroup
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_compute_servergroup.sg_1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -90,7 +89,7 @@ func TestAccComputeServerGroup_members(t *testing.T) {
 }
 
 func TestAccComputeServerGroup_concurrency(t *testing.T) {
-	name := fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+	rName := acceptance.RandomAccResourceNameWithDash()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -98,7 +97,7 @@ func TestAccComputeServerGroup_concurrency(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeServerGroup_concurrency(name),
+				Config: testAccComputeServerGroup_concurrency(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckOutput("members_attached", "true"),
 					resource.TestCheckOutput("volumes_attached", "true"),

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_volume_attach_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_volume_attach_test.go
@@ -4,34 +4,30 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ecs"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func getVolumeAttachResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	c, err := conf.ComputeV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud compute v1 client: %s", err)
+		return nil, fmt.Errorf("error creating compute v1 client: %s", err)
 	}
 
-	instanceId, volumeId, err := ecs.ParseComputeVolumeAttachmentId(state.Primary.ID)
-	if err != nil {
-		return nil, err
-	}
-
+	instanceId := state.Primary.Attributes["instance_id"]
+	volumeId := state.Primary.Attributes["volume_id"]
 	found, err := block_devices.Get(c, instanceId, volumeId).Extract()
 	if err != nil {
 		return nil, err
 	}
 
 	if found.ServerId != instanceId || found.VolumeId != volumeId {
-		return nil, fmt.Errorf("volumeAttach not found %s", state.Primary.ID)
+		return nil, fmt.Errorf("volume attach not found %s", state.Primary.ID)
 	}
 
 	return found, nil

--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_flavors.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_flavors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/flavors"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 )
@@ -102,8 +103,7 @@ func dataSourceEcsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	}
 
 	if len(ids) < 1 {
-		return diag.Errorf("Your query returned no results. " +
-			"Please change your search criteria and try again.")
+		return diag.Errorf("your query returned no results, please change your search criteria and try again.")
 	}
 
 	d.SetId(hashcode.Strings(ids))

--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_instance.go
@@ -2,7 +2,6 @@ package ecs
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers"
 	"github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -214,7 +214,7 @@ func buildListOptsWithoutStatus(d *schema.ResourceData, conf *config.Config) *cl
 func queryEcsInstances(client *golangsdk.ServiceClient, opt *cloudservers.ListOpts) ([]cloudservers.CloudServer, error) {
 	pages, err := cloudservers.List(client, opt).AllPages()
 	if err != nil {
-		return []cloudservers.CloudServer{}, fmt.Errorf("error getting cloud servers: %s", err)
+		return nil, err
 	}
 	return cloudservers.ExtractServers(pages)
 }
@@ -230,7 +230,7 @@ func dataSourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, me
 	opt := buildListOptsWithoutStatus(d, conf)
 	allServers, err := queryEcsInstances(ecsClient, opt)
 	if err != nil {
-		return diag.Errorf("unable to retrieve cloud servers: %s", err)
+		return diag.Errorf("unable to retrieve ECS instances: %s", err)
 	}
 
 	filter := map[string]interface{}{
@@ -243,10 +243,10 @@ func dataSourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, me
 	}
 
 	if len(filterServers) < 1 {
-		return diag.Errorf("Your query returned no results, please change your search criteria and try again.")
+		return diag.Errorf("your query returned no results, please change your search criteria and try again.")
 	}
 	if len(filterServers) > 1 {
-		return diag.Errorf("Your query returned more than one result, please try a more specific search criteria.")
+		return diag.Errorf("your query returned more than one result, please try a more specific search criteria.")
 	}
 
 	server := allServers[0]

--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_servergroups.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_servergroups.go
@@ -3,10 +3,12 @@ package ecs
 import (
 	"context"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/ecs/v1/servergroups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -100,7 +102,8 @@ func dataSourceComputeServerGroupsRead(_ context.Context, d *schema.ResourceData
 	}
 
 	d.SetId(hashcode.Strings(serverGroupsIds))
-	d.Set("servergroups", serverGroupsToSet)
-
-	return nil
+	mErr := multierror.Append(nil,
+		d.Set("servergroups", serverGroupsToSet),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_volume_attach.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices"
-	"github.com/chnsz/golangsdk/openstack/ecs/v1/jobs"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices"
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/jobs"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -134,7 +135,7 @@ func resourceComputeVolumeAttachRead(_ context.Context, d *schema.ResourceData, 
 		return diag.Errorf("Error creating compute V1 client: %s", err)
 	}
 
-	instanceId, volumeId, err := ParseComputeVolumeAttachmentId(d.Id())
+	instanceId, volumeId, err := parseComputeVolumeAttachmentId(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -228,14 +229,14 @@ func parseRequestError(respErr error) error {
 	return respErr
 }
 
-func ParseComputeVolumeAttachmentId(id string) (string, string, error) {
+func parseComputeVolumeAttachmentId(id string) (instanceID, volumeID string, err error) {
 	idParts := strings.Split(id, "/")
 	if len(idParts) < 2 {
-		return "", "", fmt.Errorf("unable to determine volume attachment ID")
+		err = fmt.Errorf("unable to determine volume attachment ID")
+		return
 	}
 
-	instanceId := idParts[0]
-	volumeId := idParts[1]
-
-	return instanceId, volumeId, nil
+	instanceID = idParts[0]
+	volumeID = idParts[1]
+	return
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

fixes lint issues, now, we can get the following issues and will fix it later.
```
==> Checking for golangci-lint...
huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go:1039:1: cyclomatic complexity 62 of func `resourceComputeInstanceUpdate` is high (> 20) (gocyclo)
func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
^
huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go:559:1: cyclomatic complexity 56 of func `resourceComputeInstanceCreate` is high (> 20) (gocyclo)
func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
^
huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go:867:1: cyclomatic complexity 24 of func `resourceComputeInstanceRead` is high (> 20) (gocyclo)
func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
^
huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go:604:2: `if !hasDeprecatedConfig(d)` has complex nested blocks (complexity: 44) (nestif)
	if !hasDeprecatedConfig(d) {
	^
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeEIPAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeEIPAssociate_basic
=== PAUSE TestAccComputeEIPAssociate_basic
=== CONT  TestAccComputeEIPAssociate_basic
--- PASS: TestAccComputeEIPAssociate_basic (166.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       166.841s

$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (254.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       254.418s

$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeVolumeAttach_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeVolumeAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeVolumeAttach_basic
=== PAUSE TestAccComputeVolumeAttach_basic
=== CONT  TestAccComputeVolumeAttach_basic
--- PASS: TestAccComputeVolumeAttach_basic (191.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       191.592s

 $ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccEcsFlavorsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccEcsFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEcsFlavorsDataSource_basic
=== PAUSE TestAccEcsFlavorsDataSource_basic
=== CONT  TestAccEcsFlavorsDataSource_basic
--- PASS: TestAccEcsFlavorsDataSource_basic (13.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       14.021s

$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstanceDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (144.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       144.936s

$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstancesDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstancesDataSource_basic
=== PAUSE TestAccComputeInstancesDataSource_basic
=== CONT  TestAccComputeInstancesDataSource_basic
--- PASS: TestAccComputeInstancesDataSource_basic (148.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       148.946s

$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeServerGroupsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeServerGroupsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeServerGroupsDataSource_basic
=== PAUSE TestAccComputeServerGroupsDataSource_basic
=== CONT  TestAccComputeServerGroupsDataSource_basic
--- PASS: TestAccComputeServerGroupsDataSource_basic (9.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       9.799s
```
