### PR TITLE
feat(vpc/peering): support description param

### DIFF
--- a/docs/data-sources/vpc_peering_connection.md
+++ b/docs/data-sources/vpc_peering_connection.md
@@ -40,6 +40,8 @@ must match exactly one VPC peering connection whose data will be exported as att
 
 * `id` - (Optional, String) The ID of the specific VPC Peering Connection to retrieve.
 
+* `name` - (Optional, String) The name of the specific VPC Peering Connection to retrieve.
+
 * `status` - (Optional, String) The status of the specific VPC Peering Connection to retrieve.
 
 * `vpc_id` - (Optional, String) The ID of the requester VPC of the specific VPC Peering Connection to retrieve.
@@ -49,4 +51,8 @@ must match exactly one VPC peering connection whose data will be exported as att
 * `peer_tenant_id` - (Optional, String) The Tenant ID of the accepter/peer VPC of the specific VPC Peering Connection to
   retrieve.
 
-* `name` - (Optional, String) The name of the specific VPC Peering Connection to retrieve.
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - The description of the VPC Peering Connection.

--- a/docs/resources/vpc_peering_connection.md
+++ b/docs/resources/vpc_peering_connection.md
@@ -41,6 +41,8 @@ The following arguments are supported:
 * `peer_tenant_id` - (Optional, String, ForceNew) Specifies the tenant ID of the accepter tenant. Changing this creates
   a new VPC peering connection.
 
+* `description` - (Optional, String) Specifies the description of the VPC peering connection.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/vpc_peering_connection_accepter.md
+++ b/docs/resources/vpc_peering_connection_accepter.md
@@ -77,11 +77,13 @@ state file and management, but will not destroy the VPC Peering Connection.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `name` - The VPC peering connection name.
-
 * `id` - The VPC peering connection ID.
 
+* `name` - The VPC peering connection name.
+
 * `status` - The VPC peering connection status.
+
+* `description` - The description of the VPC peering connection.
 
 * `vpc_id` - The ID of requester VPC involved in a VPC peering connection.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86
+	github.com/chnsz/golangsdk v0.0.0-20230506090304-87303819e581
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86 h1:oWzyOHSL7cjZCCIEO4S9H1Zc5Pwn5HCI7fvpNxpiXUs=
-github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230506090304-87303819e581 h1:PItTABm3TkNQcii8i3pCzP9A+RM/Mk6ZinS6EGdQPK4=
+github.com/chnsz/golangsdk v0.0.0-20230506090304-87303819e581/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connection_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connection_test.go
@@ -25,6 +25,7 @@ func TestAccVpcPeeringConnectionDataSource_basic(t *testing.T) {
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "vpc1 peers to vpc2"),
 				),
 			},
 		},
@@ -100,21 +101,22 @@ func TestAccVpcPeeringConnectionDataSource_byVpcIds(t *testing.T) {
 func testAccVpcPeeringConnectionDataSource_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "vpc_1" {
-  name = "%s_1"
+  name = "%[1]s_1"
   cidr = "172.16.0.0/20"
 }
 
 resource "huaweicloud_vpc" "vpc_2" {
-  name = "%s_2"
+  name = "%[1]s_2"
   cidr = "172.16.128.0/20"
 }
 
 resource "huaweicloud_vpc_peering_connection" "test" {
-  name        = "%s"
+  name        = "%[1]s"
   vpc_id      = huaweicloud_vpc.vpc_1.id
   peer_vpc_id = huaweicloud_vpc.vpc_2.id
+  description = "vpc1 peers to vpc2"
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccVpcPeeringConnectionDataSource_basic(rName string) string {

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_peering_connection_test.go
@@ -26,6 +26,8 @@ func TestAccVpcPeeringConnection_basic(t *testing.T) {
 
 	randName := acceptance.RandomAccResourceName()
 	updateName := randName + "_update"
+	basicDesc := "vpc1 peers to vpc2"
+	updateDesc := "vpc1 peering to vpc2"
 	resourceName := "huaweicloud_vpc_peering_connection.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -40,19 +42,21 @@ func TestAccVpcPeeringConnection_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConnection_basic(randName),
+				Config: testAccVpcPeeringConnection_config(randName, randName, basicDesc),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "description", basicDesc),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_vpc_id", "huaweicloud_vpc.test2", "id"),
 				),
 			},
 			{
-				Config: testAccVpcPeeringConnection_basic(updateName),
+				Config: testAccVpcPeeringConnection_config(randName, updateName, updateDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", updateDesc),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_vpc_id", "huaweicloud_vpc.test2", "id"),
@@ -67,15 +71,15 @@ func TestAccVpcPeeringConnection_basic(t *testing.T) {
 	})
 }
 
-func testAccVpcPeeringConnection_basic(rName string) string {
+func testAccVpcPeeringConnection_config(vpcName, peerName, desc string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test1" {
-  name = "%s_1"
+  name = "%[1]s_1"
   cidr = "172.16.0.0/20"
 }
 
 resource "huaweicloud_vpc" "test2" {
-  name = "%s_2"
+  name = "%[1]s_2"
   cidr = "172.16.128.0/20"
 }
 
@@ -83,6 +87,7 @@ resource "huaweicloud_vpc_peering_connection" "test" {
   name        = "%s"
   vpc_id      = huaweicloud_vpc.test1.id
   peer_vpc_id = huaweicloud_vpc.test2.id
+  description = "%s"
 }
-`, rName, rName, rName)
+`, vpcName, peerName, desc)
 }

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connection.go
@@ -55,6 +55,10 @@ func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -100,6 +104,7 @@ func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceD
 		d.Set("region", region),
 		d.Set("name", item.Name),
 		d.Set("status", item.Status),
+		d.Set("description", item.Description),
 		d.Set("vpc_id", item.RequestVpcInfo.VpcId),
 		d.Set("peer_vpc_id", item.AcceptVpcInfo.VpcId),
 		d.Set("peer_tenant_id", item.AcceptVpcInfo.TenantId),

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection.go
@@ -61,6 +61,11 @@ func ResourceVpcPeeringConnectionV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -88,6 +93,7 @@ func resourceVPCPeeringCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	createOpts := peerings.CreateOpts{
 		Name:           d.Get("name").(string),
+		Description:    d.Get("description").(string),
 		RequestVpcInfo: requestvpcinfo,
 		AcceptVpcInfo:  acceptvpcinfo,
 	}
@@ -133,6 +139,7 @@ func resourceVPCPeeringRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("region", region),
 		d.Set("name", n.Name),
 		d.Set("status", n.Status),
+		d.Set("description", n.Description),
 		d.Set("vpc_id", n.RequestVpcInfo.VpcId),
 		d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId),
 		d.Set("peer_tenant_id", n.AcceptVpcInfo.TenantId),
@@ -154,7 +161,8 @@ func resourceVPCPeeringUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	updateOpts := peerings.UpdateOpts{
-		Name: d.Get("name").(string),
+		Name:        d.Get("name").(string),
+		Description: utils.String(d.Get("description").(string)),
 	}
 
 	_, err = peerings.Update(peeringClient, d.Id(), updateOpts).Extract()

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_peering_connection_accepter.go
@@ -56,6 +56,10 @@ func ResourceVpcPeeringConnectionAccepterV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -143,6 +147,7 @@ func resourceVpcPeeringAccepterRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("region", region),
 		d.Set("name", n.Name),
 		d.Set("status", n.Status),
+		d.Set("description", n.Description),
 		d.Set("vpc_id", n.RequestVpcInfo.VpcId),
 		d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId),
 		d.Set("peer_tenant_id", n.AcceptVpcInfo.TenantId),

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
@@ -80,6 +80,8 @@ type Spec struct {
 	RunTime *RunTimeSpec `json:"runtime,omitempty"`
 	// taints to created nodes to configure anti-affinity
 	Taints []TaintSpec `json:"taints,omitempty"`
+	// The name of the created partition
+	Partition string `json:"partition,omitempty"`
 }
 
 // Gives the Nic spec of the node

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/peerings/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/peerings/requests.go
@@ -137,24 +137,25 @@ func Reject(c *golangsdk.ServiceClient, id string) (r RejectResult) {
 	return
 }
 
-//CreateOptsBuilder is an interface by which can build the request body of vpc peering connection.
+// CreateOptsBuilder is an interface by which can build the request body of vpc peering connection.
 type CreateOptsBuilder interface {
 	ToPeeringCreateMap() (map[string]interface{}, error)
 }
 
-//CreateOpts is a struct which is used to create vpc peering connection.
+// CreateOpts is a struct which is used to create vpc peering connection.
 type CreateOpts struct {
 	Name           string  `json:"name"`
 	RequestVpcInfo VpcInfo `json:"request_vpc_info" required:"true"`
 	AcceptVpcInfo  VpcInfo `json:"accept_vpc_info" required:"true"`
+	Description    string  `json:"description,omitempty"`
 }
 
-//ToVpcPeeringCreateMap builds a create request body from CreateOpts.
+// ToVpcPeeringCreateMap builds a create request body from CreateOpts.
 func (opts CreateOpts) ToPeeringCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "peering")
 }
 
-//Create is a method by which can access to create the vpc peering connection.
+// Create is a method by which can access to create the vpc peering connection.
 func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPeeringCreateMap()
 	if err != nil {
@@ -167,28 +168,29 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 	return
 }
 
-//Delete is a method by which can be able to delete a vpc peering connection.
+// Delete is a method by which can be able to delete a vpc peering connection.
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(resourceURL(client, id), nil)
 	return
 }
 
-//UpdateOptsBuilder is an interface by which can be able to build the request body of vpc peering connection.
+// UpdateOptsBuilder is an interface by which can be able to build the request body of vpc peering connection.
 type UpdateOptsBuilder interface {
 	ToVpcPeeringUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the request body of update method.
+// UpdateOpts is a struct which represents the request body of update method.
 type UpdateOpts struct {
-	Name string `json:"name,omitempty"`
+	Name        string  `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
-//ToVpcPeeringUpdateMap builds a update request body from UpdateOpts.
+// ToVpcPeeringUpdateMap builds a update request body from UpdateOpts.
 func (opts UpdateOpts) ToVpcPeeringUpdateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "peering")
 }
 
-//Update is a method which can be able to update the name of vpc peering connection.
+// Update is a method which can be able to update the name of vpc peering connection.
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToVpcPeeringUpdateMap()
 	if err != nil {

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/peerings/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/peerings/results.go
@@ -11,7 +11,7 @@ type VpcInfo struct {
 }
 
 // Peering represents a Neutron VPC peering connection.
-//Manage and perform other operations on VPC peering connections,
+// Manage and perform other operations on VPC peering connections,
 // including querying VPC peering connections as well as
 // creating, querying, deleting, and updating a VPC peering connection.
 type Peering struct {
@@ -25,10 +25,13 @@ type Peering struct {
 	// Status indicates whether or not a vpc_peering_connections is currently operational.
 	Status string `json:"status"`
 
+	// Description is the supplementary information about the VPC peering connection.
+	Description string `json:"description"`
+
 	// RequestVpcInfo indicates information about the local VPC
 	RequestVpcInfo VpcInfo `json:"request_vpc_info"`
 
-	// AcceptVpcInfo indicates information about the peer  VPC
+	// AcceptVpcInfo indicates information about the peer VPC
 	AcceptVpcInfo VpcInfo `json:"accept_vpc_info"`
 }
 
@@ -94,10 +97,13 @@ func (r commonResult) ExtractResult() (Peering, error) {
 		// Status indicates whether or not a vpc is currently operational.
 		Status string `json:"status"`
 
-		// Status indicates whether or not a vpc is currently operational.
+		// Description is the supplementary information about the VPC peering connection.
+		Description string `json:"description"`
+
+		// RequestVpcInfo indicates information about the local VPC
 		RequestVpcInfo VpcInfo `json:"request_vpc_info"`
 
-		//Provides informaion about shared snat
+		// AcceptVpcInfo indicates information about the peer VPC
 		AcceptVpcInfo VpcInfo `json:"accept_vpc_info"`
 	}
 	err1 := r.ExtractInto(&s)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86
+# github.com/chnsz/golangsdk v0.0.0-20230506090304-87303819e581
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

support `description` param

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcPeeringConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcPeeringConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnection_basic
=== PAUSE TestAccVpcPeeringConnection_basic
=== CONT  TestAccVpcPeeringConnection_basic
--- PASS: TestAccVpcPeeringConnection_basic (49.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       49.868s

$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcPeeringConnectionDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcPeeringConnectionDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcPeeringConnectionDataSource_basic
=== PAUSE TestAccVpcPeeringConnectionDataSource_basic
=== CONT  TestAccVpcPeeringConnectionDataSource_basic
--- PASS: TestAccVpcPeeringConnectionDataSource_basic (43.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       43.193s
```
