### PR TITLE
feat(Live): add live bucket authorization resource

### DIFF
--- a/docs/resources/live_bucket_authorization.md
+++ b/docs/resources/live_bucket_authorization.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Live"
+---
+
+# huaweicloud_live_bucket_authorization
+
+Manages a Live bucket authorization resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "bucket" {}
+
+resource "huaweicloud_live_bucket_authorization" "test"{
+  bucket = var.bucket
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `bucket` - (Required, String, ForceNew) Specifies the bucket name of the OBS.
+
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The live bucket authorize can be imported using the `bucket`, e.g.
+
+```bash
+$ terraform import huaweicloud_live_bucket_authorization.test <bucket>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -868,10 +868,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_pool":         lb.ResourcePoolV2(),
 			"huaweicloud_lb_whitelist":    lb.ResourceWhitelistV2(),
 
-			"huaweicloud_live_domain":          live.ResourceDomain(),
-			"huaweicloud_live_recording":       live.ResourceRecording(),
-			"huaweicloud_live_record_callback": live.ResourceRecordCallback(),
-			"huaweicloud_live_transcoding":     live.ResourceTranscoding(),
+			"huaweicloud_live_domain":               live.ResourceDomain(),
+			"huaweicloud_live_recording":            live.ResourceRecording(),
+			"huaweicloud_live_record_callback":      live.ResourceRecordCallback(),
+			"huaweicloud_live_transcoding":          live.ResourceTranscoding(),
+			"huaweicloud_live_bucket_authorization": live.ResourceLiveBucketAuthorization(),
 
 			"huaweicloud_lts_group":  ResourceLTSGroupV2(),
 			"huaweicloud_lts_stream": ResourceLTSStreamV2(),

--- a/huaweicloud/services/acceptance/live/resource_huaweicloud_live_bucket_authorization_test.go
+++ b/huaweicloud/services/acceptance/live/resource_huaweicloud_live_bucket_authorization_test.go
@@ -1,0 +1,50 @@
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccLiveBucketAuthorization_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceNameWithDash()
+	rName := "huaweicloud_live_bucket_authorization.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testLiveBucketAuthorization_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "bucket", name),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testLiveBucketAuthorization_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_live_bucket_authorization" "test" {
+  depends_on = [huaweicloud_obs_bucket.test]
+
+  bucket = "%[1]s"
+}
+`, name)
+}

--- a/huaweicloud/services/live/resource_huaweicloud_live_bucket_authorization.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_bucket_authorization.go
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product Live
+// ---------------------------------------------------------------
+
+package live
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceLiveBucketAuthorization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLiveBucketAuthorizationCreate,
+		ReadContext:   resourceLiveBucketAuthorizationRead,
+		DeleteContext: resourceLiveBucketAuthorizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"bucket": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the bucket name of the OBS.`,
+			},
+		},
+	}
+}
+
+func resourceLiveBucketAuthorizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createLiveBucketAuthorization: create Live bucket authorization
+	var (
+		createLiveBucketAuthorizationHttpUrl = "v1/{project_id}/obs/authority"
+		createLiveBucketAuthorizationProduct = "live"
+	)
+	createLiveBucketAuthorizationClient, err := cfg.NewServiceClient(createLiveBucketAuthorizationProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Live Client: %s", err)
+	}
+
+	createLiveBucketAuthorizationPath := createLiveBucketAuthorizationClient.Endpoint + createLiveBucketAuthorizationHttpUrl
+	createLiveBucketAuthorizationPath = strings.ReplaceAll(createLiveBucketAuthorizationPath, "{project_id}",
+		createLiveBucketAuthorizationClient.ProjectID)
+
+	createLiveBucketAuthorizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createLiveBucketAuthorizationOpt.JSONBody = utils.RemoveNil(buildLiveBucketAuthorizationBodyParams(d, 1))
+	_, err = createLiveBucketAuthorizationClient.Request("PUT", createLiveBucketAuthorizationPath,
+		&createLiveBucketAuthorizationOpt)
+	if err != nil {
+		return diag.Errorf("error creating Live bucket Authorization: %s", err)
+	}
+
+	d.SetId(d.Get("bucket").(string))
+
+	return resourceLiveBucketAuthorizationRead(ctx, d, meta)
+}
+
+func buildLiveBucketAuthorizationBodyParams(d *schema.ResourceData, operation int) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bucket":    utils.ValueIngoreEmpty(d.Get("bucket")),
+		"operation": operation,
+	}
+	return bodyParams
+}
+
+func resourceLiveBucketAuthorizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("bucket", d.Id()),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceLiveBucketAuthorizationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteLiveBucketAuthorization: Delete Live bucket Authorization
+	var (
+		deleteLiveBucketAuthorizationHttpUrl = "v1/{project_id}/obs/authority"
+		deleteLiveBucketAuthorizationProduct = "live"
+	)
+	deleteLiveBucketAuthorizationClient, err := cfg.NewServiceClient(deleteLiveBucketAuthorizationProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Live Client: %s", err)
+	}
+
+	deleteLiveBucketAuthorizationPath := deleteLiveBucketAuthorizationClient.Endpoint + deleteLiveBucketAuthorizationHttpUrl
+	deleteLiveBucketAuthorizationPath = strings.ReplaceAll(deleteLiveBucketAuthorizationPath, "{project_id}",
+		deleteLiveBucketAuthorizationClient.ProjectID)
+
+	deleteLiveBucketAuthorizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	deleteLiveBucketAuthorizationOpt.JSONBody = utils.RemoveNil(buildLiveBucketAuthorizationBodyParams(d, 0))
+	_, err = deleteLiveBucketAuthorizationClient.Request("PUT", deleteLiveBucketAuthorizationPath,
+		&deleteLiveBucketAuthorizationOpt)
+	if err != nil {
+		return diag.Errorf("error deleting Live bucket Authorization: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add live bucket authorize resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add live bucket authorize resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/live/' TESTARGS='-run TestAccLiveBucketAuthorize_basic'            
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/live/ -v -run TestAccLiveBucketAuthorize_basic -timeout 360m -parallel 4 
=== RUN   TestAccLiveBucketAuthorize_basic 
=== PAUSE TestAccLiveBucketAuthorize_basic
=== CONT  TestAccLiveBucketAuthorize_basic
--- PASS: TestAccLiveBucketAuthorize_basic (15.20s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      15.256s
```
