### PR TITLE
feat(util/json): support a function to compare two json strings

### DIFF
--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -468,4 +469,38 @@ func Reverse(s string) string {
 		right--
 	}
 	return string(bs)
+}
+
+func jsonBytesEqual(b1, b2 []byte) bool {
+	var o1 interface{}
+	if err := json.Unmarshal(b1, &o1); err != nil {
+		return false
+	}
+
+	var o2 interface{}
+	if err := json.Unmarshal(b2, &o2); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(o1, o2)
+}
+
+// JSONStringsEqual is the function for comparing the contents of two json strings regardless of their formatting.
+// Tabs (\r \n \t) and the order of elements are not included in the comparison.
+// These json strings are same:
+// + "{\n\"key1\":\"value1\",\n\"key2\":\"value2\"\n}"
+// + "{\"key1\":\"value1\",\"key2\":\"value2\"}"
+// + "{\"key2\":\"value2\",\"key1\":\"value1\"}"
+func JSONStringsEqual(s1, s2 string) bool {
+	b1 := bytes.NewBufferString("")
+	if err := json.Compact(b1, []byte(s1)); err != nil {
+		return false
+	}
+
+	b2 := bytes.NewBufferString("")
+	if err := json.Compact(b2, []byte(s2)); err != nil {
+		return false
+	}
+
+	return jsonBytesEqual(b1.Bytes(), b2.Bytes())
 }

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -68,3 +68,16 @@ func TestAccFunction_reverse(t *testing.T) {
 	}
 	t.Logf("The processing result of function 'Reverse' meets expectation: %s", green(expected))
 }
+
+func TestAccFunction_jsonStringsEqual(t *testing.T) {
+	var (
+		jsonStr1 = "{\n\"key1\":\"value1\",\n\"key2\":\"value2\"\n}"
+		jsonStr2 = "{\"key2\":\"value2\",\"key1\":\"value1\"}"
+	)
+
+	if !JSONStringsEqual(jsonStr1, jsonStr2) {
+		t.Fatalf("The processing result of the function 'JSONStringsEqual' is not as expected, want '%v', "+
+			"but got '%v'", green(true), yellow(false))
+	}
+	t.Logf("The processing result of function 'JSONStringsEqual' meets expectation: %s", green(true))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Support a new tion to compare two json strings.
2. Support the related acc test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a function to compare two json strings
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
go test -v -run=TestAccFunction_jsonStringsEqual
=== RUN   TestAccFunction_jsonStringsEqual
    utils_test.go:82: The processing result of function 'JSONStringsEqual' meets expectation: true
--- PASS: TestAccFunction_jsonStringsEqual (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.016s
```
