### PR TITLE
fix(RDS): fix rds test

### DIFF
--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -553,8 +553,6 @@ resource "huaweicloud_rds_instance" "test" {
 
 func testAccRdsInstance_sqlserver(name, pwd string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_vpc" "test" {
@@ -565,10 +563,14 @@ data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
 
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
 resource "huaweicloud_rds_instance" "test" {
   name                = "%s"
   flavor              = "rds.mssql.spec.se.c6.large.4"
-  security_group_id   = huaweicloud_networking_secgroup.test.id
+  security_group_id   = data.huaweicloud_networking_secgroup.test.id
   subnet_id           = data.huaweicloud_vpc_subnet.test.id
   vpc_id              = data.huaweicloud_vpc.test.id
   collation           = "Chinese_PRC_CI_AS"
@@ -589,7 +591,7 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, common.TestBaseNetwork(name), name, pwd)
+`, name, pwd)
 }
 
 func testAccRdsInstance_prePaid(name, pwd string, isAutoRenew bool) string {

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
@@ -115,8 +115,6 @@ func testAccReadReplicaInstance_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_availability_zones" "test" {}
-
 resource "huaweicloud_rds_read_replica_instance" "test" {
   name                = "%s"
   flavor              = "rds.pg.n1.large.2.rr"
@@ -132,14 +130,12 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     foo = "bar"
   }
 }
-`, common.TestBaseNetwork(name), name)
+`, testAccReadReplicaInstance_base(name), name)
 }
 
 func testAccReadReplicaInstance_update(name string) string {
 	return fmt.Sprintf(`
 %s
-
-data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_rds_read_replica_instance" "test" {
   name                = "%s"
@@ -156,14 +152,12 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     foo = "bar2"
   }
 }
-`, common.TestBaseNetwork(name), name)
+`, testAccReadReplicaInstance_base(name), name)
 }
 
 func testAccReadReplicaInstance_withEpsId(name string) string {
 	return fmt.Sprintf(`
 %s
-
-data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_rds_read_replica_instance" "test" {
   name                  = "%s"
@@ -176,5 +170,5 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     type = "CLOUDSSD"
   }
 }
-`, common.TestBaseNetwork(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccReadReplicaInstance_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds test
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccReadReplicaInstance_' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_ -timeout 360m -parallel 4 
=== RUN   TestAccReadReplicaInstance_basic 
=== PAUSE TestAccReadReplicaInstance_basic
=== RUN   TestAccReadReplicaInstance_withEpsId
=== PAUSE TestAccReadReplicaInstance_withEpsId
=== CONT  TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_withEpsId
--- PASS: TestAccReadReplicaInstance_withEpsId (874.86s) 
--- PASS: TestAccReadReplicaInstance_basic (1170.24s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1170.287s


make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsInstance_sqlserver'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_sqlserver -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_sqlserver
--- PASS: TestAccRdsInstance_sqlserver (683.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       683.324s
```
