### PR TITLE
fix(AS): fix as test error

### DIFF
--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
@@ -246,6 +246,7 @@ resource "huaweicloud_ces_alarmrule" "alarmrule_1" {
     value               = 3600
     unit                = "bit/s"
     count               = 2
+    suppress_duration   = 300
   }
 
   alarm_actions {

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -270,6 +270,7 @@ resource "huaweicloud_ces_alarmrule" "alarm_rule" {
     value               = 60
     unit                = "%%"
     count               = 1
+    suppress_duration   = 300
   }
   alarm_actions {
     type              = "autoscaling"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix as test error
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- the error message `error: After applying this test step, the plan was not empty` cause resource_huaweicloud_ces_alarmrule.
For the field `conditon` hash method ignored default value `0`, this error will fix in another PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASBandWidthPolicy_alarm'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_alarm -timeout 360m -parallel 4 
=== RUN   TestAccASBandWidthPolicy_alarm 
=== PAUSE TestAccASBandWidthPolicy_alarm
=== CONT  TestAccASBandWidthPolicy_alarm
--- PASS: TestAccASBandWidthPolicy_alarm (26.72s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        26.773s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceASGroup_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceASGroup_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceASGroup_basic 
=== PAUSE TestAccDataSourceASGroup_basic
=== CONT  TestAccDataSourceASGroup_basic
--- PASS: TestAccDataSourceASGroup_basic (147.71s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        147.763s
```

