### PR TITLE
feat(aom): add new resource alarm action rule

### DIFF
--- a/docs/resources/aom_alarm_action_rule.md
+++ b/docs/resources/aom_alarm_action_rule.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Application Operations Management (AOM)"
+---
+
+# huaweicloud_aom_alarm_action_rule
+
+Manages an AOM alarm action rule resource within HuaweiCloud.
+
+~> This resource can only be used in region **cn-east-3** for now.
+
+## Example Usage
+
+```hcl
+variable "topic_urn" {}
+
+resource "huaweicloud_aom_alarm_action_rule" "test" {
+  name                  = "test_rule"
+  description           = "terraform test"
+  type                  = "1"
+  notification_template = "aom.built-in.template.zh"
+
+  smn_topics {
+    topic_urn = var.topic_urn
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the action rule name. The value can be a string of 1 to 100
+  characters that can consist of letters, digits, underscores (_), hyphens (-) and Chinese characters,
+  and it must start and end with letters, digits or Chinese characters.
+
+  Changing this parameter will create a new resource.
+
+* `type` - (Required, String) Specifies the action rule type. The value can be **1**, which indicates notification.
+
+* `smn_topics` - (Required, List) Specifies the SMN topic configurations. A maximum of 5 topics are allowed.
+  The [SmnTopics](#AlarmActionRule_SmnTopics) structure is documented below.
+
+* `notification_template` - (Required, String) Specifies the notification template.
+
+* `description` - (Optional, String) Specifies the action rule description.
+  The value can be a string of 0 to 1024 characters.
+
+<a name="AlarmActionRule_SmnTopics"></a>
+The `SmnTopics` block supports:
+
+* `topic_urn` - (Required, String) Specifies the SMN topic URN.
+
+* `name` - (Optional, String) Specifies the SMN topic name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the rule name.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The last update time.
+
+## Import
+
+The application operations management can be imported using the `id` (name), e.g.
+
+```bash
+$ terraform import huaweicloud_aom_alarm_action_rule.test test_rule
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -619,6 +619,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_aom_alarm_rule":             aom.ResourceAlarmRule(),
 			"huaweicloud_aom_service_discovery_rule": aom.ResourceServiceDiscoveryRule(),
+			"huaweicloud_aom_alarm_action_rule":      aom.ResourceAlarmActionRule(),
 
 			"huaweicloud_rfs_stack": rfs.ResourceStack(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -651,3 +651,10 @@ func TestAccPreCheckCcePartitionAz(t *testing.T) {
 		t.Skip("Skip the interface acceptance test because of the cce partition az is missing.")
 	}
 }
+
+// lintignore:AT003
+func TestAccPreCheckCnEast3(t *testing.T) {
+	if HW_REGION_NAME != "cn-east-3" {
+		t.Skip("HW_REGION_NAME must be cn-east-3 for this test.")
+	}
+}

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_action_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_action_rule_test.go
@@ -1,0 +1,150 @@
+package aom
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAlarmActionRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getAlarmActionRule: Query the Alarm Action Rule
+	var (
+		getAlarmActionRuleHttpUrl = "v2/{project_id}/alert/action-rules/{id}"
+		getAlarmActionRuleProduct = "aom"
+	)
+	getAlarmActionRuleClient, err := cfg.NewServiceClient(getAlarmActionRuleProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOM Client: %s", err)
+	}
+
+	getAlarmActionRulePath := getAlarmActionRuleClient.Endpoint + getAlarmActionRuleHttpUrl
+	getAlarmActionRulePath = strings.ReplaceAll(getAlarmActionRulePath, "{project_id}", getAlarmActionRuleClient.ProjectID)
+	getAlarmActionRulePath = strings.ReplaceAll(getAlarmActionRulePath, "{id}", state.Primary.ID)
+
+	getAlarmActionRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	getAlarmActionRuleOpt.MoreHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+	getAlarmActionRuleResp, err := getAlarmActionRuleClient.Request("GET", getAlarmActionRulePath, &getAlarmActionRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AlarmActionRule: %s", err)
+	}
+	return utils.FlattenResponse(getAlarmActionRuleResp)
+}
+
+func TestAccAlarmActionRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_aom_alarm_action_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAlarmActionRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCnEast3(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAlarmActionRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "type", "1"),
+					resource.TestCheckResourceAttr(rName, "notification_template", "aom.built-in.template.zh"),
+					resource.TestCheckResourceAttrPair(rName, "smn_topics.0.topic_urn",
+						"huaweicloud_smn_topic.topic_1", "topic_urn"),
+				),
+			},
+			{
+				Config: testAlarmActionRule_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(rName, "type", "1"),
+					resource.TestCheckResourceAttr(rName, "notification_template", "aom.built-in.template.en"),
+					resource.TestCheckResourceAttrPair(rName, "smn_topics.0.topic_urn",
+						"huaweicloud_smn_topic.topic_1", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "smn_topics.1.topic_urn",
+						"huaweicloud_smn_topic.topic_2", "topic_urn"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAlarmActionRule_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "topic_1" {
+  name = "%[1]s_1"
+}
+
+resource "huaweicloud_aom_alarm_action_rule" "test" {
+  name                  = "%[1]s"
+  description           = "terraform test"
+  type                  = "1"
+  notification_template = "aom.built-in.template.zh"
+
+  smn_topics {
+    topic_urn = huaweicloud_smn_topic.topic_1.topic_urn
+  }
+}
+`, name)
+}
+
+func testAlarmActionRule_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "topic_1" {
+  name = "%[1]s_1"
+}
+
+resource "huaweicloud_smn_topic" "topic_2" {
+  name = "%[1]s_2"
+}
+
+resource "huaweicloud_aom_alarm_action_rule" "test" {
+  name                  = "%[1]s"
+  description           = "terraform test update"
+  type                  = "1"
+  notification_template = "aom.built-in.template.en"
+
+  smn_topics {
+    topic_urn = huaweicloud_smn_topic.topic_1.topic_urn
+  }
+
+  smn_topics {
+    topic_urn = huaweicloud_smn_topic.topic_2.topic_urn
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_action_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_action_rule.go
@@ -1,0 +1,313 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product AOM
+// ---------------------------------------------------------------
+
+package aom
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceAlarmActionRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlarmActionRuleCreate,
+		UpdateContext: resourceAlarmActionRuleUpdate,
+		ReadContext:   resourceAlarmActionRuleRead,
+		DeleteContext: resourceAlarmActionRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the action rule name.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the action rule type.`,
+			},
+			"smn_topics": {
+				Type:        schema.TypeList,
+				Elem:        AlarmActionRuleSmnTopicsSchema(),
+				Required:    true,
+				Description: `Specifies the SMN topic configurations.`,
+			},
+			"notification_template": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the notification template.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the action rule description.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The last update time.`,
+			},
+		},
+	}
+}
+
+func AlarmActionRuleSmnTopicsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the SMN topic URN.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the SMN topic name.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceAlarmActionRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createAlarmActionRule: create a Alarm Action Rule.
+	var (
+		createAlarmActionRuleHttpUrl = "v2/{project_id}/alert/action-rules"
+		createAlarmActionRuleProduct = "aom"
+	)
+	createAlarmActionRuleClient, err := cfg.NewServiceClient(createAlarmActionRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	createAlarmActionRulePath := createAlarmActionRuleClient.Endpoint + createAlarmActionRuleHttpUrl
+	createAlarmActionRulePath = strings.ReplaceAll(createAlarmActionRulePath, "{project_id}", createAlarmActionRuleClient.ProjectID)
+
+	createAlarmActionRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createAlarmActionRuleOpt.JSONBody = utils.RemoveNil(buildAlarmActionRuleBodyParams(d))
+	_, err = createAlarmActionRuleClient.Request("POST", createAlarmActionRulePath, &createAlarmActionRuleOpt)
+	if err != nil {
+		return diag.Errorf("error creating AlarmActionRule: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceAlarmActionRuleRead(ctx, d, meta)
+}
+
+func buildAlarmActionRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"rule_name":             utils.ValueIngoreEmpty(d.Get("name")),
+		"desc":                  utils.ValueIngoreEmpty(d.Get("description")),
+		"type":                  utils.ValueIngoreEmpty(d.Get("type")),
+		"smn_topics":            buildAlarmActionRuleRequestBodySmnTopics(d.Get("smn_topics")),
+		"notification_template": utils.ValueIngoreEmpty(d.Get("notification_template")),
+	}
+	return bodyParams
+}
+
+func buildAlarmActionRuleRequestBodySmnTopics(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"topic_urn": utils.ValueIngoreEmpty(raw["topic_urn"]),
+			}
+
+			if raw["name"] != "" {
+				rst[i]["name"] = raw["name"]
+			} else {
+				parts := strings.Split(raw["topic_urn"].(string), ":")
+				rst[i]["name"] = parts[len(parts)-1]
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceAlarmActionRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getAlarmActionRule: Query the Alarm Action Rule
+	var (
+		getAlarmActionRuleHttpUrl = "v2/{project_id}/alert/action-rules/{id}"
+		getAlarmActionRuleProduct = "aom"
+	)
+	getAlarmActionRuleClient, err := cfg.NewServiceClient(getAlarmActionRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	getAlarmActionRulePath := getAlarmActionRuleClient.Endpoint + getAlarmActionRuleHttpUrl
+	getAlarmActionRulePath = strings.ReplaceAll(getAlarmActionRulePath, "{project_id}", getAlarmActionRuleClient.ProjectID)
+	getAlarmActionRulePath = strings.ReplaceAll(getAlarmActionRulePath, "{id}", d.Id())
+
+	getAlarmActionRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	getAlarmActionRuleOpt.MoreHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+	getAlarmActionRuleResp, err := getAlarmActionRuleClient.Request("GET", getAlarmActionRulePath, &getAlarmActionRuleOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving AlarmActionRule")
+	}
+
+	getAlarmActionRuleRespBody, err := utils.FlattenResponse(getAlarmActionRuleResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("rule_name", getAlarmActionRuleRespBody, nil)),
+		d.Set("description", utils.PathSearch("desc", getAlarmActionRuleRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getAlarmActionRuleRespBody, nil)),
+		d.Set("smn_topics", flattenGetAlarmActionRuleResponseBodySmnTopics(getAlarmActionRuleRespBody)),
+		d.Set("notification_template", utils.PathSearch("notification_template", getAlarmActionRuleRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", getAlarmActionRuleRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", getAlarmActionRuleRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetAlarmActionRuleResponseBodySmnTopics(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("smn_topics", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"topic_urn": utils.PathSearch("topic_urn", v, nil),
+			"name":      utils.PathSearch("name", v, nil),
+		})
+	}
+	return rst
+}
+
+func resourceAlarmActionRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateAlarmActionRuleChanges := []string{
+		"description",
+		"type",
+		"smn_topics",
+		"notification_template",
+	}
+
+	if d.HasChanges(updateAlarmActionRuleChanges...) {
+		// updateAlarmActionRule: update the Alarm Action Rule
+		var (
+			updateAlarmActionRuleHttpUrl = "v2/{project_id}/alert/action-rules"
+			updateAlarmActionRuleProduct = "aom"
+		)
+		updateAlarmActionRuleClient, err := cfg.NewServiceClient(updateAlarmActionRuleProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating AOM Client: %s", err)
+		}
+
+		updateAlarmActionRulePath := updateAlarmActionRuleClient.Endpoint + updateAlarmActionRuleHttpUrl
+		updateAlarmActionRulePath = strings.ReplaceAll(updateAlarmActionRulePath, "{project_id}", updateAlarmActionRuleClient.ProjectID)
+
+		updateAlarmActionRuleOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				204,
+			},
+		}
+		updateAlarmActionRuleOpt.JSONBody = utils.RemoveNil(buildAlarmActionRuleBodyParams(d))
+		_, err = updateAlarmActionRuleClient.Request("PUT", updateAlarmActionRulePath, &updateAlarmActionRuleOpt)
+		if err != nil {
+			return diag.Errorf("error updating AlarmActionRule: %s", err)
+		}
+	}
+	return resourceAlarmActionRuleRead(ctx, d, meta)
+}
+
+func resourceAlarmActionRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteAlarmActionRule: delete the Alarm Action Rule
+	var (
+		deleteAlarmActionRuleHttpUrl = "v2/{project_id}/alert/action-rules"
+		deleteAlarmActionRuleProduct = "aom"
+	)
+	deleteAlarmActionRuleClient, err := cfg.NewServiceClient(deleteAlarmActionRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	deleteAlarmActionRulePath := deleteAlarmActionRuleClient.Endpoint + deleteAlarmActionRuleHttpUrl
+	deleteAlarmActionRulePath = strings.ReplaceAll(deleteAlarmActionRulePath, "{project_id}", deleteAlarmActionRuleClient.ProjectID)
+
+	deleteAlarmActionRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	deleteAlarmActionRuleOpt.JSONBody = []string{d.Id()}
+	_, err = deleteAlarmActionRuleClient.Request("DELETE", deleteAlarmActionRulePath, &deleteAlarmActionRuleOpt)
+	if err != nil {
+		return diag.Errorf("error deleting AlarmActionRule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAlarmActionRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAlarmActionRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAlarmActionRule_basic
=== PAUSE TestAccAlarmActionRule_basic
=== CONT  TestAccAlarmActionRule_basic
--- PASS: TestAccAlarmActionRule_basic (30.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       30.901s
```
