### PR TITLE
feat(apig/plugin): add a new resource support

### DIFF
--- a/docs/resources/apig_plugin.md
+++ b/docs/resources/apig_plugin.md
@@ -1,0 +1,409 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_plugin
+
+Manages a plugin resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a CORS plugin
+
+```hcl
+variable "instance_id" {}
+variable "plugin_name" {}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = var.instance_id
+  name        = var.plugin_name
+  type        = "cors"
+  content     = jsonencode(
+    {
+      allow_origin      = "*"
+      allow_methods     = "GET,PUT,DELETE,HEAD,PATCH"
+      allow_headers     = "Content-Type,Accept,Cache-Control"
+      expose_headers    = "X-Request-Id,X-Apig-Latency"
+      max_age           = 12700
+      allow_credentials = true
+    }
+  )
+}
+```
+
+### Create an HTTP Response Header Management plugin
+
+```hcl
+variable "instance_id" {}
+variable "plugin_name" {}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = var.instance_id
+  name        = var.plugin_name
+  type        = "set_resp_headers"
+  content     = jsonencode(
+    {
+      response_headers = [{
+        name   = "X-Custom-Pwd"
+        value  = "**********"
+        action = "override"
+      },
+      {
+        name   = "X-Custom-Debug-Step"
+        value  = "Beta"
+        action = "skip"
+      },
+      {
+        name   = "X-Custom-Config"
+        value  = "<HTTP response test>"
+        action = "append"
+      },
+      {
+        name   = "X-Custom-Id"
+        value  = ""
+        action = "delete"
+      },
+      {
+        name   = "X-Custom-Log-Level"
+        value  = "DEBUG"
+        action = "add"
+      }]
+    }
+  )
+}
+```
+
+### Create a Request Throttling 2.0 plugin
+
+```hcl
+variable "instance_id" {}
+variable "plugin_name" {}
+variable "application_id" {}
+variable "user_id" {}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = var.instance_id
+  name        = var.plugin_name
+  type        = "rate_limit"
+  content     = jsonencode(
+    {
+      "scope": "basic",
+      "default_time_unit": "minute",
+      "default_interval": 1,
+      "api_limit": 25,
+      "app_limit": 10,
+      "user_limit": 15,
+      "ip_limit": 25,
+      "algorithm": "counter",
+      "specials": [
+        {
+          "type": "app",
+          "policies": [
+            {
+              "key": "${var.application_id}",
+              "limit": 10
+            }
+          ]
+        },
+        {
+          "type": "user",
+          "policies": [
+            {
+              "key": "${var.user_id}",
+              "limit": 10
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "type": "path",
+          "name": "reqPath",
+          "value": "reqPath"
+        },
+        {
+          "type": "method",
+          "name": "method",
+          "value": "method"
+        },
+        {
+          "type": "system",
+          "name": "serverName",
+          "value": "serverName"
+        }
+      ],
+      "rules": [
+        {
+          "rule_name": "rule-0001",
+          "match_regex": "[\"AND\",[\"method\",\"~=\",\"POST\"],[\"method\",\"~=\",\"PATCH\"]]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 20
+        },
+        {
+          "rule_name": "rule-0002",
+          "match_regex": "[\"reqPath\",\"~~\",\"/terraform/test/*/\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 10
+        },
+        {
+          "rule_name": "rule-0003",
+          "match_regex": "[\"serverName\",\"==\",\"terraform\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 15
+        },
+        {
+          "rule_name": "rule-0004",
+          "match_regex": "[\"method\",\"in\",\"PATCH\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 5
+        }
+      ]
+    }
+  )
+}
+```
+
+### Create a Kafka Log Push plugin
+
+```hcl
+variable "instance_id" {}
+variable "plugin_name" {}
+variable "connect_addresses" {
+  type = list(string)
+}
+variable "topic_name" {}
+variable "connect_port" {}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = var.instance_id
+  name        = var.plugin_name
+  type        = "kafka_log"
+  content     = jsonencode(
+    {
+      "broker_list": [for v in var.connect_addresses: format("%s:%d", v, var.connect_port)],
+      "topic": "${var.topic_name}",
+      "key": "",
+      "max_retry_count": 3,
+      "retry_backoff": 10,
+      "sasl_config": {
+        "security_protocol": "PLAINTEXT",
+        "sasl_mechanisms": "PLAIN",
+        "sasl_username": "",
+        "sasl_password": "",
+        "ssl_ca_content": ""
+      },
+      "meta_config": {
+        "system": {
+          "start_time": true,
+          "request_id": true,
+          "client_ip": true,
+          "api_id": false,
+          "user_name": false,
+          "app_id": false,
+          "access_model1": false,
+          "request_time": true,
+          "http_status": true,
+          "server_protocol": false,
+          "scheme": true,
+          "request_method": true,
+          "host": false,
+          "api_uri_mode": false,
+          "uri": false,
+          "request_size": false,
+          "response_size": false,
+          "upstream_uri": false,
+          "upstream_addr": true,
+          "upstream_status": true,
+          "upstream_connect_time": false,
+          "upstream_header_time": false,
+          "upstream_response_time": true,
+          "all_upstream_response_time": false,
+          "region_id": false,
+          "auth_type": false,
+          "http_x_forwarded_for": true,
+          "http_user_agent": true,
+          "error_type": true,
+          "access_model2": false,
+          "inner_time": false,
+          "proxy_protocol_vni": false,
+          "proxy_protocol_vpce_id": false,
+          "proxy_protocol_addr": false,
+          "body_bytes_sent": false,
+          "api_name": false,
+          "app_name": false,
+          "provider_app_id": false,
+          "provider_app_name": false,
+          "custom_data_log01": false,
+          "custom_data_log02": false,
+          "custom_data_log03": false,
+          "custom_data_log04": false,
+          "custom_data_log05": false,
+          "custom_data_log06": false,
+          "custom_data_log07": false,
+          "custom_data_log08": false,
+          "custom_data_log09": false,
+          "custom_data_log10": false,
+          "response_source": false
+        },
+        "call_data": {
+          "log_request_header": true,
+          "log_request_query_string": true,
+          "log_request_body": true,
+          "log_response_header": true,
+          "log_response_body": true,
+          "request_header_filter": "X-Custom-Auth-Type",
+          "request_query_string_filter": "authId",
+          "response_header_filter": "X-Trace-Id",
+          "custom_authorizer": {
+            "frontend": [
+              "user_name",
+              "user_age"
+            ],
+            "backend": [
+              "userName",
+              "userAge"
+            ]
+          }
+        }
+      }
+    }
+  )
+}
+```
+
+### Create a Circuit Breaker plugin
+
+```hcl
+variable "instance_id" {}
+variable "plugin_name" {}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = var.instance_id
+  name        = var.plugin_name
+  type        = "breaker"
+  content     = jsonencode(
+    {
+      "breaker_condition": {
+        "breaker_type": "condition",
+        "breaker_mode": "counter",
+        "unhealthy_condition": "[\"OR\",[\"$context.statusCode\",\"in\",\"500,501,504\"],[\"$context.backendResponseTime\",\">\",6000]]",
+        "unhealthy_threshold": 30,
+        "min_call_threshold": 20,
+        "unhealthy_percentage": 51,
+        "time_window": 15,
+        "open_breaker_time": 15
+      },
+      "downgrade_default": null,
+      "downgrade_parameters": [
+        {
+          "type": "path",
+          "name": "reqPath",
+          "value": "reqPath"
+        },
+        {
+          "type": "method",
+          "name": "method",
+          "value": "method"
+        },
+        {
+          "type": "query",
+          "name": "authType",
+          "value": "authType"
+        }
+      ],
+      "downgrade_rules": [
+        {
+          "breaker_condition": {
+            "breaker_type": "timeout",
+            "breaker_mode": "percentage",
+            "unhealthy_condition": "",
+            "unhealthy_threshold": 30,
+            "min_call_threshold": 20,
+            "unhealthy_percentage": 51,
+            "time_window": 15,
+            "open_breaker_time": 15
+          },
+          "downgrade_backend": null,
+          "rule_name": "rule-qkqe",
+          "match_regex": "[\"authType\",\"~=\",\"Token\"]",
+          "parameters": [
+            "reqPath",
+            "method",
+            "authType"
+          ]
+        }
+      ],
+      "scope": "basic"
+    }
+  )
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the plugin is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the plugin
+  belongs.  
+  Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the plugin name.  
+  The valid length is limited from `3` to `255`, only Chinese characters, English letters, digits, hyphens (-) and
+  underscores (_) are allowed. The name must start with an English letter or Chinese character.
+
+* `type` - (Required, String, ForceNew) Specifies the plugin type.  
+  The valid values are as follows:
+  + **cors**: CORS, specify preflight request headers and response headers and automatically create preflight request
+    APIs for cross-origin API access.
+  + **set_resp_headers**: HTTP Response Header Management, customize HTTP headers that will be contained in an API
+    response.
+  + **rate_limit**: Request Throttling 2.0, limits the number of times an API can be called within a specific time
+    period. It supports parameter-based, basic, and excluded throttling.
+  + **kafka_log**: Kafka Log Push, Push detailed API calling logs to kafka for you to easily obtain logs.
+  + **breaker**: Circuit Breaker, circuit breaker protect the system when performance issues occur on backend service.
+
+  Changing this will create a new resource.
+
+* `content` - (Required, String) Specifies the configuration details for plugin.
+  + For `CORS` plugins, you can refer to this [document](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0021.html).
+  + For `HTTP Response Header Management` plugins, you can refer to this [document](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0022.html).
+  + For `Request Throttling 2.0` plugins, you can refer to this [document](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0054.html).
+  + For `Kafka Log Push` plugins, you can refer to this [document](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0061.html).
+  + For `Circuit Breaker` plugins, you can refer to this [document](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0023.html).
+
+  -> All default values in content need to be filled in, otherwise `terraform plan` will prompt the script to change.
+     You can confirm the content of a policy through the console (**APIG** -> **API Policies** -> **Your Policy**
+     -> **Policy Content**).
+
+  ~> For sensitive values filled in `content` (such as **SASL password**), the API response will not be returned, so
+     `terraform plan` will prompt script changes, and you can ignore these changes through `ignorechanges` in the
+     `lifecycle`.
+
+* `description` - (Optional, String) Specifies the plugin description.  
+  The valid length is limited from `3` to `255` characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the plugin.
+
+* `created_at` - The creation time of the plugin.
+
+* `updated_at` - The latest update time of the plugin.
+
+## Import
+
+Plugins can be imported using their related dedicated instance ID (`instance_id`) and their ID (`id`), separated by a
+slash, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_plugin.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -636,6 +636,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_group":                       apig.ResourceApigGroupV2(),
 			"huaweicloud_apig_instance_routes":             apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                    apig.ResourceApigInstanceV2(),
+			"huaweicloud_apig_plugin":                      apig.ResourcePlugin(),
 			"huaweicloud_apig_response":                    apig.ResourceApigResponseV2(),
 			"huaweicloud_apig_signature_associate":         apig.ResourceSignatureAssociate(),
 			"huaweicloud_apig_signature":                   apig.ResourceSignature(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -239,9 +239,9 @@ func TestAccPreCheckMigrateEpsID(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckBms(t *testing.T) {
+func TestAccPreCheckUserId(t *testing.T) {
 	if HW_USER_ID == "" {
-		t.Skip("HW_USER_ID must be set for BMS acceptance tests")
+		t.Skip("The environment variables does not support the user ID (HW_USER_ID) for acc tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_test.go
@@ -1,0 +1,991 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func getPluginFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	return plugins.Get(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+// The basic test is used to test CORS plugin.
+func TestAccPlugin_basic(t *testing.T) {
+	var (
+		plugin plugins.Plugin
+
+		rName      = "huaweicloud_apig_plugin.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccPlugin_basicConfig(name)
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&plugin,
+			getPluginFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlugin_basic_step1(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "cors"),
+				),
+			},
+			{
+				Config: testAccPlugin_basic_step2(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "cors"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPluginImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccPluginImportStateFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", n, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s/%s'",
+				rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccPlugin_basicConfig(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+  ]
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccPlugin_basic_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Created by acc test"
+  type        = "cors"
+  content     = jsonencode(
+    {
+      allow_origin      = "*"
+      allow_methods     = "GET,PUT,DELETE,HEAD,PATCH"
+      allow_headers     = "Content-Type,Accept,Cache-Control"
+      expose_headers    = "X-Request-Id,X-Apig-Latency"
+      max_age           = 12700
+      allow_credentials = true
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func testAccPlugin_basic_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Updated by acc test" # Description cannot be updated to a empty value.
+  type        = "cors"
+  content     = jsonencode(
+    {
+      allow_origin      = "*.terraform.test.com"
+      allow_methods     = "POST,PATCH"
+      allow_headers     = "Content-Type,Accept,Accept-Ranges"
+      expose_headers    = "X-Request-Id,X-Apig-Auth-Type"
+      max_age           = 800
+      allow_credentials = false
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func TestAccPlugin_httpResponse(t *testing.T) {
+	var (
+		plugin plugins.Plugin
+
+		rName      = "huaweicloud_apig_plugin.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccPlugin_basicConfig(name)
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&plugin,
+			getPluginFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlugin_httpResponse_step1(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "set_resp_headers"),
+				),
+			},
+			{
+				Config: testAccPlugin_httpResponse_step2(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "set_resp_headers"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPluginImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccPlugin_httpResponse_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Created by acc test"
+  type        = "set_resp_headers"
+  content     = jsonencode(
+    {
+      response_headers = [{
+        name   = "X-Custom-Pwd"
+        value  = "**********"
+        action = "override"
+      },
+      {
+        name   = "X-Custom-Debug-Step"
+        value  = "Beta"
+        action = "skip"
+      },
+      {
+        name   = "X-Custom-Config"
+        value  = "<HTTP response test>"
+        action = "append"
+      },
+      {
+        name   = "X-Custom-Id"
+        value  = ""
+        action = "delete"
+      },
+      {
+        name   = "X-Custom-Log-Level"
+        value  = "DEBUG"
+        action = "add"
+      }]
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func testAccPlugin_httpResponse_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Updated by acc test" # Description cannot be updated to a empty value.
+  type        = "set_resp_headers"
+  content     = jsonencode(
+    {
+      response_headers = [{
+        name   = "X-Custom-Pwd"
+        value  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        action = "delete"
+      },
+      {
+        name   = "X-Custom-Log-PATH"
+        value  = "/tmp/debug.log"
+        action = "add"
+      }]
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func TestAccPlugin_rateLimit(t *testing.T) {
+	var (
+		plugin plugins.Plugin
+
+		rName      = "huaweicloud_apig_plugin.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccPlugin_basicConfig(name)
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&plugin,
+			getPluginFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUserId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlugin_rateLimit_step1(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "rate_limit"),
+				),
+			},
+			{
+				Config: testAccPlugin_rateLimit_step2(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "rate_limit"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPluginImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccPlugin_rateLimit_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Created by acc test"
+  type        = "rate_limit"
+  content     = jsonencode(
+    {
+      "scope": "basic",
+      "default_time_unit": "minute",
+      "default_interval": 1,
+      "api_limit": 25,
+      "app_limit": 10,
+      "user_limit": 15,
+      "ip_limit": 25,
+      "algorithm": "counter",
+      "specials": [
+        {
+          "type": "app",
+          "policies": [
+            {
+              "key": "${huaweicloud_apig_application.test.id}",
+              "limit": 10
+            }
+          ]
+        },
+        {
+          "type": "user",
+          "policies": [
+            {
+              "key": "%[3]s",
+              "limit": 10
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "type": "path",
+          "name": "reqPath",
+          "value": "reqPath"
+        },
+        {
+          "type": "method",
+          "name": "method",
+          "value": "method"
+        },
+        {
+          "type": "system",
+          "name": "serverName",
+          "value": "serverName"
+        }
+      ],
+      "rules": [
+        {
+          "rule_name": "rule-0001",
+          "match_regex": "[\"AND\",[\"method\",\"~=\",\"POST\"],[\"method\",\"~=\",\"PATCH\"]]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 20
+        },
+        {
+          "rule_name": "rule-0002",
+          "match_regex": "[\"reqPath\",\"~~\",\"/terraform/test/*/\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 10
+        },
+        {
+          "rule_name": "rule-0003",
+          "match_regex": "[\"serverName\",\"==\",\"terraform\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 15
+        },
+        {
+          "rule_name": "rule-0004",
+          "match_regex": "[\"method\",\"in\",\"PATCH\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 5
+        }
+      ]
+    }
+  )
+}
+`, baseConfig, name, acceptance.HW_USER_ID)
+}
+
+func testAccPlugin_rateLimit_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Updated by acc test" # Description cannot be updated to a empty value.
+  type        = "rate_limit"
+  content     = jsonencode(
+    {
+      "scope": "basic",
+      "default_time_unit": "minute",
+      "default_interval": 2,
+      "api_limit": 35,
+      "app_limit": 15,
+      "user_limit": 25,
+      "ip_limit": 30,
+      "algorithm": "haht",
+      "specials": [
+        {
+          "type": "app",
+          "policies": [
+            {
+              "key": "${huaweicloud_apig_application.test.id}",
+              "limit": 15
+            }
+          ]
+        },
+        {
+          "type": "user",
+          "policies": [
+            {
+              "key": "%[3]s",
+              "limit": 15
+            }
+          ]
+        }
+      ],
+      "parameters": [
+        {
+          "type": "path",
+          "name": "reqPath",
+          "value": "reqPath"
+        },
+        {
+          "type": "method",
+          "name": "method",
+          "value": "method"
+        },
+        {
+          "type": "system",
+          "name": "serverName",
+          "value": "serverName"
+        }
+      ],
+      "rules": [
+        {
+          "rule_name": "rule-0001",
+          "match_regex": "[\"AND\",[\"method\",\"~=\",\"POST\"],[\"method\",\"~=\",\"PATCH\"]]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 25
+        },
+        {
+          "rule_name": "rule-0002",
+          "match_regex": "[\"reqPath\",\"~~\",\"/terraform/test/*/\"]",
+          "time_unit": "minute",
+          "interval": 2,
+          "limit": 15
+        },
+        {
+          "rule_name": "rule-0003",
+          "match_regex": "[\"serverName\",\"==\",\"terraform\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 20
+        },
+        {
+          "rule_name": "rule-0004",
+          "match_regex": "[\"method\",\"in\",\"PATCH\"]",
+          "time_unit": "minute",
+          "interval": 1,
+          "limit": 15
+        }
+      ]
+    }
+  )
+}
+`, baseConfig, name, acceptance.HW_USER_ID)
+}
+
+func TestAccPlugin_kafkaLog(t *testing.T) {
+	var (
+		plugin plugins.Plugin
+
+		rName      = "huaweicloud_apig_plugin.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccPlugin_kafkaLog_base(name)
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&plugin,
+			getPluginFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlugin_kafkaLog_step1(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "kafka_log"),
+				),
+			},
+			{
+				Config: testAccPlugin_kafkaLog_step2(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "kafka_log"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPluginImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccPlugin_kafkaLog_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results     = data.huaweicloud_dms_kafka_flavors.test
+  flavor            = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
+  connect_addresses = split(",", huaweicloud_dms_kafka_instance.test.connect_address)
+}
+
+resource "huaweicloud_dms_kafka_instance" "test" {
+  name              = "%[2]s"
+  vpc_id            = huaweicloud_vpc.test.id
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  flavor_id          = local.flavor.id
+  storage_spec_code  = local.flavor.ios[0].storage_spec_code
+  availability_zones = local.flavor.ios[0].availability_zones
+  engine_version     = element(local.query_results.versions, length(local.query_results.versions)-1)
+  storage_space      = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
+  broker_num         = 3
+
+  access_user      = "user"
+  password         = "Kafkatest@123"
+  manager_user     = "kafka-user"
+  manager_password = "Kafkatest@123"
+
+  lifecycle {
+    ignore_changes = [
+      availability_zones, manager_password, password,
+    ]
+  }
+}
+
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%[2]s"
+  partitions  = 20
+}
+`, testAccPlugin_basicConfig(name), name)
+}
+
+func testAccPlugin_kafkaLog_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Created by acc test"
+  type        = "kafka_log"
+  content     = jsonencode(
+    {
+      "broker_list": [for v in local.connect_addresses: format("%%s:%%d", v, huaweicloud_dms_kafka_instance.test.port)],
+      "topic": "${huaweicloud_dms_kafka_topic.test.name}",
+      "key": "",
+      "max_retry_count": 0,
+      "retry_backoff": 1,
+      "sasl_config": {
+        "security_protocol": "PLAINTEXT",
+        "sasl_mechanisms": "PLAIN",
+        "sasl_username": "",
+        "sasl_password": "",
+        "ssl_ca_content": ""
+      },
+      "meta_config": {
+        "system": {
+          "start_time": false,
+          "request_id": false,
+          "client_ip": false,
+          "api_id": false,
+          "user_name": false,
+          "app_id": false,
+          "access_model1": false,
+          "request_time": true,
+          "http_status": true,
+          "server_protocol": false,
+          "scheme": true,
+          "request_method": true,
+          "host": false,
+          "api_uri_mode": false,
+          "uri": false,
+          "request_size": false,
+          "response_size": false,
+          "upstream_uri": false,
+          "upstream_addr": false,
+          "upstream_status": true,
+          "upstream_connect_time": false,
+          "upstream_header_time": false,
+          "upstream_response_time": false,
+          "all_upstream_response_time": false,
+          "region_id": true,
+          "auth_type": false,
+          "http_x_forwarded_for": false,
+          "http_user_agent": false,
+          "error_type": false,
+          "access_model2": false,
+          "inner_time": false,
+          "proxy_protocol_vni": false,
+          "proxy_protocol_vpce_id": false,
+          "proxy_protocol_addr": false,
+          "body_bytes_sent": false,
+          "api_name": true,
+          "app_name": true,
+          "provider_app_id": false,
+          "provider_app_name": false,
+          "custom_data_log01": false,
+          "custom_data_log02": false,
+          "custom_data_log03": false,
+          "custom_data_log04": false,
+          "custom_data_log05": false,
+          "custom_data_log06": false,
+          "custom_data_log07": false,
+          "custom_data_log08": false,
+          "custom_data_log09": false,
+          "custom_data_log10": false,
+          "response_source": false
+        },
+        "call_data": {
+          "log_request_header": false,
+          "log_request_query_string": false,
+          "log_request_body": false,
+          "log_response_header": false,
+          "log_response_body": false,
+          "request_header_filter": "",
+          "request_query_string_filter": "",
+          "response_header_filter": "",
+          "custom_authorizer": {
+            "frontend": [],
+            "backend": []
+          }
+        }
+      }
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func testAccPlugin_kafkaLog_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Updated by acc test" # Description cannot be updated to a empty value.
+  type        = "kafka_log"
+  content     = jsonencode(
+    {
+      "broker_list": [for v in local.connect_addresses: format("%%s:%%d", v, huaweicloud_dms_kafka_instance.test.port)],
+      "topic": "${huaweicloud_dms_kafka_topic.test.name}",
+      "key": "",
+      "max_retry_count": 3,
+      "retry_backoff": 10,
+      "sasl_config": {
+        "security_protocol": "PLAINTEXT",
+        "sasl_mechanisms": "PLAIN",
+        "sasl_username": "",
+        "sasl_password": "",
+        "ssl_ca_content": ""
+      },
+      "meta_config": {
+        "system": {
+          "start_time": true,
+          "request_id": true,
+          "client_ip": true,
+          "api_id": false,
+          "user_name": false,
+          "app_id": false,
+          "access_model1": false,
+          "request_time": true,
+          "http_status": true,
+          "server_protocol": false,
+          "scheme": true,
+          "request_method": true,
+          "host": false,
+          "api_uri_mode": false,
+          "uri": false,
+          "request_size": false,
+          "response_size": false,
+          "upstream_uri": false,
+          "upstream_addr": true,
+          "upstream_status": true,
+          "upstream_connect_time": false,
+          "upstream_header_time": false,
+          "upstream_response_time": true,
+          "all_upstream_response_time": false,
+          "region_id": false,
+          "auth_type": false,
+          "http_x_forwarded_for": true,
+          "http_user_agent": true,
+          "error_type": true,
+          "access_model2": false,
+          "inner_time": false,
+          "proxy_protocol_vni": false,
+          "proxy_protocol_vpce_id": false,
+          "proxy_protocol_addr": false,
+          "body_bytes_sent": false,
+          "api_name": false,
+          "app_name": false,
+          "provider_app_id": false,
+          "provider_app_name": false,
+          "custom_data_log01": false,
+          "custom_data_log02": false,
+          "custom_data_log03": false,
+          "custom_data_log04": false,
+          "custom_data_log05": false,
+          "custom_data_log06": false,
+          "custom_data_log07": false,
+          "custom_data_log08": false,
+          "custom_data_log09": false,
+          "custom_data_log10": false,
+          "response_source": false
+        },
+        "call_data": {
+          "log_request_header": true,
+          "log_request_query_string": true,
+          "log_request_body": true,
+          "log_response_header": true,
+          "log_response_body": true,
+          "request_header_filter": "X-Custom-Auth-Type",
+          "request_query_string_filter": "authId",
+          "response_header_filter": "X-Trace-Id",
+          "custom_authorizer": {
+            "frontend": [
+              "user_name",
+              "user_age"
+            ],
+            "backend": [
+              "userName",
+              "userAge"
+            ]
+          }
+        }
+      }
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func TestAccPlugin_breaker(t *testing.T) {
+	var (
+		plugin plugins.Plugin
+
+		rName      = "huaweicloud_apig_plugin.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccPlugin_basicConfig(name)
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&plugin,
+			getPluginFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPlugin_breaker_step1(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "breaker"),
+				),
+			},
+			{
+				Config: testAccPlugin_breaker_step2(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by acc test"),
+					resource.TestCheckResourceAttr(rName, "type", "breaker"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPluginImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccPlugin_breaker_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Created by acc test"
+  type        = "breaker"
+  content     = jsonencode(
+    {
+      "breaker_condition": {
+        "breaker_type": "timeout",
+        "breaker_mode": "percentage",
+        "unhealthy_condition": "",
+        "unhealthy_threshold": 30,
+        "min_call_threshold": 20,
+        "unhealthy_percentage": 51,
+        "time_window": 15,
+        "open_breaker_time": 15
+      },
+      "downgrade_default": null,
+      "downgrade_parameters": null,
+      "downgrade_rules": null,
+      "scope": "share"
+    }
+  )
+}
+`, baseConfig, name)
+}
+
+func testAccPlugin_breaker_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+  description = "Updated by acc test" # Description cannot be updated to a empty value.
+  type        = "breaker"
+  content     = jsonencode(
+    {
+      "breaker_condition": {
+        "breaker_type": "condition",
+        "breaker_mode": "counter",
+        "unhealthy_condition": "[\"OR\",[\"$context.statusCode\",\"in\",\"500,501,504\"],[\"$context.backendResponseTime\",\">\",6000]]",
+        "unhealthy_threshold": 30,
+        "min_call_threshold": 20,
+        "unhealthy_percentage": 51,
+        "time_window": 15,
+        "open_breaker_time": 15
+      },
+      "downgrade_default": null,
+      "downgrade_parameters": [
+        {
+          "type": "path",
+          "name": "reqPath",
+          "value": "reqPath"
+        },
+        {
+          "type": "method",
+          "name": "method",
+          "value": "method"
+        },
+        {
+          "type": "query",
+          "name": "authType",
+          "value": "authType"
+        }
+      ],
+      "downgrade_rules": [
+        {
+          "breaker_condition": {
+            "breaker_type": "timeout",
+            "breaker_mode": "percentage",
+            "unhealthy_condition": "",
+            "unhealthy_threshold": 30,
+            "min_call_threshold": 20,
+            "unhealthy_percentage": 51,
+            "time_window": 15,
+            "open_breaker_time": 15
+          },
+          "downgrade_backend": null,
+          "rule_name": "rule-qkqe",
+          "match_regex": "[\"authType\",\"~=\",\"Token\"]",
+          "parameters": [
+            "reqPath",
+            "method",
+            "authType"
+          ]
+        }
+      ],
+      "scope": "basic"
+    }
+  )
+}
+`, baseConfig, name)
+}

--- a/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
+++ b/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
@@ -22,7 +22,7 @@ func TestAccBmsInstance_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acceptance.TestAccPreCheckBms(t)
+			acceptance.TestAccPreCheckUserId(t)
 			acceptance.TestAccPreCheckEpsID(t)
 			acceptance.TestAccPreCheckChargingMode(t)
 		},

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
@@ -1,0 +1,207 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// ResourcePlugin defines the provider resource of the APIG plugin.
+func ResourcePlugin() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePluginCreate,
+		ReadContext:   resourcePluginRead,
+		UpdateContext: resourcePluginUpdate,
+		DeleteContext: resourcePluginDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePluginImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the plugin is located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the dedicated instance to which the plugin belongs.",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[\x{4E00}-\x{9FFC}A-Za-z]([\x{4E00}-\x{9FFC}\w-]*)?$`),
+						"Only Chinese characters, English letters, digits hyphens (-) and underscores (_) are "+
+							"allowed, and must start with an English letter or Chinese character."),
+					validation.StringLenBetween(3, 255),
+				),
+				Description: "The plugin name.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The plugin type.",
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					return utils.JSONStringsEqual(old, new)
+				},
+				Description: "The configuration details for plugin.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The plugin description.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the plugin.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the plugin.",
+			},
+		},
+	}
+}
+
+func resourcePluginCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	opts := plugins.CreateOpts{
+		InstanceId:  d.Get("instance_id").(string),
+		Name:        d.Get("name").(string),
+		Type:        d.Get("type").(string),
+		Scope:       "global",
+		Content:     d.Get("content").(string),
+		Description: d.Get("description").(string),
+	}
+	resp, err := plugins.Create(client, opts)
+	if err != nil {
+		return diag.Errorf("error creating the plugin: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	return resourcePluginRead(ctx, d, meta)
+}
+
+func resourcePluginRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	pluginId := d.Id()
+	resp, err := plugins.Get(client, instanceId, pluginId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "plugin policy")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", resp.Name),
+		d.Set("type", resp.Type),
+		d.Set("content", resp.Content),
+		d.Set("description", resp.Description),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving plugin fields: %s", err)
+	}
+	return nil
+}
+
+func resourcePluginUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		pluginId = d.Id()
+		opts     = plugins.UpdateOpts{
+			InstanceId:  d.Get("instance_id").(string),
+			ID:          pluginId,
+			Name:        d.Get("name").(string),
+			Type:        d.Get("type").(string),
+			Scope:       "global",
+			Content:     d.Get("content").(string),
+			Description: utils.String(d.Get("description").(string)),
+		}
+	)
+
+	_, err = plugins.Update(client, opts)
+	if err != nil {
+		return diag.Errorf("error updating the plugin (%s): %s", pluginId, err)
+	}
+
+	return resourcePluginRead(ctx, d, meta)
+}
+
+func resourcePluginDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		pluginId   = d.Id()
+	)
+	err = plugins.Delete(client, instanceId, pluginId)
+	if err != nil {
+		return diag.Errorf("error deleting the plugin (%s): %s", pluginId, err)
+	}
+	return nil
+}
+
+func resourcePluginImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+	err := d.Set("instance_id", parts[0])
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error saving instance ID field: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/requests.go
@@ -1,0 +1,210 @@
+package plugins
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create a new plugin.
+type CreateOpts struct {
+	// The ID of the dedicated instance to which the plugin belongs.
+	InstanceId string `json:"-" required:"true"`
+	// Plugin name.
+	// The valid length is limited from `3` to `255`, only Chinese characters, English letters, digits, hyphens (-) and
+	// underscores (_) are allowed. The name must start with an English letter or Chinese character.
+	Name string `json:"plugin_name" required:"true"`
+	// Plugin type.
+	// The valid values are as follows:
+	// + 'cors': CORS, specify preflight request headers and response headers and automatically create preflight
+	//   request APIs for cross-origin API access.
+	// + 'set_resp_headers': HTTP Response Header Management, customize HTTP headers that will be contained in an API
+	//   response.
+	// + 'rate_limit': Request Throttling 2.0, limits the number of times an API can be called within a specific time
+	//   period. It supports parameter-based, basic, and excluded throttling.
+	// + 'kafka_log': Kafka Log Push, Push detailed API calling logs to kafka for you to easily obtain logs.
+	// + 'breaker': Circuit Breaker, circuit breaker protect the system when performance issues occur on backend
+	//   service.
+	Type string `json:"plugin_type" required:"true"`
+	// The available scope for plugin, the valid value is 'global'.
+	Scope string `json:"plugin_scope" required:"true"`
+	// The configuration details for plugin.
+	Content string `json:"plugin_content" required:"true"`
+	// The plugin description.
+	// The valid length is limited from `3` to `255` characters.
+	Description string `json:"remark,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method used to create a new plugin using given parameters.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*Plugin, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Plugin
+	_, err = c.Post(rootURL(c, opts.InstanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Get is a method to obtain an existing plugin detail by its ID and related instance ID.
+func Get(client *golangsdk.ServiceClient, instanceId, pluginId string) (*Plugin, error) {
+	var r Plugin
+	_, err := client.Get(resourceURL(client, instanceId, pluginId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// UpdateOpts is the structure used to update the plugin configuration.
+type UpdateOpts struct {
+	// The instnace ID to which the plugin belongs.
+	InstanceId string `json:"-" required:"true"`
+	// The plugin ID.
+	ID string `json:"-" required:"true"`
+	// Plugin name.
+	// The valid length is limited from `3` to `255`, only Chinese characters, English letters, digits, hyphens (-) and
+	// underscores (_) are allowed. The name must start with an English letter or Chinese character.
+	Name string `json:"plugin_name" required:"true"`
+	// Plugin type.
+	// The valid values are as follows:
+	// + 'cors': CORS, specify preflight request headers and response headers and automatically create preflight
+	//   request APIs for cross-origin API access.
+	// + 'set_resp_headers': HTTP Response Header Management, customize HTTP headers that will be contained in an API
+	//   response.
+	// + 'rate_limit': Request Throttling 2.0, limits the number of times an API can be called within a specific time
+	//   period. It supports parameter-based, basic, and excluded throttling.
+	// + 'kafka_log': Kafka Log Push, Push detailed API calling logs to kafka for you to easily obtain logs.
+	// + 'breaker': Circuit Breaker, circuit breaker protect the system when performance issues occur on backend
+	//   service.
+	Type string `json:"plugin_type" required:"true"`
+	// The available scope for plugin, the valid value is 'global'.
+	Scope string `json:"plugin_scope" required:"true"`
+	// The configuration details for plugin.
+	Content string `json:"plugin_content" required:"true"`
+	// The plugin description.
+	// The valid length is limited from `3` to `255` characters.
+	Description *string `json:"remark,omitempty"`
+}
+
+// Update is a method used to update a plugin using given parameters.
+func Update(c *golangsdk.ServiceClient, opts UpdateOpts) (*Plugin, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Plugin
+	_, err = c.Put(resourceURL(c, opts.InstanceId, opts.ID), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Delete is a method to remove the specified plugin using its ID and related dedicated instance ID.
+func Delete(c *golangsdk.ServiceClient, instanceId, pluginId string) error {
+	_, err := c.Delete(resourceURL(c, instanceId, pluginId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}
+
+// BindOpts is the structure that used to bind a plugin to the published APIs.
+type BindOpts struct {
+	// The instnace ID to which the plugin belongs.
+	InstanceId string `json:"-" required:"true"`
+	// The plugin ID.
+	PluginId string `json:"-" required:"true"`
+	// The environment ID where the API is published.
+	EnvId string `json:"env_id" required:"true"`
+	// The IDs of the API publish record.
+	ApiIds []string `json:"api_ids" required:"true"`
+}
+
+// Bind is a method to bind a plugin to one or more APIs.
+func Bind(c *golangsdk.ServiceClient, opts BindOpts) ([]PluginBindDetail, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r BindResp
+	_, err = c.Post(bindURL(c, opts.InstanceId, opts.PluginId), b, &r, nil)
+	return r.Bindings, err
+}
+
+// ListBindOpts is the structure used to querying published API list that plugin associated.
+type ListBindOpts struct {
+	// The instnace ID to which the plugin belongs.
+	InstanceId string `json:"-" required:"true"`
+	// The plugin ID.
+	PluginId string `json:"-" required:"true"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// The environment ID where the API is published.
+	EnvId string `q:"env_id"`
+	// The API name.
+	ApiName string `q:"api_name"`
+	// The API ID.
+	ApiId string `q:"api_id"`
+	// The group ID where the API is located.
+	GroupId string `q:"group_id"`
+	// The request method.
+	RequestMethod string `q:"req_method"`
+	// The request URI.
+	RequestUri string `q:"req_uri"`
+}
+
+// ListBind is a method to obtain all API to which the plugin bound.
+func ListBind(c *golangsdk.ServiceClient, opts ListBindOpts) ([]BindApiInfo, error) {
+	url := listBindURL(c, opts.InstanceId, opts.PluginId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := BindPage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractBindInfos(pages)
+}
+
+// UnbindOpts is the structure that used to unbind the published APIs from the plugin.
+type UnbindOpts struct {
+	// The instnace ID to which the plugin belongs.
+	InstanceId string `json:"-" required:"true"`
+	// The plugin ID.
+	PluginId string `json:"-" required:"true"`
+	// The environment ID where the API is published.
+	EnvId string `json:"env_id" required:"true"`
+	// The IDs of the API publish record.
+	ApiIds []string `json:"api_ids" required:"true"`
+}
+
+// Unbind is an method used to unbind one or more APIs from the plugin.
+func Unbind(c *golangsdk.ServiceClient, opts UnbindOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Put(unbindURL(c, opts.InstanceId, opts.PluginId), b, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+		OkCodes:     []int{204},
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/results.go
@@ -1,0 +1,133 @@
+package plugins
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// Plugin is the structure that represents the plugin detail.
+type Plugin struct {
+	// The plugin ID.
+	ID string `json:"plugin_id"`
+	// Plugin name.
+	// The valid length is limited from `3` to `255`, only Chinese characters, English letters, digits, hyphens (-) and
+	// underscores (_) are allowed. The name must start with an English letter or Chinese character.
+	Name string `json:"plugin_name"`
+	// Plugin type.
+	// The valid values are as follows:
+	// + 'cors': CORS, specify preflight request headers and response headers and automatically create preflight
+	//   request APIs for cross-origin API access.
+	// + 'set_resp_headers': HTTP Response Header Management, customize HTTP headers that will be contained in an API
+	//   response.
+	// + 'rate_limit': Request Throttling 2.0, limits the number of times an API can be called within a specific time
+	//   period. It supports parameter-based, basic, and excluded throttling.
+	// + 'kafka_log': Kafka Log Push, Push detailed API calling logs to kafka for you to easily obtain logs.
+	// + 'breaker': Circuit Breaker, circuit breaker protect the system when performance issues occur on backend
+	//   service.
+	Type string `json:"plugin_type"`
+	// The available scope for plugin, the valid value is 'global'.
+	Scope string `json:"plugin_scope"`
+	// The configuration details for plugin.
+	Content string `json:"plugin_content"`
+	// The plugin description.
+	// The valid length is limited from `3` to `255` characters.
+	Description string `json:"remark"`
+	// The creation time.
+	CreatedAt string `json:"created_at"`
+	// The latest update time.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// BindResp is the structure that represents the API response of the plugin binding.
+type BindResp struct {
+	// The published APIs of the binding relationship.
+	Bindings []PluginBindDetail `json:"bindings"`
+}
+
+// PluginBindDetail is the structure that represents the binding details.
+type PluginBindDetail struct {
+	// The binding ID.
+	BindId string `json:"plugin_attach_id"`
+	// The plugin ID.
+	PluginId string `json:"plugin_id"`
+	// The plugin name.
+	PluginName string `json:"plugin_name"`
+	// Plugin type.
+	// The valid values are as follows:
+	// + 'cors': CORS, specify preflight request headers and response headers and automatically create preflight
+	//   request APIs for cross-origin API access.
+	// + 'set_resp_headers': HTTP Response Header Management, customize HTTP headers that will be contained in an API
+	//   response.
+	// + 'rate_limit': Request Throttling 2.0, limits the number of times an API can be called within a specific time
+	//   period. It supports parameter-based, basic, and excluded throttling.
+	// + 'kafka_log': Kafka Log Push, Push detailed API calling logs to kafka for you to easily obtain logs.
+	// + 'breaker': Circuit Breaker, circuit breaker protect the system when performance issues occur on backend
+	//   service.
+	PluginType string `json:"plugin_type"`
+	// The available scope for plugin, the valid value is 'global'.
+	PluginScope string `json:"plugin_scope"`
+	// The environment ID where the API is published.
+	EnvId string `json:"env_id"`
+	// The name of the environment published by the API.
+	EnvName string `json:"env_name"`
+	// The API ID.
+	ApiId string `json:"api_id"`
+	// The API name.
+	ApiName string `json:"apig_name"`
+	// The time when the API and the plugin were bound.
+	BoundAt string `json:"attached_time"`
+}
+
+// BindPage is a single page maximum result representing a query by offset page.
+type BindPage struct {
+	pagination.OffsetPageBase
+}
+
+// IsEmpty checks whether a BindPage struct is empty.
+func (b BindPage) IsEmpty() (bool, error) {
+	arr, err := ExtractBindInfos(b)
+	return len(arr) == 0, err
+}
+
+// ExtractBindInfos is a method to extract the list of binding details for plugin.
+func ExtractBindInfos(r pagination.Page) ([]BindApiInfo, error) {
+	var s []BindApiInfo
+	err := r.(BindPage).Result.ExtractIntoSlicePtr(&s, "apis")
+	return s, err
+}
+
+// BindApiInfo is an object that represents the bind detail.
+type BindApiInfo struct {
+	// API ID.
+	ApiId string `json:"api_id"`
+	// API name.
+	ApiName string `json:"api_name"`
+	// API type.
+	Type int `json:"type"`
+	// The request protocol of the API.
+	RequestProtocol string `json:"req_protocol"`
+	// The request method of the API.
+	RequestMethod string `json:"req_method"`
+	// The request URI of the API.
+	RequestUri string `json:"request_uri"`
+	// The authorization type of the API.
+	AuthType string `json:"auth_type"`
+	// The match mode of the API.
+	MatchMode string `json:"match_mode"`
+	// The description of the API.
+	Remark string `json:"remark"`
+	// The ID of API group to which the API belongs.
+	GroupId string `json:"group_id"`
+	// The name of API group to which the API belongs.
+	GroupName string `json:"group_name"`
+	// Home integration application code, which is compatible with the field of the Roma instance.
+	// Generally, the value is null.
+	RomaAppId string `json:"roma_app_id"`
+	// The ID of environment where the API was published.
+	EnvId string `json:"env_id"`
+	// The name of environment where the API was published.
+	EnvName string `json:"env_name"`
+	// The API publish ID.
+	PublishId string `json:"publish_id"`
+	// The ID of plugin policy binding.
+	BindId string `json:"plugin_attach_id"`
+	// The bound time.
+	BoundAt string `json:"attached_time"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/urls.go
@@ -1,0 +1,23 @@
+package plugins
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "plugins")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, pluginId string) string {
+	return c.ServiceURL("instances", instanceId, "plugins", pluginId)
+}
+
+func bindURL(c *golangsdk.ServiceClient, instanceId, pluginId string) string {
+	return c.ServiceURL("instances", instanceId, "plugins", pluginId, "attach")
+}
+
+func listBindURL(c *golangsdk.ServiceClient, instanceId, pluginId string) string {
+	return c.ServiceURL("instances", instanceId, "plugins", pluginId, "attached-apis")
+}
+
+func unbindURL(c *golangsdk.ServiceClient, instanceId, pluginId string) string {
+	return c.ServiceURL("instances", instanceId, "plugins", pluginId, "detach")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,6 +29,7 @@ github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances
+github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/responses
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/signs
 github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/throttles


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new resource for APIG plugin policy.
For plugin policy type, we have support these kinds:
- [`CORS`](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0021.html)
- [`HTTP Response Header Management`](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0022.html)
- [`Request Throttling 2.0`](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0054.html)
- [`Kafka Log Push`](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0061.html)
- [`Circuit Breaker`](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0023.html)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource support.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPlugin_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPlugin_basic -timeout 360m -parallel 4
=== RUN   TestAccPlugin_basic
=== PAUSE TestAccPlugin_basic
=== CONT  TestAccPlugin_basic
--- PASS: TestAccPlugin_basic (469.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig 469.604s
```
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPlugin_httpResponse'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPlugin_httpResponse -timeout 360m -parallel 4
=== RUN   TestAccPlugin_httpResponse
=== PAUSE TestAccPlugin_httpResponse
=== CONT  TestAccPlugin_httpResponse
--- PASS: TestAccPlugin_httpResponse (466.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig 466.785s
```
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPlugin_rateLimit'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPlugin_rateLimit -timeout 360m -parallel 4
=== RUN   TestAccPlugin_rateLimit
=== PAUSE TestAccPlugin_rateLimit
=== CONT  TestAccPlugin_rateLimit
--- PASS: TestAccPlugin_rateLimit (481.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      481.818s
```
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPlugin_kafkaLog'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPlugin_kafkaLog -timeout 360m -parallel 4
=== RUN   TestAccPlugin_kafkaLog
=== PAUSE TestAccPlugin_kafkaLog
=== CONT  TestAccPlugin_kafkaLog
--- PASS: TestAccPlugin_kafkaLog (678.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      678.350s
```
