### PR TITLE
feat(aom): add new resource alarm silence rule

### DIFF
--- a/docs/resources/aom_alarm_silence_rule.md
+++ b/docs/resources/aom_alarm_silence_rule.md
@@ -1,0 +1,112 @@
+---
+subcategory: "Application Operations Management (AOM)"
+---
+
+# huaweicloud_aom_alarm_silence_rule
+
+Manages an AOM alarm silence rule resource within HuaweiCloud.
+
+~> This resource can only be used in region **cn-east-3** for now.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_aom_alarm_silence_rule" "test" {
+  name        = "test_rule"
+  description = "terraform test"
+  time_zone   = "Asia/Shanghai"
+
+  silence_time {
+    type      = "WEEKLY"
+    starts_at = 64800
+    ends_at   = 86399
+    scope     = [1, 2, 3, 4, 5]
+  }
+
+  silence_conditions {
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the rule name.
+
+  Changing this parameter will create a new resource.
+
+* `time_zone` - (Required, String, ForceNew) Specifies the time zone, e.g. **Asia/Shanghai**.
+
+  Changing this parameter will create a new resource.
+
+* `silence_time` - (Required, List) Specifies the silence time of the rule.
+  The [silence_time](#silence_time) structure is documented below.
+
+* `silence_conditions` - (Required, List) Specifies the silence conditions of the rule.
+  Different silence conditions are parallel. A maximum of 10 silence conditions are allowed.
+  The [silence_conditions](#silence_conditions) structure is documented below.
+
+* `description` - (Optional, String) Specifies the description.
+
+<a name="silence_time"></a>
+The `silence_time` block supports:
+
+* `type` - (Required, String) Specifies the effective time type of the silence rule.
+  The value can be: **FIXED**, **DAILY**, **WEEKLY** and **MONTHLY**.
+
+* `starts_at` - (Required, Int) Specifies the start time of the silence rule.
+  When the `type` is **FIXED**, the value is a time stamp, e.g. **1684466549755**,
+  which indicates **2023-05-19 11:22:29.755**. When the `type` is **DAILY**, **WEEKLY**
+  or **MONTHLY**, the value range is **0** to **86399**, which indicates **00:00:00** to **23:59:59**.
+
+* `ends_at` - (Optional, Int) Specifies the end time of the silence rule.
+  When the `type` is **FIXED**, the value is a time stamp, e.g. **1684466549755**,
+  which indicates **2023-05-19 11:22:29.755**. When the `type` is **DAILY**, **WEEKLY**
+  or **MONTHLY**, the value range is **0** to **86399**, which indicates **00:00:00** to **23:59:59**.
+
+* `scope` - (Optional, List) Specifies the silence time of the rule.
+  It's required when the type is **WEEKLY** or **MONTHLY**.
+
+<a name="silence_conditions"></a>
+  The `silence_conditions` block supports:
+
+* `conditions` - (Required, List) Specifies the serial conditions.
+  A maximum of 10 conditions are allowed.
+  The [conditions](#conditions) structure is documented below.
+
+<a name="conditions"></a>
+The `conditions` block supports:
+
+* `key` - (Required, String) Specifies the key of the match condition.
+
+* `operate` - (Required, String) Specifies the operate of the match condition.
+  The value can be: **EQUALS**, **REGEX** and **EXIST**.
+
+* `value` - (Optional, List) Specifies the value list of the match condition.
+  A maximum of 5 values are allowed. This should be empty when the value of operate is *EXIST**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the rule name.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The last update time.
+
+## Import
+
+The application operations management can be imported using the `id` (name), e.g.
+
+```bash
+$ terraform import huaweicloud_aom_alarm_silence_rule.test test_rule
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -620,6 +620,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_alarm_rule":             aom.ResourceAlarmRule(),
 			"huaweicloud_aom_service_discovery_rule": aom.ResourceServiceDiscoveryRule(),
 			"huaweicloud_aom_alarm_action_rule":      aom.ResourceAlarmActionRule(),
+			"huaweicloud_aom_alarm_silence_rule":     aom.ResourceAlarmSilenceRule(),
 
 			"huaweicloud_rfs_stack": rfs.ResourceStack(),
 

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_silence_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_silence_rule_test.go
@@ -1,0 +1,164 @@
+package aom
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAlarmSilenceRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getAlarmSilenceRule: Query the Alarm Silence Rule
+	var (
+		getAlarmSilenceRuleHttpUrl = "v2/{project_id}/alert/mute-rules"
+		getAlarmSilenceRuleProduct = "aom"
+	)
+	getAlarmSilenceRuleClient, err := cfg.NewServiceClient(getAlarmSilenceRuleProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOM Client: %s", err)
+	}
+
+	getAlarmSilenceRulePath := getAlarmSilenceRuleClient.Endpoint + getAlarmSilenceRuleHttpUrl
+	getAlarmSilenceRulePath = strings.ReplaceAll(getAlarmSilenceRulePath, "{project_id}", getAlarmSilenceRuleClient.ProjectID)
+
+	getAlarmSilenceRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getAlarmSilenceRuleOpt.MoreHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+	getAlarmSilenceRuleResp, err := getAlarmSilenceRuleClient.Request("GET", getAlarmSilenceRulePath, &getAlarmSilenceRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AlarmSilenceRule: %s", err)
+	}
+
+	getAlarmSilenceRuleRespBody, err := utils.FlattenResponse(getAlarmSilenceRuleResp)
+	if err != nil {
+		return nil, err
+	}
+
+	rules := aom.FilterListAlarmSilenceRules(getAlarmSilenceRuleRespBody.([]interface{}), state.Primary.ID)
+	if len(rules) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return rules[0], nil
+}
+
+func TestAccAlarmSilenceRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_aom_alarm_silence_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAlarmSilenceRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCnEast3(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAlarmSilenceRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr(rName, "silence_time.0.type", "DAILY"),
+					resource.TestCheckResourceAttr(rName, "silence_time.0.starts_at", "0"),
+					resource.TestCheckResourceAttr(rName, "silence_time.0.ends_at", "86399"),
+					resource.TestCheckResourceAttr(rName, "silence_conditions.0.conditions.0.key", "event_severity"),
+					resource.TestCheckResourceAttr(rName, "silence_conditions.0.conditions.0.operate", "EQUALS"),
+				),
+			},
+			{
+				Config: testAlarmSilenceRule_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "Asia/Shanghai"),
+					resource.TestCheckResourceAttr(rName, "silence_time.0.type", "WEEKLY"),
+					resource.TestCheckResourceAttr(rName, "silence_time.0.starts_at", "64800"),
+					resource.TestCheckResourceAttr(rName, "silence_time.0.ends_at", "86399"),
+					resource.TestCheckResourceAttr(rName, "silence_conditions.0.conditions.0.key", "event_severity"),
+					resource.TestCheckResourceAttr(rName, "silence_conditions.0.conditions.0.operate", "EXIST"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAlarmSilenceRule_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_alarm_silence_rule" "test" {
+  name        = "%s"
+  description = "terraform test"
+  time_zone   = "Asia/Shanghai"
+
+  silence_time {
+    type      = "DAILY"
+    starts_at = 0
+    ends_at   = 86399
+  }
+
+  silence_conditions {
+    conditions {
+      key     = "event_severity"
+      operate = "EQUALS"
+      value   = ["Info"]
+    }
+  }
+}
+`, name)
+}
+
+func testAlarmSilenceRule_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_alarm_silence_rule" "test" {
+  name        = "%s"
+  description = "terraform test update"
+  time_zone   = "Asia/Shanghai"
+
+  silence_time {
+    type      = "WEEKLY"
+    starts_at = 64800
+    ends_at   = 86399
+    scope     = [1, 2, 3, 4, 5]   
+  }
+
+  silence_conditions {
+    conditions {
+      key     = "event_severity"
+      operate = "EXIST"
+    }
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_silence_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_silence_rule.go
@@ -1,0 +1,454 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product AOM
+// ---------------------------------------------------------------
+
+package aom
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceAlarmSilenceRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlarmSilenceRuleCreate,
+		UpdateContext: resourceAlarmSilenceRuleUpdate,
+		ReadContext:   resourceAlarmSilenceRuleRead,
+		DeleteContext: resourceAlarmSilenceRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the rule name.`,
+			},
+			"time_zone": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the time zone.`,
+			},
+			"silence_time": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     AlarmSilenceRuleSilenceTimeSchema(),
+				Required: true,
+			},
+			"silence_conditions": {
+				Type:        schema.TypeList,
+				Elem:        AlarmSilenceRuleSilenceConditionsSchema(),
+				Required:    true,
+				Description: `Specifies the silence conditions of the rule.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the description.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The last update time.`,
+			},
+		},
+	}
+}
+
+func AlarmSilenceRuleSilenceTimeSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the effective time type of the silence rule.`,
+			},
+			"starts_at": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the start time of the silence rule.`,
+			},
+			"ends_at": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the end time of the silence rule.`,
+			},
+			"scope": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the silence time of the rule.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func AlarmSilenceRuleSilenceConditionsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"conditions": {
+				Type:        schema.TypeList,
+				Elem:        AlarmSilenceRuleconditionsSchema(),
+				Required:    true,
+				Description: `Specifies the serial conditions.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func AlarmSilenceRuleconditionsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the key of the match condition.`,
+			},
+			"operate": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the operate of the match condition.`,
+			},
+			"value": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the value list of the match condition.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceAlarmSilenceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createAlarmSilenceRule: create a Alarm Silence Rule.
+	var (
+		createAlarmSilenceRuleHttpUrl = "v2/{project_id}/alert/mute-rules"
+		createAlarmSilenceRuleProduct = "aom"
+	)
+	createAlarmSilenceRuleClient, err := cfg.NewServiceClient(createAlarmSilenceRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	createAlarmSilenceRulePath := createAlarmSilenceRuleClient.Endpoint + createAlarmSilenceRuleHttpUrl
+	createAlarmSilenceRulePath = strings.ReplaceAll(createAlarmSilenceRulePath, "{project_id}", createAlarmSilenceRuleClient.ProjectID)
+
+	createAlarmSilenceRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	createAlarmSilenceRuleOpt.JSONBody = utils.RemoveNil(buildAlarmSilenceRuleBodyParams(d, cfg))
+	_, err = createAlarmSilenceRuleClient.Request("POST", createAlarmSilenceRulePath, &createAlarmSilenceRuleOpt)
+	if err != nil {
+		return diag.Errorf("error creating AlarmSilenceRule: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceAlarmSilenceRuleRead(ctx, d, meta)
+}
+
+func buildAlarmSilenceRuleBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        utils.ValueIngoreEmpty(d.Get("name")),
+		"desc":        utils.ValueIngoreEmpty(d.Get("description")),
+		"user_id":     cfg.GetProjectID(cfg.GetRegion(d)),
+		"timezone":    utils.ValueIngoreEmpty(d.Get("time_zone")),
+		"mute_config": buildAlarmSilenceRuleRequestBodyMuteConfig(d.Get("silence_time")),
+		"match":       buildAlarmSilenceRuleSilenceConditions(d.Get("silence_conditions")),
+	}
+	return bodyParams
+}
+
+func buildAlarmSilenceRuleRequestBodyMuteConfig(rawParams interface{}) map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+		raw := rawArray[0].(map[string]interface{})
+		params := map[string]interface{}{
+			"type":      utils.ValueIngoreEmpty(raw["type"]),
+			"starts_at": raw["starts_at"],
+			"ends_at":   utils.ValueIngoreEmpty(raw["ends_at"]),
+			"scope":     utils.ValueIngoreEmpty(raw["scope"]),
+		}
+		return params
+	}
+	return nil
+}
+
+func buildAlarmSilenceRuleSilenceConditions(rawParams interface{}) [][]map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([][]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = buildAlarmSilenceRuleconditions(raw["conditions"])
+		}
+		return rst
+	}
+	return nil
+}
+
+func buildAlarmSilenceRuleconditions(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"key":     utils.ValueIngoreEmpty(raw["key"]),
+				"operate": utils.ValueIngoreEmpty(raw["operate"]),
+				"value":   utils.ValueIngoreEmpty(raw["value"]),
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceAlarmSilenceRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getAlarmSilenceRule: Query the Alarm Silence Rule
+	var (
+		getAlarmSilenceRuleHttpUrl = "v2/{project_id}/alert/mute-rules"
+		getAlarmSilenceRuleProduct = "aom"
+	)
+	getAlarmSilenceRuleClient, err := cfg.NewServiceClient(getAlarmSilenceRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	getAlarmSilenceRulePath := getAlarmSilenceRuleClient.Endpoint + getAlarmSilenceRuleHttpUrl
+	getAlarmSilenceRulePath = strings.ReplaceAll(getAlarmSilenceRulePath, "{project_id}", getAlarmSilenceRuleClient.ProjectID)
+
+	getAlarmSilenceRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	getAlarmSilenceRuleOpt.MoreHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	getAlarmSilenceRuleResp, err := getAlarmSilenceRuleClient.Request("GET", getAlarmSilenceRulePath, &getAlarmSilenceRuleOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving AlarmSilenceRule")
+	}
+
+	getAlarmSilenceRuleRespBody, err := utils.FlattenResponse(getAlarmSilenceRuleResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	rules := FilterListAlarmSilenceRules(getAlarmSilenceRuleRespBody.([]interface{}), d.Id())
+	if len(rules) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving AlarmSilenceRule")
+	}
+
+	rule := rules[0]
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", rule, nil)),
+		d.Set("description", utils.PathSearch("desc", rule, nil)),
+		d.Set("time_zone", utils.PathSearch("timezone", rule, nil)),
+		d.Set("silence_time", flattenSilenceRuleSilenceTime(rule)),
+		d.Set("silence_conditions", flattenSilenceRuleSilenceConditions(rule)),
+		d.Set("created_at", utils.PathSearch("create_time", rule, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", rule, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSilenceRuleSilenceTime(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson, err := jmespath.Search("mute_config", resp)
+	if err != nil {
+		log.Printf("[ERROR] error parsing silence_time from response= %#v", resp)
+		return rst
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"type":      utils.PathSearch("type", curJson, nil),
+			"starts_at": utils.PathSearch("starts_at", curJson, nil),
+			"ends_at":   utils.PathSearch("ends_at", curJson, nil),
+			"scope":     utils.PathSearch("scope", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenSilenceRuleSilenceConditions(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("match", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"conditions": flattenSilenceRuleConditions(v),
+		})
+	}
+	return rst
+}
+
+func flattenSilenceRuleConditions(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curArray := resp.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"key":     utils.PathSearch("key", v, nil),
+			"operate": utils.PathSearch("operate", v, nil),
+			"value":   utils.PathSearch("value", v, nil),
+		})
+	}
+	return rst
+}
+
+func FilterListAlarmSilenceRules(all []interface{}, id string) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if id != fmt.Sprint(utils.PathSearch("name", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func resourceAlarmSilenceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateAlarmSilenceRuleChanges := []string{
+		"description",
+		"silence_time",
+		"silence_conditions",
+	}
+
+	if d.HasChanges(updateAlarmSilenceRuleChanges...) {
+		// updateAlarmSilenceRule: update the Alarm Silence Rule
+		var (
+			updateAlarmSilenceRuleHttpUrl = "v2/{project_id}/alert/mute-rules"
+			updateAlarmSilenceRuleProduct = "aom"
+		)
+		updateAlarmSilenceRuleClient, err := cfg.NewServiceClient(updateAlarmSilenceRuleProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating AOM Client: %s", err)
+		}
+
+		updateAlarmSilenceRulePath := updateAlarmSilenceRuleClient.Endpoint + updateAlarmSilenceRuleHttpUrl
+		updateAlarmSilenceRulePath = strings.ReplaceAll(updateAlarmSilenceRulePath, "{project_id}", updateAlarmSilenceRuleClient.ProjectID)
+
+		updateAlarmSilenceRuleOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				204,
+			},
+		}
+		updateAlarmSilenceRuleOpt.JSONBody = utils.RemoveNil(buildAlarmSilenceRuleBodyParams(d, cfg))
+		_, err = updateAlarmSilenceRuleClient.Request("PUT", updateAlarmSilenceRulePath, &updateAlarmSilenceRuleOpt)
+		if err != nil {
+			return diag.Errorf("error updating AlarmSilenceRule: %s", err)
+		}
+	}
+	return resourceAlarmSilenceRuleRead(ctx, d, meta)
+}
+
+func resourceAlarmSilenceRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteAlarmSilenceRule: delete the Alarm Silence Rule
+	var (
+		deleteAlarmSilenceRuleHttpUrl = "v2/{project_id}/alert/mute-rules"
+		deleteAlarmSilenceRuleProduct = "aom"
+	)
+	deleteAlarmSilenceRuleClient, err := cfg.NewServiceClient(deleteAlarmSilenceRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	deleteAlarmSilenceRulePath := deleteAlarmSilenceRuleClient.Endpoint + deleteAlarmSilenceRuleHttpUrl
+	deleteAlarmSilenceRulePath = strings.ReplaceAll(deleteAlarmSilenceRulePath, "{project_id}", deleteAlarmSilenceRuleClient.ProjectID)
+
+	deleteAlarmSilenceRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	deleteAlarmSilenceRuleOpt.JSONBody = []map[string]interface{}{
+		{
+			"name": d.Id(),
+		},
+	}
+	_, err = deleteAlarmSilenceRuleClient.Request("DELETE", deleteAlarmSilenceRulePath, &deleteAlarmSilenceRuleOpt)
+	if err != nil {
+		return diag.Errorf("error deleting AlarmSilenceRule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAlarmSilenceRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAlarmSilenceRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAlarmSilenceRule_basic
=== PAUSE TestAccAlarmSilenceRule_basic
=== CONT  TestAccAlarmSilenceRule_basic
--- PASS: TestAccAlarmSilenceRule_basic (21.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       21.560s
```
