### PR TITLE
feat(apig/plugin): support the associate resource

### DIFF
--- a/docs/resources/apig_plugin_associate.md
+++ b/docs/resources/apig_plugin_associate.md
@@ -1,0 +1,62 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_plugin_associate
+
+Use this resource to bind the APIs to the plugin within HuaweiCloud.
+
+-> A published API can only create one `huaweicloud_apig_plugin_associate` resource.
+   For each type of plugin, the API can only bind at most one.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "plugin_id" {}
+variable "publish_environment_id" {}
+variable "bind_api_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_apig_plugin_associate" "test" {
+  instance_id = var.instance_id
+  plugin_id   = var.plugin_id
+  env_id      = var.publish_environment_id
+  api_ids     = var.bind_api_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the plugin and the APIs are located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the APIs and the
+  plugin belong.  
+  Changing this will create a new resource.
+
+* `plugin_id` - (Required, String, ForceNew) Specifies the plugin ID for APIs binding.  
+  Changing this will create a new resource.
+
+* `env_id` - (Required, String, ForceNew) The environment ID where the API was published.
+  Changing this will create a new resource.
+
+* `api_ids` - (Required, List) Specifies the API IDs bound by the plugin.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. The format is `<instance_id>/<plugin_id>/<env_id>`.
+
+## Import
+
+Associate resources can be imported using their related dedicated instance ID of plugin (`instance_id`), `plugin_id` and
+`env_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_plugin_associate.test <instance_id>/<plugin_id>/<env_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -636,6 +636,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_group":                       apig.ResourceApigGroupV2(),
 			"huaweicloud_apig_instance_routes":             apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                    apig.ResourceApigInstanceV2(),
+			"huaweicloud_apig_plugin_associate":            apig.ResourcePluginAssociate(),
 			"huaweicloud_apig_plugin":                      apig.ResourcePlugin(),
 			"huaweicloud_apig_response":                    apig.ResourceApigResponseV2(),
 			"huaweicloud_apig_signature_associate":         apig.ResourceSignatureAssociate(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_associate_test.go
@@ -1,0 +1,579 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func getPluginAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	listOpts := plugins.ListBindOpts{
+		InstanceId: state.Primary.Attributes["instance_id"],
+		PluginId:   state.Primary.Attributes["plugin_id"],
+		EnvId:      state.Primary.Attributes["env_id"],
+	}
+	return plugins.ListBind(client, listOpts)
+}
+
+func TestAccPluginAssociate_basic(t *testing.T) {
+	var (
+		bindList []plugins.BindApiInfo
+
+		rName1 = "huaweicloud_apig_plugin_associate.cors_bind"
+		rName2 = "huaweicloud_apig_plugin_associate.http_resp_bind"
+		rName3 = "huaweicloud_apig_plugin_associate.rate_limit_bind"
+		rName4 = "huaweicloud_apig_plugin_associate.kafka_log_bind"
+		rName5 = "huaweicloud_apig_plugin_associate.breaker_bind"
+		name   = acceptance.RandomAccResourceName()
+
+		rc1 = acceptance.InitResourceCheck(rName1, &bindList, getPluginAssociateFunc)
+		rc2 = acceptance.InitResourceCheck(rName2, &bindList, getPluginAssociateFunc)
+		rc3 = acceptance.InitResourceCheck(rName3, &bindList, getPluginAssociateFunc)
+		rc4 = acceptance.InitResourceCheck(rName4, &bindList, getPluginAssociateFunc)
+		rc5 = acceptance.InitResourceCheck(rName5, &bindList, getPluginAssociateFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc1.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPluginAssociate_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName1, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "plugin_id",
+						"huaweicloud_apig_plugin.cors", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "env_id",
+						"huaweicloud_apig_environment.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName2, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "plugin_id",
+						"huaweicloud_apig_plugin.http_resp", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "env_id",
+						"huaweicloud_apig_environment.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc3.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName3, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "plugin_id",
+						"huaweicloud_apig_plugin.rate_limit", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "env_id",
+						"huaweicloud_apig_environment.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc4.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName4, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName4, "plugin_id",
+						"huaweicloud_apig_plugin.kafka_log", "id"),
+					resource.TestCheckResourceAttrPair(rName4, "env_id",
+						"huaweicloud_apig_environment.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName4, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc5.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName5, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName5, "plugin_id",
+						"huaweicloud_apig_plugin.breaker", "id"),
+					resource.TestCheckResourceAttrPair(rName5, "env_id",
+						"huaweicloud_apig_environment.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName5, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+				),
+			},
+			{
+				Config: testAccPluginAssociate_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName1, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "plugin_id",
+						"huaweicloud_apig_plugin.cors", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "env_id",
+						"huaweicloud_apig_environment.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName1, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName2, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "plugin_id",
+						"huaweicloud_apig_plugin.http_resp", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "env_id",
+						"huaweicloud_apig_environment.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName2, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc3.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName3, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "plugin_id",
+						"huaweicloud_apig_plugin.rate_limit", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "env_id",
+						"huaweicloud_apig_environment.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName3, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc4.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName4, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName4, "plugin_id",
+						"huaweicloud_apig_plugin.kafka_log", "id"),
+					resource.TestCheckResourceAttrPair(rName4, "env_id",
+						"huaweicloud_apig_environment.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName4, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+					rc5.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName5, "instance_id",
+						"huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName5, "plugin_id",
+						"huaweicloud_apig_plugin.breaker", "id"),
+					resource.TestCheckResourceAttrPair(rName5, "env_id",
+						"huaweicloud_apig_environment.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName5, "api_ids.0",
+						"huaweicloud_apig_api.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName3,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName4,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName5,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPluginAssociate_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results     = data.huaweicloud_dms_kafka_flavors.test
+  flavor            = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
+  connect_addresses = split(",", huaweicloud_dms_kafka_instance.test.connect_address)
+  plugin_ids = [
+    huaweicloud_apig_plugin.cors.id,
+    huaweicloud_apig_plugin.http_resp.id,
+    huaweicloud_apig_plugin.rate_limit.id,
+    huaweicloud_apig_plugin.kafka_log.id,
+    huaweicloud_apig_plugin.breaker.id
+  ]
+}
+
+resource "huaweicloud_dms_kafka_instance" "test" {
+  name              = "%[2]s"
+  vpc_id            = huaweicloud_vpc.test.id
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  flavor_id          = local.flavor.id
+  storage_spec_code  = local.flavor.ios[0].storage_spec_code
+  availability_zones = local.flavor.ios[0].availability_zones
+  engine_version     = element(local.query_results.versions, length(local.query_results.versions)-1)
+  storage_space      = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
+  broker_num         = 3
+
+  access_user      = "user"
+  password         = "Kafkatest@123"
+  manager_user     = "kafka-user"
+  manager_password = "Kafkatest@123"
+
+  lifecycle {
+    ignore_changes = [
+      availability_zones, manager_password, password,
+    ]
+  }
+}
+
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%[2]s"
+  partitions  = 20
+}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_vpc_channel" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+  port        = 80
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    id = huaweicloud_compute_instance.test.id
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+  
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  count = 2
+
+  name        = "%[2]s_${count.index}"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  count = 2
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[count.index].id
+}
+
+resource "huaweicloud_apig_plugin" "cors" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_cors"
+  type        = "cors"
+  content     = jsonencode(
+    {
+      allow_origin      = "*"
+      allow_methods     = "GET,PUT,DELETE,HEAD,PATCH"
+      allow_headers     = "Content-Type,Accept,Cache-Control"
+      expose_headers    = "X-Request-Id,X-Apig-Latency"
+      max_age           = 12700
+      allow_credentials = true
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin" "http_resp" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_http_resp"
+  type        = "set_resp_headers"
+  content     = jsonencode(
+    {
+      response_headers = [{
+        name   = "X-Custom-Pwd"
+        value  = "**********"
+        action = "override"
+      }]
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin" "rate_limit" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_rate_limit"
+  type        = "rate_limit"
+  content     = jsonencode(
+    {
+      "scope": "basic",
+      "default_time_unit": "minute",
+      "default_interval": 1,
+      "api_limit": 25,
+      "app_limit": 15,
+      "user_limit": 15,
+      "ip_limit": 10,
+      "algorithm": "counter",
+      "specials": [],
+      "parameters": [],
+      "rules": []
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin" "kafka_log" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_kafka_log"
+  type        = "kafka_log"
+  content     = jsonencode(
+    {
+      "broker_list": [for v in local.connect_addresses: format("%%s:%%d", v, huaweicloud_dms_kafka_instance.test.port)],
+      "topic": "${huaweicloud_dms_kafka_topic.test.name}",
+      "key": "",
+      "max_retry_count": 0,
+      "retry_backoff": 1,
+      "sasl_config": {
+        "security_protocol": "PLAINTEXT",
+        "sasl_mechanisms": "PLAIN",
+        "sasl_username": "",
+        "sasl_password": "",
+        "ssl_ca_content": ""
+      },
+      "meta_config": {
+        "system": {
+          "start_time": false,
+          "request_id": false,
+          "client_ip": false,
+          "api_id": false,
+          "user_name": false,
+          "app_id": false,
+          "access_model1": false,
+          "request_time": true,
+          "http_status": true,
+          "server_protocol": false,
+          "scheme": true,
+          "request_method": true,
+          "host": false,
+          "api_uri_mode": false,
+          "uri": false,
+          "request_size": false,
+          "response_size": false,
+          "upstream_uri": false,
+          "upstream_addr": false,
+          "upstream_status": true,
+          "upstream_connect_time": false,
+          "upstream_header_time": false,
+          "upstream_response_time": false,
+          "all_upstream_response_time": false,
+          "region_id": true,
+          "auth_type": false,
+          "http_x_forwarded_for": false,
+          "http_user_agent": false,
+          "error_type": false,
+          "access_model2": false,
+          "inner_time": false,
+          "proxy_protocol_vni": false,
+          "proxy_protocol_vpce_id": false,
+          "proxy_protocol_addr": false,
+          "body_bytes_sent": false,
+          "api_name": true,
+          "app_name": true,
+          "provider_app_id": false,
+          "provider_app_name": false,
+          "custom_data_log01": false,
+          "custom_data_log02": false,
+          "custom_data_log03": false,
+          "custom_data_log04": false,
+          "custom_data_log05": false,
+          "custom_data_log06": false,
+          "custom_data_log07": false,
+          "custom_data_log08": false,
+          "custom_data_log09": false,
+          "custom_data_log10": false,
+          "response_source": false
+        },
+        "call_data": {
+          "log_request_header": false,
+          "log_request_query_string": false,
+          "log_request_body": false,
+          "log_response_header": false,
+          "log_response_body": false,
+          "request_header_filter": "",
+          "request_query_string_filter": "",
+          "response_header_filter": "",
+          "custom_authorizer": {
+            "frontend": [],
+            "backend": []
+          }
+        }
+      }
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin" "breaker" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_breaker"
+  type        = "breaker"
+  content     = jsonencode(
+    {
+      "breaker_condition": {
+        "breaker_type": "timeout",
+        "breaker_mode": "percentage",
+        "unhealthy_condition": "",
+        "unhealthy_threshold": 30,
+        "min_call_threshold": 20,
+        "unhealthy_percentage": 51,
+        "time_window": 15,
+        "open_breaker_time": 15
+      },
+      "downgrade_default": null,
+      "downgrade_parameters": null,
+      "downgrade_rules": null,
+      "scope": "share"
+    }
+  )
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testAccPluginAssociate_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin_associate" "cors_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[0]
+  env_id      = huaweicloud_apig_environment.test[0].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "http_resp_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[1]
+  env_id      = huaweicloud_apig_environment.test[0].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "rate_limit_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[2]
+  env_id      = huaweicloud_apig_environment.test[0].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "kafka_log_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[3]
+  env_id      = huaweicloud_apig_environment.test[0].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "breaker_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[4]
+  env_id      = huaweicloud_apig_environment.test[0].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+`, testAccPluginAssociate_base(name), name)
+}
+
+func testAccPluginAssociate_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_plugin_associate" "cors_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[0]
+  env_id      = huaweicloud_apig_environment.test[1].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "http_resp_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[1]
+  env_id      = huaweicloud_apig_environment.test[1].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "rate_limit_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[2]
+  env_id      = huaweicloud_apig_environment.test[1].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "kafka_log_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[3]
+  env_id      = huaweicloud_apig_environment.test[1].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+
+resource "huaweicloud_apig_plugin_associate" "breaker_bind" {
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = local.plugin_ids[4]
+  env_id      = huaweicloud_apig_environment.test[1].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+`, testAccPluginAssociate_base(name), name)
+}

--- a/huaweicloud/services/apig/common.go
+++ b/huaweicloud/services/apig/common.go
@@ -1,0 +1,44 @@
+package apig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/chnsz/golangsdk"
+)
+
+type requestErr struct {
+	// The error code.
+	ErrCode string `json:"error_code"`
+	// The error message.
+	ErrMsg string `json:"error_msg"`
+}
+
+// The APIG API is limited to only one attach operation at a time for standrad policy and plugin policy.
+// In addition to locking and waiting between multiple operations, a retry method is required to ensure that the
+// request can be executed correctly.
+func handleMultiOperationsError(err error) (bool, error) {
+	if err == nil {
+		// The operation was executed successfully and does not need to be executed again.
+		return false, nil
+	}
+
+	if errCode, ok := err.(golangsdk.ErrDefault500); ok {
+		var apiError requestErr
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
+		}
+
+		// Some error codes that need to be retried coming from https://console-intl.huaweicloud.com/apiexplorer/#/errorcenter/APIG.
+		retryErrCodes := map[string]struct{}{
+			"APIG.3500": {},
+		}
+		if _, ok := retryErrCodes[apiError.ErrCode]; ok {
+			// The operation failed to execute and needs to be executed again, because other operations are
+			// currently in progress.
+			return true, err
+		}
+	}
+	// Operation execution failed due to some resource or server issues, no need to try again.
+	return false, err
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin_associate.go
@@ -1,0 +1,286 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// ResourcePluginAssociate defines the provider resource of the APIG plugin binding.
+func ResourcePluginAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePluginAssociateCreate,
+		ReadContext:   resourcePluginAssociateRead,
+		UpdateContext: resourcePluginAssociateUpdate,
+		DeleteContext: resourcePluginAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePluginAssociateImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the plugin is located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the dedicated instance to which the plugin belongs.",
+			},
+			"plugin_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The plugin ID.",
+			},
+			"env_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The environment ID where the API was published.",
+			},
+			"api_ids": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The APIs bound by the plugin.",
+			},
+		},
+	}
+}
+
+func resourcePluginAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		pluginId   = d.Get("plugin_id").(string)
+		envId      = d.Get("env_id").(string)
+		opts       = plugins.BindOpts{
+			InstanceId: instanceId,
+			PluginId:   pluginId,
+			EnvId:      envId,
+			ApiIds:     utils.ExpandToStringListBySet(d.Get("api_ids").(*schema.Set)),
+		}
+	)
+
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		_, err = plugins.Bind(client, opts)
+		retryable, err := handleMultiOperationsError(err)
+		if retryable {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("error binding the plugin to the APIs: %s", err)
+	}
+	d.SetId(fmt.Sprintf("%s/%s/%s", instanceId, pluginId, envId))
+
+	return resourcePluginAssociateRead(ctx, d, meta)
+}
+
+func flattenBindApis(bindList []plugins.BindApiInfo) []string {
+	if len(bindList) < 1 {
+		return nil
+	}
+
+	result := make([]string, len(bindList))
+	for i, v := range bindList {
+		result[i] = v.ApiId
+	}
+	return result
+}
+
+func resourcePluginAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		pluginId   = d.Get("plugin_id").(string)
+		listOpts   = plugins.ListBindOpts{
+			InstanceId: instanceId,
+			PluginId:   pluginId,
+			EnvId:      d.Get("env_id").(string),
+		}
+	)
+
+	resp, err := plugins.ListBind(client, listOpts)
+	if err != nil {
+		return diag.Errorf("error querying the bind details of the plugin: %s", err)
+	}
+
+	bindApiIds := flattenBindApis(resp)
+	if len(bindApiIds) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "plugin associate")
+	}
+	if err = d.Set("api_ids", bindApiIds); err != nil {
+		return diag.Errorf("error saving API IDs field: %s", err)
+	}
+	return nil
+}
+
+func resourcePluginAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId     = d.Get("instance_id").(string)
+		pluginId       = d.Get("plugin_id").(string)
+		envId          = d.Get("env_id").(string)
+		oldVal, newVal = d.GetChange("api_ids")
+		rmRaw          = oldVal.(*schema.Set).Difference(newVal.(*schema.Set))
+		addRaw         = newVal.(*schema.Set).Difference(oldVal.(*schema.Set))
+	)
+
+	// Step 1, unbind the APIs.
+	if rmRaw.Len() > 0 {
+		unbindOpts := plugins.UnbindOpts{
+			InstanceId: instanceId,
+			PluginId:   pluginId,
+			EnvId:      envId,
+			ApiIds:     utils.ExpandToStringListBySet(rmRaw),
+		}
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			err = plugins.Unbind(client, unbindOpts)
+			retryable, err := handleMultiOperationsError(err)
+			if retryable {
+				return resource.RetryableError(err)
+			}
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return diag.Errorf("an error occurred while updating plugin bindings, some APIs could not be unbound from "+
+				"the plugin (%s): %s", pluginId, err)
+		}
+	}
+
+	// Step 2, bind the APIs.
+	if addRaw.Len() > 0 {
+		bindOpts := plugins.BindOpts{
+			InstanceId: instanceId,
+			PluginId:   pluginId,
+			EnvId:      envId,
+			ApiIds:     utils.ExpandToStringListBySet(addRaw),
+		}
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			_, err = plugins.Bind(client, bindOpts)
+			retryable, err := handleMultiOperationsError(err)
+			if retryable {
+				return resource.RetryableError(err)
+			}
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return diag.Errorf("an error occurred while updating plugin bindings, some APIs could not be bound to the "+
+				"plugin (%s): %s", pluginId, err)
+		}
+	}
+
+	return resourcePluginAssociateRead(ctx, d, meta)
+}
+
+func resourcePluginAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	var (
+		instanceId = d.Get("instance_id").(string)
+		pluginId   = d.Get("plugin_id").(string)
+		envId      = d.Get("env_id").(string)
+		listOpts   = plugins.ListBindOpts{
+			InstanceId: instanceId,
+			PluginId:   pluginId,
+			EnvId:      d.Get("env_id").(string),
+		}
+	)
+	resp, err := plugins.ListBind(client, listOpts)
+	if err != nil {
+		return diag.Errorf("error querying the bind details of the plugin: %s", err)
+	}
+
+	if apiIds := flattenBindApis(resp); len(apiIds) > 0 {
+		unbindOpts := plugins.UnbindOpts{
+			InstanceId: instanceId,
+			PluginId:   pluginId,
+			EnvId:      envId,
+			ApiIds:     apiIds,
+		}
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			err = plugins.Unbind(client, unbindOpts)
+			retryable, err := handleMultiOperationsError(err)
+			if retryable {
+				return resource.RetryableError(err)
+			}
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return diag.Errorf("an error occurred while deleting plugin bindings, some APIs could not be unbound from "+
+				"the plugin (%s): %s", pluginId, err)
+		}
+	}
+	return nil
+}
+
+func resourcePluginAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<plugin_id>/<env_id>', "+
+			"but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("plugin_id", parts[1]),
+		d.Set("env_id", parts[2]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error saving associate resource field: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support an associate resource to manage plugin bindings.
The CRD options are support retry logic because of the API is limited to only one attach operation at a time for standrad policy and plugin policy.
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPluginAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPluginAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccPluginAssociate_basic
=== PAUSE TestAccPluginAssociate_basic
=== CONT  TestAccPluginAssociate_basic
2023/05/12 16:19:25 ----------------------------------------------------------------------------
2023/05/12 16:19:25 An error was occured
2023/05/12 16:19:25 The error is: golangsdk.ErrDefault500{ErrUnexpectedResponseCode:golangsdk.ErrUnexpectedResponseCode{BaseError:golangsdk.BaseError{DefaultErrString:"", Info:""}, URL:"https://apig.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/apigw/instances/c513d5edc7c146cdb7aefcc234f0339d/plugins/801bce1d1f3146f1b696b7d8e65d411a/attach", Method:"POST", Expected:[]int{200, 201, 202}, Actual:500, Body:[]uint8{0x7b, 0x22, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x63, 0x6f, 0x64, 0x65, 0x22, 0x3a, 0x22, 0x41, 0x50, 0x49, 0x47, 0x2e, 0x33, 0x35, 0x30, 0x30, 0x22, 0x2c, 0x22, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x6d, 0x73, 0x67, 0x22, 0x3a, 0x22, 0x46, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x20, 0x74, 0x6f, 0x20, 0x73, 0x79, 0x6e, 0x63, 0x68, 0x72, 0x6f, 0x6e, 0x69, 0x7a, 0x65, 0x20, 0x64, 0x61, 0x74, 0x61, 0x20, 0x74, 0x6f, 0x20, 0x65, 0x74, 0x63, 0x64, 0x22, 0x7d}}}
2023/05/12 16:19:25 The error code is 500!!!
2023/05/12 16:19:25 The actual error message is "APIG.3500"
2023/05/12 16:19:25 Matched the error code!
2023/05/12 16:19:25 ----------------------------------------------------------------------------
2023/05/12 16:19:54 ----------------------------------------------------------------------------
2023/05/12 16:19:54 An error was occured
2023/05/12 16:19:54 The error is: golangsdk.ErrDefault500{ErrUnexpectedResponseCode:golangsdk.ErrUnexpectedResponseCode{BaseError:golangsdk.BaseError{DefaultErrString:"", Info:""}, URL:"https://apig.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/apigw/instances/c513d5edc7c146cdb7aefcc234f0339d/plugins/6c26a1c8520d4f738cf601d7fbd59855/attach", Method:"POST", Expected:[]int{200, 201, 202}, Actual:500, Body:[]uint8{0x7b, 0x22, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x63, 0x6f, 0x64, 0x65, 0x22, 0x3a, 0x22, 0x41, 0x50, 0x49, 0x47, 0x2e, 0x33, 0x35, 0x30, 0x30, 0x22, 0x2c, 0x22, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x6d, 0x73, 0x67, 0x22, 0x3a, 0x22, 0x46, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x20, 0x74, 0x6f, 0x20, 0x73, 0x79, 0x6e, 0x63, 0x68, 0x72, 0x6f, 0x6e, 0x69, 0x7a, 0x65, 0x20, 0x64, 0x61, 0x74, 0x61, 0x20, 0x74, 0x6f, 0x20, 0x65, 0x74, 0x63, 0x64, 0x22, 0x7d}}}
2023/05/12 16:19:54 The error code is 500!!!
2023/05/12 16:19:54 The actual error message is "APIG.3500"
2023/05/12 16:19:54 Matched the error code!
2023/05/12 16:19:54 ----------------------------------------------------------------------------
--- PASS: TestAccPluginAssociate_basic (671.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      671.711s
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support the associate resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPluginAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPluginAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccPluginAssociate_basic
=== PAUSE TestAccPluginAssociate_basic
=== CONT  TestAccPluginAssociate_basic
--- PASS: TestAccPluginAssociate_basic (665.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig  665.197s
```
