### PR TITLE
fix(func/update): move the start logic into inner layer

### DIFF
--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook.go
@@ -328,17 +328,17 @@ func resourceNotebookUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return fmtp.DiagErrorf("Error update ModelArts notebook: %s", err)
 		}
-	}
 
-	//start
-	_, err = notebook.Start(client, d.Id(), -1)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+		// start the instance
+		_, err = notebook.Start(client, d.Id(), -1)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	err = waitingNotebookForRunning(ctx, client, d.Id(), d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return diag.FromErr(err)
+		err = waitingNotebookForRunning(ctx, client, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceNotebookRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The start method location is not right, if we just update the name, the instance will not be stoped.
```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccResourceNotebook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccResourceNotebook_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceNotebook_basic
=== PAUSE TestAccResourceNotebook_basic
=== CONT  TestAccResourceNotebook_basic
    resource_huaweicloud_modelarts_notebook_test.go:37: Step 2/3 error: Error running apply: exit status 1
        
        Error: Bad request with: [POST https://modelarts.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/notebooks/c4f2050c-03d2-49c4-bf74-2bb665003ed1/start?duration=-1], error message: {
                "error_code":"ModelArts.6357",
                "error_msg":"The operation is not allowed because another operation is being performed on the instance tf_test_x92vx or the instance is in the target state."
        }
        
          with huaweicloud_modelarts_notebook.test,
          on terraform_plugin_test.tf line 2, in resource "huaweicloud_modelarts_notebook" "test":
           2: resource "huaweicloud_modelarts_notebook" "test" {
        
--- FAIL: TestAccResourceNotebook_basic (88.51s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 88.619s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccResourceNotebook_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccResourceNotebook_ -timeout 360m -parallel 4
=== RUN   TestAccResourceNotebook_basic
=== PAUSE TestAccResourceNotebook_basic
=== RUN   TestAccResourceNotebook_all
=== PAUSE TestAccResourceNotebook_all
=== CONT  TestAccResourceNotebook_basic
=== CONT  TestAccResourceNotebook_all
--- PASS: TestAccResourceNotebook_basic (81.53s)
--- PASS: TestAccResourceNotebook_all (192.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 192.519s
```
