### PR TITLE
feat(aom): add new resource event alarm rule

### DIFF
--- a/docs/resources/aom_event_alarm_rule.md
+++ b/docs/resources/aom_event_alarm_rule.md
@@ -1,0 +1,87 @@
+---
+subcategory: "Application Operations Management (AOM)"
+---
+
+# huaweicloud_aom_event_alarm_rule
+
+Manages an AOM event alarm rule resource within HuaweiCloud.
+
+~> This resource can only be used in region **cn-east-3** for now.
+
+## Example Usage
+
+variable "action_rule_name" {}
+
+```hcl
+resource "huaweicloud_aom_event_alarm_rule" "test" {
+  name                = "test_rule"
+  description         = "terraform test"
+  alarm_type          = "notification"
+  action_rule         = var.action_rule_name
+  enabled             = true
+  trigger_type        = "accumulative"
+  period              = "300"
+  comparison_operator = ">="
+  trigger_count       = 2
+  alarm_source        = "AOM"
+
+  select_object = {
+    "event_type"     ="alarm",
+    "event_severity" = "Critical"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the rule.
+
+  Changing this parameter will create a new resource.
+
+* `alarm_type` - (Required, String) Specifies the alarm type of the rule.
+  The value can be **notification** and **denoising**.
+
+* `alarm_source` - (Required, String) Specifies the alarm source of the rule.
+
+* `select_object` - (Required, Map) Specifies the select object of the rule.
+
+* `trigger_type` - (Required, String) Specifies the trigger type.
+  The value can be **accumulative** and **immediately**.
+
+* `description` - (Optional, String) Specifies the description of the rule.
+
+* `action_rule` - (Optional, String) Specifies the action rule name.
+
+* `grouping_rule` - (Optional, String) Specifies the route grouping rule name.
+
+* `enabled` - (Optional, Bool) Specifies whether the rule is enabled. Defaults to **true**.
+
+* `trigger_count` - (Optional, Int) Specifies the accumulated times to trigger the alarm.
+
+* `comparison_operator` - (Optional, String) Specifies the comparison condition of alarm.
+  The value can be **>** and **>=**.
+
+* `period` - (Optional, Int) Specifies the monitoring period in seconds.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the rule name.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The last updated time.
+
+## Import
+
+The application operations management can be imported using the `id` (name), e.g.
+
+```bash
+$ terraform import huaweicloud_aom_event_alarm_rule.test test_rule
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -618,6 +618,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_antiddos_basic": antiddos.ResourceCloudNativeAntiDdos(),
 
 			"huaweicloud_aom_alarm_rule":             aom.ResourceAlarmRule(),
+			"huaweicloud_aom_event_alarm_rule":       aom.ResourceEventAlarmRule(),
 			"huaweicloud_aom_service_discovery_rule": aom.ResourceServiceDiscoveryRule(),
 			"huaweicloud_aom_alarm_action_rule":      aom.ResourceAlarmActionRule(),
 

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_event_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_event_alarm_rule_test.go
@@ -1,0 +1,168 @@
+package aom
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getEventAlarmRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getEventAlarmRule: Query the Event Alarm Rule
+	var (
+		getEventAlarmRuleHttpUrl = "v2/{project_id}/event2alarm-rule"
+		getEventAlarmRuleProduct = "aom"
+	)
+	getEventAlarmRuleClient, err := cfg.NewServiceClient(getEventAlarmRuleProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOM Client: %s", err)
+	}
+
+	getEventAlarmRulePath := getEventAlarmRuleClient.Endpoint + getEventAlarmRuleHttpUrl
+	getEventAlarmRulePath = strings.ReplaceAll(getEventAlarmRulePath, "{project_id}", getEventAlarmRuleClient.ProjectID)
+
+	getEventAlarmRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	getEventAlarmRuleOpt.MoreHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	getEventAlarmRuleResp, err := getEventAlarmRuleClient.Request("GET", getEventAlarmRulePath, &getEventAlarmRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving EventAlarmRule: %s", err)
+	}
+
+	getEventAlarmRuleRespBody, err := utils.FlattenResponse(getEventAlarmRuleResp)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonPath := fmt.Sprintf("[?name=='%s']|[0]", state.Primary.ID)
+	rule := utils.PathSearch(jsonPath, getEventAlarmRuleRespBody, nil)
+	if rule == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return rule, nil
+}
+
+func TestAccEventAlarmRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_aom_event_alarm_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getEventAlarmRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCnEast3(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testEventAlarmRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "alarm_type", "notification"),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "trigger_type", "accumulative"),
+					resource.TestCheckResourceAttr(rName, "comparison_operator", ">="),
+					resource.TestCheckResourceAttr(rName, "trigger_count", "2"),
+					resource.TestCheckResourceAttr(rName, "period", "300"),
+					resource.TestCheckResourceAttr(rName, "alarm_source", "AOM"),
+					resource.TestCheckResourceAttr(rName, "select_object.event_type", "alarm"),
+					resource.TestCheckResourceAttr(rName, "select_object.event_severity", "Critical"),
+					resource.TestCheckResourceAttrPair(rName, "action_rule",
+						"huaweicloud_aom_alarm_action_rule.test", "id"),
+				),
+			},
+			{
+				Config: testEventAlarmRule_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(rName, "alarm_type", "notification"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "trigger_type", "immediately"),
+					resource.TestCheckResourceAttr(rName, "alarm_source", "AOM"),
+					resource.TestCheckResourceAttr(rName, "select_object.event_type", "SELECT_ALL"),
+					resource.TestCheckResourceAttrPair(rName, "action_rule",
+						"huaweicloud_aom_alarm_action_rule.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testEventAlarmRule_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_aom_event_alarm_rule" "test" {
+  name                = "%s"
+  description         = "terraform test"
+  alarm_type          = "notification"
+  action_rule         = huaweicloud_aom_alarm_action_rule.test.id
+  enabled             = false
+  trigger_type        = "accumulative"
+  period              = "300"
+  comparison_operator = ">="
+  trigger_count       = 2
+  alarm_source        = "AOM"
+
+  select_object = {
+    "event_type"     ="alarm",
+    "event_severity" = "Critical"
+  }
+}
+`, testAlarmActionRule_basic(name), name)
+}
+
+func testEventAlarmRule_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_aom_event_alarm_rule" "test" {
+  name         = "%s"
+  description  = "terraform test update"
+  alarm_type   = "notification"
+  action_rule  = huaweicloud_aom_alarm_action_rule.test.id
+  enabled      = true
+  trigger_type = "immediately"
+  alarm_source = "AOM"
+
+  select_object = {
+    "event_type" = "SELECT_ALL"
+  }
+}
+`, testAlarmActionRule_basic(name), name)
+}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_event_alarm_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_event_alarm_rule.go
@@ -1,0 +1,328 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product AOM
+// ---------------------------------------------------------------
+
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceEventAlarmRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEventAlarmRuleCreate,
+		UpdateContext: resourceEventAlarmRuleUpdate,
+		ReadContext:   resourceEventAlarmRuleRead,
+		DeleteContext: resourceEventAlarmRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of the rule.`,
+			},
+			"alarm_source": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the alarm source of the rule.`,
+			},
+			"select_object": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the select object of the rule.`,
+			},
+			"alarm_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the alarm type of the rule.`,
+			},
+			"trigger_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the trigger type.`,
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Specifies whether the rule is enabled.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the description of the rule.`,
+			},
+			"action_rule": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the action rule name.`,
+			},
+			"grouping_rule": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the route grouping rule name.`,
+			},
+			"trigger_count": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the accumulated times to trigger the alarm.`,
+			},
+			"comparison_operator": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the comparison condition of alarm.`,
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the monitoring period in seconds.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The last updated time.`,
+			},
+		},
+	}
+}
+
+func resourceEventAlarmRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createEventAlarmRule: create a Event Alarm Rule.
+	var (
+		createEventAlarmRuleHttpUrl = "v2/{project_id}/event2alarm-rule"
+		createEventAlarmRuleProduct = "aom"
+	)
+	createEventAlarmRuleClient, err := cfg.NewServiceClient(createEventAlarmRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	createEventAlarmRulePath := createEventAlarmRuleClient.Endpoint + createEventAlarmRuleHttpUrl
+	createEventAlarmRulePath = strings.ReplaceAll(createEventAlarmRulePath, "{project_id}", createEventAlarmRuleClient.ProjectID)
+
+	createEventAlarmRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	createEventAlarmRuleOpt.JSONBody = utils.RemoveNil(buildEventAlarmRuleBodyParams(d, cfg))
+	_, err = createEventAlarmRuleClient.Request("POST", createEventAlarmRulePath, &createEventAlarmRuleOpt)
+	if err != nil {
+		return diag.Errorf("error creating EventAlarmRule: %s", err)
+	}
+
+	d.SetId(d.Get("name").(string))
+
+	return resourceEventAlarmRuleRead(ctx, d, meta)
+}
+
+func buildEventAlarmRuleBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":              utils.ValueIngoreEmpty(d.Get("name")),
+		"description":       utils.ValueIngoreEmpty(d.Get("description")),
+		"alarm_type":        utils.ValueIngoreEmpty(d.Get("alarm_type")),
+		"action_rule":       utils.ValueIngoreEmpty(d.Get("action_rule")),
+		"route_group_rule":  utils.ValueIngoreEmpty(d.Get("grouping_rule")),
+		"enable":            utils.ValueIngoreEmpty(d.Get("enabled")),
+		"resource_provider": utils.ValueIngoreEmpty(d.Get("alarm_source")),
+		"metadata":          utils.ValueIngoreEmpty(d.Get("select_object")),
+		"trigger_policies":  buildEventAlarmRuleTriggerPolicies(d),
+		"user_id":           cfg.GetProjectID(cfg.GetRegion(d)),
+	}
+	return bodyParams
+}
+
+func buildEventAlarmRuleTriggerPolicies(d *schema.ResourceData) []map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"trigger_type": utils.ValueIngoreEmpty(d.Get("trigger_type")),
+		"count":        utils.ValueIngoreEmpty(d.Get("trigger_count")),
+		"operator":     utils.ValueIngoreEmpty(d.Get("comparison_operator")),
+		"period":       utils.ValueIngoreEmpty(d.Get("period")),
+	}
+
+	return []map[string]interface{}{bodyParams}
+}
+
+func resourceEventAlarmRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getEventAlarmRule: Query the Event Alarm Rule
+	var (
+		getEventAlarmRuleHttpUrl = "v2/{project_id}/event2alarm-rule"
+		getEventAlarmRuleProduct = "aom"
+	)
+	getEventAlarmRuleClient, err := cfg.NewServiceClient(getEventAlarmRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	getEventAlarmRulePath := getEventAlarmRuleClient.Endpoint + getEventAlarmRuleHttpUrl
+	getEventAlarmRulePath = strings.ReplaceAll(getEventAlarmRulePath, "{project_id}", getEventAlarmRuleClient.ProjectID)
+
+	getEventAlarmRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	getEventAlarmRuleOpt.MoreHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	getEventAlarmRuleResp, err := getEventAlarmRuleClient.Request("GET", getEventAlarmRulePath, &getEventAlarmRuleOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving EventAlarmRule")
+	}
+
+	getEventAlarmRuleRespBody, err := utils.FlattenResponse(getEventAlarmRuleResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jsonPath := fmt.Sprintf("[?name=='%s']|[0]", d.Id())
+	rule := utils.PathSearch(jsonPath, getEventAlarmRuleRespBody, nil)
+	if rule == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving EventAlarmRule")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", rule, nil)),
+		d.Set("description", utils.PathSearch("description", rule, nil)),
+		d.Set("alarm_type", utils.PathSearch("alarm_type", rule, nil)),
+		d.Set("action_rule", utils.PathSearch("action_rule", rule, nil)),
+		d.Set("grouping_rule", utils.PathSearch("route_group_rule", rule, nil)),
+		d.Set("enabled", utils.PathSearch("enable", rule, nil)),
+		d.Set("alarm_source", utils.PathSearch("resource_provider", rule, nil)),
+		d.Set("select_object", utils.PathSearch("metadata", rule, nil)),
+		d.Set("trigger_type", utils.PathSearch("trigger_policies[0].trigger_type", rule, nil)),
+		d.Set("trigger_count", utils.PathSearch("trigger_policies[0].count", rule, nil)),
+		d.Set("comparison_operator", utils.PathSearch("trigger_policies[0].operator", rule, nil)),
+		d.Set("period", utils.PathSearch("trigger_policies[0].period", rule, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", rule, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", rule, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceEventAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateEventAlarmRuleChanges := []string{
+		"description",
+		"alarm_type",
+		"action_rule",
+		"grouping_rule",
+		"enabled",
+		"alarm_source",
+		"select_object",
+		"trigger_type",
+		"trigger_count",
+		"comparison_operator",
+		"period",
+	}
+
+	if d.HasChanges(updateEventAlarmRuleChanges...) {
+		// updateEventAlarmRule: update the Event Alarm Rule
+		var (
+			updateEventAlarmRuleHttpUrl = "v2/{project_id}/event2alarm-rule"
+			updateEventAlarmRuleProduct = "aom"
+		)
+		updateEventAlarmRuleClient, err := cfg.NewServiceClient(updateEventAlarmRuleProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating AOM Client: %s", err)
+		}
+
+		updateEventAlarmRulePath := updateEventAlarmRuleClient.Endpoint + updateEventAlarmRuleHttpUrl
+		updateEventAlarmRulePath = strings.ReplaceAll(updateEventAlarmRulePath, "{project_id}", updateEventAlarmRuleClient.ProjectID)
+		updateEventAlarmRuleOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				204,
+			},
+		}
+		updateEventAlarmRuleOpt.JSONBody = utils.RemoveNil(buildEventAlarmRuleBodyParams(d, cfg))
+		_, err = updateEventAlarmRuleClient.Request("PUT", updateEventAlarmRulePath, &updateEventAlarmRuleOpt)
+		if err != nil {
+			return diag.Errorf("error updating EventAlarmRule: %s", err)
+		}
+	}
+	return resourceEventAlarmRuleRead(ctx, d, meta)
+}
+
+func resourceEventAlarmRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteEventAlarmRule: missing operation notes
+	var (
+		deleteEventAlarmRuleHttpUrl = "v2/{project_id}/event2alarm-rule"
+		deleteEventAlarmRuleProduct = "aom"
+	)
+	deleteEventAlarmRuleClient, err := cfg.NewServiceClient(deleteEventAlarmRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM Client: %s", err)
+	}
+
+	deleteEventAlarmRulePath := deleteEventAlarmRuleClient.Endpoint + deleteEventAlarmRuleHttpUrl
+	deleteEventAlarmRulePath = strings.ReplaceAll(deleteEventAlarmRulePath, "{project_id}", deleteEventAlarmRuleClient.ProjectID)
+
+	deleteEventAlarmRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	deleteEventAlarmRuleOpt.JSONBody = []string{d.Id()}
+	_, err = deleteEventAlarmRuleClient.Request("DELETE", deleteEventAlarmRulePath, &deleteEventAlarmRuleOpt)
+	if err != nil {
+		return diag.Errorf("error deleting EventAlarmRule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccEventAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccEventAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccEventAlarmRule_basic
=== PAUSE TestAccEventAlarmRule_basic
=== CONT  TestAccEventAlarmRule_basic
--- PASS: TestAccEventAlarmRule_basic (33.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       34.007s
```
