### PR TITLE
fix(WAF): waf resource support import with epsID

### DIFF
--- a/docs/resources/waf_address_group.md
+++ b/docs/resources/waf_address_group.md
@@ -62,8 +62,16 @@ The `rules` block supports:
 
 ## Import
 
-The WAF address group can be imported using the `id`, e.g.
+There are two ways to import WAF address group state.
+
+* Using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_waf_address_group.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_waf_address_group.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_address_group.test <id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -65,10 +65,18 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Certificates can be imported using the `id`, e.g.
+There are two ways to import WAF certificate state.
 
-```sh
-terraform import huaweicloud_waf_certificate.certificate_2 3ebd3201238d41f9bfc3623b61435954
+* Using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_certificate.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_certificate.test <id>/<enterprise_project_id>
 ```
 
 Note that the imported state is not identical to your resource definition, due to security reason. The missing

--- a/docs/resources/waf_cloud_instance.md
+++ b/docs/resources/waf_cloud_instance.md
@@ -109,10 +109,18 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-Cloud WAFs can be imported using their `id`, e.g.
+There are two ways to import WAF cloud instance state.
 
-```shell
-$ terraform import huaweicloud_waf_cloud_instance.test f4e99b39a0bf40619dd6b776e77410ff
+* Using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_cloud_instance.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_cloud_instance.test <id>/<enterprise_project_id>
 ```
 
 Note that the imported state is not identical to your resource definition, due to API response reason.  

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -131,8 +131,16 @@ The following attributes are exported:
 
 ## Import
 
-Dedicated mode domain can be imported using the `id`, e.g.
+There are two ways to import WAF dedicated domain state.
 
-```sh
-terraform import huaweicloud_waf_dedicated_domain.domain_1 69e9a86becb4424298cc6bdeacbf69d5
+* Using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_dedicated_domain.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_dedicated_domain.test <id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -103,20 +103,16 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-There are two ways to import state, include `Without Enterprise Project ID` and `With Enterprise Project ID`.
+There are two ways to import WAF dedicated instance state.
 
-### Without Enterprise Project ID
+* Using the `id`, e.g.
 
-WAF dedicated instance can be imported using the `id`, e.g.
-
-```sh
-terraform import huaweicloud_waf_dedicated_instance.instance_1 2f87641090206b821f07e0f6bd6
+```bash
+$ terraform import huaweicloud_waf_dedicated_instance.test <id>
 ```
 
-### With Enterprise Project ID
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
 
-WAF dedicated instance can be imported using the instance ID and Enterprise Project ID separated by a slash, e.g.:
-
-```sh
-terraform import huaweicloud_waf_dedicated_instance.instance_1 2003b024bee141bcb3aed2fc4142033c/3cf9c5a4-583e-4259-aba1-b7745690246f
+```bash
+$ terraform import huaweicloud_waf_dedicated_instance.test <id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -112,8 +112,16 @@ The following attributes are exported:
 
 ## Import
 
-Domains can be imported using the `id`, e.g.
+There are two ways to import WAF domain state.
 
-```sh
-terraform import huaweicloud_waf_domain.domain_2 7902bd9e01104cb794dcb668f235e0c5
+* Using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_domain.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_domain.test <id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -91,8 +91,16 @@ The `options` block supports:
 
 ## Import
 
-Policies can be imported using the `id`, e.g.
+There are two ways to import WAF policy state.
 
-```sh
-terraform import huaweicloud_waf_policy.policy_2 25e1df831bea4022a6e22bebe678915a
+* Using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_policy.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_policy.test <id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_reference_table.md
+++ b/docs/resources/waf_reference_table.md
@@ -57,8 +57,16 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The reference table can be imported using the `id`, e.g.
+There are two ways to import WAF reference table state.
 
-```sh
-terraform import huaweicloud_waf_reference_table.ref_table 96e46e5e702b4e2aa5609ad287de4788
+* Using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_reference_table.test <id>
+```
+
+* Using `id` and `enterprise_project_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_reference_table.test <id>/<enterprise_project_id>
 ```

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_address_group_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_address_group_test.go
@@ -130,6 +130,12 @@ func TestAccAddressGroup_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "rules.#"),
 				),
 			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFResourceImportState(rName),
+			},
 		},
 	})
 }
@@ -175,4 +181,19 @@ resource "huaweicloud_waf_address_group" "test" {
   depends_on = [huaweicloud_waf_dedicated_instance.instance_1]
 }
 `, testAccWafDedicatedInstance_epsId(name, enterpriseProjectID), name, enterpriseProjectID)
+}
+
+// testWAFResourceImportState use to return an id with format <id> or <id>/<enterprise_project_id>
+func testWAFResourceImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		epsID := rs.Primary.Attributes["enterprise_project_id"]
+		if epsID == "" {
+			return rs.Primary.ID, nil
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.ID, epsID), nil
+	}
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -100,6 +100,13 @@ func TestAccWafCertificateV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate", "private_key"},
+				ImportStateIdFunc:       testWAFResourceImportState(resourceName),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_cloud_instance_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_cloud_instance_test.go
@@ -120,6 +120,19 @@ func TestAccCloudInstance_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "auto_renew", "true"),
 				),
 			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"enterprise_project_id",
+					"charging_mode",
+					"period_unit",
+					"period",
+					"auto_renew",
+				},
+				ImportStateIdFunc: testWAFResourceImportState(rName),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -174,6 +174,13 @@ func TestAccWafDedicateDomainV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"keep_policy"},
+				ImportStateIdFunc:       testWAFResourceImportState(resourceName),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
@@ -130,7 +130,7 @@ func TestAccWafDedicatedInstance_withEpsId(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccWafDedicatedInstanceImportStateIdFunc(resourceName),
+				ImportStateIdFunc: testWAFResourceImportState(resourceName),
 			},
 		},
 	})
@@ -178,18 +178,6 @@ func TestAccWafDedicatedInstance_elb_model(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccWafDedicatedInstanceImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmtp.Errorf("resource not found")
-		}
-		instanceId := rs.Primary.ID
-		epsId := rs.Primary.Attributes["enterprise_project_id"]
-		return fmt.Sprintf("%s/%s", instanceId, epsId), nil
-	}
 }
 
 func testAccWafDedicatedInstanceV1_conf(name string) string {

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -114,6 +114,13 @@ func TestAccWafDomainV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"keep_policy", "charging_mode"},
+				ImportStateIdFunc:       testWAFResourceImportState(resourceName),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
@@ -88,6 +88,12 @@ func TestAccWafPolicyV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "level", "3"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFResourceImportState(resourceName),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
@@ -96,6 +96,12 @@ func TestAccWafReferenceTableV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFResourceImportState(resourceName),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
@@ -23,7 +23,7 @@ func ResourceWafCertificateV1() *schema.Resource {
 		Update: resourceWafCertificateV1Update,
 		Delete: resourceWafCertificateV1Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: resourceWAFImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -62,7 +62,7 @@ func ResourceCloudInstance() *schema.Resource {
 		DeleteContext: resourceCloudInstanceDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceWAFImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -33,7 +33,7 @@ func ResourceWafDedicatedDomainV1() *schema.Resource {
 		Delete: resourceWafDedicatedDomainV1Delete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: resourceWAFImportState,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -2,7 +2,6 @@ package waf
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -46,7 +45,7 @@ func ResourceWafDedicatedInstance() *schema.Resource {
 		UpdateContext: resourceDedicatedInstanceUpdate,
 		DeleteContext: resourceDedicatedInstanceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceWafDedicatedInstanceImport,
+			StateContext: resourceWAFImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -373,23 +372,4 @@ func resourceDedicatedInstanceDelete(ctx context.Context, d *schema.ResourceData
 	}
 	d.SetId("")
 	return nil
-}
-
-func resourceWafDedicatedInstanceImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
-	if !strings.Contains(d.Id(), "/") {
-		return []*schema.ResourceData{d}, nil
-	}
-
-	parts := strings.SplitN(d.Id(), "/", 2)
-	if len(parts) != 2 {
-		err := fmtp.Errorf("Invalid format specified for WAF Dedicated. Format must be <instance id>/<eps id>")
-		return nil, err
-	}
-	instanceId := parts[0]
-	epsId := parts[1]
-
-	d.SetId(instanceId)
-	d.Set("enterprise_project_id", epsId)
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -28,7 +28,7 @@ func ResourceWafDomainV1() *schema.Resource {
 		Update: resourceWafDomainV1Update,
 		Delete: resourceWafDomainV1Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: resourceWAFImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
@@ -28,7 +28,7 @@ func ResourceWafPolicyV1() *schema.Resource {
 		Update: resourceWafPolicyV1Update,
 		Delete: resourceWafPolicyV1Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: resourceWAFImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
@@ -25,7 +25,7 @@ func ResourceWafReferenceTableV1() *schema.Resource {
 		Update: resourceWafReferenceTableUpdate,
 		Delete: resourceWafReferenceTableDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: resourceWAFImportState,
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
waf resource support import with epsID: 
- waf_address_group
- waf_certificate
- waf_cloud_instance
- waf_dedicated_domain
- waf_dedicated_instance
- waf_domain
- waf_policy
- waf_reference_table
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

- waf_address_group
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccAddressGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccAddressGroup_ -timeout 360m -parallel 4
=== RUN   TestAccAddressGroup_basic
=== PAUSE TestAccAddressGroup_basic
=== RUN   TestAccAddressGroup_withEpsId
=== PAUSE TestAccAddressGroup_withEpsId
=== CONT  TestAccAddressGroup_basic
=== CONT  TestAccAddressGroup_withEpsId
--- PASS: TestAccAddressGroup_withEpsId (402.45s) 
--- PASS: TestAccAddressGroup_basic (403.03s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       403.119s
```

- waf_certificate
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafCertificateV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafCertificateV1_ -timeout 360m -parallel 4
=== RUN   TestAccWafCertificateV1_basic
=== PAUSE TestAccWafCertificateV1_basic
=== RUN   TestAccWafCertificateV1_withEpsID
=== PAUSE TestAccWafCertificateV1_withEpsID
=== CONT  TestAccWafCertificateV1_basic
=== CONT  TestAccWafCertificateV1_withEpsID
--- PASS: TestAccWafCertificateV1_withEpsID (349.87s) 
--- PASS: TestAccWafCertificateV1_basic (406.11s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       406.227s
```

- waf_cloud_instance
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccCloudInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCloudInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudInstance_basic 
=== PAUSE TestAccCloudInstance_basic 
=== CONT  TestAccCloudInstance_basic 
--- PASS: TestAccCloudInstance_basic (123.61s) 
PASS                                                                                                             
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       123.669s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccCloudInstance_withEpsID'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCloudInstance_withEpsID -timeout 360m -parallel 4 
=== RUN   TestAccCloudInstance_withEpsID 
=== PAUSE TestAccCloudInstance_withEpsID
=== CONT  TestAccCloudInstance_withEpsID
--- PASS: TestAccCloudInstance_withEpsID (146.03s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       146.078s
```


- waf_dedicated_instance
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_ -timeout 360m -parallel 4 
=== RUN   TestAccWafDedicatedInstance_basic 
=== PAUSE TestAccWafDedicatedInstance_basic
=== RUN   TestAccWafDedicatedInstance_withEpsId
=== PAUSE TestAccWafDedicatedInstance_withEpsId
=== RUN   TestAccWafDedicatedInstance_elb_model
=== PAUSE TestAccWafDedicatedInstance_elb_model
=== CONT  TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_elb_model
=== CONT  TestAccWafDedicatedInstance_withEpsId
--- PASS: TestAccWafDedicatedInstance_elb_model (347.48s) 
--- PASS: TestAccWafDedicatedInstance_basic (351.88s) 
--- PASS: TestAccWafDedicatedInstance_withEpsId (419.89s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       419.938s
```

- waf_domain
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4 
=== RUN   TestAccWafDomainV1_basic 
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (128.78s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       128.832s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4 
=== RUN   TestAccWafDomainV1_withEpsID 
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (110.95s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       111.004s
```



- waf_dedicated_domain
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_ -timeout 360m -parallel 4 
=== RUN   TestAccWafDedicateDomainV1_basic 
=== PAUSE TestAccWafDedicateDomainV1_basic
=== RUN   TestAccWafDedicateDomainV1_withEpsID
=== PAUSE TestAccWafDedicateDomainV1_withEpsID
=== CONT  TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_withEpsID
--- PASS: TestAccWafDedicateDomainV1_withEpsID (452.06s) 
--- PASS: TestAccWafDedicateDomainV1_basic (454.78s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       454.898s
```

- waf_policy
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1_ -timeout 360m -parallel 4 
=== RUN   TestAccWafPolicyV1_basic 
=== PAUSE TestAccWafPolicyV1_basic
=== RUN   TestAccWafPolicyV1_withEpsID
=== PAUSE TestAccWafPolicyV1_withEpsID
=== CONT  TestAccWafPolicyV1_basic
=== CONT  TestAccWafPolicyV1_withEpsID 
--- PASS: TestAccWafPolicyV1_basic (375.79s) 
--- PASS: TestAccWafPolicyV1_withEpsID (380.32s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       380.694s
```

- waf_reference_table
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafReferenceTableV1_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafReferenceTableV1_ -timeout 360m -parallel 4 
=== RUN   TestAccWafReferenceTableV1_basic 
=== PAUSE TestAccWafReferenceTableV1_basic
=== RUN   TestAccWafReferenceTableV1_withEpsID
=== PAUSE TestAccWafReferenceTableV1_withEpsID
=== CONT  TestAccWafReferenceTableV1_basic
=== CONT  TestAccWafReferenceTableV1_withEpsID
--- PASS: TestAccWafReferenceTableV1_basic (431.06s) 
--- PASS: TestAccWafReferenceTableV1_withEpsID (437.83s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       437.893s
```



