### PR TITLE
fix(WAF): waf rule resource support import id with epsid

### DIFF
--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -85,8 +85,16 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Blacklist and Whitelist Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+There are two ways to import WAF rule blacklist state.
 
-```sh
-terraform import huaweicloud_waf_rule_blacklist.rule_1 d78b439fd5e54ea08886e5f63ee7b3f5/ac01a092d50e4e6ba3cd622c1128ba2c
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_blacklist.test <policy_id>/<rule_id>
+```
+
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_blacklist.test <policy_id>/<rule_id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_rule_cc_protection.md
+++ b/docs/resources/waf_rule_cc_protection.md
@@ -168,20 +168,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-There are two ways to import state, include `Without Enterprise Project ID` and `With Enterprise Project ID`.
+There are two ways to import WAF rule cc protection state.
 
-### Without Enterprise Project ID
-
-The waf cc protection rule can be imported using `policy_id`, `rule_id`, separated by a slash, e.g.
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
 
 ```bash
 $ terraform import huaweicloud_waf_rule_cc_protection.test <policy_id>/<rule_id>
 ```
 
-### With Enterprise Project ID
-
-The waf cc protection rule can be imported using `policy_id`, `rule_id`, `enterprise_project_id`,
-separated by slashes, e.g.
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
 
 ```bash
 $ terraform import huaweicloud_waf_rule_cc_protection.test <policy_id>/<rule_id>/<enterprise_project_id>

--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -54,8 +54,16 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Data Masking Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+There are two ways to import WAF rule data masking state.
 
-```sh
-terraform import huaweicloud_waf_rule_data_masking.rule_1 d78b439fd5e54ea08886e5f63ee7b3f5/ac01a092d50e4e6ba3cd622c1128ba2c
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_data_masking.test <policy_id>/<rule_id>
+```
+
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_data_masking.test <policy_id>/<rule_id>/<enterprise_project_id>
 ```

--- a/docs/resources/waf_rule_global_protection_whitelist.md
+++ b/docs/resources/waf_rule_global_protection_whitelist.md
@@ -159,20 +159,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-There are two ways to import state, include `Without Enterprise Project ID` and `With Enterprise Project ID`.
+There are two ways to import WAF rule global protection whitelist state.
 
-### Without Enterprise Project ID
-
-The waf global protection whitelist rule can be imported using `policy_id`, `rule_id`, separated by a slash, e.g.
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
 
 ```bash
 $ terraform import huaweicloud_waf_rule_global_protection_whitelist.test <policy_id>/<rule_id>
 ```
 
-### With Enterprise Project ID
-
-The waf global protection whitelist rule can be imported using `policy_id`, `rule_id`, `enterprise_project_id`,
-separated by slashes, e.g.
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
 
 ```bash
 $ terraform import huaweicloud_waf_rule_global_protection_whitelist.test <policy_id>/<rule_id>/<enterprise_project_id>

--- a/docs/resources/waf_rule_precise_protection.md
+++ b/docs/resources/waf_rule_precise_protection.md
@@ -142,20 +142,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-There are two ways to import state, include `Without Enterprise Project ID` and `With Enterprise Project ID`.
+There are two ways to import WAF rule precise protection state.
 
-### Without Enterprise Project ID
-
-The waf precise protection rule can be imported using `policy_id`, `rule_id`, separated by a slash, e.g.
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
 
 ```bash
 $ terraform import huaweicloud_waf_rule_precise_protection.test <policy_id>/<rule_id>
 ```
 
-### With Enterprise Project ID
-
-The waf precise protection rule can be imported using `policy_id`, `rule_id`, `enterprise_project_id`,
-separated by slashes, e.g.
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
 
 ```bash
 $ terraform import huaweicloud_waf_rule_precise_protection.test <policy_id>/<rule_id>/<enterprise_project_id>

--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -48,8 +48,16 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Web Tamper Protection Rules can be imported using the policy ID and rule ID separated by a slash, e.g.:
+There are two ways to import WAF rule web tamper protection state.
 
-```sh
-terraform import huaweicloud_waf_rule_web_tamper_protection.rule_1 840c6dfdd5604c1781eea033eae2004f/c6dbc13bb7e74788ae53ecc9254b3ea8
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_web_tamper_protection.test <policy_id>/<rule_id>
+```
+
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_web_tamper_protection.test <policy_id>/<rule_id>/<enterprise_project_id>
 ```

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -71,7 +71,7 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 				ResourceName:      rName1,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(rName1),
+				ImportStateIdFunc: testWAFRuleImportState(rName1),
 			},
 		},
 	})
@@ -115,6 +115,12 @@ func TestAccWafRuleBlackList_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "address_group_name"),
 					resource.TestCheckResourceAttrSet(rName, "address_group_size"),
 				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -172,26 +178,6 @@ func testAccCheckWafRuleBlackListExists(n string, rule *rules.WhiteBlackIP) reso
 		*rule = *found
 
 		return nil
-	}
-}
-
-// testAccWafRuleImportStateIdFunc is used to test exporting rule information from the HuaweiCloud to terraform.
-// It is also called by other rules unit tests.
-func testAccWafRuleImportStateIdFunc(name string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		policy, ok := s.RootModule().Resources["huaweicloud_waf_policy.policy_1"]
-		if !ok {
-			return "", fmt.Errorf("WAF policy not found")
-		}
-		rule, ok := s.RootModule().Resources[name]
-		if !ok {
-			return "", fmt.Errorf("WAF rule not found")
-		}
-
-		if policy.Primary.ID == "" || rule.Primary.ID == "" {
-			return "", fmt.Errorf("resource not found: %s/%s", policy.Primary.ID, rule.Primary.ID)
-		}
-		return fmt.Sprintf("%s/%s", policy.Primary.ID, rule.Primary.ID), nil
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_cc_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_cc_protection_test.go
@@ -126,7 +126,7 @@ func TestAccRuleCCProtection_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testRuleCCProtectionImportState(rName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -177,7 +177,7 @@ func TestAccRuleCCProtection_withEpsID(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testRuleCCProtectionImportState(rName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -288,24 +288,4 @@ resource "huaweicloud_waf_rule_cc_protection" "test" {
   }
 }
 `, testAccWafPolicyV1_basic_withEpsID(name, epsID), name, epsID)
-}
-
-func testRuleCCProtectionImportState(name string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		if policyID == "" {
-			return "", fmt.Errorf("attribute (policy_id) of Resource (%s) not found: %s", name, rs)
-		}
-
-		epsID := rs.Primary.Attributes["enterprise_project_id"]
-		if epsID == "" {
-			return policyID + "/" + rs.Primary.ID, nil
-		}
-		return policyID + "/" + rs.Primary.ID + "/" + epsID, nil
-	}
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -61,7 +61,7 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 				ResourceName:      resourceName1,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName1),
+				ImportStateIdFunc: testWAFRuleImportState(resourceName1),
 			},
 		},
 	})
@@ -100,6 +100,12 @@ func TestAccWafRuleDataMasking_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subfield", "secret"),
 					resource.TestCheckResourceAttr(resourceName, "field", "params"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(resourceName),
 			},
 		},
 	})

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_global_protection_whitelist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_global_protection_whitelist_test.go
@@ -116,7 +116,7 @@ func TestAccRuleGlobalProtectionWhitelist_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testRuleGlobalProtectionWhitelistImportState(rName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -162,7 +162,7 @@ func TestAccRuleGlobalProtectionWhitelist_withEpsID(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testRuleGlobalProtectionWhitelistImportState(rName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -248,24 +248,4 @@ resource "huaweicloud_waf_rule_global_protection_whitelist" "test" {
   }
 }
 `, testAccWafDedicatedDomainV1_policy_withEpsID(randName, epsID), epsID)
-}
-
-func testRuleGlobalProtectionWhitelistImportState(name string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		if policyID == "" {
-			return "", fmt.Errorf("attribute (policy_id) of Resource (%s) not found: %s", name, rs)
-		}
-
-		epsID := rs.Primary.Attributes["enterprise_project_id"]
-		if epsID == "" {
-			return policyID + "/" + rs.Primary.ID, nil
-		}
-		return policyID + "/" + rs.Primary.ID + "/" + epsID, nil
-	}
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_precise_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_precise_protection_test.go
@@ -118,7 +118,7 @@ func TestAccRulePreciseProtection_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testRulePreciseProtectionImportState(rName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -177,7 +177,7 @@ func TestAccRulePreciseProtection_WithEpsID(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testRulePreciseProtectionImportState(rName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
@@ -310,7 +310,8 @@ resource "huaweicloud_waf_rule_precise_protection" "test" {
 `, testAccWafPolicyV1_basic_withEpsID(name, epsID), name, epsID)
 }
 
-func testRulePreciseProtectionImportState(name string) resource.ImportStateIdFunc {
+// testWAFRuleImportState use to return an id with format <policy_id>/<id> or <policy_id>/<id>/<enterprise_project_id>
+func testWAFRuleImportState(name string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -42,7 +42,7 @@ func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+				ImportStateIdFunc: testWAFRuleImportState(resourceName),
 			},
 		},
 	})
@@ -70,6 +70,12 @@ func TestAccWafRuleWebTamperProtection_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
 					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(resourceName),
 			},
 		},
 	})

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
@@ -1,7 +1,6 @@
 package waf
 
 import (
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -33,7 +32,7 @@ func ResourceWafRuleBlackListV1() *schema.Resource {
 		Update: resourceWafRuleBlackListUpdate,
 		Delete: resourceWafRuleBlackListDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceWafRulesImport,
+			StateContext: resourceWAFRuleImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -225,22 +224,4 @@ func resourceWafRuleBlackListDelete(d *schema.ResourceData, meta interface{}) er
 
 	d.SetId("")
 	return nil
-}
-
-// resourceWafRulesImport query the rules from HuaweiCloud and imports them to Terraform.
-// It is a common function in waf and is also called by other rule resources.
-func resourceWafRulesImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.SplitN(d.Id(), "/", 2)
-	if len(parts) != 2 {
-		err := fmtp.Errorf("Invalid format specified for WAF rule. Format must be <policy id>/<rule id>")
-		return nil, err
-	}
-
-	policyID := parts[0]
-	ruleID := parts[1]
-
-	d.SetId(ruleID)
-	d.Set("policy_id", policyID)
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
@@ -31,7 +31,7 @@ func ResourceWafRuleDataMaskingV1() *schema.Resource {
 		Update: resourceWafRuleDataMaskingUpdate,
 		Delete: resourceWafRuleDataMaskingDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceWafRulesImport,
+			StateContext: resourceWAFRuleImportState,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
@@ -23,7 +23,7 @@ func ResourceWafRuleWebTamperProtectionV1() *schema.Resource {
 		Read:   resourceWafRuleWebTamperProtectionRead,
 		Delete: resourceWafRuleWebTamperProtectionDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceWafRulesImport,
+			StateContext: resourceWAFRuleImportState,
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
waf rule resource support import id with epsid:
- waf_rule_blacklist
- waf_cc_protection
- waf_data_masking
- waf_rule_global_protection_whitelist
- waf_rule_precise_protection
- waf_rule_web_tamper_protection

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

- waf_rule_blacklist
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleBlackList_basic 
=== PAUSE TestAccWafRuleBlackList_basic
=== RUN   TestAccWafRuleBlackList_withEpsID
=== PAUSE TestAccWafRuleBlackList_withEpsID
=== CONT  TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_withEpsID
--- PASS: TestAccWafRuleBlackList_basic (381.78s) 
--- PASS: TestAccWafRuleBlackList_withEpsID (432.27s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       432.353s 
```

- waf_rule_cc_protection
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRuleCCProtection_' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleCCProtection_ -timeout 360m -parallel 4 
=== RUN   TestAccRuleCCProtection_basic 
=== PAUSE TestAccRuleCCProtection_basic
=== RUN   TestAccRuleCCProtection_withEpsID
=== PAUSE TestAccRuleCCProtection_withEpsID
=== CONT  TestAccRuleCCProtection_basic
=== CONT  TestAccRuleCCProtection_withEpsID
--- PASS: TestAccRuleCCProtection_withEpsID (371.16s) 
--- PASS: TestAccRuleCCProtection_basic (418.31s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       418.388s
```

- waf_rule_data_masking
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleDataMasking_basic 
=== PAUSE TestAccWafRuleDataMasking_basic
=== RUN   TestAccWafRuleDataMasking_withEpsID
=== PAUSE TestAccWafRuleDataMasking_withEpsID
=== CONT  TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_withEpsID
--- PASS: TestAccWafRuleDataMasking_basic (357.33s) 
--- PASS: TestAccWafRuleDataMasking_withEpsID (417.68s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       417.740s
```


- waf_rule_global_protection_whitelist
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRuleGlobalProtectionWhitelist_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleGlobalProtectionWhitelist_ -timeout 360m -parallel 4 
=== RUN   TestAccRuleGlobalProtectionWhitelist_basic 
=== PAUSE TestAccRuleGlobalProtectionWhitelist_basic
=== RUN   TestAccRuleGlobalProtectionWhitelist_withEpsID
=== PAUSE TestAccRuleGlobalProtectionWhitelist_withEpsID
=== CONT  TestAccRuleGlobalProtectionWhitelist_basic
=== CONT  TestAccRuleGlobalProtectionWhitelist_withEpsID
--- PASS: TestAccRuleGlobalProtectionWhitelist_basic (362.15s) 
--- PASS: TestAccRuleGlobalProtectionWhitelist_withEpsID (432.87s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       432.954s
```

- waf_rule_precise_protection
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRulePreciseProtection_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRulePreciseProtection_ -timeout 360m -parallel 4 
=== RUN   TestAccRulePreciseProtection_basic 
=== PAUSE TestAccRulePreciseProtection_basic
=== RUN   TestAccRulePreciseProtection_WithEpsID
=== PAUSE TestAccRulePreciseProtection_WithEpsID
=== CONT  TestAccRulePreciseProtection_basic
=== CONT  TestAccRulePreciseProtection_WithEpsID
--- PASS: TestAccRulePreciseProtection_WithEpsID (402.60s) 
--- PASS: TestAccRulePreciseProtection_basic (402.85s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       402.938s
```

- waf_rule_web_tamper_protection
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_ -timeout 360m -parallel 4 
=== RUN   TestAccWafRuleWebTamperProtection_basic 
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== RUN   TestAccWafRuleWebTamperProtection_withEpsID
=== PAUSE TestAccWafRuleWebTamperProtection_withEpsID
=== CONT  TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_withEpsID
--- PASS: TestAccWafRuleWebTamperProtection_basic (366.72s) 
--- PASS: TestAccWafRuleWebTamperProtection_withEpsID (367.01s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       367.062s
```



