### PR TITLE
feat(rds/instance): instance support automatic expansion

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -282,6 +282,15 @@ The `volume` block supports:
 * `disk_encryption_id` - (Optional, String, ForceNew) Specifies the key ID for disk encryption.
   Changing this parameter will create a new resource.
 
+* `limit_size` - (Optional, Int) Specifies the upper limit of automatic expansion of storage, in GB.
+
+* `trigger_threshold` - (Optional, Int) Specifies the threshold to trigger automatic expansion.  
+  If the available storage drops to this threshold or `10` GB, the automatic expansion is triggered.  
+  The valid values are as follows:
+  + **10**
+  + **15**
+  + **20**
+
 The `backup_strategy` block supports:
 
 * `keep_days` - (Optional, Int) Specifies the retention days for specific backup files. The value range is from 0 to


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The valid storage types of the auto-expansion instance are `CLOUDSSD` and `ESSD`.
Updating flavor name and AZ because of only dedicated and normal instance are support `CLOUDSSD` storage type.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the instance support automatic expansion function.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run=TestAc
cRdsInstance_mysql'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run=TestAccRdsInstance_mysql -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_mysql
--- PASS: TestAccRdsInstance_mysql (753.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds  753.433s
```
