### PR TITLE
refactor(drs/job): remove the validation from schema

### DIFF
--- a/docs/resources/drs_job.md
+++ b/docs/resources/drs_job.md
@@ -82,6 +82,10 @@ The following arguments are supported:
   + **mongodb**: Mongodb migration use.
   + **cloudDataGuard-mysql**: Disaster recovery use.
   + **gaussdbv5**: GaussDB (for openGauss) synchronization use.
+  + **mysql-to-kafka**: Synchronization from MySQL to Kafka use.
+  + **taurus-to-kafka**: Synchronization from GaussDB(for MySQL) to Kafka use.
+  + **gaussdbv5ha-to-kafka**: Synchronization from GaussDB primary/standby to Kafka use.
+  + **postgresql**: Synchronization from PostgreSQL to PostgreSQL use.
 
 * `direction` - (Required, String, ForceNew) Specifies the direction of data flow.
  Changing this parameter will create a new resource. The options are as follows:
@@ -104,7 +108,7 @@ The following arguments are supported:
   + **vpc**: suitable for migration from one cloud database to another.
   + **vpn**: suitable for migration from an on-premises self-built database to a destination cloud database,
    or from one cloud database to another in a different region.
-  
+
  The default value is `eip`.
 
 * `migration_type` - (Optional, String, ForceNew) Specifies migration type.
@@ -116,7 +120,7 @@ The following arguments are supported:
   + **FULL_INCR_TRANS**:  Full+Incremental migration. This allows to migrate data with minimal downtime. After a full
    migration initializes the destination database, an incremental migration parses logs to ensure data consistency
    between the source and destination databases.
-  
+
  The default value is `FULL_INCR_TRANS`.
 
 * `migrate_definer` - (Optional, Bool, ForceNew) Specifies whether to migrate the definers of all source database

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -51,25 +51,21 @@ func ResourceDrsJob() *schema.Resource {
 			},
 
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"migration", "sync", "cloudDataGuard"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"engine_type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{"mysql", "mongodb", "cloudDataGuard-mysql",
-					"gaussdbv5"}, false),
 			},
 
 			"direction": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"up", "down", "non-dbs"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"source_db": {
@@ -96,19 +92,17 @@ func ResourceDrsJob() *schema.Resource {
 			},
 
 			"net_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      "eip",
-				ValidateFunc: validation.StringInSlice([]string{"vpn", "vpc", "eip"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "eip",
 			},
 
 			"migration_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      "FULL_INCR_TRANS",
-				ValidateFunc: validation.StringInSlice([]string{"FULL_TRANS", "FULL_INCR_TRANS", "INCR_TRANS"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "FULL_INCR_TRANS",
 			},
 
 			"description": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For parameter `type`, `engine_type`, `direction`, `net_type` and `migration_type`, the validation should be removed.
Some enums of engine_type  in document are missing.
- mysql-to-kafka
- taurus-to-kafka
- gaussdbv5ha-to-kafka
- postgresql

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Remove the validation from schema.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
