### PR TITLE
fix(docs): images resource example usage error

### DIFF
--- a/docs/resources/images_image_share.md
+++ b/docs/resources/images_image_share.md
@@ -12,7 +12,7 @@ Manages an IMS image share resource within HuaweiCloud.
 variable "source_image_id" {}
 variable "target_project_ids" {}
 
-resource "resource_huaweicloud_images_image_share" "test" {
+resource "huaweicloud_images_image_share" "test" {
   source_image_id    = var.source_image_id
   target_project_ids = var.target_project_ids
 }

--- a/docs/resources/images_image_share_accepter.md
+++ b/docs/resources/images_image_share_accepter.md
@@ -11,7 +11,7 @@ Manages an IMS image share accepter resource within HuaweiCloud.
 ```hcl
 variable "image_id" {}
 
-resource "resource_huaweicloud_images_image_share_accepter" "test" {
+resource "huaweicloud_images_image_share_accepter" "test" {
   image_id   = var.image_id
 }
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The example usage of resources huaweicloud_images_image_share and  huaweicloud_images_image_share_accepter in the docs is error, Using examples will result in errors.

resource "resource_huaweicloud_images_image_share" "test" {
  source_image_id    = var.source_image_id
  target_project_ids = var.target_project_ids
}

resource "resource_huaweicloud_images_image_share_accepter" "test" {
  image_id   = var.image_id
}

**Which issue this PR fixes**:
(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged)
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
1.  fix erroe in example usage of resources huaweicloud_images_image_share and  huaweicloud_images_image_share_accepter

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
