### PR TITLE
feat(DWS): add a new resource to manage alarm subscription

### DIFF
--- a/docs/resources/dws_alarm_subscription.md
+++ b/docs/resources/dws_alarm_subscription.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# huaweicloud_dws_alarm_subscription
+
+Manages a DWS alarm subscription resource within HuaweiCloud.  
+
+## Example Usage
+
+```hcl
+variable "smn_urn" {}
+variable "smn_name" {}
+
+resource "huaweicloud_dws_alarm_subscription" "test" {
+  name                     = "demo"
+  enable                   = 1
+  notification_target      = var.smn_urn
+  notification_target_name = var.smn_name
+  notification_target_type = "SMN"
+  alarm_level              = "urgent,important"
+  time_zone                = "GMT+08:00"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) The name of the alarm subscription.
+
+* `enable` - (Required, Int) Whether the alarm subscription is enabled.  
+  The options are as follows:
+    + **1**: enable.
+    + **0**: closed.
+
+* `notification_target` - (Required, String) The notification target.  
+
+* `notification_target_name` - (Required, String) The name of notification target.  
+
+* `notification_target_type` - (Required, String) The type of notification target. Currently only **SMN** is supported.
+
+* `time_zone` - (Required, String, ForceNew) The time_zone of the alarm subscription.  
+
+  Changing this parameter will create a new resource.
+
+* `alarm_level` - (Optional, String) The level of alarm. separate multiple alarm levels with commas (,).
+  The valid values are **urgent**, **important**, **minor**, and **prompt**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The DWS alarm subscription can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dws_alarm_subscription.test 535d9c3c-e135-4a6f-bcbf-4db51446f471
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -776,6 +776,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dws_cluster":            dws.ResourceDwsCluster(),
 			"huaweicloud_dws_event_subscription": dws.ResourceDwsEventSubs(),
+			"huaweicloud_dws_alarm_subscription": dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_snapshot":           dws.ResourceDwsSnapshot(),
 			"huaweicloud_dws_snapshot_policy":    dws.ResourceDwsSnapshotPolicy(),
 

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_alarm_subscription_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_alarm_subscription_test.go
@@ -1,0 +1,164 @@
+package dws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDwsAlarmSubsResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getDwsAlarmSubs: Query the DWS alarm subscription.
+	var (
+		getDwsAlarmSubsHttpUrl = "v2/{project_id}/alarm-subs"
+		getDwsAlarmSubsProduct = "dws"
+	)
+	getDwsAlarmSubsClient, err := cfg.NewServiceClient(getDwsAlarmSubsProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	getDwsAlarmSubsPath := getDwsAlarmSubsClient.Endpoint + getDwsAlarmSubsHttpUrl
+	getDwsAlarmSubsPath = strings.ReplaceAll(getDwsAlarmSubsPath, "{project_id}", getDwsAlarmSubsClient.ProjectID)
+
+	getDwsAlarmSubsResp, err := pagination.ListAllItems(
+		getDwsAlarmSubsClient,
+		"offset",
+		getDwsAlarmSubsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsAlarmSubs: %s", err)
+	}
+
+	getDwsAlarmSubsRespJson, err := json.Marshal(getDwsAlarmSubsResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+	var getDwsAlarmSubsRespBody interface{}
+	err = json.Unmarshal(getDwsAlarmSubsRespJson, &getDwsAlarmSubsRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DwsEventSubs: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("alarm_subscriptions[?id=='%s']|[0]", state.Primary.ID)
+	rawData := utils.PathSearch(jsonPath, getDwsAlarmSubsRespBody, nil)
+	if rawData == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return rawData, nil
+}
+
+func TestAccDwsAlarmSubs_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dws_alarm_subscription.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDwsAlarmSubsResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDwsAlarmSubs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enable", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "huaweicloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "huaweicloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "urgent,important"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				Config: testDwsAlarmSubs_basic_update(name + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "enable", "0"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "huaweicloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "huaweicloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "urgent,important,minor"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				Config: testDwsAlarmSubs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enable", "1"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target", "huaweicloud_smn_topic.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name", "huaweicloud_smn_topic.test", "name"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttr(rName, "alarm_level", "urgent,important"),
+					resource.TestCheckResourceAttr(rName, "time_zone", "GMT+09:00"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDwsAlarmSubs_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%s"
+  display_name = "The display name of topic"
+}
+
+resource "huaweicloud_dws_alarm_subscription" "test" {
+  name                     = "%s"
+  enable                   = "1"
+  notification_target      = huaweicloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = huaweicloud_smn_topic.test.name
+  time_zone                = "GMT+09:00"
+  alarm_level              = "urgent,important"
+}
+`, name, name)
+}
+
+func testDwsAlarmSubs_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%s"
+  display_name = "The display name of topic"
+}
+
+resource "huaweicloud_dws_alarm_subscription" "test" {
+  name                     = "%s"
+  enable                   = "0"
+  notification_target      = huaweicloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = huaweicloud_smn_topic.test.name
+  time_zone                = "GMT+09:00"
+  alarm_level              = "urgent,important,minor"
+}
+`, name, name)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
@@ -1,0 +1,287 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DWS
+// ---------------------------------------------------------------
+
+package dws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDwsAlarmSubs() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDwsAlarmSubsCreate,
+		UpdateContext: resourceDwsAlarmSubsUpdate,
+		ReadContext:   resourceDwsAlarmSubsRead,
+		DeleteContext: resourceDwsAlarmSubsDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the alarm subscription.`,
+			},
+			"enable": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `whether the alarm subscription is enabled.`,
+			},
+			"notification_target": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The notification target.`,
+			},
+			"notification_target_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of notification target.`,
+			},
+			"notification_target_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of notification target. Currently only **SMN** is supported.`,
+			},
+			"time_zone": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The time_zone of the alarm subscription.`,
+			},
+			"alarm_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: `The level of alarm. separate multiple alarm levels with commas (,).
+`,
+			},
+		},
+	}
+}
+
+func resourceDwsAlarmSubsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createDwsAlarmSubs: create a DWS alarm subscription.
+	var (
+		createDwsAlarmSubsHttpUrl = "v2/{project_id}/alarm-subs"
+		createDwsAlarmSubsProduct = "dws"
+	)
+	createDwsAlarmSubsClient, err := cfg.NewServiceClient(createDwsAlarmSubsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS Client: %s", err)
+	}
+
+	createDwsAlarmSubsPath := createDwsAlarmSubsClient.Endpoint + createDwsAlarmSubsHttpUrl
+	createDwsAlarmSubsPath = strings.ReplaceAll(createDwsAlarmSubsPath, "{project_id}", createDwsAlarmSubsClient.ProjectID)
+
+	createDwsAlarmSubsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createDwsAlarmSubsOpt.JSONBody = utils.RemoveNil(buildCreateDwsAlarmSubsBodyParams(d))
+	createDwsAlarmSubsResp, err := createDwsAlarmSubsClient.Request("POST", createDwsAlarmSubsPath, &createDwsAlarmSubsOpt)
+	if err != nil {
+		return diag.Errorf("error creating DWS alarm subscription: %s", err)
+	}
+
+	createDwsAlarmSubsRespBody, err := utils.FlattenResponse(createDwsAlarmSubsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("id", createDwsAlarmSubsRespBody)
+	if err != nil {
+		return diag.Errorf("error creating DWS alarm subscription: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceDwsAlarmSubsRead(ctx, d, meta)
+}
+
+func buildCreateDwsAlarmSubsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                     utils.ValueIngoreEmpty(d.Get("name")),
+		"alarm_level":              utils.ValueIngoreEmpty(d.Get("alarm_level")),
+		"enable":                   d.Get("enable"),
+		"notification_target":      utils.ValueIngoreEmpty(d.Get("notification_target")),
+		"notification_target_name": utils.ValueIngoreEmpty(d.Get("notification_target_name")),
+		"notification_target_type": utils.ValueIngoreEmpty(d.Get("notification_target_type")),
+		"time_zone":                utils.ValueIngoreEmpty(d.Get("time_zone")),
+	}
+	return bodyParams
+}
+
+func resourceDwsAlarmSubsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getDwsAlarmSubs: Query the DWS alarm subscription.
+	var (
+		getDwsAlarmSubsHttpUrl = "v2/{project_id}/alarm-subs"
+		getDwsAlarmSubsProduct = "dws"
+	)
+	getDwsAlarmSubsClient, err := cfg.NewServiceClient(getDwsAlarmSubsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS Client: %s", err)
+	}
+
+	getDwsAlarmSubsPath := getDwsAlarmSubsClient.Endpoint + getDwsAlarmSubsHttpUrl
+	getDwsAlarmSubsPath = strings.ReplaceAll(getDwsAlarmSubsPath, "{project_id}", getDwsAlarmSubsClient.ProjectID)
+
+	getDwsAlarmSubsResp, err := pagination.ListAllItems(
+		getDwsAlarmSubsClient,
+		"offset",
+		getDwsAlarmSubsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DWS alarm subscription")
+	}
+
+	getDwsAlarmSubsRespJson, err := json.Marshal(getDwsAlarmSubsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getDwsAlarmSubsRespBody interface{}
+	err = json.Unmarshal(getDwsAlarmSubsRespJson, &getDwsAlarmSubsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jsonPath := fmt.Sprintf("alarm_subscriptions[?id=='%s']|[0]", d.Id())
+	rawData := utils.PathSearch(jsonPath, getDwsAlarmSubsRespBody, nil)
+	if rawData == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "no data found")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", rawData, nil)),
+		d.Set("alarm_level", utils.PathSearch("alarm_level", rawData, nil)),
+		d.Set("enable", utils.PathSearch("enable", rawData, nil)),
+		d.Set("notification_target", utils.PathSearch("notification_target", rawData, nil)),
+		d.Set("notification_target_name", utils.PathSearch("notification_target_name", rawData, nil)),
+		d.Set("notification_target_type", utils.PathSearch("notification_target_type", rawData, nil)),
+		d.Set("time_zone", utils.PathSearch("time_zone", rawData, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDwsAlarmSubsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateDwsAlarmSubsChanges := []string{
+		"name",
+		"alarm_level",
+		"enable",
+		"notification_target",
+		"notification_target_name",
+		"notification_target_type",
+	}
+
+	if d.HasChanges(updateDwsAlarmSubsChanges...) {
+		// updateDwsAlarmSubs: update the DWS alarm subscription.
+		var (
+			updateDwsAlarmSubsHttpUrl = "v2/{project_id}/alarm-subs/{id}"
+			updateDwsAlarmSubsProduct = "dws"
+		)
+		updateDwsAlarmSubsClient, err := cfg.NewServiceClient(updateDwsAlarmSubsProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating DWS Client: %s", err)
+		}
+
+		updateDwsAlarmSubsPath := updateDwsAlarmSubsClient.Endpoint + updateDwsAlarmSubsHttpUrl
+		updateDwsAlarmSubsPath = strings.ReplaceAll(updateDwsAlarmSubsPath, "{project_id}", updateDwsAlarmSubsClient.ProjectID)
+		updateDwsAlarmSubsPath = strings.ReplaceAll(updateDwsAlarmSubsPath, "{id}", d.Id())
+
+		updateDwsAlarmSubsOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateDwsAlarmSubsOpt.JSONBody = utils.RemoveNil(buildUpdateDwsAlarmSubsBodyParams(d))
+		_, err = updateDwsAlarmSubsClient.Request("PUT", updateDwsAlarmSubsPath, &updateDwsAlarmSubsOpt)
+		if err != nil {
+			return diag.Errorf("error updating DWS alarm subscription: %s", err)
+		}
+	}
+	return resourceDwsAlarmSubsRead(ctx, d, meta)
+}
+
+func buildUpdateDwsAlarmSubsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":                     utils.ValueIngoreEmpty(d.Get("name")),
+		"alarm_level":              utils.ValueIngoreEmpty(d.Get("alarm_level")),
+		"enable":                   d.Get("enable"),
+		"notification_target":      utils.ValueIngoreEmpty(d.Get("notification_target")),
+		"notification_target_name": utils.ValueIngoreEmpty(d.Get("notification_target_name")),
+		"notification_target_type": utils.ValueIngoreEmpty(d.Get("notification_target_type")),
+	}
+	return bodyParams
+}
+
+func resourceDwsAlarmSubsDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteDwsAlarmSubs: delete DWS alarm subscription
+	var (
+		deleteDwsAlarmSubsHttpUrl = "v2/{project_id}/alarm-subs/{id}"
+		deleteDwsAlarmSubsProduct = "dws"
+	)
+	deleteDwsAlarmSubsClient, err := cfg.NewServiceClient(deleteDwsAlarmSubsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS Client: %s", err)
+	}
+
+	deleteDwsAlarmSubsPath := deleteDwsAlarmSubsClient.Endpoint + deleteDwsAlarmSubsHttpUrl
+	deleteDwsAlarmSubsPath = strings.ReplaceAll(deleteDwsAlarmSubsPath, "{project_id}", deleteDwsAlarmSubsClient.ProjectID)
+	deleteDwsAlarmSubsPath = strings.ReplaceAll(deleteDwsAlarmSubsPath, "{id}", d.Id())
+
+	deleteDwsAlarmSubsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	_, err = deleteDwsAlarmSubsClient.Request("DELETE", deleteDwsAlarmSubsPath, &deleteDwsAlarmSubsOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DWS alarm subscription: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccDwsAlarmSubs_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws -v

=== RUN   TestAccDwsAlarmSubs_basic
=== PAUSE TestAccDwsAlarmSubs_basic
=== CONT  TestAccDwsAlarmSubs_basic
--- PASS: TestAccDwsAlarmSubs_basic (27.93s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws	27.966s
```
