### PR TITLE
feat(cce/addon): support updating version and values

### DIFF
--- a/docs/resources/cce_addon.md
+++ b/docs/resources/cce_addon.md
@@ -31,38 +31,30 @@ The following arguments are supported:
 * `template_name` - (Required, String, ForceNew) Specifies the name of the add-on template.
   Changing this parameter will create a new resource.
 
-* `version` - (Required, String, ForceNew) Specifies the version of the add-on.
-  Changing this parameter will create a new resource.
+* `version` - (Optional, String) Specifies the version of the add-on.
 
-* `values` - (Optional, List, ForceNew) Specifies the add-on template installation parameters.
+* `values` - (Optional, List) Specifies the add-on template installation parameters.
   These parameters vary depending on the add-on. Structure is documented below.
-  Changing this parameter will create a new resource.
 
 * The `values` block supports:
 
-* `basic_json` - (Optional, String, ForceNew) Specifies the json string vary depending on the add-on.
-  Changing this parameter will create a new resource.
+* `basic_json` - (Optional, String) Specifies the json string vary depending on the add-on.
 
-* `custom_json` - (Optional, String, ForceNew) Specifies the json string vary depending on the add-on.
-  Changing this parameter will create a new resource.
+* `custom_json` - (Optional, String) Specifies the json string vary depending on the add-on.
 
-* `flavor_json` - (Optional, String, ForceNew) Specifies the json string vary depending on the add-on.
-  Changing this parameter will create a new resource.
+* `flavor_json` - (Optional, String) Specifies the json string vary depending on the add-on.
 
-* `basic` - (Optional, Map, ForceNew) Specifies the key/value pairs vary depending on the add-on.
+* `basic` - (Optional, Map) Specifies the key/value pairs vary depending on the add-on.
   Only supports non-nested structure and only supports string type elements.
   This is an alternative to `basic_json`, but it is not recommended.
-  Changing this parameter will create a new resource.
 
-* `custom` - (Optional, Map, ForceNew) Specifies the key/value pairs vary depending on the add-on.
+* `custom` - (Optional, Map) Specifies the key/value pairs vary depending on the add-on.
   Only supports non-nested structure and only supports string type elements.
   This is an alternative to `custom_json`, but it is not recommended.
-  Changing this parameter will create a new resource.
 
-* `flavor` - (Optional, Map, ForceNew) Specifies the key/value pairs vary depending on the add-on.
+* `flavor` - (Optional, Map) Specifies the key/value pairs vary depending on the add-on.
   Only supports non-nested structure and only supports string type elements.
   This is an alternative to `flavor_json`, but it is not recommended.
-  Changing this parameter will create a new resource.
 
 Arguments which can be passed to the `basic_json`, `custom_json` and `flavor_json` add-on parameters depends on
 the add-on type and version. For more detailed description of add-ons
@@ -81,6 +73,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
 * `delete` - Default is 3 minute.
 
 ## Import

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9
+	github.com/chnsz/golangsdk v0.0.0-20230522025655-f4e01be42b05
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230512064740-25051b6b01db h1:25dsiieC3p00Zv6jspbLfeTHE4sefhlEU/ms1tlqQy8=
-github.com/chnsz/golangsdk v0.0.0-20230512064740-25051b6b01db/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9 h1:iqjmoZ7ufJxAQ3FbrPbqUXLpMEIiYCUnuqxMj5Aa2tA=
-github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230522025655-f4e01be42b05 h1:SeHi7l46SK6e3uf/oUVeR2xNsisWVIHXBu0M/qmDql0=
+github.com/chnsz/golangsdk v0.0.0-20230522025655-f4e01be42b05/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -394,7 +394,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cbh_instances": cbh.DataSourceCbhInstances(),
 
-			"huaweicloud_cce_addon_template": cce.DataSourceCCEAddonTemplateV3(),
+			"huaweicloud_cce_addon_template": cce.DataSourceAddonTemplate(),
 			"huaweicloud_cce_cluster":        cce.DataSourceCCEClusterV3(),
 			"huaweicloud_cce_clusters":       cce.DataSourceCCEClusters(),
 			"huaweicloud_cce_node":           cce.DataSourceNode(),
@@ -666,7 +666,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_cluster":     cce.ResourceCluster(),
 			"huaweicloud_cce_node":        cce.ResourceNode(),
 			"huaweicloud_cce_node_attach": cce.ResourceCCENodeAttachV3(),
-			"huaweicloud_cce_addon":       cce.ResourceCCEAddonV3(),
+			"huaweicloud_cce_addon":       cce.ResourceAddon(),
 			"huaweicloud_cce_node_pool":   cce.ResourceCCENodePool(),
 			"huaweicloud_cce_namespace":   cce.ResourceCCENamespaceV1(),
 			"huaweicloud_cce_pvc":         cce.ResourceCcePersistentVolumeClaimsV1(),

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_addon_template_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_addon_template_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
+func TestAccAddonTemplateDataSource_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -17,7 +18,7 @@ func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCEAddonTemplateV3DataSource_basic(rName),
+				Config: testAccAddonTemplateDataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.huaweicloud_cce_addon_template.spark_operator_test", "spec"),
 					resource.TestCheckResourceAttrSet("data.huaweicloud_cce_addon_template.nginx_ingress_test", "spec"),
@@ -27,7 +28,7 @@ func TestAccCCEAddonTemplateV3DataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCCEAddonTemplateV3DataSource_basic(rName string) string {
+func testAccAddonTemplateDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_test.go
@@ -4,18 +4,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/addons"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccCCEAddonV3_basic(t *testing.T) {
+func TestAccAddon_basic(t *testing.T) {
 	var addon addons.Addon
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -25,12 +24,12 @@ func TestAccCCEAddonV3_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCEAddonV3Destroy,
+		CheckDestroy:      testAccCheckAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCEAddonV3_basic(rName),
+				Config: testAccAddon_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCEAddonV3Exists(resourceName, clusterName, &addon),
+					testAccCheckAddonExists(resourceName, clusterName, &addon),
 					resource.TestCheckResourceAttr(resourceName, "status", "running"),
 				),
 			},
@@ -38,13 +37,13 @@ func TestAccCCEAddonV3_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCCEAddonImportStateIdFunc(),
+				ImportStateIdFunc: testAccAddonImportStateIdFunc(),
 			},
 		},
 	})
 }
 
-func TestAccCCEAddonV3_values(t *testing.T) {
+func TestAccAddon_values(t *testing.T) {
 	var addon addons.Addon
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
@@ -57,12 +56,12 @@ func TestAccCCEAddonV3_values(t *testing.T) {
 			acceptance.TestAccPreCheckProjectID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCEAddonV3Destroy,
+		CheckDestroy:      testAccCheckAddonDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCEAddonV3_values(rName),
+				Config: testAccAddon_values(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCEAddonV3Exists(resourceName, clusterName, &addon),
+					testAccCheckAddonExists(resourceName, clusterName, &addon),
 					resource.TestCheckResourceAttr(resourceName, "status", "running"),
 				),
 			},
@@ -70,11 +69,11 @@ func TestAccCCEAddonV3_values(t *testing.T) {
 	})
 }
 
-func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	cceClient, err := config.CceAddonV3Client(acceptance.HW_REGION_NAME)
+func testAccCheckAddonDestroy(s *terraform.State) error {
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	cceClient, err := cfg.CceAddonV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud CCE Addon client: %s", err)
+		return fmt.Errorf("error creating CCE Addon client: %s", err)
 	}
 
 	var clusterId string
@@ -91,35 +90,35 @@ func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
 		if clusterId != "" {
 			_, err := addons.Get(cceClient, rs.Primary.ID, clusterId).Extract()
 			if err == nil {
-				return fmtp.Errorf("addon still exists")
+				return fmt.Errorf("addon still exists")
 			}
 		}
 	}
 	return nil
 }
 
-func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon) resource.TestCheckFunc {
+func testAccCheckAddonExists(n string, cluster string, addon *addons.Addon) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 		c, ok := s.RootModule().Resources[cluster]
 		if !ok {
-			return fmtp.Errorf("Cluster not found: %s", c)
+			return fmt.Errorf("cluster not found: %s", c)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 		if c.Primary.ID == "" {
-			return fmtp.Errorf("Cluster id is not set")
+			return fmt.Errorf("cluster id is not set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		cceClient, err := config.CceAddonV3Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		cceClient, err := cfg.CceAddonV3Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud CCE Addon client: %s", err)
+			return fmt.Errorf("error creating CCE Addon client: %s", err)
 		}
 
 		found, err := addons.Get(cceClient, rs.Primary.ID, c.Primary.ID).Extract()
@@ -128,7 +127,7 @@ func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon)
 		}
 
 		if found.Metadata.Id != rs.Primary.ID {
-			return fmtp.Errorf("Addon not found")
+			return fmt.Errorf("addon not found")
 		}
 
 		*addon = *found
@@ -137,7 +136,7 @@ func testAccCheckCCEAddonV3Exists(n string, cluster string, addon *addons.Addon)
 	}
 }
 
-func testAccCCEAddonImportStateIdFunc() resource.ImportStateIdFunc {
+func testAccAddonImportStateIdFunc() resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		var clusterID string
 		var addonID string
@@ -149,13 +148,13 @@ func testAccCCEAddonImportStateIdFunc() resource.ImportStateIdFunc {
 			}
 		}
 		if clusterID == "" || addonID == "" {
-			return "", fmtp.Errorf("resource not found: %s/%s", clusterID, addonID)
+			return "", fmt.Errorf("resource not found: %s/%s", clusterID, addonID)
 		}
 		return fmt.Sprintf("%s/%s", clusterID, addonID), nil
 	}
 }
 
-func testAccCCEAddonV3_Base(rName string) string {
+func testAccAddon_Base(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -178,7 +177,7 @@ resource "huaweicloud_cce_node" "test" {
 `, testAccNode_Base(rName), rName)
 }
 
-func testAccCCEAddonV3_basic(rName string) string {
+func testAccAddon_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -188,10 +187,10 @@ resource "huaweicloud_cce_addon" "test" {
   template_name = "metrics-server"
   depends_on    = [huaweicloud_cce_node.test]
 }
-`, testAccCCEAddonV3_Base(rName))
+`, testAccAddon_Base(rName))
 }
 
-func testAccCCEAddonV3_values(rName string) string {
+func testAccAddon_values(rName string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_addon.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_addon.go
@@ -3,32 +3,33 @@ package cce
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log"
 	"strings"
 	"time"
-
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/cce/v3/addons"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cce/v3/addons"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func ResourceCCEAddonV3() *schema.Resource {
+func ResourceAddon() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceCCEAddonV3Create,
-		ReadContext:   resourceCCEAddonV3Read,
-		DeleteContext: resourceCCEAddonV3Delete,
+		CreateContext: resourceAddonCreate,
+		ReadContext:   resourceAddonRead,
+		DeleteContext: resourceAddonDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceCCEAddonV3Import,
+			StateContext: resourceAddonImport,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -148,7 +149,7 @@ func getValuesValues(d *schema.ResourceData) (basic, custom, flavor map[string]i
 	if basicJsonRaw := valuesMap["basic_json"].(string); basicJsonRaw != "" {
 		err = json.Unmarshal([]byte(basicJsonRaw), &basic)
 		if err != nil {
-			err = fmtp.Errorf("Error unmarshalling basic json: %s", err)
+			err = fmt.Errorf("error unmarshalling basic json: %s", err)
 			return
 		}
 	}
@@ -159,7 +160,7 @@ func getValuesValues(d *schema.ResourceData) (basic, custom, flavor map[string]i
 	if customJsonRaw := valuesMap["custom_json"].(string); customJsonRaw != "" {
 		err = json.Unmarshal([]byte(customJsonRaw), &custom)
 		if err != nil {
-			err = fmtp.Errorf("Error unmarshalling custom json: %s", err)
+			err = fmt.Errorf("error unmarshalling custom json: %s", err)
 			return
 		}
 	}
@@ -170,7 +171,7 @@ func getValuesValues(d *schema.ResourceData) (basic, custom, flavor map[string]i
 	if flavorJsonRaw := valuesMap["flavor_json"].(string); flavorJsonRaw != "" {
 		err = json.Unmarshal([]byte(flavorJsonRaw), &flavor)
 		if err != nil {
-			err = fmtp.Errorf("Error unmarshalling flavor json %s", err)
+			err = fmt.Errorf("error unmarshalling flavor json %s", err)
 			return
 		}
 	}
@@ -178,18 +179,18 @@ func getValuesValues(d *schema.ResourceData) (basic, custom, flavor map[string]i
 	return
 }
 
-func resourceCCEAddonV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	cceClient, err := config.CceAddonV3Client(config.GetRegion(d))
+func resourceAddonCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	cceClient, err := cfg.CceAddonV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud CCE client : %s", err)
+		return diag.Errorf("unable to create CCE client : %s", err)
 	}
 
-	var cluster_id = d.Get("cluster_id").(string)
+	var clusterID = d.Get("cluster_id").(string)
 
 	basic, custom, flavor, err := getValuesValues(d)
 	if err != nil {
-		return fmtp.DiagErrorf("error getting values for CCE addon: %s", err)
+		return diag.Errorf("error getting values for CCE addon: %s", err)
 	}
 
 	createOpts := addons.CreateOpts{
@@ -202,7 +203,7 @@ func resourceCCEAddonV3Create(ctx context.Context, d *schema.ResourceData, meta 
 		},
 		Spec: addons.RequestSpec{
 			Version:           d.Get("version").(string),
-			ClusterID:         cluster_id,
+			ClusterID:         clusterID,
 			AddonTemplateName: d.Get("template_name").(string),
 			Values: addons.Values{
 				Basic:  basic,
@@ -212,18 +213,18 @@ func resourceCCEAddonV3Create(ctx context.Context, d *schema.ResourceData, meta 
 		},
 	}
 
-	create, err := addons.Create(cceClient, createOpts, cluster_id).Extract()
+	create, err := addons.Create(cceClient, createOpts, clusterID).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud CCEAddon: %s", err)
+		return diag.Errorf("error creating CCEAddon: %s", err)
 	}
 
 	d.SetId(create.Metadata.Id)
 
-	logp.Printf("[DEBUG] Waiting for HuaweiCloud CCEAddon (%s) to become available", create.Metadata.Id)
+	log.Printf("[DEBUG] Waiting for CCEAddon (%s) to become available", create.Metadata.Id)
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"installing", "abnormal"},
 		Target:       []string{"running", "available"},
-		Refresh:      waitForCCEAddonActive(cceClient, create.Metadata.Id, cluster_id),
+		Refresh:      waitForAddonActive(cceClient, create.Metadata.Id, clusterID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -231,28 +232,28 @@ func resourceCCEAddonV3Create(ctx context.Context, d *schema.ResourceData, meta 
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud CCEAddon: %s", err)
+		return diag.Errorf("error creating CCEAddon: %s", err)
 	}
 
-	return resourceCCEAddonV3Read(ctx, d, meta)
+	return resourceAddonRead(ctx, d, meta)
 }
 
-func resourceCCEAddonV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	cceClient, err := config.CceAddonV3Client(config.GetRegion(d))
+func resourceAddonRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	cceClient, err := cfg.CceAddonV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud CCE client: %s", err)
+		return diag.Errorf("error creating CCE client: %s", err)
 	}
 
-	var cluster_id = d.Get("cluster_id").(string)
+	var clusterID = d.Get("cluster_id").(string)
 
-	n, err := addons.Get(cceClient, d.Id(), cluster_id).Extract()
+	n, err := addons.Get(cceClient, d.Id(), clusterID).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error retrieving HuaweiCloud CCE Addon")
+		return common.CheckDeletedDiag(d, err, "error retrieving CCE Addon")
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("cluster_id", n.Spec.ClusterID),
 		d.Set("version", n.Spec.Version),
 		d.Set("template_name", n.Spec.AddonTemplateName),
@@ -260,29 +261,29 @@ func resourceCCEAddonV3Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("description", n.Spec.Description),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("Error setting CCE Addon fields: %s", err)
+		return diag.Errorf("error setting CCE Addon fields: %s", err)
 	}
 
 	return nil
 }
 
-func resourceCCEAddonV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	cceClient, err := config.CceAddonV3Client(config.GetRegion(d))
+func resourceAddonDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	cceClient, err := cfg.CceAddonV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud CCEAddon Client: %s", err)
+		return diag.Errorf("error creating CCEAddon Client: %s", err)
 	}
 
-	var cluster_id = d.Get("cluster_id").(string)
+	var clusterID = d.Get("cluster_id").(string)
 
-	err = addons.Delete(cceClient, d.Id(), cluster_id).ExtractErr()
+	err = addons.Delete(cceClient, d.Id(), clusterID).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting HuaweiCloud CCE Addon: %s", err)
+		return diag.Errorf("error deleting CCE Addon: %s", err)
 	}
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"Deleting", "Available", "Unavailable"},
 		Target:       []string{"Deleted"},
-		Refresh:      waitForCCEAddonDelete(cceClient, d.Id(), cluster_id),
+		Refresh:      waitForAddonDelete(cceClient, d.Id(), clusterID),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -291,14 +292,14 @@ func resourceCCEAddonV3Delete(ctx context.Context, d *schema.ResourceData, meta 
 	_, err = stateConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting HuaweiCloud CCE Addon: %s", err)
+		return diag.Errorf("error deleting CCE Addon: %s", err)
 	}
 
 	d.SetId("")
 	return nil
 }
 
-func waitForCCEAddonActive(cceAddonClient *golangsdk.ServiceClient, id, clusterID string) resource.StateRefreshFunc {
+func waitForAddonActive(cceAddonClient *golangsdk.ServiceClient, id, clusterID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		n, err := addons.Get(cceAddonClient, id, clusterID).Extract()
 		if err != nil {
@@ -309,15 +310,15 @@ func waitForCCEAddonActive(cceAddonClient *golangsdk.ServiceClient, id, clusterI
 	}
 }
 
-func waitForCCEAddonDelete(cceClient *golangsdk.ServiceClient, id, clusterID string) resource.StateRefreshFunc {
+func waitForAddonDelete(cceClient *golangsdk.ServiceClient, id, clusterID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		logp.Printf("[DEBUG] Attempting to delete HuaweiCloud CCE Addon %s.\n", id)
+		log.Printf("[DEBUG] Attempting to delete CCE Addon %s.\n", id)
 
 		r, err := addons.Get(cceClient, id, clusterID).Extract()
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[DEBUG] Successfully deleted HuaweiCloud CCE Addon %s", id)
+				log.Printf("[DEBUG] Successfully deleted CCE Addon %s", id)
 				return r, "Deleted", nil
 			}
 			return nil, "Available", err
@@ -326,15 +327,15 @@ func waitForCCEAddonDelete(cceClient *golangsdk.ServiceClient, id, clusterID str
 		if r.Status.Status == "Deleting" {
 			return r, "Deleting", nil
 		}
-		logp.Printf("[DEBUG] HuaweiCloud CCE Addon %s still available.\n", id)
+		log.Printf("[DEBUG] CCE Addon %s still available.\n", id)
 		return r, "Available", nil
 	}
 }
 
-func resourceCCEAddonV3Import(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.SplitN(d.Id(), "/", 2)
+func resourceAddonImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
-		err := fmtp.Errorf("Invalid format specified for CCE Addon. Format must be <cluster id>/<addon id>")
+		err := fmt.Errorf("invalid format specified for CCE Addon. Format must be <cluster id>/<addon id>")
 		return nil, err
 	}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/addons/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/addons/results.go
@@ -26,7 +26,7 @@ type Addon struct {
 	Status Status `json:"status"`
 }
 
-//Metadata required to create an addon
+// Metadata required to create an addon
 type MetaData struct {
 	// Addon unique name
 	Name string `json:"name"`
@@ -38,7 +38,7 @@ type MetaData struct {
 	Annotations map[string]string `json:"annotaions"`
 }
 
-//Specifications to create an addon
+// Specifications to create an addon
 type Spec struct {
 	// For the addon version.
 	Version string `json:"version"`
@@ -117,6 +117,12 @@ type ListResult struct {
 // CreateResult represents the result of a create operation. Call its Extract
 // method to interpret it as an Addon.
 type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a create operation. Call its Extract
+// method to interpret it as an Addon.
+type UpdateResult struct {
 	commonResult
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/geminidb/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/geminidb/v3/instances/requests.go
@@ -40,6 +40,7 @@ type CreateGeminiDBOpts struct {
 	EnterpriseProjectId string             `json:"enterprise_project_id,omitempty"`
 	DedicatedResourceId string             `json:"dedicated_resource_id,omitempty"`
 	Ssl                 string             `json:"ssl_option,omitempty"`
+	Port                string             `json:"port,omitempty"`
 	DataStore           DataStore          `json:"datastore" required:"true"`
 	Flavor              []FlavorOpt        `json:"flavor" required:"true"`
 	BackupStrategy      *BackupStrategyOpt `json:"backup_strategy,omitempty"`
@@ -408,4 +409,66 @@ func ListDeh(client *golangsdk.ServiceClient) pagination.Pager {
 	pageList.Headers = map[string]string{"Content-Type": "application/json"}
 
 	return pageList
+}
+
+type UpdateSslOpts struct {
+	Ssl string `json:"ssl_option" required:"true"`
+}
+
+type UpdateSslBuilder interface {
+	ToSslUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateSslOpts) ToSslUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func UpdateSsl(client *golangsdk.ServiceClient, instanceId string, opts UpdateSslBuilder) (r UpdateResult) {
+	b, err := opts.ToSslUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(updateSslURL(client, instanceId), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{202},
+		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+	})
+	return
+}
+
+type UpdatePublicIpOpts struct {
+	Action     string `json:"action" required:"true"`
+	PublicIp   string `json:"public_ip,omitempty"`
+	PublicIpId string `json:"public_ip_id,omitempty"`
+}
+
+type UpdatePublicIpBuilder interface {
+	ToPublicIpUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdatePublicIpOpts) ToPublicIpUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func UpdatePublicIp(client *golangsdk.ServiceClient, instanceId, nodeId string, opts UpdatePublicIpOpts) (r PublicIpResult) {
+	b, err := opts.ToPublicIpUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(updatePublicIpURL(client, instanceId, nodeId), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{202},
+		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+	})
+	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/geminidb/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/geminidb/v3/instances/results.go
@@ -41,6 +41,7 @@ type GeminiDBBase struct {
 type CreateResponse struct {
 	GeminiDBBase
 	JobId            string            `json:"job_id"`
+	OrderId          string            `json:"order_id"`
 	AvailabilityZone string            `json:"availability_zone"`
 	Flavor           []Flavor          `json:"flavor"`
 	BackupStrategy   BackupStrategyOpt `json:"backup_strategy"`
@@ -81,6 +82,7 @@ type Nodes struct {
 	Name             string `json:"name"`
 	Status           string `json:"status"`
 	PrivateIp        string `json:"private_ip"`
+	PublicIp         string `json:"public_ip"`
 	SpecCode         string `json:"spec_code"`
 	AvailabilityZone string `json:"availability_zone"`
 	SupportReduce    bool   `json:"support_reduce"`
@@ -190,4 +192,32 @@ func ExtractDehResources(r pagination.Page) (ListDehResponse, error) {
 	var s ListDehResponse
 	err := (r.(DehResourcePage)).ExtractInto(&s)
 	return s, err
+}
+
+type SslResult struct {
+	commonResult
+}
+
+type SslResponse struct {
+	JobId string `json:"job_id"`
+}
+
+func (r SslResult) Extract() (*SslResponse, error) {
+	var response SslResponse
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type PublicIpResult struct {
+	commonResult
+}
+
+type PublicIpResponse struct {
+	JobId string `json:"job_id"`
+}
+
+func (r PublicIpResult) Extract() (*PublicIpResponse, error) {
+	var response PublicIpResponse
+	err := r.ExtractInto(&response)
+	return &response, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/geminidb/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/geminidb/v3/instances/urls.go
@@ -45,3 +45,11 @@ func listURL(c *golangsdk.ServiceClient) string {
 func listDehURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("dedicated-resources")
 }
+
+func updateSslURL(c *golangsdk.ServiceClient, instanceID string) string {
+	return c.ServiceURL("instances", instanceID, "ssl-option")
+}
+
+func updatePublicIpURL(c *golangsdk.ServiceClient, instanceID, nodeID string) string {
+	return c.ServiceURL("instances", instanceID, "nodes", nodeID, "public-ip")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -6,26 +6,27 @@ import (
 )
 
 type CreateOpts struct {
-	Name                string          `json:"name"  required:"true"`
-	Datastore           *Datastore      `json:"datastore" required:"true"`
-	Ha                  *Ha             `json:"ha,omitempty"`
-	ConfigurationId     string          `json:"configuration_id,omitempty"`
-	Port                string          `json:"port,omitempty"`
-	Password            string          `json:"password" required:"true"`
-	BackupStrategy      *BackupStrategy `json:"backup_strategy,omitempty"`
-	EnterpriseProjectId string          `json:"enterprise_project_id,omitempty"`
-	DiskEncryptionId    string          `json:"disk_encryption_id,omitempty"`
-	FlavorRef           string          `json:"flavor_ref" required:"true"`
-	Volume              *Volume         `json:"volume" required:"true"`
-	Region              string          `json:"region" required:"true"`
-	AvailabilityZone    string          `json:"availability_zone" required:"true"`
-	VpcId               string          `json:"vpc_id" required:"true"`
-	SubnetId            string          `json:"subnet_id" required:"true"`
-	SecurityGroupId     string          `json:"security_group_id" required:"true"`
-	ChargeInfo          *ChargeInfo     `json:"charge_info,omitempty"`
-	TimeZone            string          `json:"time_zone,omitempty"`
-	FixedIp             string          `json:"data_vip,omitempty"`
-	Collation           string          `json:"collation,omitempty"`
+	Name                string             `json:"name"  required:"true"`
+	Datastore           *Datastore         `json:"datastore" required:"true"`
+	Ha                  *Ha                `json:"ha,omitempty"`
+	ConfigurationId     string             `json:"configuration_id,omitempty"`
+	Port                string             `json:"port,omitempty"`
+	Password            string             `json:"password" required:"true"`
+	BackupStrategy      *BackupStrategy    `json:"backup_strategy,omitempty"`
+	EnterpriseProjectId string             `json:"enterprise_project_id,omitempty"`
+	DiskEncryptionId    string             `json:"disk_encryption_id,omitempty"`
+	FlavorRef           string             `json:"flavor_ref" required:"true"`
+	Volume              *Volume            `json:"volume" required:"true"`
+	Region              string             `json:"region" required:"true"`
+	AvailabilityZone    string             `json:"availability_zone" required:"true"`
+	VpcId               string             `json:"vpc_id" required:"true"`
+	SubnetId            string             `json:"subnet_id" required:"true"`
+	SecurityGroupId     string             `json:"security_group_id" required:"true"`
+	ChargeInfo          *ChargeInfo        `json:"charge_info,omitempty"`
+	TimeZone            string             `json:"time_zone,omitempty"`
+	FixedIp             string             `json:"data_vip,omitempty"`
+	Collation           string             `json:"collation,omitempty"`
+	UnchangeableParam   *UnchangeableParam `json:"unchangeable_param,omitempty"`
 }
 
 type CreateReplicaOpts struct {
@@ -48,6 +49,10 @@ type Datastore struct {
 type Ha struct {
 	Mode            string `json:"mode" required:"true"`
 	ReplicationMode string `json:"replication_mode,omitempty"`
+}
+
+type UnchangeableParam struct {
+	LowerCaseTableNames string `json:"lower_case_table_names"`
 }
 
 type BackupStrategy struct {
@@ -494,4 +499,92 @@ func RebootInstance(c *golangsdk.ServiceClient, instanceID string) (r RebootResu
 		OkCodes: []int{200, 202},
 	})
 	return
+}
+
+var (
+	enableAutoExpand  bool = true
+	disableAutoExpand bool = false
+)
+
+// EnableAutoExpandOpts is the structure used to enable the volume automatic expansion of RDS instance.
+type EnableAutoExpandOpts struct {
+	// The instnace ID.
+	InstanceId string `json:"-" required:"true"`
+	// The upper limit of automatic expansion of storage, in GB.
+	// This parameter is mandatory when switch_option is set to true.
+	// The value ranges from 40 GB to 4,000 GB and must be no less than the current storage of the instance.
+	LimitSize int `json:"limit_size" required:"true"`
+	// The threshold to trigger automatic expansion.
+	// If the available storage drops to this threshold or 10 GB, the automatic expansion is triggered.
+	// This parameter is mandatory when switch_option is set to true.
+	// The valid values are as follows:
+	// + 10
+	// + 15
+	// + 20
+	TriggerThreshold int `json:"trigger_threshold" required:"true"`
+}
+
+// autoExpandOpts is the structure used to configure the volume automatic expansion of RDS instance.
+type autoExpandOpts struct {
+	// Whether the auto-expansion is enabled.
+	SwitchOption *bool `json:"switch_option" required:"true"`
+	// The upper limit of automatic expansion of storage, in GB.
+	// This parameter is mandatory when switch_option is set to true.
+	// The value ranges from 40 GB to 4,000 GB and must be no less than the current storage of the instance.
+	LimitSize int `json:"limit_size,omitempty"`
+	// The threshold to trigger automatic expansion.
+	// If the available storage drops to this threshold or 10 GB, the automatic expansion is triggered.
+	// This parameter is mandatory when switch_option is set to true.
+	// The valid values are as follows:
+	// + 10
+	// + 15
+	// + 20
+	TriggerThreshold int `json:"trigger_threshold,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// EnableAutoExpand is a method used to configure the volume automatic expansion of RDS instance.
+func EnableAutoExpand(c *golangsdk.ServiceClient, opts EnableAutoExpandOpts) error {
+	enableOpts := autoExpandOpts{
+		SwitchOption:     &enableAutoExpand,
+		LimitSize:        opts.LimitSize,
+		TriggerThreshold: opts.TriggerThreshold,
+	}
+	b, err := golangsdk.BuildRequestBody(enableOpts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Put(autoExpandURL(c, opts.InstanceId), b, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}
+
+// DisableAutoExpand is a method used to remove the volume automatic expansion configuration of RDS instance.
+func DisableAutoExpand(c *golangsdk.ServiceClient, instanceId string) error {
+	autoExpandOpts := autoExpandOpts{
+		SwitchOption: &disableAutoExpand,
+	}
+	b, err := golangsdk.BuildRequestBody(autoExpandOpts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Put(autoExpandURL(c, instanceId), b, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}
+
+// GetAutoExpand is a method used to obtain the automatic expansion configuarion of instance storage.
+func GetAutoExpand(c *golangsdk.ServiceClient, instanceId string) (*AutoExpansion, error) {
+	var r AutoExpansion
+	_, err := c.Get(autoExpandURL(c, instanceId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -361,3 +361,21 @@ type VersionInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
+
+// AutoExpansion is an object that represents the automatic expansion configuration.
+type AutoExpansion struct {
+	// Whether the automatic expansion is enabled.
+	SwitchOption bool `json:"switch_option"`
+	// The upper limit of automatic expansion of storage, in GB.
+	// This parameter is mandatory when switch_option is set to true.
+	// The value ranges from 40 GB to 4,000 GB and must be no less than the current storage of the instance.
+	LimitSize int `json:"limit_size"`
+	// The threshold to trigger automatic expansion.
+	// If the available storage drops to this threshold or 10 GB, the automatic expansion is triggered.
+	// This parameter is mandatory when switch_option is set to true.
+	// The valid values are as follows:
+	// + 10
+	// + 15
+	// + 20
+	TriggerThreshold int `json:"trigger_threshold"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
@@ -37,3 +37,7 @@ func configurationsURL(c *golangsdk.ServiceClient, instancesId string) string {
 func actionURL(c *golangsdk.ServiceClient, instancesId string) string {
 	return c.ServiceURL("instances", instancesId, "action")
 }
+
+func autoExpandURL(c *golangsdk.ServiceClient, instancesId string) string {
+	return c.ServiceURL("instances", instancesId, "disk-auto-expansion")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9
+# github.com/chnsz/golangsdk v0.0.0-20230522025655-f4e01be42b05
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update import, func name and error message
2. make the version optional
3. support updating version and values

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccAddon_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccAddon_basic -timeout 360m -parallel 4
=== RUN   TestAccAddon_basic
=== PAUSE TestAccAddon_basic
=== CONT  TestAccAddon_basic
--- PASS: TestAccAddon_basic (873.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       874.021s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccAddonTemplateDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccAddonTemplateDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccAddonTemplateDataSource_basic
=== PAUSE TestAccAddonTemplateDataSource_basic
=== CONT  TestAccAddonTemplateDataSource_basic
--- PASS: TestAccAddonTemplateDataSource_basic (481.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       481.306s
```
