### PR TITLE
fix(VPCEP): fix ci-lint and tf features error

### DIFF
--- a/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_public_services_test.go
+++ b/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_public_services_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_approval_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_approval_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_endpoint_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_endpoint_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -188,7 +190,7 @@ resource "huaweicloud_vpcep_endpoint" "test" {
 `, testAccVPCEndpoint_Precondition(rName), rName)
 }
 
-var testAccVPCEndpointPublic string = `
+var testAccVPCEndpointPublic = `
 data "huaweicloud_vpc" "myvpc" {
   name = "vpc-default"
 }

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )

--- a/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_public_services.go
+++ b/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_public_services.go
@@ -3,11 +3,13 @@ package vpcep
 import (
 	"context"
 
-	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -62,9 +64,9 @@ func DataSourceVPCEPPublicServices() *schema.Resource {
 }
 
 func dataSourceVpcepPublicRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
@@ -79,11 +81,11 @@ func dataSourceVpcepPublicRead(_ context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("unable to retrieve VPC endpoint public services: %s", err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	id, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(id)
 
 	mErr := multierror.Append(
 		d.Set("region", region),
@@ -97,9 +99,9 @@ func flattenListVpcEndpointsServices(allServices []services.PublicService) []map
 	if allServices == nil {
 		return nil
 	}
-	services := make([]map[string]interface{}, len(allServices))
+	endpointServices := make([]map[string]interface{}, len(allServices))
 	for i, v := range allServices {
-		services[i] = map[string]interface{}{
+		endpointServices[i] = map[string]interface{}{
 			"id":           v.ID,
 			"service_name": v.ServiceName,
 			"service_type": v.ServiceType,
@@ -107,5 +109,5 @@ func flattenListVpcEndpointsServices(allServices []services.PublicService) []map
 			"is_charge":    v.IsChange,
 		}
 	}
-	return services
+	return endpointServices
 }

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_endpoint.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_endpoint.go
@@ -5,11 +5,14 @@ import (
 	"log"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -108,14 +111,13 @@ func ResourceVPCEndpoint() *schema.Resource {
 }
 
 func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
 
-	enableDNS := d.Get("enable_dns").(bool)
 	enableACL := d.Get("enable_whitelist").(bool)
 	createOpts := endpoints.CreateOpts{
 		ServiceID:       d.Get("service_id").(string),
@@ -123,24 +125,14 @@ func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 		SubnetID:        d.Get("network_id").(string),
 		PortIP:          d.Get("ip_address").(string),
 		Description:     d.Get("description").(string),
-		EnableDNS:       &enableDNS,
-		EnableWhitelist: &enableACL,
+		EnableDNS:       utils.Bool(d.Get("enable_dns").(bool)),
+		EnableWhitelist: utils.Bool(enableACL),
+		Tags:            utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 	}
 
 	raw := d.Get("whitelist").(*schema.Set).List()
 	if enableACL && len(raw) > 0 {
-		whitelists := make([]string, len(raw))
-		for i, v := range raw {
-			whitelists[i] = v.(string)
-		}
-		createOpts.Whitelist = whitelists
-	}
-
-	//set tags
-	tagRaw := d.Get("tags").(map[string]interface{})
-	if len(tagRaw) > 0 {
-		taglist := utils.ExpandResourceTags(tagRaw)
-		createOpts.Tags = taglist
+		createOpts.Whitelist = utils.ExpandToStringList(raw)
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -169,9 +161,9 @@ func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceVPCEndpointRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
@@ -182,58 +174,53 @@ func resourceVPCEndpointRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] retrieving VPC endpoint: %#v", ep)
-	d.Set("region", region)
-	d.Set("status", ep.Status)
-	d.Set("service_id", ep.ServiceID)
-	d.Set("service_name", ep.ServiceName)
-	d.Set("service_type", ep.ServiceType)
-	d.Set("vpc_id", ep.VpcID)
-	d.Set("network_id", ep.SubnetID)
-	d.Set("ip_address", ep.IPAddr)
-	d.Set("description", ep.Description)
-	d.Set("enable_dns", ep.EnableDNS)
-	d.Set("enable_whitelist", ep.EnableWhitelist)
-	d.Set("whitelist", ep.Whitelist)
-	d.Set("packet_id", ep.MarkerID)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("status", ep.Status),
+		d.Set("service_id", ep.ServiceID),
+		d.Set("service_name", ep.ServiceName),
+		d.Set("service_type", ep.ServiceType),
+		d.Set("vpc_id", ep.VpcID),
+		d.Set("network_id", ep.SubnetID),
+		d.Set("ip_address", ep.IPAddr),
+		d.Set("description", ep.Description),
+		d.Set("enable_dns", ep.EnableDNS),
+		d.Set("enable_whitelist", ep.EnableWhitelist),
+		d.Set("whitelist", ep.Whitelist),
+		d.Set("packet_id", ep.MarkerID),
+		d.Set("tags", utils.TagsToMap(ep.Tags)),
+	)
 
 	if len(ep.DNSNames) > 0 {
-		d.Set("private_domain_name", ep.DNSNames[0])
+		mErr = multierror.Append(mErr, d.Set("private_domain_name", ep.DNSNames[0]))
 	} else {
-		d.Set("private_domain_name", nil)
+		mErr = multierror.Append(mErr, d.Set("private_domain_name", nil))
 	}
-
-	// fetch tags from endpoints.Endpoint
-	tagmap := make(map[string]string)
-	for _, val := range ep.Tags {
-		tagmap[val.Key] = val.Value
-	}
-	d.Set("tags", tagmap)
-
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceVPCEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
 
-	//update tags
+	// update tags
 	if d.HasChange("tags") {
 		tagErr := utils.UpdateResourceTags(vpcepClient, d, tagVPCEP, d.Id())
 		if tagErr != nil {
-			return diag.Errorf("error updating tags of VPC endpoint service %s: %s", d.Id(), tagErr)
+			return diag.Errorf("error updating tags of VPC endpoint %s: %s", d.Id(), tagErr)
 		}
 	}
 	return resourceVPCEndpointRead(ctx, d, meta)
 }
 
 func resourceVPCEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
@@ -7,12 +7,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -152,15 +155,16 @@ func ResourceVPCEndpointService() *schema.Resource {
 	}
 }
 
-func expandPortMappingOpts(d *schema.ResourceData) []services.PortOpts {
+func buildPortMappingOpts(d *schema.ResourceData) []services.PortOpts {
 	portMapping := d.Get("port_mapping").([]interface{})
-
 	portOpts := make([]services.PortOpts, len(portMapping))
 	for i, raw := range portMapping {
 		port := raw.(map[string]interface{})
-		portOpts[i].Protocol = port["protocol"].(string)
-		portOpts[i].ServerPort = port["service_port"].(int)
-		portOpts[i].ClientPort = port["terminal_port"].(int)
+		portOpts[i] = services.PortOpts{
+			Protocol:   port["protocol"].(string),
+			ServerPort: port["service_port"].(int),
+			ClientPort: port["terminal_port"].(int),
+		}
 	}
 	return portOpts
 }
@@ -169,11 +173,7 @@ func doPermissionAction(client *golangsdk.ServiceClient, serviceID, action strin
 	if len(raw) == 0 {
 		return nil
 	}
-
-	permissions := make([]string, len(raw))
-	for i, v := range raw {
-		permissions[i] = v.(string)
-	}
+	permissions := utils.ExpandToStringList(raw)
 	permOpts := services.PermActionOpts{
 		Action:      action,
 		Permissions: permissions,
@@ -181,19 +181,17 @@ func doPermissionAction(client *golangsdk.ServiceClient, serviceID, action strin
 
 	log.Printf("[DEBUG] %s permissions %#v to VPC endpoint service %s", action, permissions, serviceID)
 	result := services.PermAction(client, serviceID, permOpts)
-
 	return result.Err
 }
 
 func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
 
-	approval := d.Get("approval").(bool)
 	createOpts := services.CreateOpts{
 		VpcID:       d.Get("vpc_id").(string),
 		PortID:      d.Get("port_id").(string),
@@ -201,16 +199,10 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 		ServiceName: d.Get("name").(string),
 		ServiceType: d.Get("service_type").(string),
 		Description: d.Get("description").(string),
-		Approval:    &approval,
-		Ports:       expandPortMappingOpts(d),
+		Approval:    utils.Bool(d.Get("approval").(bool)),
+		Ports:       buildPortMappingOpts(d),
+		Tags:        utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 	}
-	//set tags
-	tagRaw := d.Get("tags").(map[string]interface{})
-	if len(tagRaw) > 0 {
-		taglist := utils.ExpandResourceTags(tagRaw)
-		createOpts.Tags = taglist
-	}
-
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	n, err := services.Create(vpcepClient, createOpts).Extract()
 	if err != nil {
@@ -244,67 +236,54 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceVPCEndpointServiceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
 
 	n, err := services.Get(vpcepClient, d.Id()).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "VPC endpoint")
+		return common.CheckDeletedDiag(d, err, "VPC endpoint service")
 	}
 
 	log.Printf("[DEBUG] retrieving VPC endpoint service: %#v", n)
-	d.Set("region", region)
-	d.Set("status", n.Status)
-	d.Set("service_name", n.ServiceName)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("status", n.Status),
+		d.Set("service_name", n.ServiceName),
+		d.Set("vpc_id", n.VpcID),
+		d.Set("port_id", n.PortID),
+		d.Set("approval", n.Approval),
+		d.Set("server_type", n.ServerType),
+		d.Set("service_type", n.ServiceType),
+		d.Set("description", n.Description),
+		d.Set("port_mapping", flattenVPCEndpointServicePorts(n)),
+		d.Set("tags", utils.TagsToMap(n.Tags)),
+	)
+
 	nameList := strings.Split(n.ServiceName, ".")
 	if len(nameList) > 2 {
-		d.Set("name", nameList[1])
+		mErr = multierror.Append(mErr, d.Set("name", nameList[1]))
 	}
-
-	d.Set("vpc_id", n.VpcID)
-	d.Set("port_id", n.PortID)
-	d.Set("approval", n.Approval)
-	d.Set("server_type", n.ServerType)
-	d.Set("service_type", n.ServiceType)
-	d.Set("description", n.Description)
-
-	ports := make([]map[string]interface{}, len(n.Ports))
-	for i, v := range n.Ports {
-		ports[i] = map[string]interface{}{
-			"protocol":      v.Protocol,
-			"service_port":  v.ServerPort,
-			"terminal_port": v.ClientPort,
-		}
-	}
-	d.Set("port_mapping", ports)
-
-	// fetch tags from Services.Service
-	tagmap := make(map[string]string)
-	for _, val := range n.Tags {
-		tagmap[val.Key] = val.Value
-	}
-	d.Set("tags", tagmap)
 
 	// fetch connections
-	if conns, err := flattenVPCEndpointConnections(vpcepClient, d.Id()); err == nil {
-		d.Set("connections", conns)
+	if connections, err := flattenVPCEndpointConnections(vpcepClient, d.Id()); err == nil {
+		mErr = multierror.Append(mErr, d.Set("connections", connections))
 	}
 
 	// fetch permissions
 	if perms, err := flattenVPCEndpointPermissions(vpcepClient, d.Id()); err == nil {
-		d.Set("permissions", perms)
+		mErr = multierror.Append(mErr, d.Set("permissions", perms))
 	}
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
@@ -323,7 +302,7 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 			updateOpts.PortID = d.Get("port_id").(string)
 		}
 		if d.HasChange("port_mapping") {
-			updateOpts.Ports = expandPortMappingOpts(d)
+			updateOpts.Ports = buildPortMappingOpts(d)
 		}
 
 		_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()
@@ -332,7 +311,7 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	//update tags
+	// update tags
 	if d.HasChange("tags") {
 		tagErr := utils.UpdateResourceTags(vpcepClient, d, tagVPCEPService, d.Id())
 		if tagErr != nil {
@@ -342,9 +321,9 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 
 	// update
 	if d.HasChange("permissions") {
-		old, new := d.GetChange("permissions")
-		oldPermSet := old.(*schema.Set)
-		newPermSet := new.(*schema.Set)
+		oldVal, newVal := d.GetChange("permissions")
+		oldPermSet := oldVal.(*schema.Set)
+		newPermSet := newVal.(*schema.Set)
 		added := newPermSet.Difference(oldPermSet)
 		removed := oldPermSet.Difference(newPermSet)
 
@@ -363,9 +342,9 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceVPCEndpointServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	vpcepClient, err := config.VPCEPClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
@@ -392,16 +371,28 @@ func resourceVPCEndpointServiceDelete(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
+func flattenVPCEndpointServicePorts(n *services.Service) []map[string]interface{} {
+	ports := make([]map[string]interface{}, len(n.Ports))
+	for i, v := range n.Ports {
+		ports[i] = map[string]interface{}{
+			"protocol":      v.Protocol,
+			"service_port":  v.ServerPort,
+			"terminal_port": v.ClientPort,
+		}
+	}
+	return ports
+}
+
 func flattenVPCEndpointConnections(client *golangsdk.ServiceClient, id string) ([]map[string]interface{}, error) {
-	allConns, err := services.ListConnections(client, id, nil)
+	allConnections, err := services.ListConnections(client, id, nil)
 	if err != nil {
 		log.Printf("[WARN] Error querying connections of VPC endpoint service: %s", err)
 		return nil, err
 	}
 
-	log.Printf("[DEBUG] retrieving connections of VPC endpoint service: %#v", allConns)
-	connections := make([]map[string]interface{}, len(allConns))
-	for i, v := range allConns {
+	log.Printf("[DEBUG] retrieving connections of VPC endpoint service: %#v", allConnections)
+	connections := make([]map[string]interface{}, len(allConnections))
+	for i, v := range allConnections {
 		connections[i] = map[string]interface{}{
 			"endpoint_id": v.EndpointID,
 			"packet_id":   v.MarkerID,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix ci-lint and tf features error
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEPPublicServicesDataSource_Basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPPublicServicesDataSource_Basic -timeout 360m -parallel 4 
=== RUN   TestAccVPCEPPublicServicesDataSource_Basic 
=== PAUSE TestAccVPCEPPublicServicesDataSource_Basic
=== CONT  TestAccVPCEPPublicServicesDataSource_Basic
--- PASS: TestAccVPCEPPublicServicesDataSource_Basic (8.47s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     8.518s
```

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEndpointApproval_Basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpointApproval_Basic -timeout 360m -parallel 4 
=== RUN   TestAccVPCEndpointApproval_Basic 
=== PAUSE TestAccVPCEndpointApproval_Basic
=== CONT  TestAccVPCEndpointApproval_Basic
--- PASS: TestAccVPCEndpointApproval_Basic (209.39s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     209.474s
```

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEndpoint_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_ -timeout 360m -parallel 4 
=== RUN   TestAccVPCEndpoint_Basic 
=== PAUSE TestAccVPCEndpoint_Basic
=== RUN   TestAccVPCEndpoint_Public
=== PAUSE TestAccVPCEndpoint_Public
=== CONT  TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Public
--- PASS: TestAccVPCEndpoint_Public (23.08s) 
--- PASS: TestAccVPCEndpoint_Basic (209.56s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     209.616s
```

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEPService_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPService_ -timeout 360m -parallel 4 
=== RUN   TestAccVPCEPService_Basic 
=== PAUSE TestAccVPCEPService_Basic 
=== RUN   TestAccVPCEPService_Permission
=== PAUSE TestAccVPCEPService_Permission
=== CONT  TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Permission
--- PASS: TestAccVPCEPService_Permission (183.57s) 
--- PASS: TestAccVPCEPService_Basic (198.99s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     199.046s
```
