### PR TITLE
fix(OBS): correct the pre-check of eps

### DIFF
--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -74,7 +74,7 @@ func TestAccObsBucket_withEpsId(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckOBS(t)
-			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccObsBucket_withEpsId$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs -v

=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== CONT  TestAccObsBucket_withEpsId
    /home/hm/git/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs/acceptance.go:237: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccObsBucket_withEpsId (0.00s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs	0.046s

```
