### PR TITLE
fix(vpc): The fixed description field may cause data errors during concurrency

### DIFF
--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroups_test.go
@@ -25,7 +25,7 @@ func TestAccNetworkingSecGroupsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
-						"[Acc Test] The security group created by Terraform."),
+						"[Acc Test] The security group name is "+rName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
 						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
@@ -54,7 +54,7 @@ func TestAccNetworkingSecGroupsDataSource_description(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
-						"[Acc Test] The security group created by Terraform."),
+						"[Acc Test] The security group name is "+rName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
 						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
@@ -83,7 +83,7 @@ func TestAccNetworkingSecGroupsDataSource_id(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.name", rName),
 					resource.TestCheckResourceAttr(dataSourceName, "security_groups.0.description",
-						"[Acc Test] The security group created by Terraform."),
+						"[Acc Test] The security group name is "+rName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.0.id",
 						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "security_groups.0.enterprise_project_id"),
@@ -99,9 +99,9 @@ func testAccNetworkingSecGroupsDataSource_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_networking_secgroup" "test" {
   name        = "%s"
-  description = "[Acc Test] The security group created by Terraform."
+  description = "[Acc Test] The security group name is %s"
 }
-`, rName)
+`, rName, rName)
 }
 
 func testAccNetworkingSecGroupsDataSource_basic(rName string) string {


### PR DESCRIPTION
…ncurrency

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There is three test case in this file, the same description value may cause data errors during concurrency, 
so add the random name to the description

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^(TestAccNetworkingSecGroupsDataSource_basic|TestAccNetworkingSecGroupsDataSource_description|TestAccNetworkingSecGroupsDataSource_id)$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc -v

=== RUN   TestAccNetworkingSecGroupsDataSource_basic
=== PAUSE TestAccNetworkingSecGroupsDataSource_basic
=== RUN   TestAccNetworkingSecGroupsDataSource_description
=== PAUSE TestAccNetworkingSecGroupsDataSource_description
=== RUN   TestAccNetworkingSecGroupsDataSource_id
=== PAUSE TestAccNetworkingSecGroupsDataSource_id
=== CONT  TestAccNetworkingSecGroupsDataSource_basic
=== CONT  TestAccNetworkingSecGroupsDataSource_id
=== CONT  TestAccNetworkingSecGroupsDataSource_description
--- PASS: TestAccNetworkingSecGroupsDataSource_basic (21.88s)
--- PASS: TestAccNetworkingSecGroupsDataSource_id (22.08s)
--- PASS: TestAccNetworkingSecGroupsDataSource_description (22.59s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc	22.637s


```
