### PR TITLE
fix(EPS): fix eps datasource lint error and support filter target project by input name

### DIFF
--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -38,6 +38,8 @@ resource "huaweicloud_enterprise_project" "test" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - Indicates the ID of the enterprise project.
+
 * `status` - Indicates the status of an enterprise project.
   + **1**: Indicates enabled.
   + **2**: Indicates disabled.

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go
@@ -2,6 +2,7 @@ package eps
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -66,18 +67,10 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 		return diag.Errorf("Error retrieving enterprise projects %s", err)
 	}
 
-	if len(projects) < 1 {
-		return diag.Errorf("Your query returned no results. " +
-			"Please change your search criteria and try again.")
+	project, err := flattenEnterpriseProject(d, projects)
+	if err != nil {
+		return diag.FromErr(err)
 	}
-
-	if len(projects) > 1 {
-		return diag.Errorf("Your query returned more than one result." +
-			" Please try a more specific search criteria")
-	}
-
-	project := projects[0]
-
 	d.SetId(project.ID)
 	mErr := multierror.Append(nil,
 		d.Set("name", project.Name),
@@ -88,8 +81,35 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting enterprise project fields: %w", err)
+		return diag.Errorf("Error setting enterprise project fields: %s", err)
 	}
 
 	return nil
+}
+
+func flattenEnterpriseProject(d *schema.ResourceData, projects []enterpriseprojects.Project) (
+	*enterpriseprojects.Project, error) {
+	if len(projects) < 1 {
+		return nil, fmt.Errorf("your query returned no results." +
+			" Please change your search criteria and try again")
+	}
+
+	if len(projects) > 1 {
+		name := d.Get("name").(string)
+		// there is no condition to find the target enterprise project
+		if name == "" {
+			return nil, fmt.Errorf("your query returned more than one result." +
+				" Please specify your enterprise project name or enterprise project id")
+		}
+
+		for _, v := range projects {
+			if v.Name == name {
+				// use name to find the target enterprise project
+				return &v, nil
+			}
+		}
+		return nil, fmt.Errorf("cannot find the target enterprise project through your input name." +
+			" Please change your search criteria and try again")
+	}
+	return &projects[0], nil
 }

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go
@@ -3,12 +3,12 @@ package eps
 import (
 	"context"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -48,11 +48,11 @@ func DataSourceEnterpriseProject() *schema.Resource {
 }
 
 func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	epsClient, err := config.EnterpriseProjectClient(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	epsClient, err := cfg.EnterpriseProjectClient(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud eps client %s", err)
+		return diag.Errorf("Error creating EPS client %s", err)
 	}
 
 	listOpts := enterpriseprojects.ListOpts{
@@ -63,16 +63,16 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 	projects, err := enterpriseprojects.List(epsClient, listOpts).Extract()
 
 	if err != nil {
-		return fmtp.DiagErrorf("Error retrieving enterprise projects %s", err)
+		return diag.Errorf("Error retrieving enterprise projects %s", err)
 	}
 
 	if len(projects) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	if len(projects) > 1 {
-		return fmtp.DiagErrorf("Your query returned more than one result." +
+		return diag.Errorf("Your query returned more than one result." +
 			" Please try a more specific search criteria")
 	}
 
@@ -88,7 +88,7 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("error setting HuaweiCloud enterprise project fields: %w", err)
+		return diag.Errorf("error setting enterprise project fields: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- docs: add an attribute reference field document
- fix: fix eps datasource lint error
- fix: eps datasource support filter target project by input name

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eps' TESTARGS='-run TestAccEnterpriseProjectDataSource_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/eps -v -run TestAccEnterpriseProjectDataSource_basic -timeout 360m -parallel 4 
=== RUN   TestAccEnterpriseProjectDataSource_basic 
=== PAUSE TestAccEnterpriseProjectDataSource_basic
=== CONT  TestAccEnterpriseProjectDataSource_basic
--- PASS: TestAccEnterpriseProjectDataSource_basic (6.39s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       6.456s
```
