### PR TITLE
fix(CSS): css cluster support use local dist flavor

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -73,6 +73,35 @@ resource "huaweicloud_css_cluster" "cluster" {
 }
 ```
 
+### create a cluster with ess-data node and cold node use local disk
+
+```hcl
+variable "availability_zone" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "secgroup_id" {}
+
+resource "huaweicloud_css_cluster" "cluster" {
+  name           = "terraform_test_cluster"
+  engine_version = "7.10.2"
+
+  ess_node_config {
+    flavor          = "ess.spec-ds.xlarge.8"
+    instance_number = 1
+  }
+
+  cold_node_config {
+    flavor          = "ess.spec-ds.2xlarge.8"
+    instance_number = 2
+  }
+
+  availability_zone = var.availability_zone
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.secgroup_id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -177,8 +206,17 @@ The `ess_node_config` and `cold_node_config` block supports:
   + When it is `ess_node_config`, The value range is 1 to 200.
   + When it is `cold_node_config`, The value range is 1 to 32.
 
-* `volume` - (Required, List) Specifies the information about the volume.
-  The [volume](#Css_volume) structure is documented below.
+* `volume` - (Optional, List, ForceNew) Specifies the information about the volume. This field should not be specified
+  when `flavor` is set to a local dist flavor. But It is required when `flavor` is not a local disk flavor.
+  Currently, the following local disk flavors are supported:
+  + ess.spec-i3small
+  + ess.spec-i3medium
+  + ess.spec-i3.8xlarge.8
+  + ess.spec-ds.xlarge.8
+  + ess.spec-ds.2xlarge.8
+  + ess.spec-ds.4xlarge.8
+
+  The [volume](#Css_volume) structure is documented below. Changing this parameter will create a new resource.
 
 <a name="Css_volume"></a>
 The `volume` block supports:
@@ -213,9 +251,12 @@ The `volume` block supports:
 * `size` - (Required, Int, ForceNew) Specifies the volume size in GB, which must be a multiple of 10.
   Changing this parameter will create a new resource.
 
-* `volume_type` - (Required, String, ForceNew) Specifies the volume type. COMMON: Common I/O. The SATA disk is used.
-  HIGH: High I/O. The SAS disk is used. ULTRAHIGH: Ultra-high I/O. The solid-state drive (SSD) is used. Changing this
-  parameter will create a new resource.
+* `volume_type` - (Required, String, ForceNew) Specifies the volume type. Value options are as follows:
+  + **COMMON**: Common I/O. The SATA disk is used.
+  + **HIGH**: High I/O. The SAS disk is used.
+  + **ULTRAHIGH**: Ultra-high I/O. The solid-state drive (SSD) is used.
+
+  Changing this parameter will create a new resource.
 
 <a name="Css_public_access"></a>
 The `public_access` block supports:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

### css cluster support use local dist flavor
- when ess node or cold node use a local disk flavor, the volume information could be empty
- add descriptions for local disk flavor in document
- add a test for local disk flavor

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_localDisk'
...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_localDisk -timeout 360m -parallel 4 
=== RUN   TestAccCssCluster_localDisk 
=== PAUSE TestAccCssCluster_localDisk
=== CONT  TestAccCssCluster_localDisk
--- PASS: TestAccCssCluster_localDisk (2162.88s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       2162.942s
```

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_basic -timeout 360m -parallel 4 
=== RUN   TestAccCssCluster_basic 
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (1927.36s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1927.415s
```
```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_prePaid'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_prePaid -timeout 360m -parallel 4 
=== RUN   TestAccCssCluster_prePaid 
=== PAUSE TestAccCssCluster_prePaid
=== CONT  TestAccCssCluster_prePaid
--- PASS: TestAccCssCluster_prePaid (1297.29s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1297.353s
```


