### PR TITLE
feat(vpc/subnet): add extra dhcp options support

### DIFF
--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -33,6 +33,16 @@ resource "huaweicloud_vpc_subnet" "subnet_with_tags" {
   }
 }
 
+resource "huaweicloud_vpc_subnet" "subnet_with_dhcp" {
+  name       = var.subnet_name
+  cidr       = var.subnet_cidr
+  gateway_ip = var.subnet_gateway_ip
+  vpc_id     = huaweicloud_vpc.vpc.id
+
+  dhcp_lease_time    = "24h"
+  ntp_server_address = "10.100.0.33,10.100.0.34"
+}
+
  ```
 
 ## Argument Reference
@@ -67,6 +77,14 @@ The following arguments are supported:
 
 * `secondary_dns` - (Optional, String) Specifies the IP address of DNS server 2 on the subnet. The value must be a valid
   IP address.
+
+* `dhcp_lease_time` - (Optional, String) Specifies the DHCP lease expiration time. The value can be -1, which indicates
+  unlimited lease time, or Number+h. the number ranges from 1 to 30,000. For example, the value can be 5h. The default
+  value is 24h.
+
+* `ntp_server_address` - (Optional, String) Specifies the NTP server address. Currently only IPv4 addresses are supported.
+  A maximum of four IP addresses can be configured, and each address must be unique. Multiple IP addresses must be
+  separated using commas(,). Removing this parameter indicates that no NTP server is configured.
 
 * `dns_list` - (Optional, List) Specifies the DNS server address list of a subnet. This field is required if you need to
   use more than two DNS servers. This parameter value is the superset of both DNS server address 1 and DNS server


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. ntp server with null value indicates no ntp server configured on API side. so ntp_server_address parameter without Computed
2. the default value of dhcp lease time is 1day, which will not returned only if you specify one time or changed the default one.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/vpc TESTARGS='-run=TestAccVpcSubnetV1_dhcp'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcSubnetV1_dhcp -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_dhcp
=== PAUSE TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_dhcp
--- PASS: TestAccVpcSubnetV1_dhcp (97.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc 
```
