### PR TITLE
refactor(DMS): rabbitmq supports flaovr id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230530080832-5259e6637c95
+	github.com/chnsz/golangsdk v0.0.0-20230531032846-271e0b51bd73
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230530080832-5259e6637c95 h1:inZTt5LVHKEUp/iVMvgQWiKeIZKB0n78Xn8uafU11YU=
-github.com/chnsz/golangsdk v0.0.0-20230530080832-5259e6637c95/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230531032846-271e0b51bd73 h1:0RCtUbvSK/IrTl4chRD7MHfHUsXn95J/xglVyagQA10=
+github.com/chnsz/golangsdk v0.0.0-20230531032846-271e0b51bd73/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -20,8 +21,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
-
-const lockKey = "DMS"
 
 func ResourceDmsRabbitmqInstance() *schema.Resource {
 	return &schema.Resource{
@@ -106,9 +105,17 @@ func ResourceDmsRabbitmqInstance() *schema.Resource {
 				Set:           schema.HashString,
 				Description:   "schema: Required",
 			},
-			"product_id": {
-				Type:     schema.TypeString,
-				Required: true,
+			"flavor_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"product_id"},
+				RequiredWith: []string{"storage_space"},
+			},
+			"broker_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"maintain_begin": {
 				Type:     schema.TypeString,
@@ -192,6 +199,11 @@ func ResourceDmsRabbitmqInstance() *schema.Resource {
 				AtLeastOneOf: []string{"available_zones", "availability_zones"},
 				Deprecated:   "available_zones has deprecated, please use \"availability_zones\" instead.",
 			},
+			"product_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "product_id has deprecated, please use \"flavor_id\" instead.",
+			},
 			// Typo, it is only kept in the code, will not be shown in the docs.
 			"manegement_connect_address": {
 				Type:       schema.TypeString,
@@ -244,9 +256,20 @@ func getRabbitMQProductDetail(cfg *config.Config, d *schema.ResourceData) (*prod
 }
 
 func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config.MutexKV.Lock(lockKey)
-	defer config.MutexKV.Unlock(lockKey)
+	var dErr diag.Diagnostics
+	if _, ok := d.GetOk("flavor_id"); ok {
+		dErr = createRabbitMQInstanceWithFlavor(ctx, d, meta)
+	} else {
+		dErr = createRabbitMQInstanceWithProductID(ctx, d, meta)
+	}
+	if dErr != nil {
+		return dErr
+	}
 
+	return resourceDmsRabbitmqInstanceRead(ctx, d, meta)
+}
+
+func createRabbitMQInstanceWithFlavor(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.DmsV2Client(region)
@@ -255,16 +278,95 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	var availableZones []string // Available zones IDs
-	azIDs, ok := d.GetOk("available_zones")
+	azIDs, ok := d.GetOk("availability_zones")
 	if ok {
-		availableZones = utils.ExpandToStringList(azIDs.([]interface{}))
-	} else {
 		// convert the codes of the availability zone into ids
-		azCodes := d.Get("availability_zones").(*schema.Set)
+		azCodes := azIDs.(*schema.Set)
 		availableZones, err = getAvailableZoneIDByCode(cfg, region, azCodes.List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
+	} else {
+		availableZones = utils.ExpandToStringList(d.Get("available_zones").([]interface{}))
+	}
+
+	createOpts := &instances.CreateOps{
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		Engine:              engineRabbitMQ,
+		EngineVersion:       d.Get("engine_version").(string),
+		StorageSpace:        d.Get("storage_space").(int),
+		AccessUser:          d.Get("access_user").(string),
+		VPCID:               d.Get("vpc_id").(string),
+		SecurityGroupID:     d.Get("security_group_id").(string),
+		SubnetID:            d.Get("network_id").(string),
+		AvailableZones:      availableZones,
+		ProductID:           d.Get("flavor_id").(string),
+		BrokerNum:           d.Get("broker_num").(int),
+		MaintainBegin:       d.Get("maintain_begin").(string),
+		MaintainEnd:         d.Get("maintain_end").(string),
+		SslEnable:           d.Get("ssl_enable").(bool),
+		StorageSpecCode:     d.Get("storage_spec_code").(string),
+		EnterpriseProjectID: common.GetEnterpriseProjectID(d, cfg),
+	}
+
+	if pubIpID, ok := d.GetOk("public_ip_id"); ok {
+		createOpts.EnablePublicIP = true
+		createOpts.PublicIpID = pubIpID.(string)
+	}
+
+	// set tags
+	if tagRaw := d.Get("tags").(map[string]interface{}); len(tagRaw) > 0 {
+		createOpts.Tags = utils.ExpandResourceTags(tagRaw)
+	}
+
+	log.Printf("[DEBUG] Create DMS RabbitMQ instance Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
+
+	v, err := instances.CreateWithEngine(client, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating DMS RabbitMQ instance: %s", err)
+	}
+	instanceID := v.InstanceID
+	// Store the instance ID now
+	d.SetId(instanceID)
+	log.Printf("[INFO] Creating RabbitMQ instance, ID: %s", instanceID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"CREATING"},
+		Target:       []string{"RUNNING"},
+		Refresh:      rabbitmqInstanceStateRefreshFunc(client, instanceID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        300 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.Errorf("error waiting for RabbitMQ instance (%s) to be ready: %s", instanceID, err)
+	}
+
+	return nil
+}
+
+func createRabbitMQInstanceWithProductID(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DmsV2Client(region)
+	if err != nil {
+		return diag.Errorf("error initializing DMS RabbitMQ(v2) client: %s", err)
+	}
+	var availableZones []string // Available zones IDs
+	azIDs, ok := d.GetOk("availability_zones")
+	if ok {
+		// convert the codes of the availability zone into ids
+		azCodes := azIDs.(*schema.Set)
+		availableZones, err = getAvailableZoneIDByCode(cfg, region, azCodes.List())
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		availableZones = utils.ExpandToStringList(d.Get("available_zones").([]interface{}))
 	}
 
 	storageSpace := d.Get("storage_space").(int)
@@ -273,7 +375,6 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		if err != nil || product == nil {
 			return diag.Errorf("failed to query DMS RabbitMQ product details: %s", err)
 		}
-
 		defaultStorageSpace, err := strconv.ParseInt(product.Storage, 10, 32)
 		if err != nil {
 			return diag.Errorf("failed to create RabbitMQ instance, error parsing storage_space to int %v: %s",
@@ -319,15 +420,16 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.Errorf("error creating DMS RabbitMQ instance: %s", err)
 	}
-	log.Printf("[INFO] Creating RabbitMQ instance, ID: %s", v.InstanceID)
+	// Store the instance ID now
+	d.SetId(v.InstanceID)
 
+	log.Printf("[INFO] Creating RabbitMQ instance, ID: %s", v.InstanceID)
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"CREATING"},
 		Target:       []string{"RUNNING"},
 		Refresh:      rabbitmqInstanceStateRefreshFunc(client, v.InstanceID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        300 * time.Second,
-		MinTimeout:   10 * time.Second,
 		PollInterval: 15 * time.Second,
 	}
 
@@ -335,10 +437,7 @@ func resourceDmsRabbitmqInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error waiting for RabbitMQ instance (%s) to be ready: %s", v.InstanceID, err)
 	}
 
-	// Store the instance ID now
-	d.SetId(v.InstanceID)
-
-	return resourceDmsRabbitmqInstanceRead(ctx, d, meta)
+	return nil
 }
 
 func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -378,13 +477,14 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 		d.Set("network_id", v.SubnetID),
 		d.Set("available_zones", v.AvailableZones),
 		d.Set("availability_zones", asCodes),
-		d.Set("product_id", v.ProductID),
+		setRabbitMQFlavorId(d, v.ProductID),
 		d.Set("maintain_begin", v.MaintainBegin),
 		d.Set("maintain_end", v.MaintainEnd),
 		d.Set("enable_public_ip", v.EnablePublicIP),
 		d.Set("public_ip_id", v.PublicIPID),
 		d.Set("ssl_enable", v.SslEnable),
 		d.Set("storage_spec_code", v.StorageSpecCode),
+		d.Set("broker_num", v.BrokerNum),
 		d.Set("enterprise_project_id", v.EnterpriseProjectID),
 		d.Set("used_storage_space", v.UsedStorageSpace),
 		d.Set("connect_address", v.ConnectAddress),
@@ -420,10 +520,15 @@ func resourceDmsRabbitmqInstanceRead(_ context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config.MutexKV.Lock(lockKey)
-	defer config.MutexKV.Unlock(lockKey)
+func setRabbitMQFlavorId(d *schema.ResourceData, flavorId string) error {
+	re := regexp.MustCompile(`^[a-z0-9]+\.\d+u\d+g\.cluster|single$`)
+	if re.MatchString(flavorId) {
+		return d.Set("flavor_id", flavorId)
+	}
+	return d.Set("product_id", flavorId)
+}
 
+func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -473,7 +578,7 @@ func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	if d.HasChange("product_id") {
+	if d.HasChanges("product_id", "flavor_id") {
 		err = resizeRabbitMQInstance(ctx, d, meta, engineRabbitMQ)
 		if err != nil {
 			mErr = multierror.Append(mErr, err)
@@ -493,56 +598,80 @@ func resizeRabbitMQInstance(ctx context.Context, d *schema.ResourceData, meta in
 		return fmt.Errorf("error initializing DMS(v2) client: %s", err)
 	}
 
-	product, err := getRabbitMQProductDetail(cfg, d)
-	if err != nil {
-		return fmt.Errorf("failed to resize RabbitMQ instance, query product details error: %s", err)
+	if d.HasChanges("product_id") {
+		product, err := getRabbitMQProductDetail(cfg, d)
+		if err != nil {
+			return fmt.Errorf("failed to resize RabbitMQ instance, query product details error: %s", err)
+		}
+		storage, err := strconv.Atoi(product.Storage)
+		if err != nil {
+			return fmt.Errorf("failed to resize RabbitMQ instance, error parsing storage_space to int %v: %s",
+				product.Storage, err)
+		}
+
+		resizeOpts := instances.ResizeInstanceOpts{
+			NewSpecCode:     &product.SpecCode,
+			NewStorageSpace: &storage,
+		}
+		log.Printf("[DEBUG] Resize DMS RabbitMQ instance option : %#v", resizeOpts)
+
+		if err = doRabbitMQInstanceResize(ctx, d, client, resizeOpts); err != nil {
+			return err
+		}
 	}
 
-	storage, err := strconv.Atoi(product.Storage)
-	if err != nil {
-		return fmt.Errorf("failed to resize RabbitMQ instance, error parsing storage_space to int %v: %s",
-			product.Storage, err)
-	}
+	if d.HasChanges("flavor_id") {
+		flavorID := d.Get("flavor_id").(string)
+		operType := "vertical"
+		resizeOpts := instances.ResizeInstanceOpts{
+			OperType:     &operType,
+			NewProductID: &flavorID,
+		}
+		log.Printf("[DEBUG] Resize RabbitMQ instance flavor ID options: %s", utils.MarshalValue(resizeOpts))
 
-	resizeOpts := instances.ResizeInstanceOpts{
-		NewSpecCode:     product.SpecCode,
-		NewStorageSpace: storage,
-	}
-	log.Printf("[DEBUG] Resize DMS %s instance option : %#v", engineType, resizeOpts)
-
-	_, err = instances.Resize(client, d.Id(), resizeOpts)
-	if err != nil {
-		return fmt.Errorf("resize RabbitMQ instance failed: %s", err)
-	}
-
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"EXTENDING", "PENDING"},
-		Target:       []string{"RUNNING"},
-		Refresh:      rabbitMQResizeStateRefresh(client, d.Id(), product.ProductID),
-		Timeout:      d.Timeout(schema.TimeoutUpdate),
-		Delay:        180 * time.Second,
-		PollInterval: 15 * time.Second,
-	}
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("error waiting for RabbitMQ instance (%s) to resize: %v", d.Id(), err)
+		if err = doRabbitMQInstanceResize(ctx, d, client, resizeOpts); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func rabbitMQResizeStateRefresh(client *golangsdk.ServiceClient, instanceID, productID string) resource.StateRefreshFunc {
+func doRabbitMQInstanceResize(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, opts instances.ResizeInstanceOpts) error {
+	if _, err := instances.Resize(client, d.Id(), opts); err != nil {
+		return fmt.Errorf("resize RabbitMQ instance failed: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"RUNNING"},
+		Refresh:      rabbitMQResizeStateRefresh(client, d, opts.OperType),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for instance (%s) to resize: %v", d.Id(), err)
+	}
+	return nil
+}
+
+func rabbitMQResizeStateRefresh(client *golangsdk.ServiceClient, d *schema.ResourceData, operType *string) resource.StateRefreshFunc {
+	productID := d.Get("flavor_id").(string)
+	if productID == "" {
+		productID = d.Get("product_id").(string)
+	}
+
 	return func() (interface{}, string, error) {
-		v, err := instances.Get(client, instanceID).Extract()
+		v, err := instances.Get(client, d.Id()).Extract()
 		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return v, "failed", fmt.Errorf("unable to resize RabbitMQ instance which has been deleted: %s",
-					instanceID)
-			}
 			return nil, "failed", err
 		}
-		if v.Status == "RUNNING" && v.ProductID != productID {
+
+		if (operType == nil || *operType == "vertical") && v.ProductID != productID {
 			return v, "PENDING", nil
 		}
+
 		return v, v.Status, nil
 	}
 }
@@ -568,7 +697,6 @@ func resourceDmsRabbitmqInstanceDelete(ctx context.Context, d *schema.ResourceDa
 		Refresh:      rabbitmqInstanceStateRefreshFunc(client, d.Id()),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        90 * time.Second,
-		MinTimeout:   5 * time.Second,
 		PollInterval: 15 * time.Second,
 	}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
@@ -68,6 +68,9 @@ type CreateOps struct {
 	// Indicates a product ID.
 	ProductID string `json:"product_id" required:"true"`
 
+	// Indicates the maximum number of brokers in a RabbitMQ instance.
+	BrokerNum int `json:"broker_num,omitempty"`
+
 	// Indicates the time at which a maintenance time window starts.
 	// Format: HH:mm:ss
 	MaintainBegin string `json:"maintain_begin,omitempty"`
@@ -93,6 +96,26 @@ type CreateOps struct {
 
 	// Indicates the tags of the instance
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
+
+	// Indicates the parameter related to the yearly/monthly billing mode.
+	BssParam *BssParam `json:"bss_param,omitempty"`
+}
+
+type BssParam struct {
+	// Indicates the charging mode of the instance.
+	ChargingMode string `json:"charging_mode" required:"true"`
+
+	// Indicates the charging period unit of the instance
+	PeriodType string `json:"period_type,omitempty"`
+
+	// Indicates the charging period of the instance.
+	PeriodNum int `json:"period_num,omitempty"`
+
+	// Indicates whether auto renew is enabled.
+	IsAutoRenew *bool `json:"is_auto_renew,omitempty"`
+
+	// Indicates whether the order is automatically or manually paid.
+	IsAutoPay *bool `json:"is_auto_pay,omitempty"`
 }
 
 // ToInstanceCreateMap is used for type convert
@@ -109,6 +132,21 @@ func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder) (r CreateResu
 	}
 
 	_, r.Err = client.Post(createURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// Create an instance with given parameters.
+func CreateWithEngine(client *golangsdk.ServiceClient, ops CreateOpsBuilder) (r CreateResult) {
+	b, err := ops.ToInstanceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createWithEngineURL(client), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 
@@ -228,8 +266,11 @@ func List(client *golangsdk.ServiceClient, opts ListOpsBuilder) pagination.Pager
 }
 
 type ResizeInstanceOpts struct {
-	NewSpecCode     string `json:"new_spec_code" required:"true"`
-	NewStorageSpace int    `json:"new_storage_space" required:"true"`
+	OperType        *string `json:"oper_type,omitempty"`
+	NewSpecCode     *string `json:"new_spec_code,omitempty"`
+	NewStorageSpace *int    `json:"new_storage_space,omitempty"`
+	NewBrokerNum    *int    `json:"new_broker_num,omitempty"`
+	NewProductID    *string `json:"new_product_id,omitempty"`
 }
 
 func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts) (string, error) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/results.go
@@ -47,6 +47,7 @@ type Instance struct {
 	Status                   string             `json:"status"`
 	InstanceID               string             `json:"instance_id"`
 	ResourceSpecCode         string             `json:"resource_spec_code"`
+	BrokerNum                int                `json:"broker_num"`
 	ChargingMode             int                `json:"charging_mode"`
 	VPCID                    string             `json:"vpc_id"`
 	VPCName                  string             `json:"vpc_name"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
@@ -5,9 +5,16 @@ import "github.com/chnsz/golangsdk"
 // endpoint/instances
 const resourcePath = "instances"
 
+const rabbitMqEngine = "rabbitmq"
+
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
+}
+
+// createWithEngineURL will build the rest query url of creation
+func createWithEngineURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(rabbitMqEngine, client.ProjectID, resourcePath)
 }
 
 // deleteURL will build the url of deletion

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230530080832-5259e6637c95
+# github.com/chnsz/golangsdk v0.0.0-20230531032846-271e0b51bd73
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- rabbitmq can be created by flavor id 
- rabbitmq support new format path of API

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRabbitmqInstances_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRabbitmqInstances_ -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_newFormat_cluster
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_cluster
=== RUN   TestAccDmsRabbitmqInstances_newFormat_single
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_single
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
=== CONT  TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_compatible
--- PASS: TestAccDmsRabbitmqInstances_single (471.93s)
=== CONT  TestAccDmsRabbitmqInstances_newFormat_single
--- PASS: TestAccDmsRabbitmqInstances_compatible (942.67s)
=== CONT  TestAccDmsRabbitmqInstances_newFormat_cluster
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (1409.39s)
--- PASS: TestAccDmsRabbitmqInstances_basic (2962.02s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_single (2777.65s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_cluster (2863.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3806.505s
```
