### PR TITLE
refactor(DMS): rabbitmq support prepaid

### DIFF
--- a/docs/resources/dms_rabbitmq_instance.md
+++ b/docs/resources/dms_rabbitmq_instance.md
@@ -81,7 +81,8 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the name of the DMS RabbitMQ instance. An instance name starts with a letter,
   consists of 4 to 64 characters, and supports only letters, digits, hyphens (-) and underscores (_).
 
-* `flavor_id` - (Optional, String) Specifies a flavor ID. Changing this creates a new instance resource.
+* `flavor_id` - (Optional, String) Specifies a flavor ID.
+  It is mandatory when the `charging_mode` is **prePaid**.
 
 * `broker_num` - (Optional, Int, ForceNew) Specifies the broker numbers.
   It is required when creating a cluster instance with `flavor_id`.
@@ -152,6 +153,19 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the RabbitMQ instance.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the instance. Valid values are
+  **prePaid** and **postPaid**, defaults to **postPaid**. Changing this creates a new resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the instance.
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this creates a new resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the instance. If `period_unit` is set to
+  **month**, the value ranges from 1 to 9. If `period_unit` is set to **year**, the value ranges from 1 to 3.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**. Changing this creates a new resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled. Valid values are **true** and **false**.
+
 * `tags` - (Optional, Map) The key/value pairs to associate with the DMS RabbitMQ instance.
 
 ## Attributes Reference
@@ -191,9 +205,9 @@ DMS RabbitMQ instance can be imported using the instance id, e.g.
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`password`. It is generally recommended running `terraform plan` after importing a DMS RabbitMQ instance. You can then
-decide if changes should be applied to the instance, or the resource definition should be updated to align with the
-instance. Also you can ignore changes as below.
+`password`, `auto_renew`, `period` and `period_unit`. It is generally recommended running `terraform plan` after
+importing a DMS RabbitMQ instance. You can then decide if changes should be applied to the instance, or the resource
+definition should be updated to align with the instance. Also you can ignore changes as below.
 
 ```
 resource "huaweicloud_dms_rabbitmq_instance" "instance_1" {
@@ -201,7 +215,7 @@ resource "huaweicloud_dms_rabbitmq_instance" "instance_1" {
 
   lifecycle {
     ignore_changes = [
-      password
+      password, auto_renew, period, period_unit,
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rabbitmq support prepaid
- rabbitmq can be created by flavor id 
- rabbitmq support new format path of API

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rabbitmq support prepaid
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRabbitmqInstances_' TEST_PARALLELISM=7
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRabbitmqInstances_ -timeout 360m -parallel 7
=== RUN   TestAccDmsRabbitmqInstances_basic
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_newFormat_cluster
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_cluster
=== RUN   TestAccDmsRabbitmqInstances_newFormat_single
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_single
=== RUN   TestAccDmsRabbitmqInstances_prePaid
=== PAUSE TestAccDmsRabbitmqInstances_prePaid
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
=== CONT  TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_newFormat_single
=== CONT  TestAccDmsRabbitmqInstances_prePaid
=== CONT  TestAccDmsRabbitmqInstances_newFormat_cluster
=== CONT  TestAccDmsRabbitmqInstances_compatible
--- PASS: TestAccDmsRabbitmqInstances_single (466.46s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_single (886.34s)
--- PASS: TestAccDmsRabbitmqInstances_compatible (958.00s)
--- PASS: TestAccDmsRabbitmqInstances_prePaid (1075.76s)
--- PASS: TestAccDmsRabbitmqInstances_withEpsId (1091.30s)
--- PASS: TestAccDmsRabbitmqInstances_basic (1101.56s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_cluster (1141.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1141.620ss
```
