### PR TITLE
fix(iam/agency): skip scanning the internal MOS project

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
@@ -111,7 +111,7 @@ resource "huaweicloud_identity_agency" "test" {
   domain_roles = [
     "Anti-DDoS Administrator",
     "SMN Administrator",
-    "Ticket Administrator",
+    "OBS Administrator",
   ]
   all_resources_roles = [
     "VPCEndpoint Administrator"

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
@@ -106,6 +106,7 @@ func ResourceIAMAgencyV3() *schema.Resource {
 			"all_resources_roles": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 25,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -399,6 +400,11 @@ func resourceIAMAgencyV3Read(_ context.Context, d *schema.ResourceData, meta int
 
 	prs := schema.Set{F: resourceIAMAgencyProRoleHash}
 	for pn, pid := range allProjects {
+		// MOS is a special project, not visible to the user
+		if pn == "MOS" {
+			continue
+		}
+
 		allRoles, err := agency.ListRolesAttachedOnProject(iamClient, agencyID, pid).ExtractRoles()
 		if err != nil && !utils.IsResourceNotFound(err) {
 			log.Printf("[ERROR] error querying the roles attached on project(%s): %s", pn, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**MOS** is an internal project, maybe used for OBS service, we should not scan the roles in MOS project.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityAgency_domain"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityAgency_domain -timeout 360m -parallel 4
=== RUN   TestAccIdentityAgency_domain
=== PAUSE TestAccIdentityAgency_domain
=== CONT  TestAccIdentityAgency_domain
--- PASS: TestAccIdentityAgency_domain (1122.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam 1122.453s
```
