### PR TITLE
fix(apig): update acc test and related param behavior

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -84,7 +84,7 @@ The following arguments are supported:
   This parameter is required for enterprise users. Changing this will create a new resource.
 
 * `bandwidth_size` - (Optional, Int) Specifies the egress bandwidth size of the dedicated instance.  
-  The valid value is range from `1` to `2,000`.
+  The valid value ranges from `0` to `2,000`.
 
 * `maintain_begin` - (Optional, String) Specifies the start time of the maintenance time window.  
   The format is **xx:00:00**, the value of **xx** can be `02`, `06`, `10`, `14`, `18` or `22`.

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_associate_test.go
@@ -96,7 +96,7 @@ resource "huaweicloud_apig_instance" "test" {
 
 resource "huaweicloud_compute_instance" "test" {
   name               = "%[2]s"
-  image_id           = data.huaweicloud_images_images.test.images[0].id
+  image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -139,8 +139,7 @@ func ResourceApigInstanceV2() *schema.Resource {
 			"bandwidth_size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(1, 2000),
+				ValidateFunc: validation.IntBetween(0, 2000),
 				Description:  `The egress bandwidth size of the dedicated instance.`,
 			},
 			"eip_id": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. The value of bandwith size cannot update to **0**.
```
[2023/06/02 00:33:23.682] === CONT  TestAccInstance_egress
[2023/06/02 00:33:23.682]     resource_huaweicloud_apig_instance_test.go:96: Step 4/5 error: Check failed: Check 4/4 error: huaweicloud_apig_instance.test: Attribute 'bandwidth_size' expected "0", got "5"
```
2. The image ID reference is invalid.
```
[2023/06/02 00:41:00.820]     resource_huaweicloud_apig_throttling_policy_associate_test.go:44: Step 1/3 error: Error running pre-apply refresh: exit status 1
[2023/06/02 00:41:00.820]
[2023/06/02 00:41:00.820]         Error: Reference to undeclared resource
[2023/06/02 00:41:00.820]
[2023/06/02 00:41:00.820]           on terraform_plugin_test.tf line 58, in resource "huaweicloud_compute_instance" "test":
[2023/06/02 00:41:00.820]           58:   image_id           = data.huaweicloud_images_images.test.images[0].id
[2023/06/02 00:41:00.820]
[2023/06/02 00:41:00.820]         A data resource "huaweicloud_images_images" "test" has not been declared in
[2023/06/02 00:41:00.820]         the root module.
[2023/06/02 00:41:00.820] --- FAIL: TestAccThrottlingPolicyAssociate_basic (0.22s)
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update acc test and related param behavior.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccInstance_egress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccInstance_egress -timeout 360m -parallel 4
=== RUN   TestAccInstance_egress
=== PAUSE TestAccInstance_egress
=== CONT  TestAccInstance_egress
--- PASS: TestAccInstance_egress (554.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      555.023s
```
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccThrottlingPolicyAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccThrottlingPolicyAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (506.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      506.494s
```
