### PR TITLE
feat(ecs/instance): support root volume encryption

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -242,6 +242,12 @@ The following arguments are supported:
 * `system_disk_size` - (Optional, Int) Specifies the system disk size in GB, The value range is 1 to 1024.
   Shrinking the disk is not supported.
 
+* `system_disk_kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key used to encrypt the system disk.
+  Changing this creates a new instance.
+
+  -> **NOTE:** This parameter is only supported in some regions, such as ap-southeast-3.
+    If not supported, please contact technical support.
+
 * `data_disks` - (Optional, List, ForceNew) Specifies an array of one or more data disks to attach to the instance.
   The data_disks object structure is documented below. Changing this creates a new instance.
 

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -204,6 +204,12 @@ func ResourceComputeInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"system_disk_kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"data_disks": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -833,6 +839,7 @@ func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta
 				d.Set("system_disk_id", b.ID)
 				d.Set("system_disk_size", volumeInfo.Size)
 				d.Set("system_disk_type", volumeInfo.VolumeType)
+				d.Set("system_disk_kms_key_id", volumeInfo.Metadata.SystemCmkID)
 			}
 		}
 		d.Set("volume_attached", bds)
@@ -1653,6 +1660,15 @@ func buildInstanceRootVolume(d *schema.ResourceData) cloudservers.RootVolume {
 		VolumeType: diskType,
 		Size:       d.Get("system_disk_size").(int),
 	}
+
+	if v, ok := d.GetOk("system_disk_kms_key_id"); ok {
+		matadata := cloudservers.VolumeMetadata{
+			SystemEncrypted: "1",
+			SystemCmkid:     v.(string),
+		}
+		volRequest.Metadata = &matadata
+	}
+
 	return volRequest
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* new parameter: `system_disk_kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key used to encrypt the system disk. Changing this creates a new instance.

* This parameter is only supported in some regions, such as **ap-southeast-3**. If not supported, please contact technical support.

* The default region of acceptance is **cn-north-4**, so the basic test does not include this parameter. I have tested it  **ap-southeast-3** manaually.
```hcl
resource "huaweicloud_compute_instance" "test_ecs1" {
    access_ip_v4           = "10.1.7.89"
    availability_zone      = "ap-southeast-3e"
    charging_mode          = "postPaid"
    created_at             = "2023-06-05T06:52:33Z"
    enterprise_project_id  = "0"
    flavor_id              = "s6.small.1"
    flavor_name            = "s6.small.1"
    id                     = "2ad924e1-109a-4872-a992-ccfc54d612bf"
    image_id               = "4ba262ad-b622-40f6-b335-af78ceeb6da6"
    image_name             = "CentOS 7.2 64bit"
    name                   = "test_compute123"
    region                 = "ap-southeast-3"
    security_group_ids     = [
        "7b4b43c0-ae5e-4ef8-b1b3-d294f9ac20a3",
    ]
    security_groups        = [
        "default",
    ]
    status                 = "ACTIVE"
    system_disk_id         = "84ab06a1-b516-4ebb-b9d3-39a43e7051ae"
    system_disk_kms_key_id = "c7117413-0334-4535-8e92-a052ad35b3fc"
    system_disk_size       = 40
    system_disk_type       = "SSD"

    network {
        access_network    = false
        fixed_ip_v4       = "10.1.7.89"
        ipv6_enable       = false
        mac               = "fa:16:3e:8f:95:e7"
        port              = "0262a2e5-8641-4993-934b-c1b27066aaa0"
        source_dest_check = true
        uuid              = "af93eb61-8801-471b-89b7-3df9be3f2273"
    }
}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (293.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       293.122s
```
