### PR TITLE
feat(cce/cluster): support multi eni subnet IDs, and updating the eni subnets

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -96,10 +96,17 @@ resource "huaweicloud_vpc_subnet" "mysubnet" {
   vpc_id        = huaweicloud_vpc.myvpc.id
 }
 
-resource "huaweicloud_vpc_subnet" "eni_test" {
-  name          = "subnet-eni"
+resource "huaweicloud_vpc_subnet" "eni_test_1" {
+  name          = "subnet-eni-1"
   cidr          = "192.168.2.0/24"
   gateway_ip    = "192.168.2.1"
+  vpc_id        = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_vpc_subnet" "eni_test_2" {
+  name          = "subnet-eni-2"
+  cidr          = "192.168.3.0/24"
+  gateway_ip    = "192.168.3.1"
   vpc_id        = huaweicloud_vpc.test.id
 }
 
@@ -109,8 +116,10 @@ resource "huaweicloud_cce_cluster" "test" {
   vpc_id                 = huaweicloud_vpc.myvpc.id
   subnet_id              = huaweicloud_vpc_subnet.mysubnet.id
   container_network_type = "eni"
-  eni_subnet_id          = huaweicloud_vpc_subnet.eni_test.ipv4_subnet_id
-  eni_subnet_cidr        = huaweicloud_vpc_subnet.eni_test.cidr
+  eni_subnet_id          = join(",", [
+    huaweicloud_vpc_subnet.eni_test_1.ipv4_subnet_id,
+    huaweicloud_vpc_subnet.eni_test_2.ipv4_subnet_id,
+  ])
 }
 ```
 
@@ -164,11 +173,9 @@ The following arguments are supported:
 * `service_network_cidr` - (Optional, String, ForceNew) Specifies the service network segment.
   Changing this parameter will create a new cluster resource.
 
-* `eni_subnet_id` - (Optional, String, ForceNew) Specifies the **IPv4 subnet ID** of the subnet where the ENI resides.
-  Specified when creating a CCE Turbo cluster. Changing this parameter will create a new cluster resource.
-
-* `eni_subnet_cidr` - (Optional, String, ForceNew) Specifies the ENI network segment. Specified when creating a CCE
-  Turbo cluster. Changing this parameter will create a new cluster resource.
+* `eni_subnet_id` - (Optional, String) Specifies the **IPv4 subnet ID** of the subnet where the ENI resides.
+  Specified when creating a CCE Turbo cluster. You can add multiple IPv4 subnet ID, separated with comma (,).
+  Only adding subnets is allowed, removing subnets is not allowed.
 
 * `authentication_mode` - (Optional, String, ForceNew) Specifies the authentication mode of the cluster, possible values
   are **rbac** and **authenticating_proxy**. Defaults to **rbac**.
@@ -270,6 +277,8 @@ In addition to all arguments above, the following attributes are exported:
 * `certificate_users` - The certificate users. Structure is documented below.
 
 * `security_group_id` - Security group ID of the cluster.
+
+* `eni_subnet_cidr` - The ENI network segment. This value is valid when only one eni_subnet_id is specified.
 
 * `kube_config_raw` - Raw Kubernetes config to be used by kubectl and other compatible tools.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230531061124-d429dbae2745
+	github.com/chnsz/golangsdk v0.0.0-20230606014615-294b13be665c
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230531061124-d429dbae2745 h1:ckMNfcGvvNLQ83N/8OJk+9E91Fx1XiI2a2irIS6K8V4=
-github.com/chnsz/golangsdk v0.0.0-20230531061124-d429dbae2745/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230606014615-294b13be665c h1:LVrtDLNLT8OnLCfXwLRQXRJV+bHPRLZdvz5takpJEns=
+github.com/chnsz/golangsdk v0.0.0-20230606014615-294b13be665c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -634,7 +634,7 @@ resource "huaweicloud_cce_node_pool" "test" {
     volumetype = "SSD"
   }
 }
-`, testAccCluster_turbo(rName), rName)
+`, testAccCluster_turbo(rName, 1), rName)
 }
 
 func testAccCCENodePool_tagsLabelsTaints(rName string) string {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -181,6 +181,8 @@ type UpdateOpts struct {
 type UpdateSpec struct {
 	// Cluster description
 	Description string `json:"description,omitempty"`
+	//ENI network parameters
+	EniNetwork *EniNetworkSpec `json:"eniNetwork,omitempty"`
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
@@ -106,10 +106,16 @@ type CidrSpec struct {
 }
 
 type EniNetworkSpec struct {
-	//Eni network subnet id
-	SubnetId string `json:"eniSubnetId" required:"true"`
-	//Eni network cidr
-	Cidr string `json:"eniSubnetCIDR" required:"true"`
+	//Eni network subnet id, will be deprecated in the future
+	SubnetId string `json:"eniSubnetId,omitempty"`
+	//Eni network cidr, will be deprecated in the future
+	Cidr string `json:"eniSubnetCIDR,omitempty"`
+	// Eni network subnet IDs
+	Subnets []EniSubnetSpec `json:"subnets" required:"true"`
+}
+
+type EniSubnetSpec struct {
+	SubnetID string `json:"subnetID" required:"true"`
 }
 
 // Authentication parameters

--- a/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/topics/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/topics/requests.go
@@ -9,13 +9,13 @@ var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
 	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
 }
 
-//CreateOpsBuilder is used for creating topic parameters.
-//any struct providing the parameters should implement this interface
+// CreateOpsBuilder is used for creating topic parameters.
+// any struct providing the parameters should implement this interface
 type CreateOpsBuilder interface {
 	ToTopicCreateMap() (map[string]interface{}, error)
 }
 
-//CreateOps is a struct that contains all the parameters.
+// CreateOps is a struct that contains all the parameters.
 type CreateOps struct {
 	//Name of the topic to be created
 	Name string `json:"name" required:"true"`
@@ -30,13 +30,13 @@ func (ops CreateOps) ToTopicCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(ops, "")
 }
 
-//CreateOpsBuilder is used for updating topic parameters.
-//any struct providing the parameters should implement this interface
+// CreateOpsBuilder is used for updating topic parameters.
+// any struct providing the parameters should implement this interface
 type UpdateOpsBuilder interface {
 	ToTopicUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOps is a struct that contains all the parameters.
+// UpdateOps is a struct that contains all the parameters.
 type UpdateOps struct {
 	//Topic display name
 	DisplayName string `json:"display_name,omitempty"`
@@ -46,7 +46,7 @@ func (ops UpdateOps) ToTopicUpdateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(ops, "")
 }
 
-//Create a topic with given parameters.
+// Create a topic with given parameters.
 func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder) (r CreateResult) {
 	b, err := ops.ToTopicCreateMap()
 	if err != nil {
@@ -62,7 +62,7 @@ func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder) (r CreateResu
 	return
 }
 
-//Update a topic with given parameters.
+// Update a topic with given parameters.
 func Update(client *golangsdk.ServiceClient, ops UpdateOpsBuilder, id string) (r UpdateResult) {
 	b, err := ops.ToTopicUpdateMap()
 	if err != nil {
@@ -78,7 +78,7 @@ func Update(client *golangsdk.ServiceClient, ops UpdateOpsBuilder, id string) (r
 	return
 }
 
-//delete a topic via id
+// delete a topic via id
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
@@ -87,7 +87,7 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	return
 }
 
-//get a topic with detailed information by id
+// get a topic with detailed information by id
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, &golangsdk.RequestOpts{
 		MoreHeaders: RequestOpts.MoreHeaders,
@@ -95,7 +95,7 @@ func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	return
 }
 
-//list all the topics
+// list all the topics
 func List(client *golangsdk.ServiceClient) (r ListResult) {
 	pages, err := pagination.NewPager(client, listURL(client),
 		func(r pagination.PageResult) pagination.Page {
@@ -109,5 +109,34 @@ func List(client *golangsdk.ServiceClient) (r ListResult) {
 	}
 
 	r.Body = pages.GetBody()
+	return
+}
+
+type UpdatePoliciesOpts struct {
+	// the value can be empty
+	Value string `json:"value"`
+}
+
+// Update policies of the topic.
+func UpdatePolicies(client *golangsdk.ServiceClient, ops UpdatePoliciesOpts, id, policyName string) (r UpdateResult) {
+	b, err := golangsdk.BuildRequestBody(ops, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updatePoliciesURL(client, id, policyName), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+
+	return
+}
+
+// get policies of the topic
+func GetPolicies(client *golangsdk.ServiceClient, id, policyName string) (r GetPoliciesResult) {
+	_, r.Err = client.Get(getPoliciesURL(client, id, policyName), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/topics/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/topics/results.go
@@ -20,6 +20,11 @@ type TopicGet struct {
 	EnterpriseProjectId string `json:"enterprise_project_id"`
 }
 
+type Policies struct {
+	AccessPolicy string `json:"access_policy"`
+	Introduction string `json:"introduction"`
+}
+
 // Extract will get the topic object out of the commonResult object.
 func (r commonResult) Extract() (*Topic, error) {
 	var s Topic
@@ -62,6 +67,10 @@ type ListResult struct {
 	golangsdk.Result
 }
 
+type GetPoliciesResult struct {
+	commonResult
+}
+
 func (lr ListResult) Extract() ([]TopicGet, error) {
 	var a struct {
 		Topics []TopicGet `json:"topics"`
@@ -85,4 +94,12 @@ func ExtractTopics(r pagination.Page) ([]TopicGet, error) {
 	}
 	err := (r.(TopicPage)).ExtractInto(&s)
 	return s.Topics, err
+}
+
+func (r GetPoliciesResult) Extract() (Policies, error) {
+	var a struct {
+		Policies Policies `json:"attributes"`
+	}
+	err := r.Result.ExtractInto(&a)
+	return a.Policies, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/topics/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/topics/urls.go
@@ -21,3 +21,11 @@ func updateURL(c *golangsdk.ServiceClient, id string) string {
 func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("topics")
 }
+
+func getPoliciesURL(c *golangsdk.ServiceClient, id, policyName string) string {
+	return c.ServiceURL("topics", id, "attributes?name="+policyName)
+}
+
+func updatePoliciesURL(c *golangsdk.ServiceClient, id, policyName string) string {
+	return c.ServiceURL("topics", id, "attributes", policyName)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230531061124-d429dbae2745
+# github.com/chnsz/golangsdk v0.0.0-20230606014615-294b13be665c
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCluster_basic
=== PAUSE TestAccCluster_basic
=== CONT  TestAccCluster_basic
--- PASS: TestAccCluster_basic (530.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       530.412s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster_turbo'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster_turbo -timeout 360m -parallel 4
=== RUN   TestAccCluster_turbo
=== PAUSE TestAccCluster_turbo
=== CONT  TestAccCluster_turbo
--- PASS: TestAccCluster_turbo (586.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       586.370s
```
