### PR TITLE
chore: test(ims/backup): support CBR backup data-source test and update backup_id behavior

### DIFF
--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_backup_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_backup_test.go
@@ -1,0 +1,74 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataBackup_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.huaweicloud_cbr_backup.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataBackup_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataBackup_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  data_disks {
+    type = "SAS"
+    size = "10"
+  }
+}
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = "%[2]s"
+  type             = "server"
+  consistent_level = "app_consistent"
+  protection_type  = "backup"
+  size             = 200
+}
+
+resource "huaweicloud_images_image" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_compute_instance.test.id
+  vault_id    = huaweicloud_cbr_vault.test.id
+}
+
+data "huaweicloud_cbr_backup" "test" {
+  id = huaweicloud_images_image.test.backup_id
+}
+`, common.TestBaseComputeResources(name), name)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image.go
@@ -61,6 +61,7 @@ func ResourceImsImage() *schema.Resource {
 			"instance_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{"image_url", "backup_id"},
 			},
@@ -74,6 +75,7 @@ func ResourceImsImage() *schema.Resource {
 			"backup_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			// image_url and min_disk are required for creating an image from an OBS
@@ -367,6 +369,7 @@ func resourceImsImageRead(_ context.Context, d *schema.ResourceData, meta interf
 			mErr = multierror.Append(
 				mErr,
 				d.Set("instance_id", backup.ResourceId),
+				d.Set("backup_id", backup.ID),
 			)
 		}
 		mErr = multierror.Append(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Updating the behavior of parameter `backup_id` .
- Saving the value of `backup_id` even if the image is created by `instance_id`.
- Support the acc test for query whole image backup details.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support backup data-source test and update backup_id behavior.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccDataBackup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccDataBackup_basic -timeout 360m -parallel 4
=== RUN   TestAccDataBackup_basic
=== PAUSE TestAccDataBackup_basic
=== CONT  TestAccDataBackup_basic
--- PASS: TestAccDataBackup_basic (687.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       687.863s
```
