### PR TITLE
fix(VPC): delete vpc and vpc subnet validation

### DIFF
--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -14,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	client "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3"
 	v3vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -47,11 +45,6 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 64),
-					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa50-9a-zA-Z-_\\.]*$"),
-						"only letters, digits, underscores (_), hyphens (-), and dot (.) are allowed"),
-				),
 			},
 			"cidr": {
 				Type:         schema.TypeString,
@@ -61,11 +54,6 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 255),
-					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
-						"The angle brackets (< and >) are not allowed."),
-				),
 			},
 			"secondary_cidr": {
 				Type:         schema.TypeString,

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -15,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -81,11 +79,6 @@ func ResourceVpcSubnetV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 64),
-					validation.StringMatch(regexp.MustCompile("^[\u4e00-\u9fa50-9a-zA-Z-_\\.]*$"),
-						"only letters, digits, underscores (_), hyphens (-), and dot (.) are allowed"),
-				),
 			},
 			"cidr": {
 				Type:         schema.TypeString,
@@ -107,11 +100,6 @@ func ResourceVpcSubnetV1() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(0, 255),
-					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
-						"The angle brackets (< and >) are not allowed."),
-				),
 			},
 			"ipv6_enable": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_ -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcV1_secondaryCIDR
--- PASS: TestAccVpcV1_WithCustomRegion (28.30s) 
--- PASS: TestAccVpcV1_WithEpsId (31.62s) 
--- PASS: TestAccVpcV1_basic (47.13s) 
--- PASS: TestAccVpcV1_secondaryCIDR (54.02s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       54.074s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcSubnetV1_'              
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1_ -timeout 360m -parallel 4 
=== RUN   TestAccVpcSubnetV1_basic 
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== RUN   TestAccVpcSubnetV1_dhcp
=== PAUSE TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_dhcp (77.66s) 
--- PASS: TestAccVpcSubnetV1_basic (80.88s) 
--- PASS: TestAccVpcSubnetV1_ipv6 (92.98s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       93.054s
```
