### PR TITLE
fix(cce/cluster): use reflect to compare empty struct

### DIFF
--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -739,7 +740,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating CCE v3 client: %s", err)
 	}
 
-	var updateOpts clusters.UpdateOpts
+	var updateOpts = clusters.UpdateOpts{}
 
 	if d.HasChanges("description") {
 		updateOpts.Spec.Description = d.Get("description").(string)
@@ -749,7 +750,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		updateOpts.Spec.EniNetwork = buildEniNetworkOpts(d.Get("eni_subnet_id").(string))
 	}
 
-	if updateOpts != (clusters.UpdateOpts{}) {
+	if !reflect.DeepEqual(updateOpts, clusters.UpdateOpts{}) {
 		_, err = clusters.Update(cceClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return diag.Errorf("error updating CCE cluster: %s", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCluster_basic
=== PAUSE TestAccCluster_basic
=== CONT  TestAccCluster_basic
--- PASS: TestAccCluster_basic (607.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       608.077s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster_turbo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster_turbo -timeout 360m -parallel 4
=== RUN   TestAccCluster_turbo
=== PAUSE TestAccCluster_turbo
=== CONT  TestAccCluster_turbo
--- PASS: TestAccCluster_turbo (555.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       555.776s
```
