### PR TITLE
feat(cce/cluster): support specifying and updating security group ID in the cluster

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -157,6 +157,13 @@ The following arguments are supported:
     capability of VPC, uses the VPC CIDR block to allocate container addresses, and supports direct connections between
     ELB and containers to provide high performance.
 
+* `security_group_id` - (Optional, String) Specifies the default worker node security group ID of the cluster.
+  If left empty, the system will automatically create a default worker node security group for you.
+  The default worker node security group needs to allow access from certain ports to ensure normal communications.
+  For details, see [documentation](https://support.huaweicloud.com/intl/en-us/cce_faq/cce_faq_00265.html).
+  If updated, the modified security group will only be applied to nodes newly created or accepted.
+  For existing nodes, you need to manually modify the security group rules for them.
+
 * `cluster_version` - (Optional, String, ForceNew) Specifies the cluster version, defaults to the latest supported
   version. Changing this parameter will create a new cluster resource.
 
@@ -275,8 +282,6 @@ In addition to all arguments above, the following attributes are exported:
 * `certificate_clusters` - The certificate clusters. Structure is documented below.
 
 * `certificate_users` - The certificate users. Structure is documented below.
-
-* `security_group_id` - Security group ID of the cluster.
 
 * `eni_subnet_cidr` - The ENI network segment. This value is valid when only one eni_subnet_id is specified.
 

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_cluster_test.go
@@ -251,6 +251,46 @@ func TestAccCluster_multiContainerNetworkCidrs(t *testing.T) {
 	})
 }
 
+func TestAccCluster_secGroup(t *testing.T) {
+	var cluster clusters.Clusters
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_cce_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCluster_secGroup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "cce.s1.small"),
+					resource.TestCheckResourceAttr(resourceName, "container_network_type", "overlay_l2"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+					resource.TestCheckResourceAttr(resourceName, "service_network_cidr", "10.248.0.0/16"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
+						"huaweicloud_networking_secgroup.test1", "id"),
+				),
+			},
+			{
+				Config: testAccCluster_secGroup_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
+						"huaweicloud_networking_secgroup.test2", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckClusterDestroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	cceClient, err := config.CceV3Client(acceptance.HW_REGION_NAME)
@@ -529,6 +569,62 @@ resource "huaweicloud_cce_cluster" "test" {
   container_network_type = "vpc-router"
   container_network_cidr = "172.16.0.0/24,172.16.1.0/24"
   service_network_cidr   = "10.248.0.0/16"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestVpc(rName), rName)
+}
+
+func testAccCluster_secGroup(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_networking_secgroup" "test1" {
+  name = "%[2]s-secgroup-1"
+}
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%[2]s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  service_network_cidr   = "10.248.0.0/16"
+  description            = "created by terraform"
+  security_group_id      = huaweicloud_networking_secgroup.test1.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestVpc(rName), rName)
+}
+
+func testAccCluster_secGroup_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_networking_secgroup" "test1" {
+  name = "%[2]s-secgroup-1"
+}
+
+resource "huaweicloud_networking_secgroup" "test2" {
+  name = "%[2]s-secgroup-2"
+}
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%[2]s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  service_network_cidr   = "10.248.0.0/16"
+  description            = "created by terraform update"
+  security_group_id      = huaweicloud_networking_secgroup.test2.id
 
   tags = {
     foo = "bar"

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -127,6 +127,11 @@ func ResourceCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"highway_subnet_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -267,10 +272,6 @@ func ResourceCluster() *schema.Resource {
 				}, true),
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"security_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -507,6 +508,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 				VpcId:         d.Get("vpc_id").(string),
 				SubnetId:      d.Get("subnet_id").(string),
 				HighwaySubnet: d.Get("highway_subnet_id").(string),
+				SecurityGroup: d.Get("security_group_id").(string),
 			},
 			ContainerNetwork: clusters.ContainerNetworkSpec{
 				Mode:  d.Get("container_network_type").(string),
@@ -748,6 +750,12 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if d.HasChanges("eni_subnet_id") {
 		updateOpts.Spec.EniNetwork = buildEniNetworkOpts(d.Get("eni_subnet_id").(string))
+	}
+
+	if d.HasChange("security_group_id") {
+		updateOpts.Spec.HostNetwork = &clusters.UpdateHostNetworkSpec{
+			SecurityGroup: d.Get("security_group_id").(string),
+		}
 	}
 
 	if !reflect.DeepEqual(updateOpts, clusters.UpdateOpts{}) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -185,6 +185,13 @@ type UpdateSpec struct {
 	CustomSan []string `json:"customSan,omitempty"`
 	// ENI network parameters
 	EniNetwork *EniNetworkSpec `json:"eniNetwork,omitempty"`
+	// Node network parameters
+	HostNetwork *UpdateHostNetworkSpec `json:"hostNetwork,omitempty"`
+}
+
+type UpdateHostNetworkSpec struct {
+	//The ID of the Security Group used to create the node
+	SecurityGroup string `json:"SecurityGroup,omitempty"`
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/results.go
@@ -91,7 +91,14 @@ type Instance struct {
 	DiskEncrypted            bool               `json:"disk_encrypted"`
 	CesVersion               string             `json:"ces_version"`
 	AccessUser               string             `json:"access_user"`
+	Task                     Task               `json:"task"`
 	Tags                     []tags.ResourceTag `json:"tags"`
+}
+
+type Task struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
 }
 
 // UpdateResult is a struct from which can get the result of update method


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updatexd.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster_secGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster_secGroup -timeout 360m -parallel 4
=== RUN   TestAccCluster_secGroup
=== PAUSE TestAccCluster_secGroup
=== CONT  TestAccCluster_secGroup
--- PASS: TestAccCluster_secGroup (540.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       540.633s
```
