### PR TITLE
refactor(DMS): rabbitmq instance support update broker num and storage space

### DIFF
--- a/docs/resources/dms_rabbitmq_instance.md
+++ b/docs/resources/dms_rabbitmq_instance.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `flavor_id` - (Optional, String) Specifies a flavor ID.
   It is mandatory when the `charging_mode` is **prePaid**.
 
-* `broker_num` - (Optional, Int, ForceNew) Specifies the broker numbers.
+* `broker_num` - (Optional, Int) Specifies the broker numbers.
   It is required when creating a cluster instance with `flavor_id`.
 
   -> **NOTE:** Change this will change number of nodes and storage capacity. If you specify the value of
@@ -119,13 +119,13 @@ The following arguments are supported:
   and special characters (`~!@#$%^&*()-_=+\\|[{}]:'",<.>/?).
   Changing this creates a new instance resource.
 
-* `storage_space` - (Optional, Int, ForceNew) Specifies the message storage space, unit is GB.
+* `storage_space` - (Optional, Int) Specifies the message storage space, unit is GB.
   It is required when creating a instance with `flavor_id`. Value range:
   + Single-node RabbitMQ instance: 100–90,000 GB
   + Cluster RabbitMQ instance: 100 GB x number of nodes to 90,000 GB, 200 GB x number of nodes to 90,000 GB,
     and 300 GB x number of nodes to 90,000 GB
 
-  The storage capacity of the product used by default. Changing this creates a new instance resource.
+  The storage capacity of the product used by default.
 
 * `description` - (Optional, String) Specifies the description of the DMS RabbitMQ instance.
   It is a character string containing not more than 1,024 characters.

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_instance_test.go
@@ -568,9 +568,9 @@ resource "huaweicloud_dms_rabbitmq_instance" "test" {
 
   flavor_id         = local.newFlavor.id
   engine_version    = element(local.query_results.versions, length(local.query_results.versions)-1)
-  storage_space     = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
+  storage_space     = 1000
   storage_spec_code = local.flavor.ios[0].storage_spec_code
-  broker_num        = 3
+  broker_num        = 5
   access_user       = "user"
   password          = "Rabbitmqtest@123"
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3/roles/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3/roles/requests.go
@@ -62,7 +62,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+		return RolePage{pagination.PageSizeBase{PageResult: r}}
 	})
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -278,6 +278,7 @@ github.com/chnsz/golangsdk/openstack/rds/v3/securities
 github.com/chnsz/golangsdk/openstack/rf/v1/stacks
 github.com/chnsz/golangsdk/openstack/rms/v1/policyassignments
 github.com/chnsz/golangsdk/openstack/scm/v3/certificates
+github.com/chnsz/golangsdk/openstack/sdrs/v1/domains
 github.com/chnsz/golangsdk/openstack/sdrs/v1/protectiongroups
 github.com/chnsz/golangsdk/openstack/servicestage/v1/repositories
 github.com/chnsz/golangsdk/openstack/servicestage/v2/applications


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   rabbitmq instance support update node num and storage space
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRabbitmqInstances_newFormat_cluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRabbitmqInstances_newFormat_cluster -timeout 360m -parallel 4
=== RUN   TestAccDmsRabbitmqInstances_newFormat_cluster
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_cluster
=== CONT  TestAccDmsRabbitmqInstances_newFormat_cluster

--- PASS: TestAccDmsRabbitmqInstances_newFormat_cluster (1744.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1821.512s
```
