### PR TITLE
feat(GaussDB): add gaussdb mysql paramater template resource

### DIFF
--- a/docs/resources/gaussdb_mysql_parameter_template.md
+++ b/docs/resources/gaussdb_mysql_parameter_template.md
@@ -1,0 +1,59 @@
+---
+subcategory: "GaussDB"
+---
+
+# huaweicloud_gaussdb_mysql_parameter_template
+
+Manages a GaussDB MySQL parameter template resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_gaussdb_mysql_parameter_template" "test" {
+   name = "test_mysql_parameter_template"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the parameter template name. The template name can contain 1 to 64 characters.
+  Only letters (case-sensitive), digits, hyphens (-), underscores (_), and periods (.) are allowed.
+
+* `description` - (Optional, String) Specifies the parameter template description. The description can consist of
+  up to 256 characters, and cannot contain the carriage return characters or special characters (!<"='>&).
+
+* `datastore_engine` - (Optional, String, ForceNew) Specifies the DB engine. Currently, only **gaussdb-mysql** is supported.
+
+  Changing this parameter will create a new resource.
+
+* `datastore_version` - (Optional, String, ForceNew) Specifies the DB version.
+
+  Changing this parameter will create a new resource.
+
+* `parameter_values` - (Optional, Map) Specifies the mapping between parameter names and parameter values.
+  You can specify parameter values based on a default parameter template.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - Indicates the creation time in the "yyyy-MM-ddTHH:mm:ssZ" format.
+  T is the separator between calendar and hourly notation of time. Z indicates the time zone offset.
+
+* `updated_at` - Indicates the update time in the "yyyy-MM-ddTHH:mm:ssZ" format.
+  T is the separator between calendar and hourly notation of time. Z indicates the time zone offset.
+
+## Import
+
+The GaussDB Mysql parameter template can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_gaussdb_mysql_parameter_template.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -830,9 +830,10 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_gaussdb_cassandra_instance": gaussdb.ResourceGeminiDBInstanceV3(),
 
-			"huaweicloud_gaussdb_mysql_instance": gaussdb.ResourceGaussDBInstance(),
-			"huaweicloud_gaussdb_mysql_proxy":    gaussdb.ResourceGaussDBProxy(),
-			"huaweicloud_gaussdb_mysql_database": gaussdb.ResourceGaussDBDatabase(),
+			"huaweicloud_gaussdb_mysql_instance":           gaussdb.ResourceGaussDBInstance(),
+			"huaweicloud_gaussdb_mysql_proxy":              gaussdb.ResourceGaussDBProxy(),
+			"huaweicloud_gaussdb_mysql_database":           gaussdb.ResourceGaussDBDatabase(),
+			"huaweicloud_gaussdb_mysql_parameter_template": gaussdb.ResourceGaussDBMysqlTemplate(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),
 			"huaweicloud_gaussdb_redis_instance":     gaussdb.ResourceGaussRedisInstanceV3(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_parameter_template_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_parameter_template_test.go
@@ -1,0 +1,136 @@
+package gaussdb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getGaussDBMysqlTemplateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getParameterTemplate: Query the GaussDB MySQL parameter Template
+	var (
+		getParameterTemplateHttpUrl = "v3/{project_id}/configurations/{configuration_id}"
+		getParameterTemplateProduct = "gaussdb"
+	)
+	getParameterTemplateClient, err := cfg.NewServiceClient(getParameterTemplateProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	getParameterTemplatePath := getParameterTemplateClient.Endpoint + getParameterTemplateHttpUrl
+	getParameterTemplatePath = strings.ReplaceAll(getParameterTemplatePath, "{project_id}",
+		getParameterTemplateClient.ProjectID)
+	getParameterTemplatePath = strings.ReplaceAll(getParameterTemplatePath, "{configuration_id}",
+		state.Primary.ID)
+
+	getParameterTemplateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getParameterTemplateResp, err := getParameterTemplateClient.Request("GET",
+		getParameterTemplatePath, &getParameterTemplateOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving GaussDB MySQL Parameter Template: %s", err)
+	}
+	return utils.FlattenResponse(getParameterTemplateResp)
+}
+
+func TestAccGaussDBMysqlTemplate_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_gaussdb_mysql_parameter_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGaussDBMysqlTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testParameterTemplate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description",
+						"test gaussdb mysql parameter template"),
+					resource.TestCheckResourceAttr(rName, "datastore_engine", "gaussdb-mysql"),
+					resource.TestCheckResourceAttr(rName, "datastore_version", "8.0"),
+					resource.TestCheckResourceAttr(rName, "parameter_values.auto_increment_increment", "4"),
+					resource.TestCheckResourceAttr(rName, "parameter_values.auto_increment_offset", "5"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testParameterTemplate_basic_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description",
+						"test gaussdb mysql parameter template update"),
+					resource.TestCheckResourceAttr(rName, "datastore_engine", "gaussdb-mysql"),
+					resource.TestCheckResourceAttr(rName, "datastore_version", "8.0"),
+					resource.TestCheckResourceAttr(rName, "parameter_values.auto_increment_increment", "6"),
+					resource.TestCheckResourceAttr(rName, "parameter_values.auto_increment_offset", "8"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter_values"},
+			},
+		},
+	})
+}
+
+func testParameterTemplate_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_mysql_parameter_template" "test" {
+  name              = "%s"
+  description       = "test gaussdb mysql parameter template"
+  datastore_engine  = "gaussdb-mysql"
+  datastore_version = "8.0"
+
+  parameter_values = {
+    auto_increment_increment = "4"
+    auto_increment_offset    = "5"
+  }
+}
+`, name)
+}
+
+func testParameterTemplate_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_mysql_parameter_template" "test" {
+  name              = "%s"
+  description       = "test gaussdb mysql parameter template update"
+  datastore_engine  = "gaussdb-mysql"
+  datastore_version = "8.0"
+
+  parameter_values = {
+    auto_increment_increment = "6"
+    auto_increment_offset    = "8"
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_parameter_template.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_parameter_template.go
@@ -1,0 +1,296 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product GaussDB
+// ---------------------------------------------------------------
+
+package gaussdb
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceGaussDBMysqlTemplate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceParameterTemplateCreate,
+		UpdateContext: resourceParameterTemplateUpdate,
+		ReadContext:   resourceParameterTemplateRead,
+		DeleteContext: resourceParameterTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the parameter template name.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the parameter template description.`,
+			},
+			"datastore_engine": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the DB engine.`,
+			},
+			"datastore_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the DB version.`,
+				RequiredWith: []string{
+					"datastore_engine",
+				},
+			},
+			"parameter_values": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the mapping between parameter names and parameter values.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time in the "yyyy-MM-ddTHH:mm:ssZ" format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the update time in the "yyyy-MM-ddTHH:mm:ssZ" format.`,
+			},
+		},
+	}
+}
+
+func resourceParameterTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createGaussDBMysqlParameterTemplate: create a GaussDB MySQL parameter Template
+	var (
+		createParameterTemplateHttpUrl = "v3/{project_id}/configurations"
+		createParameterTemplateProduct = "gaussdb"
+	)
+	createParameterTemplateClient, err := cfg.NewServiceClient(createParameterTemplateProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	createParameterTemplatePath := createParameterTemplateClient.Endpoint + createParameterTemplateHttpUrl
+	createParameterTemplatePath = strings.ReplaceAll(createParameterTemplatePath, "{project_id}",
+		createParameterTemplateClient.ProjectID)
+
+	createParameterTemplateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createParameterTemplateOpt.JSONBody = utils.RemoveNil(buildCreateParameterTemplateBodyParams(d))
+	createParameterTemplateResp, err := createParameterTemplateClient.Request("POST",
+		createParameterTemplatePath, &createParameterTemplateOpt)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB MySQL Parameter Template: %s", err)
+	}
+
+	createParameterTemplateRespBody, err := utils.FlattenResponse(createParameterTemplateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("configurations.id", createParameterTemplateRespBody)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB MySQL Parameter Template: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceParameterTemplateRead(ctx, d, meta)
+}
+
+func buildCreateParameterTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":             utils.ValueIngoreEmpty(d.Get("name")),
+		"description":      utils.ValueIngoreEmpty(d.Get("description")),
+		"datastore":        buildCreateParameterTemplateDatastoreChildBody(d),
+		"parameter_values": utils.ValueIngoreEmpty(d.Get("parameter_values")),
+	}
+	return bodyParams
+}
+
+func buildCreateParameterTemplateDatastoreChildBody(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"type":    utils.ValueIngoreEmpty(d.Get("datastore_engine")),
+		"version": utils.ValueIngoreEmpty(d.Get("datastore_version")),
+	}
+	return params
+}
+
+func resourceParameterTemplateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getParameterTemplate: Query the GaussDB MySQL parameter Template
+	var (
+		getParameterTemplateHttpUrl = "v3/{project_id}/configurations/{configuration_id}"
+		getParameterTemplateProduct = "gaussdb"
+	)
+	getParameterTemplateClient, err := cfg.NewServiceClient(getParameterTemplateProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	getParameterTemplatePath := getParameterTemplateClient.Endpoint + getParameterTemplateHttpUrl
+	getParameterTemplatePath = strings.ReplaceAll(getParameterTemplatePath, "{project_id}",
+		getParameterTemplateClient.ProjectID)
+	getParameterTemplatePath = strings.ReplaceAll(getParameterTemplatePath, "{configuration_id}", d.Id())
+
+	getParameterTemplateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getParameterTemplateResp, err := getParameterTemplateClient.Request("GET", getParameterTemplatePath,
+		&getParameterTemplateOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving GaussDBMysqlTemplate")
+	}
+
+	getParameterTemplateRespBody, err := utils.FlattenResponse(getParameterTemplateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configurations := utils.PathSearch("configurations", getParameterTemplateRespBody, nil)
+	if configurations == nil {
+		log.Printf("[WARN] failed to get GaussDB MySQL ParameterTemplate by ID(%s)", d.Id())
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", configurations, nil)),
+		d.Set("description", utils.PathSearch("description", configurations, nil)),
+		d.Set("datastore_engine", utils.PathSearch("datastore.type", configurations, nil)),
+		d.Set("datastore_version", utils.PathSearch("datastore.version", configurations, nil)),
+		d.Set("created_at", utils.PathSearch("created", configurations, nil)),
+		d.Set("updated_at", utils.PathSearch("updated", configurations, nil)),
+	)
+
+	parameterValuesRaw := d.Get("parameter_values").(map[string]interface{})
+	parameterValuesRes := utils.PathSearch("parameter_values", getParameterTemplateRespBody,
+		make(map[string]interface{})).(map[string]interface{})
+	parameterValues := make(map[string]interface{})
+	for key := range parameterValuesRaw {
+		if v, ok := parameterValuesRes[key]; ok {
+			parameterValues[key] = v
+		}
+	}
+	mErr = multierror.Append(mErr, d.Set("parameter_values", parameterValues))
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceParameterTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateGaussDBMysqlTemplateHasChanges := []string{
+		"name",
+		"description",
+		"parameter_values",
+	}
+
+	if d.HasChanges(updateGaussDBMysqlTemplateHasChanges...) {
+		// updateParameterTemplate: update the GaussDB MySQL parameter Template
+		var (
+			updateParameterTemplateHttpUrl = "v3/{project_id}/configurations/{configuration_id}"
+			updateParameterTemplateProduct = "gaussdb"
+		)
+		updateParameterTemplateClient, err := cfg.NewServiceClient(updateParameterTemplateProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating GaussDB Client: %s", err)
+		}
+
+		updateParameterTemplatePath := updateParameterTemplateClient.Endpoint + updateParameterTemplateHttpUrl
+		updateParameterTemplatePath = strings.ReplaceAll(updateParameterTemplatePath,
+			"{project_id}", updateParameterTemplateClient.ProjectID)
+		updateParameterTemplatePath = strings.ReplaceAll(updateParameterTemplatePath,
+			"{configuration_id}", d.Id())
+
+		updateParameterTemplateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		updateParameterTemplateOpt.JSONBody = utils.RemoveNil(buildUpdateParameterTemplateBodyParams(d))
+		_, err = updateParameterTemplateClient.Request("PUT", updateParameterTemplatePath,
+			&updateParameterTemplateOpt)
+		if err != nil {
+			return diag.Errorf("error updating GaussDB MySQL ParameterTemplate: %s", err)
+		}
+	}
+	return resourceParameterTemplateRead(ctx, d, meta)
+}
+
+func buildUpdateParameterTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":             utils.ValueIngoreEmpty(d.Get("name")),
+		"description":      utils.ValueIngoreEmpty(d.Get("description")),
+		"parameter_values": utils.ValueIngoreEmpty(d.Get("parameter_values")),
+	}
+	return bodyParams
+}
+
+func resourceParameterTemplateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteParameterTemplate: delete the GaussDB MySQL parameter Template
+	var (
+		deleteParameterTemplateHttpUrl = "v3/{project_id}/configurations/{configuration_id}"
+		deleteParameterTemplateProduct = "gaussdb"
+	)
+	deleteParameterTemplateClient, err := cfg.NewServiceClient(deleteParameterTemplateProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	deleteParameterTemplatePath := deleteParameterTemplateClient.Endpoint + deleteParameterTemplateHttpUrl
+	deleteParameterTemplatePath = strings.ReplaceAll(deleteParameterTemplatePath, "{project_id}",
+		deleteParameterTemplateClient.ProjectID)
+	deleteParameterTemplatePath = strings.ReplaceAll(deleteParameterTemplatePath, "{configuration_id}", d.Id())
+
+	deleteGaussDBMysqlTemplateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = deleteParameterTemplateClient.Request("DELETE", deleteParameterTemplatePath,
+		&deleteGaussDBMysqlTemplateOpt)
+	if err != nil {
+		return diag.Errorf("error deleting GaussDB MySQL ParameterTemplate: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql paramater template resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql paramater template resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb/' TESTARGS='-run TestAccGaussDBMysqlTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMysqlTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMysqlTemplate_basic
=== PAUSE TestAccGaussDBMysqlTemplate_basic
=== CONT  TestAccGaussDBMysqlTemplate_basic
--- PASS: TestAccGaussDBMysqlTemplate_basic (22.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   22.812s
```
