### PR TITLE
fix(smn/subscription): check deleted when the topic is not exist

### DIFF
--- a/huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_subscription.go
@@ -113,7 +113,7 @@ func resourceSubscriptionRead(_ context.Context, d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] fetching subscription: %s", id)
 	subscriptionslist, err := subscriptions.ListFromTopic(client, topicUrn).Extract()
 	if err != nil {
-		return diag.Errorf("error fetching the list of subscriptions: %s", err)
+		return common.CheckDeletedDiag(d, err, "error fetching the subscriptions")
 	}
 
 	var targetSubscription *subscriptions.SubscriptionGet


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

## how to test

1. create a SMN topic and subscription with terraform;
2. delete the SMN topic with console;
3. run `terraform refresh` command, we will get the following error;
```
$ terraform refresh
huaweicloud_smn_topic.topic_1: Refreshing state... [id=urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11]
huaweicloud_smn_subscription.subscription_2: Refreshing state... [id=urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11:b27596fb68b5429fae2eaadf8e013206]
╷
│ Warning: Resource not found
│
│   with huaweicloud_smn_topic.topic_1,
│   on main.tf line 8, in resource "huaweicloud_smn_topic" "topic_1":
│    8: resource "huaweicloud_smn_topic" "topic_1" {
│
│ the resource urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11 is gone and will be removed in Terraform state.
╵
╷
│ Error: error fetching the list of subscriptions: Resource not found: [GET https://smn.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/notifications/topics/urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11/subscriptions], error message: {"request_id":"38255d65a26749638ad5296cea359417","code":"SMN.0006","message":"Topic not found."}
│
│   with huaweicloud_smn_subscription.subscription_2,
│   on main.tf line 17, in resource "huaweicloud_smn_subscription" "subscription_2":
│   17: resource "huaweicloud_smn_subscription" "subscription_2" {
│
```

## how to fix

add check deleted method to process the 404 code.

```
 $ terraform refresh
huaweicloud_smn_topic.topic_1: Refreshing state... [id=urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11]
huaweicloud_smn_subscription.subscription_2: Refreshing state... [id=urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11:d008896f19dd47508da53a0dfdf0da08]
╷
│ Warning: Resource not found
│
│   with huaweicloud_smn_topic.topic_1,
│   on main.tf line 8, in resource "huaweicloud_smn_topic" "topic_1":
│    8: resource "huaweicloud_smn_topic" "topic_1" {
│
│ the resource urn:smn:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:topic_11 is gone and will be removed in Terraform state.
│
│ (and one more similar warning elsewhere)
╵
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/smn" TESTARGS="-run TestAccSMNV2Subscription_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/smn -v -run TestAccSMNV2Subscription_basic -timeout 360m -parallel 4
=== RUN   TestAccSMNV2Subscription_basic
=== PAUSE TestAccSMNV2Subscription_basic
=== CONT  TestAccSMNV2Subscription_basic
--- PASS: TestAccSMNV2Subscription_basic (20.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       20.596s
```
