### PR TITLE
feat(GaussDB): add gaussdb mysql sql control rule resource

### DIFF
--- a/docs/resources/gaussdb_mysql_sql_control_rule.md
+++ b/docs/resources/gaussdb_mysql_sql_control_rule.md
@@ -1,0 +1,74 @@
+---
+subcategory: "GaussDB"
+---
+
+# huaweicloud_gaussdb_mysql_sql_control_rule
+
+Manages a GaussDB MySQL SQL concurrency control rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_gaussdb_mysql_sql_control_rule" "test" {
+  instance_id     = var.instance_id
+  node_id         = var.node_id
+  sql_type        = "SELECT"
+  pattern         = "select~from~t1"
+  max_concurrency = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB MySQL instance.
+
+  Changing this parameter will create a new resource.
+
+* `node_id` - (Required, String, ForceNew) Specifies ID of the GaussDB redis node.
+
+  Changing this parameter will create a new resource.
+
+* `sql_type` - (Required, String, ForceNew) Specifies SQL statement type.
+  Value options: **SELECT**, **UPDATE**, **DELETE**.
+
+  Changing this parameter will create a new resource.
+
+* `pattern` - (Required, String, ForceNew) Specifies the concurrency control rule of SQL statements. A rule can consist
+  of up to 128 keywords. The keywords are separated by tildes (~), for example, select~from~t1. The rule cannot contain
+  backslashes (\), commas (,), or double tildes (~~). It cannot end with tildes (~).
+
+  Changing this parameter will create a new resource.
+
+* `max_concurrency` - (Required, Int) Specifies the maximum number of concurrent SQL statements.
+  Value: a non-negative integer.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is formatted `<instance_id>/<node_id>/<sql_type>/<pattern>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The GaussDB MySQL SQL concurrency control rule can be imported using the `instance_id`,`node_id`,`sql_type` and
+`pattern` separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_gaussdb_mysql_sql_control_rule.test <instance_id>/<node_id>/<sql_type>/<pattern>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -834,6 +834,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_proxy":              gaussdb.ResourceGaussDBProxy(),
 			"huaweicloud_gaussdb_mysql_database":           gaussdb.ResourceGaussDBDatabase(),
 			"huaweicloud_gaussdb_mysql_account":            gaussdb.ResourceGaussDBAccount(),
+			"huaweicloud_gaussdb_mysql_sql_control_rule":   gaussdb.ResourceGaussDBSqlControlRule(),
 			"huaweicloud_gaussdb_mysql_parameter_template": gaussdb.ResourceGaussDBMysqlTemplate(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_sql_control_rule_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_sql_control_rule_test.go
@@ -1,0 +1,141 @@
+package gaussdb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getGaussDBSqlControlRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getGaussDBSqlControlRule: Query the GaussDB MySQL Sql control rule
+	var (
+		getGaussDBSqlControlRuleHttpUrl = "v3/{project_id}/instances/{instance_id}/sql-filter/rules"
+		getGaussDBSqlControlRuleProduct = "gaussdb"
+	)
+	getGaussDBSqlControlRuleClient, err := cfg.NewServiceClient(getGaussDBSqlControlRuleProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	parts := strings.SplitN(state.Primary.ID, "/", 4)
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<node_id>/<sql_type>/<pattern>")
+	}
+	instanceID := parts[0]
+	nodeId := parts[1]
+	sqlType := parts[2]
+	pattern := parts[3]
+
+	getGaussDBSqlControlRulePath := getGaussDBSqlControlRuleClient.Endpoint + getGaussDBSqlControlRuleHttpUrl
+	getGaussDBSqlControlRulePath = strings.ReplaceAll(getGaussDBSqlControlRulePath, "{project_id}",
+		getGaussDBSqlControlRuleClient.ProjectID)
+	getGaussDBSqlControlRulePath = strings.ReplaceAll(getGaussDBSqlControlRulePath, "{instance_id}", instanceID)
+
+	getGaussDBSqlControlRulePath += buildGetGaussDBSqlControlRuleQueryParams(nodeId)
+
+	getGaussDBSqlControlRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getGaussDBSqlControlRuleResp, err := getGaussDBSqlControlRuleClient.Request("GET",
+		getGaussDBSqlControlRulePath, &getGaussDBSqlControlRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving GaussDB MySQL Sql control rule: %s", err)
+	}
+
+	getGaussDBSqlControlRuleRespBody, err := utils.FlattenResponse(getGaussDBSqlControlRuleResp)
+	if err != nil {
+		return nil, err
+	}
+
+	expression := fmt.Sprintf("sql_filter_rules[?sql_type=='%s']|[0].patterns[?pattern=='%s']|[0].max_concurrency",
+		sqlType, pattern)
+	maxConcurrency := utils.PathSearch(expression, getGaussDBSqlControlRuleRespBody, nil)
+	if maxConcurrency == nil {
+		return nil, fmt.Errorf("error get GaussDB MySQL SQL control rule")
+	}
+
+	return getGaussDBSqlControlRuleRespBody, nil
+}
+
+func buildGetGaussDBSqlControlRuleQueryParams(nodeId string) string {
+	return fmt.Sprintf("?node_id=%v", nodeId)
+}
+
+func TestAccGaussDBSqlControlRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_gaussdb_mysql_sql_control_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGaussDBSqlControlRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testGaussDBSqlControlRule_basic(name, 20),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_gaussdb_mysql_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "node_id",
+						"huaweicloud_gaussdb_mysql_instance.test", "nodes.0.id"),
+					resource.TestCheckResourceAttr(rName, "sql_type", "SELECT"),
+					resource.TestCheckResourceAttr(rName, "pattern", "select~from~t1"),
+					resource.TestCheckResourceAttr(rName, "max_concurrency", "20"),
+				),
+			},
+			{
+				Config: testGaussDBSqlControlRule_basic(name, 30),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_gaussdb_mysql_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "node_id",
+						"huaweicloud_gaussdb_mysql_instance.test", "nodes.0.id"),
+					resource.TestCheckResourceAttr(rName, "sql_type", "SELECT"),
+					resource.TestCheckResourceAttr(rName, "pattern", "select~from~t1"),
+					resource.TestCheckResourceAttr(rName, "max_concurrency", "30"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testGaussDBSqlControlRule_basic(name string, maxConcurrency int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_gaussdb_mysql_sql_control_rule" "test" {
+  instance_id     = huaweicloud_gaussdb_mysql_instance.test.id
+  node_id         = huaweicloud_gaussdb_mysql_instance.test.nodes[0].id
+  sql_type        = "SELECT"
+  pattern         = "select~from~t1"
+  max_concurrency = %d
+}
+`, testAccGaussDBInstanceConfig_basic(name), maxConcurrency)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_sql_control_rule.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_sql_control_rule.go
@@ -1,0 +1,334 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product GaussDB
+// ---------------------------------------------------------------
+
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceGaussDBSqlControlRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBSqlControlRuleCreate,
+		UpdateContext: resourceGaussDBSqlControlRuleUpdate,
+		ReadContext:   resourceGaussDBSqlControlRuleRead,
+		DeleteContext: resourceGaussDBSqlControlRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the GaussDB MySQL instance.`,
+			},
+			"node_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies ID of the GaussDB MySQL node.`,
+			},
+			"sql_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies SQL statement type.`,
+			},
+			"pattern": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the concurrency control rule of SQL statements.`,
+			},
+			"max_concurrency": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the maximum number of concurrent SQL statements.`,
+			},
+		},
+	}
+}
+
+func resourceGaussDBSqlControlRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+
+	// createGaussDBSqlControlRule: create a GaussDB MySQL Sql control rule
+	err := dealGaussDBSqlControlRule(ctx, d, cfg, "creating", d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	nodeId := d.Get("node_id").(string)
+	sqlType := d.Get("sql_type").(string)
+	pattern := d.Get("pattern").(string)
+	d.SetId(instanceID + "/" + nodeId + "/" + sqlType + "/" + pattern)
+
+	return resourceGaussDBSqlControlRuleRead(ctx, d, meta)
+}
+
+func dealGaussDBSqlControlRule(ctx context.Context, d *schema.ResourceData, cfg *config.Config,
+	operateMethod string, timeout time.Duration) error {
+	region := cfg.GetRegion(d)
+	var (
+		gaussDBSqlControlRuleHttpUrl = "v3/{project_id}/instances/{instance_id}/sql-filter/rules"
+		gaussDBSqlControlRuleProduct = "gaussdb"
+	)
+	gaussDBSqlControlRuleClient, err := cfg.NewServiceClient(gaussDBSqlControlRuleProduct, region)
+	if err != nil {
+		return fmt.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	gaussDBSqlControlRulePath := gaussDBSqlControlRuleClient.Endpoint + gaussDBSqlControlRuleHttpUrl
+	gaussDBSqlControlRulePath = strings.ReplaceAll(gaussDBSqlControlRulePath, "{project_id}",
+		gaussDBSqlControlRuleClient.ProjectID)
+	gaussDBSqlControlRulePath = strings.ReplaceAll(gaussDBSqlControlRulePath, "{instance_id}", instanceID)
+
+	gaussDBSqlControlRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	gaussDBSqlControlRuleOpt.JSONBody = utils.RemoveNil(buildGaussDBSqlControlRuleBodyParams(d))
+
+	var gaussDBSqlControlRuleResp *http.Response
+	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
+		gaussDBSqlControlRuleResp, err = gaussDBSqlControlRuleClient.Request("PUT", gaussDBSqlControlRulePath,
+			&gaussDBSqlControlRuleOpt)
+		isRetry, err := handleGaussDBMysqlOperationError(err)
+		if isRetry {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error %s GaussDB MySQL SQL control rule: %s", operateMethod, err)
+	}
+
+	gaussDBSqlControlRuleRespBody, err := utils.FlattenResponse(gaussDBSqlControlRuleResp)
+	if err != nil {
+		return err
+	}
+
+	jobId, err := jmespath.Search("job_id", gaussDBSqlControlRuleRespBody)
+	if err != nil {
+		return fmt.Errorf("error %s GaussDB MySQL SQL control rule: job_id is not found in API response",
+			operateMethod)
+	}
+	return waitForJobComplete(ctx, gaussDBSqlControlRuleClient, timeout, instanceID, jobId.(string))
+}
+
+func buildGaussDBSqlControlRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	patternParams := map[string]interface{}{
+		"pattern":         utils.ValueIngoreEmpty(d.Get("pattern")),
+		"max_concurrency": utils.ValueIngoreEmpty(d.Get("max_concurrency")),
+	}
+	rulesParams := map[string]interface{}{
+		"sql_type": utils.ValueIngoreEmpty(d.Get("sql_type")),
+		"patterns": []interface{}{patternParams},
+	}
+	nodeFilterRulesParams := map[string]interface{}{
+		"node_id": utils.ValueIngoreEmpty(d.Get("node_id")),
+		"rules":   []interface{}{rulesParams},
+	}
+	bodyParams := map[string]interface{}{
+		"sql_filter_rules": []interface{}{nodeFilterRulesParams},
+	}
+	return bodyParams
+}
+
+func resourceGaussDBSqlControlRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getGaussDBSqlControlRule: Query the GaussDB MySQL SQL control rule
+	var (
+		getGaussDBSqlControlRuleHttpUrl = "v3/{project_id}/instances/{instance_id}/sql-filter/rules"
+		getGaussDBSqlControlRuleProduct = "gaussdb"
+	)
+	getGaussDBSqlControlRuleClient, err := cfg.NewServiceClient(getGaussDBSqlControlRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 4)
+	if len(parts) != 4 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<node_id>/<sql_type>/<pattern>")
+	}
+	instanceID := parts[0]
+	nodeId := parts[1]
+	sqlType := parts[2]
+	pattern := parts[3]
+
+	getGaussDBSqlControlRulePath := getGaussDBSqlControlRuleClient.Endpoint + getGaussDBSqlControlRuleHttpUrl
+	getGaussDBSqlControlRulePath = strings.ReplaceAll(getGaussDBSqlControlRulePath, "{project_id}",
+		getGaussDBSqlControlRuleClient.ProjectID)
+	getGaussDBSqlControlRulePath = strings.ReplaceAll(getGaussDBSqlControlRulePath, "{instance_id}", instanceID)
+
+	getGaussDBSqlControlRulePath += buildGetGaussDBSqlControlRuleQueryParams(nodeId)
+
+	getGaussDBSqlControlRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getGaussDBSqlControlRuleResp, err := getGaussDBSqlControlRuleClient.Request("GET",
+		getGaussDBSqlControlRulePath, &getGaussDBSqlControlRuleOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{},
+			"error retrieving GaussDB MySQL SQL control rule")
+	}
+
+	getGaussDBSqlControlRuleRespBody, err := utils.FlattenResponse(getGaussDBSqlControlRuleResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	expression := fmt.Sprintf("sql_filter_rules[?sql_type=='%s']|[0].patterns[?pattern=='%s']|[0].max_concurrency",
+		sqlType, pattern)
+	maxConcurrency := utils.PathSearch(expression, getGaussDBSqlControlRuleRespBody, nil)
+	if maxConcurrency == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+		d.Set("node_id", nodeId),
+		d.Set("sql_type", sqlType),
+		d.Set("pattern", pattern),
+		d.Set("max_concurrency", maxConcurrency),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetGaussDBSqlControlRuleQueryParams(nodeId string) string {
+	return fmt.Sprintf("?node_id=%v", nodeId)
+}
+
+func resourceGaussDBSqlControlRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+
+	// updateGaussDBSqlControlRule: update the GaussDB MySQL Sql control rule
+	err := dealGaussDBSqlControlRule(ctx, d, cfg, "updating", d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceGaussDBSqlControlRuleRead(ctx, d, meta)
+}
+
+func resourceGaussDBSqlControlRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteGaussDBSqlControlRule: delete the GaussDB MySQL Sql control rule
+	var (
+		deleteGaussDBSqlControlRuleHttpUrl = "v3/{project_id}/instances/{instance_id}/sql-filter/rules"
+		deleteGaussDBSqlControlRuleProduct = "gaussdb"
+	)
+	deleteGaussDBSqlControlRuleClient, err := cfg.NewServiceClient(deleteGaussDBSqlControlRuleProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	deleteGaussDBSqlControlRulePath := deleteGaussDBSqlControlRuleClient.Endpoint + deleteGaussDBSqlControlRuleHttpUrl
+	deleteGaussDBSqlControlRulePath = strings.ReplaceAll(deleteGaussDBSqlControlRulePath, "{project_id}",
+		deleteGaussDBSqlControlRuleClient.ProjectID)
+	deleteGaussDBSqlControlRulePath = strings.ReplaceAll(deleteGaussDBSqlControlRulePath, "{instance_id}", instanceID)
+
+	deleteGaussDBSqlControlRuleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	deleteGaussDBSqlControlRuleOpt.JSONBody = utils.RemoveNil(buildDeleteGaussDBSqlControlRuleBodyParams(d))
+
+	var deleteGaussDBSqlControlRuleResp *http.Response
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		deleteGaussDBSqlControlRuleResp, err = deleteGaussDBSqlControlRuleClient.Request("DELETE",
+			deleteGaussDBSqlControlRulePath, &deleteGaussDBSqlControlRuleOpt)
+		isRetry, err := handleGaussDBMysqlOperationError(err)
+		if isRetry {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("error deleting GaussDB MySQL SQL control rule: %s", err)
+	}
+
+	deleteGaussDBSqlControlRulesRespBody, err := utils.FlattenResponse(deleteGaussDBSqlControlRuleResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId, err := jmespath.Search("job_id", deleteGaussDBSqlControlRulesRespBody)
+	if err != nil {
+		return diag.Errorf("error deleting GaussDB MySQL SQL control rule: job_id is not found in API response")
+	}
+
+	err = waitForJobComplete(ctx, deleteGaussDBSqlControlRuleClient, d.Timeout(schema.TimeoutDelete), instanceID,
+		jobId.(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func buildDeleteGaussDBSqlControlRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rulesParams := map[string]interface{}{
+		"sql_type": utils.ValueIngoreEmpty(d.Get("sql_type")),
+		"patterns": []interface{}{utils.ValueIngoreEmpty(d.Get("pattern"))},
+	}
+	nodeFilterRulesParams := map[string]interface{}{
+		"node_id": utils.ValueIngoreEmpty(d.Get("node_id")),
+		"rules":   []interface{}{rulesParams},
+	}
+	bodyParams := map[string]interface{}{
+		"sql_filter_rules": []interface{}{nodeFilterRulesParams},
+	}
+	return bodyParams
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql sql control rule resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql sql control rule resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb/' TESTARGS='-run TestAccGaussDBSqlControlRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBSqlControlRule_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBSqlControlRule_basic
=== PAUSE TestAccGaussDBSqlControlRule_basic
=== CONT  TestAccGaussDBSqlControlRule_basic

--- PASS: TestAccGaussDBSqlControlRule_basic (836.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1108.564s
```
