### PR TITLE
fix(iam/agency): sleep 200ms to avoid API rate limit

### DIFF
--- a/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
@@ -33,14 +33,9 @@ func ResourceIAMAgencyV3() *schema.Resource {
 		ReadContext:   resourceIAMAgencyV3Read,
 		UpdateContext: resourceIAMAgencyV3Update,
 		DeleteContext: resourceIAMAgencyV3Delete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -404,6 +399,11 @@ func resourceIAMAgencyV3Read(_ context.Context, d *schema.ResourceData, meta int
 		if pn == "MOS" {
 			continue
 		}
+
+		// the provider will query the roles in all projects, but the API rate limit threshold is 10 times per second.
+		// so we should wait for some time to avoid exceeding the rate limit.
+		// lintignore:R018
+		time.Sleep(200 * time.Millisecond)
 
 		allRoles, err := agency.ListRolesAttachedOnProject(iamClient, agencyID, pid).ExtractRoles()
 		if err != nil && !utils.IsResourceNotFound(err) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

the provider will query the roles in all projects, but the API rate limit threshold is 10 times per second.
so we should wait for some time to avoid exceeding the rate limit.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityAgency_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityAgency_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityAgency_basic
=== PAUSE TestAccIdentityAgency_basic
=== CONT  TestAccIdentityAgency_basic
--- PASS: TestAccIdentityAgency_basic (92.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       92.584s
```
