### PR TITLE
refactor(GaussDB): gaussdb mysql instance support sql filter

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -145,6 +145,8 @@ The `backup_strategy` block supports:
 
 * `audit_log_enabled` - (Optional, Bool) Specifies whether audit log is enabled. The default value is `false`.
 
+* `sql_filter_enabled` - (Optional, Bool) Specifies whether sql filter is enabled. The default value is `false`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -32,6 +32,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					testAccCheckGaussDBInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "audit_log_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sql_filter_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -42,6 +43,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					testAccCheckGaussDBInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "audit_log_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sql_filter_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
@@ -150,6 +152,7 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   security_group_id     = huaweicloud_networking_secgroup.test.id
   enterprise_project_id = "0"
+  sql_filter_enabled    = true
 
   tags = {
     foo = "bar"
@@ -174,6 +177,7 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   security_group_id     = huaweicloud_networking_secgroup.test.id
   enterprise_project_id = "0"
   audit_log_enabled     = true
+  sql_filter_enabled    = false
 
   tags = {
     foo_update = "bar"

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter/requests.go
@@ -1,0 +1,45 @@
+package sqlfilter
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+type UpdateBuilder interface {
+	ToUpdateMap() (map[string]interface{}, error)
+}
+
+type UpdateSqlFilterOpts struct {
+	SwitchStatus string `json:"switch_status" required:"true"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+func (opts UpdateSqlFilterOpts) ToUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Update(c *golangsdk.ServiceClient, instanceId string, opts UpdateBuilder) (r JobResult) {
+	b, err := opts.ToUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Post(updateURL(c, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return
+}
+
+func Get(c *golangsdk.ServiceClient, instanceId string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, instanceId), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter/results.go
@@ -1,0 +1,31 @@
+package sqlfilter
+
+import "github.com/chnsz/golangsdk"
+
+type JobResponse struct {
+	JobID string `json:"job_id"`
+}
+
+type JobResult struct {
+	golangsdk.Result
+}
+
+func (r JobResult) ExtractJobResponse() (*JobResponse, error) {
+	var job JobResponse
+	err := r.ExtractInto(&job)
+	return &job, err
+}
+
+type SqlFilter struct {
+	SwitchStatus string `json:"switch_status"`
+}
+
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (*SqlFilter, error) {
+	var sqlFilter SqlFilter
+	err := r.ExtractInto(&sqlFilter)
+	return &sqlFilter, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter/urls.go
@@ -1,0 +1,11 @@
+package sqlfilter
+
+import "github.com/chnsz/golangsdk"
+
+func updateURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "sql-filter", "switch")
+}
+
+func getURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "sql-filter", "switch")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -301,6 +301,7 @@ github.com/chnsz/golangsdk/openstack/taurusdb/v3/auditlog
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/configurations
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances
+github.com/chnsz/golangsdk/openstack/taurusdb/v3/sqlfilter
 github.com/chnsz/golangsdk/openstack/utils
 github.com/chnsz/golangsdk/openstack/vbs/v2/backups
 github.com/chnsz/golangsdk/openstack/vbs/v2/policies


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support sql filter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support sql filter
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb/' TESTARGS='-run TestAccGaussDBInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_basic
--- PASS: TestAccGaussDBInstance_basic (922.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   922.490s
```
