### PR TITLE
feat(GaussDB): add gaussdb redis eip associate resource

### DIFF
--- a/docs/resources/gaussdb_redis_eip_associate.md
+++ b/docs/resources/gaussdb_redis_eip_associate.md
@@ -1,0 +1,62 @@
+---
+subcategory: "GaussDB NoSQL"
+---
+
+# huaweicloud_gaussdb_redis_eip_associate
+
+Manages a GaussDB Redis node EIP associate resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+variable "public_ip" {}
+
+resource "huaweicloud_gaussdb_redis_eip_associate" "test"{
+  instance_id = var.instance_id
+  node_id     = var.node_id
+  public_ip   = var.public_ip
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of a GaussDB Redis instance.
+
+  Changing this parameter will create a new resource.
+
+* `node_id` - (Required, String, ForceNew) Specifies the ID of a GaussDB Redis node.
+
+  Changing this parameter will create a new resource.
+
+* `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate. The value must be in the
+  standard IP address format.
+
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is formatted `<instance_id>/<node_id>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The GaussDB Redis node EIP associate can be imported using `instance_id` and `node_id` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_gaussdb_redis_eip_associate.test <instance_id>/<node_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -837,9 +837,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_parameter_template": gaussdb.ResourceGaussDBMysqlTemplate(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),
-			"huaweicloud_gaussdb_redis_instance":     gaussdb.ResourceGaussRedisInstanceV3(),
-			"huaweicloud_gaussdb_influx_instance":    gaussdb.ResourceGaussDBInfluxInstanceV3(),
-			"huaweicloud_gaussdb_mongo_instance":     gaussdb.ResourceGaussDBMongoInstanceV3(),
+
+			"huaweicloud_gaussdb_redis_instance":      gaussdb.ResourceGaussRedisInstanceV3(),
+			"huaweicloud_gaussdb_redis_eip_associate": gaussdb.ResourceGaussRedisEipAssociate(),
+
+			"huaweicloud_gaussdb_influx_instance": gaussdb.ResourceGaussDBInfluxInstanceV3(),
+			"huaweicloud_gaussdb_mongo_instance":  gaussdb.ResourceGaussDBMongoInstanceV3(),
 
 			"huaweicloud_ges_graph":    ges.ResourceGesGraph(),
 			"huaweicloud_ges_metadata": ges.ResourceGesMetadata(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_redis_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_redis_eip_associate_test.go
@@ -1,0 +1,135 @@
+package gaussdb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getGaussRedisEipAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getGaussRedisEipAssociate: Query GaussDB Redis node EIP associate
+	var (
+		getGaussRedisEipAssociateHttpUrl = "v3/{project_id}/instances"
+		getGaussRedisEipAssociateProduct = "geminidb"
+	)
+	getGaussRedisEipAssociateClient, err := cfg.NewServiceClient(getGaussRedisEipAssociateProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GaussDB for Redis Client: %s", err)
+	}
+
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<node_id>")
+	}
+	instanceID := parts[0]
+	nodeID := parts[1]
+
+	getGaussRedisEipAssociatePath := getGaussRedisEipAssociateClient.Endpoint + getGaussRedisEipAssociateHttpUrl
+	getGaussRedisEipAssociatePath = strings.ReplaceAll(getGaussRedisEipAssociatePath, "{project_id}",
+		getGaussRedisEipAssociateClient.ProjectID)
+
+	getGaussRedisEipAssociateQueryParams := buildGetGaussRedisEipAssociateQueryParams(instanceID)
+	getGaussRedisEipAssociatePath += getGaussRedisEipAssociateQueryParams
+
+	getGaussRedisEipAssociateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getGaussRedisEipAssociateResp, err := getGaussRedisEipAssociateClient.Request("GET",
+		getGaussRedisEipAssociatePath, &getGaussRedisEipAssociateOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving EipAssociate: %s", err)
+	}
+
+	getGaussRedisEipAssociateRespBody, err := utils.FlattenResponse(getGaussRedisEipAssociateResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving GaussDB Redis EIP associate")
+	}
+
+	publicIP := utils.PathSearch(fmt.Sprintf("instances[?id=='%s']|[0].groups[0].nodes[?id=='%s']|[0].public_ip",
+		instanceID, nodeID), getGaussRedisEipAssociateRespBody, "")
+	if publicIP == "" {
+		return nil, fmt.Errorf("error retrieving GaussDB Redis EIP associate")
+	}
+	return getGaussRedisEipAssociateRespBody, nil
+}
+
+func buildGetGaussRedisEipAssociateQueryParams(instanceID string) string {
+	return fmt.Sprintf("?id=%s", instanceID)
+}
+
+func TestAccGaussRedisEipAssociate_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	password := fmt.Sprintf("Acc%s@123", acctest.RandString(5))
+	rName := "huaweicloud_gaussdb_redis_eip_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGaussRedisEipAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testGaussRedisEipAssociate_basic(name, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_gaussdb_redis_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "node_id",
+						"huaweicloud_gaussdb_redis_instance.test", "nodes.0.id"),
+					resource.TestCheckResourceAttrPair(rName, "public_ip",
+						"huaweicloud_vpc_eip.test", "address"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testGaussRedisEipAssociate_basic(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "%[2]s"
+    size        = 8
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_gaussdb_redis_eip_associate" "test" {
+  instance_id = huaweicloud_gaussdb_redis_instance.test.id
+  node_id     = huaweicloud_gaussdb_redis_instance.test.nodes[0].id
+  public_ip   = huaweicloud_vpc_eip.test.address
+}
+`, testAccGaussRedisInstanceConfig_basic(name, password), name)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_redis_eip_associate.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_redis_eip_associate.go
@@ -1,0 +1,287 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product GaussDB
+// ---------------------------------------------------------------
+
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceGaussRedisEipAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussRedisEipAssociateCreate,
+		ReadContext:   resourceGaussRedisEipAssociateRead,
+		DeleteContext: resourceGaussRedisEipAssociateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of a GaussDB Redis instance.`,
+			},
+			"node_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of a GaussDB Redis node.`,
+			},
+			"public_ip": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Indicates the EIP address to associate.`,
+			},
+		},
+	}
+}
+
+func resourceGaussRedisEipAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createGaussRedisEipAssociate: create GaussDB Redis node EIP associate
+	var (
+		createGaussRedisEipAssociateHttpUrl = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/public-ip"
+		createGaussRedisEipAssociateProduct = "geminidb"
+	)
+	createGaussRedisEipAssociateClient, err := cfg.NewServiceClient(createGaussRedisEipAssociateProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB for Redis Client: %s", err)
+	}
+
+	vpcClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	nodeID := d.Get("node_id").(string)
+	publicIP := d.Get("public_ip").(string)
+	epsID := "all_granted_eps"
+	publicID, err := common.GetEipIDbyAddress(vpcClient, publicIP, epsID)
+	if err != nil {
+		return diag.Errorf("Unable to get ID of public IP %s: %s", publicIP, err)
+	}
+
+	createGaussRedisEipAssociatePath := createGaussRedisEipAssociateClient.Endpoint + createGaussRedisEipAssociateHttpUrl
+	createGaussRedisEipAssociatePath = strings.ReplaceAll(createGaussRedisEipAssociatePath, "{project_id}",
+		createGaussRedisEipAssociateClient.ProjectID)
+	createGaussRedisEipAssociatePath = strings.ReplaceAll(createGaussRedisEipAssociatePath, "{instance_id}",
+		instanceID)
+	createGaussRedisEipAssociatePath = strings.ReplaceAll(createGaussRedisEipAssociatePath, "{node_id}", nodeID)
+
+	createGaussRedisEipAssociateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	createGaussRedisEipAssociateOpt.JSONBody = utils.RemoveNil(buildGaussRedisEipAssociateBodyParams("BIND", publicIP,
+		publicID))
+
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		_, err = createGaussRedisEipAssociateClient.Request("POST", createGaussRedisEipAssociatePath,
+			&createGaussRedisEipAssociateOpt)
+		isRetry, err := handleOperationError(err)
+		if isRetry {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("error creating EipAssociate: %s", err)
+	}
+
+	d.SetId(instanceID + "/" + nodeID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"BIND_EIP"},
+		Target:  []string{"available"},
+		Refresh: GaussRedisInstanceUpdateRefreshFunc(createGaussRedisEipAssociateClient, instanceID,
+			[]string{"BIND_EIP"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for instance (%s) to become ready: %s", instanceID, err)
+	}
+
+	return resourceGaussRedisEipAssociateRead(ctx, d, meta)
+}
+
+func resourceGaussRedisEipAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getGaussRedisEipAssociate: Query GaussDB Redis node EIP associate
+	var (
+		getGaussRedisEipAssociateHttpUrl = "v3/{project_id}/instances"
+		getGaussRedisEipAssociateProduct = "geminidb"
+	)
+	getGaussRedisEipAssociateClient, err := cfg.NewServiceClient(getGaussRedisEipAssociateProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB for Redis Client: %s", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<node_id>")
+	}
+	instanceID := parts[0]
+	nodeID := parts[1]
+
+	getGaussRedisEipAssociatePath := getGaussRedisEipAssociateClient.Endpoint + getGaussRedisEipAssociateHttpUrl
+	getGaussRedisEipAssociatePath = strings.ReplaceAll(getGaussRedisEipAssociatePath, "{project_id}",
+		getGaussRedisEipAssociateClient.ProjectID)
+
+	getGaussRedisEipAssociateQueryParams := buildGetGaussRedisEipAssociateQueryParams(instanceID)
+	getGaussRedisEipAssociatePath += getGaussRedisEipAssociateQueryParams
+
+	getGaussRedisEipAssociateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getGaussRedisEipAssociateResp, err := getGaussRedisEipAssociateClient.Request("GET",
+		getGaussRedisEipAssociatePath, &getGaussRedisEipAssociateOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving EipAssociate")
+	}
+
+	getGaussRedisEipAssociateRespBody, err := utils.FlattenResponse(getGaussRedisEipAssociateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	publicIP := utils.PathSearch(fmt.Sprintf("instances[?id=='%s']|[0].groups[0].nodes[?id=='%s']|[0].public_ip",
+		instanceID, nodeID), getGaussRedisEipAssociateRespBody, "")
+	if publicIP == "" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+		d.Set("node_id", nodeID),
+		d.Set("public_ip", publicIP),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetGaussRedisEipAssociateQueryParams(instanceID string) string {
+	return fmt.Sprintf("?id=%s", instanceID)
+}
+
+func resourceGaussRedisEipAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteGaussRedisEipAssociate: Delete GaussDB Redis node EIP associate
+	var (
+		deleteGaussRedisEipAssociateHttpUrl = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/public-ip"
+		deleteGaussRedisEipAssociateProduct = "geminidb"
+	)
+	deleteGaussRedisEipAssociateClient, err := cfg.NewServiceClient(deleteGaussRedisEipAssociateProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB for Redis Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	deleteGaussRedisEipAssociatePath := deleteGaussRedisEipAssociateClient.Endpoint + deleteGaussRedisEipAssociateHttpUrl
+	deleteGaussRedisEipAssociatePath = strings.ReplaceAll(deleteGaussRedisEipAssociatePath, "{project_id}",
+		deleteGaussRedisEipAssociateClient.ProjectID)
+	deleteGaussRedisEipAssociatePath = strings.ReplaceAll(deleteGaussRedisEipAssociatePath, "{instance_id}",
+		instanceID)
+	deleteGaussRedisEipAssociatePath = strings.ReplaceAll(deleteGaussRedisEipAssociatePath, "{node_id}",
+		fmt.Sprintf("%v", d.Get("node_id")))
+
+	deleteGaussRedisEipAssociateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	publicIP := d.Get("public_ip").(string)
+
+	deleteGaussRedisEipAssociateOpt.JSONBody = utils.RemoveNil(buildGaussRedisEipAssociateBodyParams("UNBIND",
+		publicIP, nil))
+
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err = deleteGaussRedisEipAssociateClient.Request("POST", deleteGaussRedisEipAssociatePath,
+			&deleteGaussRedisEipAssociateOpt)
+		isRetry, err := handleOperationError(err)
+		if isRetry {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("error deleting EipAssociate: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"UNBIND_EIP"},
+		Target:  []string{"available"},
+		Refresh: GaussRedisInstanceUpdateRefreshFunc(deleteGaussRedisEipAssociateClient, instanceID,
+			[]string{"UNBIND_EIP"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for instance (%s) to become ready: %s", instanceID, err)
+	}
+	return diag.FromErr(err)
+}
+
+func buildGaussRedisEipAssociateBodyParams(action, publicIP, publicID interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":       action,
+		"public_ip":    publicIP,
+		"public_ip_id": publicID,
+	}
+	return bodyParams
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb redis eip associate resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb redis eip associate resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/gaussdb/' TESTARGS='-run TestAccEipAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccEipAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccEipAssociate_basic
=== PAUSE TestAccEipAssociate_basic
=== CONT  TestAccEipAssociate_basic
--- PASS: TestAccEipAssociate_basic (1257.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1257.947s6s
```
