### PR TITLE
refactor(cbr): refactor resources and related tests

### DIFF
--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -44,10 +44,9 @@ The following arguments are supported:
 * `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
 
 * `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
-  type vault. Default to **false**.
+  type vault. Defaults to **false**.
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the vault belongs.
-  Changing this will create a new vault.
 
 * `policy_id` - (Optional, String) Specifies the ID of the policy associated with the vault.
   The `policy_id` cannot be used with the vault of replicate protection type.

--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -20,25 +20,25 @@ data "huaweicloud_cbr_vaults" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the CBR vaults.
+* `region` - (Optional, String) Specifies the region in which to query the vaults.
   If omitted, the provider-level region will be used.
 
-* `name` - (Optional, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+* `name` - (Optional, String) Specifies the vault name. This parameter can contain a maximum of 64
   characters, which may consist of letters, digits, underscores(_) and hyphens (-).
 
-* `type` - (Optional, String) Specifies the object type of the CBR vault. The vaild values are as follows:
+* `type` - (Optional, String) Specifies the object type of the vault. The vaild values are as follows:
   + **server** (Cloud Servers)
   + **disk** (EVS Disks)
   + **turbo** (SFS Turbo file systems)
 
-* `consistent_level` - (Optional, String) Specifies the backup specifications.
+* `consistent_level` - (Optional, String) Specifies the consistent level (specification) of the vault.
   The valid values are as follows:
   + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
   + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
 
   Only server type vaults support application consistent.
 
-* `protection_type` - (Optional, String) Specifies the protection type of the CBR vault.
+* `protection_type` - (Optional, String) Specifies the protection type of the vault.
   The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
 
 * `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
@@ -46,12 +46,13 @@ The following arguments are supported:
 * `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
   type vault. Default to **false**.
 
-* `enterprise_project_id` - (Optional, String) Specifies a unique ID in UUID format of enterprise project.
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the vault belongs.
+  Changing this will create a new vault.
 
-* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+* `policy_id` - (Optional, String) Specifies the ID of the policy associated with the vault.
   The `policy_id` cannot be used with the vault of replicate protection type.
 
-* `status` - (Optional, String) Specifies the CBR vault status, including **available**, **lock**, **frozen** and **error**.
+* `status` - (Optional, String) Specifies the vault status, including **available**, **lock**, **frozen** and **error**.
 
 ## Attributes Reference
 
@@ -59,19 +60,19 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID in hashcode format.
 
-* `vaults` - List of CBR vault details. The object structure of each CBR vault is documented below.
+* `vaults` - List of vault details. The object structure of each vault is documented below.
 
 The `vaults` block supports:
 
 * `id` - The vault ID in UUID format.
 
-* `name` - The CBR vault name.
+* `name` - The vault name.
 
-* `type` - The object type of the CBR vault.
+* `type` - The object type of the vault.
 
-* `consistent_level` - The backup specifications.
+* `consistent_level` - The consistent level (specification) of the vault.
 
-* `protection_type` - The protection type of the CBR vault.
+* `protection_type` - The protection type of the vault.
 
 * `size` - The vault capacity, in GB.
 
@@ -79,7 +80,7 @@ The `vaults` block supports:
 
 * `enterprise_project_id` - The enterprise project ID.
 
-* `policy_id` - The policy associated with the CBR vault.
+* `policy_id` - The ID of the policy associated with the vault.
 
 * `allocated` - The allocated capacity of the vault, in GB.
 
@@ -91,9 +92,9 @@ The `vaults` block supports:
 
 * `storage` - The name of the bucket for the vault.
 
-* `tags` - The key/value pairs to associate with the CBR vault.
+* `tags` - The key/value pairs to associate with the vault.
 
-* `resources` - An array of one or more resources to attach to the CBR vault.
+* `resources` - The array of one or more resources to attach to the vault.
   The [object](#cbr_vault_resources) structure is documented below.
 
 <a name="cbr_vault_resources"></a>
@@ -101,6 +102,6 @@ The `resources` block supports:
 
 * `server_id` - The ID of the ECS instance to be backed up.
 
-* `excludes` - An array of disk IDs which will be excluded in the backup.
+* `excludes` - The array of disk IDs which will be excluded in the backup.
 
-* `includes` - An array of disk or SFS file system IDs which will be included in the backup.
+* `includes` - The array of disk or SFS file system IDs which will be included in the backup.

--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -30,14 +30,14 @@ resource "huaweicloud_cbr_policy" "test" {
 
 ```hcl
 variable "policy_name" {}
-variable "dest_region" {}
-variable "dest_project_id" {}
+variable "destination_region" {}
+variable "destination_project_id" {}
 
 resource "huaweicloud_cbr_policy" "test" {
   name                   = var.policy_name
   type                   = "replication"
-  destination_region     = var.dest_region
-  destination_project_id = var.dest_project_id
+  destination_region     = var.destination_region
+  destination_project_id = var.destination_project_id
   backup_quantity        = 20
 
   backup_cycle {

--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -52,20 +52,21 @@ resource "huaweicloud_cbr_policy" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR policy. If omitted, the
+* `region` - (Optional, String, ForceNew) Specifies the region where the policy is located. If omitted, the
   provider-level region will be used. Changing this will create a new policy.
 
-* `name` - (Required, String) Specifies a unique name of the CBR policy. This parameter can contain a maximum of 64
+* `name` - (Required, String) Specifies the policy name.  
+  This parameter can contain a maximum of 64
   characters, which may consist of chinese characters, letters, digits, underscores(_) and hyphens (-).
 
-* `type` - (Required, String, ForceNew) Specifies the protection type of the CBR policy.
+* `type` - (Required, String, ForceNew) Specifies the protection type of the policy.
   Valid values are **backup** and **replication**.
   Changing this will create a new policy.
 
-* `backup_cycle` - (Required, List) Specifies the scheduling rule for the CBR policy backup execution.
+* `backup_cycle` - (Required, List) Specifies the scheduling rule for the policy backup execution.
   The [object](#cbr_policy_backup_cycle) structure is documented below.
 
-* `enabled` - (Optional, Bool) Specifies whether to enable the CBR policy. Default to **true**.
+* `enabled` - (Optional, Bool) Specifies whether to enable the policy. Default to **true**.
 
 * `destination_region` - (Optional, String) Specifies the name of the replication destination region, which is mandatory
   for cross-region replication. Required if `protection_type` is **replication**.
@@ -88,7 +89,7 @@ The following arguments are supported:
   When the number of retained backups exceeds the preset value (number of `backup_quantity`), the system automatically
   deletes the earliest backups. By default, the system automatically clears data every other day.
 
-* `time_zone` - (Optional, String) Specifies the UTC time zone, e.g.: `UTC+08:00`.
+* `time_zone` - (Optional, String) Specifies the UTC time zone, e.g. `UTC+08:00`.
   Only available if `long_term_retention` is set.
 
 <a name="cbr_policy_backup_cycle"></a>

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -13,10 +13,8 @@ Manages a CBR Vault resource within Huaweicloud.
 ```hcl
 variable "vault_name" {}
 variable "ecs_instance_id" {}
-variable "evs_volume_id" {}
-
-data "huaweicloud_compute_instance" "test" {
-  ...
+variable "attached_volume_ids" {
+  type = list(string)
 }
 
 resource "huaweicloud_cbr_vault" "test" {
@@ -28,10 +26,7 @@ resource "huaweicloud_cbr_vault" "test" {
 
   resources {
     server_id = var.ecs_instance_id
-  
-    excludes = [
-      var.evs_volume_id
-    ]
+    excludes  = var.attached_volume_ids
   }
 
   tags = {
@@ -80,19 +75,19 @@ resource "huaweicloud_cbr_vault" "test" {
 
 ```hcl
 variable "vault_name" {}
-variable "evs_volume_id" {}
+variable "evs_volume_ids" {
+  type = list(string)
+}
 
 resource "huaweicloud_cbr_vault" "test" {
-  name             = var.vault_name
-  type             = "disk"
-  protection_type  = "backup"
-  size             = 50
-  auto_expand      = true
+  name            = var.vault_name
+  type            = "disk"
+  protection_type = "backup"
+  size            = 50
+  auto_expand     = true
 
   resources {
-    includes = [
-      var.evs_volume_id
-    ]
+    includes = var.evs_volume_ids
   }
 
   tags = {
@@ -105,18 +100,18 @@ resource "huaweicloud_cbr_vault" "test" {
 
 ```hcl
 variable "vault_name" {}
-variable "sfs_turbo_id" {}
+variable "sfs_turbo_ids" {
+  type = list(string)
+}
 
 resource "huaweicloud_cbr_vault" "test" {
-  name             = var.vault_name
-  type             = "turbo"
-  protection_type  = "backup"
-  size             = 1000
+  name            = var.vault_name
+  type            = "turbo"
+  protection_type = "backup"
+  size            = 1000
 
   resources {
-    includes = [
-      var.sfs_turbo_id
-    ]
+    includes = var.sfs_turbo_ids
   }
 
   tags = {
@@ -131,10 +126,10 @@ resource "huaweicloud_cbr_vault" "test" {
 variable "vault_name" {}
 
 resource "huaweicloud_cbr_vault" "test" {
-  name             = var.vault_name
-  type             = "turbo"
-  protection_type  = "replication"
-  size             = 1000
+  name            = var.vault_name
+  type            = "turbo"
+  protection_type = "replication"
+  size            = 1000
 }
 ```
 
@@ -270,7 +265,7 @@ with the vault. Also you can ignore changes as below.
 
 ```
 resource "huaweicloud_cbr_vault" "test" {
-    ...
+  ...
 
   lifecycle {
     ignore_changes = [

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -162,7 +162,7 @@ The following arguments are supported:
 
   -> You cannot update `size` if the vault is **prePaid** mode.
 
-* `consistent_level` - (Optional, String, ForceNew) Specifies the backup specifications.
+* `consistent_level` - (Optional, String, ForceNew) Specifies the consistent level (specification) of the vault.
   The valid values are as follows:
   + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
   + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
@@ -179,8 +179,8 @@ The following arguments are supported:
 
 * `bind_rules` - (Optional, Map) Specifies the tags to filter resources for automatic association with **auto_bind**.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies a unique ID in UUID format of enterprise project.
-  Changing this will create a new vault.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the vault
+  belongs. Changing this will create a new vault.
 
 * `policy` - (Optional, List) Specifies the policy details to associate with the CBR vault.
   The [object](#cbr_vault_policies) structure is documented below.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -394,7 +394,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_flavors": bms.DataSourceBmsFlavors(),
 
 			"huaweicloud_cbr_backup": cbr.DataSourceBackup(),
-			"huaweicloud_cbr_vaults": cbr.DataSourceCbrVaultsV3(),
+			"huaweicloud_cbr_vaults": cbr.DataSourceVaults(),
 
 			"huaweicloud_cbh_instances": cbh.DataSourceCbhInstances(),
 
@@ -668,7 +668,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instance": bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance": resourceBCSInstanceV2(),
 
-			"huaweicloud_cbr_policy": cbr.ResourceCBRPolicyV3(),
+			"huaweicloud_cbr_policy": cbr.ResourcePolicy(),
 			"huaweicloud_cbr_vault":  cbr.ResourceVault(),
 
 			"huaweicloud_cbh_instance": cbh.ResourceCBHInstance(),

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -5,36 +5,37 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 )
 
-func TestAccVaults_BasicServer(t *testing.T) {
-	randName := acceptance.RandomAccResourceNameWithDash()
-	dataSourceName := "data.huaweicloud_cbr_vaults.test"
-
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataVaults_backupServer(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_cbr_vaults.test"
+		config         = testAccVault_backupServer_step1(testAccVault_base(name), name)
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVaults_basic(testAccVault_serverBasic(randName)),
+				Config: testAccDataVaults(config),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "app_consistent"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.tags.foo", "bar"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.tags.key", "value"),
 				),
@@ -43,24 +44,35 @@ func TestAccVaults_BasicServer(t *testing.T) {
 	})
 }
 
-func TestAccVaults_ReplicaServer(t *testing.T) {
-	randName := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_cbr_vaults.test"
+func testAccDataVaults(config string) string {
+	return fmt.Sprintf(`
+%[1]s
 
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+data "huaweicloud_cbr_vaults" "test" {
+  name = huaweicloud_cbr_vault.test.name
+}
+`, config)
+}
+
+func TestAccDataVaults_replicationServer(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_cbr_vaults.test"
+		config         = testAccVault_replicationServer_step1(name)
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVaults_basic(testAccVault_serverReplication(randName)),
+				Config: testAccDataVaults(config),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
@@ -72,107 +84,97 @@ func TestAccVaults_ReplicaServer(t *testing.T) {
 	})
 }
 
-func TestAccVaults_BasicVolume(t *testing.T) {
-	randName := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_cbr_vaults.test"
-
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataVaults_volume(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_cbr_vaults.test"
+		config         = testAccVault_volume_step1(testAccVault_base(name), name)
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVaults_basic(testAccVault_volumeBasic(randName)),
+				Config: testAccDataVaults(config),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeDisk),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "50"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id", "0"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccVaults_BasicTurbo(t *testing.T) {
-	randName := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_cbr_vaults.test"
-
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataVaults_backupTurbo(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_cbr_vaults.test"
+		config         = testAccVault_backupTurbo_step1(name)
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVaults_basic(testAccVault_turboBasic(randName)),
+				Config: testAccDataVaults(config),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "800"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id", "0"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccVaults_ReplicaTurbo(t *testing.T) {
-	randName := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_cbr_vaults.test"
-
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataVaults_replicationTurbo(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_cbr_vaults.test"
+		config         = testAccVault_replicationTurbo_step1(name)
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVaults_basic(testAccVault_turboReplication(randName)),
+				Config: testAccDataVaults(config),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "replication"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "1000"),
-					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.enterprise_project_id", "0"),
 				),
 			},
 		},
 	})
-}
-
-func testAccVaults_basic(config string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_cbr_vaults" "test" {
-  name = huaweicloud_cbr_vault.test.name
-}
-`, config)
 }

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
@@ -23,13 +23,15 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region in which to query the vaults.",
 			},
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 64),
+				Description:  "The vault name.",
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -38,6 +40,7 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					VaultTypeServer, VaultTypeDisk, VaultTypeTurbo,
 				}, false),
+				Description: "The object type of the vault.",
 			},
 			"consistent_level": {
 				Type:     schema.TypeString,
@@ -45,6 +48,7 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"crash_consistent", "app_consistent",
 				}, false),
+				Description: "The consistent level (specification) of the vault.",
 			},
 			"protection_type": {
 				Type:     schema.TypeString,
@@ -52,27 +56,33 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"backup", "replication",
 				}, false),
+				Description: "The protection type of the vault.",
 			},
 			"size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 10485760),
+				Description:  "The vault sapacity, in GB.",
 			},
 			"auto_expand_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to enable automatic expansion of the backup protection type vault.",
 			},
 			"enterprise_project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the enterprise project to which the vault belongs.",
 			},
 			"policy_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the policy associated with the vault.",
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The vault status.",
 			},
 			"vaults": {
 				Type:     schema.TypeList,
@@ -80,65 +90,80 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The vault ID in UUID format.",
 						},
 						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The vault name.",
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The object type of the vault.",
 						},
 						"consistent_level": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The consistent level (specification) of the vault.",
 						},
 						"protection_type": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The protection type of the vault.",
 						},
 						"size": {
-							Type:     schema.TypeInt,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The vault capacity, in GB.",
 						},
 						"auto_expand_enabled": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether to enable automatic expansion of the backup protection type vault.",
 						},
 						"enterprise_project_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The enterprise project ID.",
 						},
 						"policy_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the policy associated with the vault.",
 						},
 						"allocated": {
-							Type:     schema.TypeFloat,
-							Computed: true,
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "The allocated capacity of the vault, in GB.",
 						},
 						"used": {
-							Type:     schema.TypeFloat,
-							Computed: true,
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "The used capacity, in GB.",
 						},
 						"spec_code": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The specification code.",
 						},
 						"status": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The vault status.",
 						},
 						"storage": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the bucket for the vault.",
 						},
 						"tags": {
-							Type:     schema.TypeMap,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The key/value pairs to associate with the vault.",
 						},
 						"resources": {
 							Type:     schema.TypeList,
@@ -146,21 +171,25 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"server_id": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the ECS instance to be backed up.",
 									},
 									"excludes": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "The array of disk IDs which will be excluded in the backup.",
 									},
 									"includes": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "The array of disk or SFS file system IDs which will be included in the backup.",
 									},
 								},
 							},
+							Description: "The array of one or more resources to attach to the vault.",
 						},
 					},
 				},

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
@@ -2,24 +2,25 @@ package cbr
 
 import (
 	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
 	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
-func DataSourceCbrVaultsV3() *schema.Resource {
+func DataSourceVaults() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceCbrVaultsV3Read,
+		ReadContext: dataSourceVaultsRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -28,41 +29,29 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 				Description: "The region in which to query the vaults.",
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-				Description:  "The vault name.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The vault name.",
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				//If the validation content has changed, please update the resource type map.
-				ValidateFunc: validation.StringInSlice([]string{
-					VaultTypeServer, VaultTypeDisk, VaultTypeTurbo,
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "The object type of the vault.",
 			},
 			"consistent_level": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"crash_consistent", "app_consistent",
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "The consistent level (specification) of the vault.",
 			},
 			"protection_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"backup", "replication",
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "The protection type of the vault.",
 			},
 			"size": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, 10485760),
-				Description:  "The vault sapacity, in GB.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The vault sapacity, in GB.",
 			},
 			"auto_expand_enabled": {
 				Type:        schema.TypeBool,
@@ -198,7 +187,7 @@ func DataSourceCbrVaultsV3() *schema.Resource {
 	}
 }
 
-func buildVaultListOpts(d *schema.ResourceData, config *config.Config) vaults.ListOpts {
+func buildVaultListOpts(d *schema.ResourceData, cfg *config.Config) vaults.ListOpts {
 	return vaults.ListOpts{
 		Limit:               100,
 		CloudType:           "public",
@@ -206,12 +195,12 @@ func buildVaultListOpts(d *schema.ResourceData, config *config.Config) vaults.Li
 		ObjectType:          d.Get("type").(string),
 		ProtectType:         d.Get("protection_type").(string),
 		PolicyID:            d.Get("policy_id").(string),
-		EnterpriseProjectID: common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 		Status:              d.Get("status").(string),
 	}
 }
 
-func filterCbrVaults(d *schema.ResourceData, vaultList []vaults.Vault) ([]interface{}, error) {
+func filterVaults(d *schema.ResourceData, vaultList []vaults.Vault) ([]interface{}, error) {
 	return utils.FilterSliceWithField(vaultList, map[string]interface{}{
 		"Billing.ConsistentLevel": d.Get("consistent_level").(string),
 		"Billing.Size":            d.Get("size").(int),
@@ -219,7 +208,7 @@ func filterCbrVaults(d *schema.ResourceData, vaultList []vaults.Vault) ([]interf
 	})
 }
 
-func getCbrPolicyOfSpecificVault(client *golangsdk.ServiceClient, vaultId string) (*policies.Policy, error) {
+func getPolicyOfSpecificVault(client *golangsdk.ServiceClient, vaultId string) (*policies.Policy, error) {
 	opt := policies.ListOpts{
 		VaultID: vaultId,
 	}
@@ -235,13 +224,14 @@ func getCbrPolicyOfSpecificVault(client *golangsdk.ServiceClient, vaultId string
 	if len(resp) > 0 {
 		return &resp[0], nil
 	}
-	return nil, fmtp.Errorf("No policies are bound to the vault.")
+	return nil, fmt.Errorf("no policies are bound to the vault")
 }
 
-func setCbrAllVaultParameters(client *golangsdk.ServiceClient, d *schema.ResourceData,
-	vaultList []interface{}) error {
+func flattenAllVaults(client *golangsdk.ServiceClient, vaultList []interface{}) []map[string]interface{} {
+	if len(vaultList) < 1 {
+		return nil
+	}
 	result := make([]map[string]interface{}, len(vaultList))
-	ids := make([]string, len(vaultList))
 	for i, val := range vaultList {
 		vault := val.(vaults.Vault)
 		vMap := map[string]interface{}{
@@ -259,53 +249,56 @@ func setCbrAllVaultParameters(client *golangsdk.ServiceClient, d *schema.Resourc
 			"storage":               vault.Billing.StorageUnit,
 			"auto_expand_enabled":   vault.AutoExpand,
 			"tags":                  utils.TagsToMap(vault.Tags),
-			"resources":             makeVaultResources(vault.Billing.ObjectType, vault.Resources),
+			"resources":             flattenVaultResources(vault.Billing.ObjectType, vault.Resources),
 		}
 
-		// Query the CBR policy which bound to the vault by ID
-		if policy, err := getCbrPolicyOfSpecificVault(client, vault.ID); err != nil {
-			logp.Printf("[DEBUG] Unable to find the policy for specific vault: %s", err)
+		// Query the CBR policy which bound to the vault by ID.
+		if policy, err := getPolicyOfSpecificVault(client, vault.ID); err != nil {
+			log.Printf("[DEBUG] No policy bound to vault (%s): %s", vault.ID, err)
 		} else {
 			vMap["policy_id"] = policy.ID
 		}
 		result[i] = vMap
-		ids[i] = vault.ID
 	}
 
-	d.SetId(hashcode.Strings(ids))
-
-	return d.Set("vaults", result)
+	return result
 }
 
-func dataSourceCbrVaultsV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(config.GetRegion(d))
+func dataSourceVaultsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating Huaweicloud CBR v3 client: %s", err)
+		return diag.Errorf("error creating CBR v3 client: %s", err)
 	}
 
-	opt := buildVaultListOpts(d, config)
-
+	opt := buildVaultListOpts(d, cfg)
 	pages, err := vaults.List(client, opt).AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("Error getting vault details: %s", err)
+		return diag.Errorf("error getting vault details: %s", err)
 	}
 
 	resp, err := vaults.ExtractVaults(pages)
 	if err != nil {
-		return fmtp.DiagErrorf("error getting vault details: %s", err)
+		return diag.Errorf("error getting vault details: %s", err)
 	}
 	// Use the following parameters to filter the result of the List method return: consistent_level, size and
 	// auto_expand_enabled.
-	vaultList, err := filterCbrVaults(d, *resp)
+	vaultList, err := filterVaults(d, *resp)
 	if err != nil {
-		return fmtp.DiagErrorf("Error filting vaults by consistent_level, size and auto_expand_enabled: %s", err)
+		return diag.Errorf("error filting vaults by consistent_level, size and auto_expand_enabled: %s", err)
 	}
 
 	// Set the ID and other parameters.
-	err = setCbrAllVaultParameters(client, d, vaultList)
+	uuid, err := uuid.GenerateUUID()
 	if err != nil {
-		return fmtp.DiagErrorf("Error setting vaults parameter: %s", err)
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+	mErr := multierror.Append(nil,
+		d.Set("vaults", flattenAllVaults(client, vaultList)),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting data-source fields: %s", err)
 	}
 	return nil
 }

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
@@ -28,20 +28,23 @@ func ResourceCBRPolicyV3() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the policy is located.",
 			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 64),
+				Description:  "The policy name.",
 			},
 			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether to enable the CBR policy.",
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -50,6 +53,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"backup", "replication",
 				}, false),
+				Description: "The protection type of the CBR policy.",
 			},
 			"backup_cycle": {
 				Type:     schema.TypeList,
@@ -87,26 +91,31 @@ func ResourceCBRPolicyV3() *schema.Resource {
 						},
 					},
 				},
+				Description: "The scheduling rule for the CBR policy backup execution.",
 			},
 			"destination_region": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the replication destination region.",
 			},
 			"destination_project_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"destination_region"},
+				Description:  "The ID of the replication destination project.",
 			},
 			"backup_quantity": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(2, 99999),
+				Description:  "The maximum number of retained backups.",
 			},
 			"time_period": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ValidateFunc:  validation.IntBetween(2, 99999),
 				ConflictsWith: []string{"backup_quantity"},
+				Description:   "The duration (in days) for retained backups.",
 			},
 			"long_term_retention": {
 				Type:     schema.TypeList,
@@ -118,25 +127,30 @@ func ResourceCBRPolicyV3() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 100),
+							Description:  "The latest backup of each day is saved in the long term.",
 						},
 						"weekly": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 100),
+							Description:  "The latest backup of each week is saved in the long term.",
 						},
 						"monthly": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 100),
+							Description:  "The latest backup of each month is saved in the long term.",
 						},
 						"yearly": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 100),
+							Description:  "The latest backup of each year is saved in the long term.",
 						},
 					},
 				},
 				RequiredWith: []string{"backup_quantity", "time_zone"},
+				Description:  "The long-term retention rules.",
 			},
 			"time_zone": {
 				Type:     schema.TypeString,
@@ -144,6 +158,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 				Computed: true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^UTC[+-]\d{2}:00$`),
 					"The time zone must be in UTC format, such as 'UTC+08:00'."),
+				Description: "The UTC time zone.",
 			},
 		},
 	}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_policy.go
@@ -1,29 +1,34 @@
 package cbr
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func ResourceCBRPolicyV3() *schema.Resource {
+func ResourcePolicy() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceCBRPolicyV3Create,
-		Read:   resourceCBRPolicyV3Read,
-		Update: resourceCBRPolicyV3Update,
-		Delete: resourceCBRPolicyV3Delete,
+		CreateContext: resourcePolicyCreate,
+		ReadContext:   resourcePolicyRead,
+		UpdateContext: resourcePolicyUpdate,
+		DeleteContext: resourcePolicyDelete,
+
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -35,10 +40,9 @@ func ResourceCBRPolicyV3() *schema.Resource {
 				Description: "The region where the policy is located.",
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
-				Description:  "The policy name.",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The policy name.",
 			},
 			"enabled": {
 				Type:        schema.TypeBool,
@@ -47,12 +51,9 @@ func ResourceCBRPolicyV3() *schema.Resource {
 				Description: "Whether to enable the CBR policy.",
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"backup", "replication",
-				}, false),
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
 				Description: "The protection type of the CBR policy.",
 			},
 			"backup_cycle": {
@@ -65,7 +66,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ExactlyOneOf: []string{"backup_cycle.0.days"},
-							ValidateFunc: validation.IntBetween(1, 30),
+							Description:  "The number of days between each backup.",
 						},
 						"days": {
 							Type:     schema.TypeString,
@@ -76,6 +77,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 									"characters except commas. The valid string of weekly date are:"+
 									"MO, TU, WE, TH, FR, SA, SU.",
 							),
+							Description: "The weekly backup time.",
 						},
 						"execution_times": {
 							Type:     schema.TypeList,
@@ -88,6 +90,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 									"the time format should be HH:MM",
 								),
 							},
+							Description: "The execution time of the policy.",
 						},
 					},
 				},
@@ -105,15 +108,13 @@ func ResourceCBRPolicyV3() *schema.Resource {
 				Description:  "The ID of the replication destination project.",
 			},
 			"backup_quantity": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(2, 99999),
-				Description:  "The maximum number of retained backups.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The maximum number of retained backups.",
 			},
 			"time_period": {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				ValidateFunc:  validation.IntBetween(2, 99999),
 				ConflictsWith: []string{"backup_quantity"},
 				Description:   "The duration (in days) for retained backups.",
 			},
@@ -124,28 +125,24 @@ func ResourceCBRPolicyV3() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"daily": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 100),
-							Description:  "The latest backup of each day is saved in the long term.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The latest backup of each day is saved in the long term.",
 						},
 						"weekly": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 100),
-							Description:  "The latest backup of each week is saved in the long term.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The latest backup of each week is saved in the long term.",
 						},
 						"monthly": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 100),
-							Description:  "The latest backup of each month is saved in the long term.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The latest backup of each month is saved in the long term.",
 						},
 						"yearly": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 100),
-							Description:  "The latest backup of each year is saved in the long term.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The latest backup of each year is saved in the long term.",
 						},
 					},
 				},
@@ -164,184 +161,21 @@ func ResourceCBRPolicyV3() *schema.Resource {
 	}
 }
 
-func resourceCBRPolicyV3Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(config.GetRegion(d))
-	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
-	}
-
-	enabled := d.Get("enabled").(bool)
-
-	schedule, err := resourceCBRPolicyV3BackupSchedule(d)
-	if err != nil {
-		return fmtp.Errorf("Error to parse the format of backup cycle: %s", err)
-	}
-	createOpts := policies.CreateOpts{
-		Name:                d.Get("name").(string),
-		OperationType:       d.Get("type").(string),
-		Enabled:             &enabled,
-		OperationDefinition: resourceCBRPolicyV3OpDefinition(d),
-		Trigger: &policies.Trigger{
-			Properties: policies.TriggerProperties{
-				Pattern: schedule,
-			},
-		},
-	}
-
-	cbrPolicy, err := policies.Create(client, createOpts).Extract()
-	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR policy: %s", err)
-	}
-
-	d.SetId(cbrPolicy.ID)
-
-	return resourceCBRPolicyV3Read(d, meta)
-}
-
-func resourceCBRPolicyV3Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(config.GetRegion(d))
-	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
-	}
-
-	cbrPolicy, err := policies.Get(client, d.Id()).Extract()
-	if err != nil {
-		return common.CheckDeleted(d, err, "Error retrieving CBRv3 policy")
-	}
-
-	logp.Printf("[DEBUG] Retrieved policy %s: %+v", d.Id(), cbrPolicy)
-	operationDefinition := cbrPolicy.OperationDefinition
-	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
-		d.Set("enabled", cbrPolicy.Enabled),
-		d.Set("name", cbrPolicy.Name),
-		d.Set("type", cbrPolicy.OperationType),
-		d.Set("destination_region", operationDefinition.DestinationRegion),
-		d.Set("destination_project_id", operationDefinition.DestinationProjectID),
-		setCBRPolicyV3BackupCycle(d, cbrPolicy.Trigger.Properties.Pattern),
-	)
-
-	if operationDefinition.MaxBackups != -1 {
-		mErr = multierror.Append(mErr,
-			d.Set("backup_quantity", operationDefinition.MaxBackups),
-			setCBRPolicyV3LongTermRetention(d, operationDefinition),
-		)
-		if operationDefinition.Timezone != "" {
-			mErr = multierror.Append(mErr, d.Set("time_zone", operationDefinition.Timezone))
-		}
-	}
-	if operationDefinition.RetentionDurationDays != -1 {
-		mErr = multierror.Append(mErr, d.Set("time_period", operationDefinition.RetentionDurationDays))
-	}
-
-	return mErr.ErrorOrNil()
-}
-
-func resourceCBRPolicyV3Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(config.GetRegion(d))
-	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
-	}
-
-	var updateOpts policies.UpdateOpts
-
-	if d.HasChange("name") {
-		newName := d.Get("name")
-		updateOpts.Name = newName.(string)
-	}
-	if d.HasChange("enabled") {
-		enabled := d.Get("enabled").(bool)
-		updateOpts.Enabled = &enabled
-	}
-	if d.HasChange("backup_cycle") {
-		schedule, err := resourceCBRPolicyV3BackupSchedule(d)
-		if err != nil {
-			return fmtp.Errorf("Error to parse the format of backup cycle: %s", err)
-		}
-		updateOpts.Trigger = &policies.Trigger{
-			Properties: policies.TriggerProperties{
-				Pattern: schedule,
-			},
-		}
-	}
-	if d.HasChanges("backup_quantity", "time_period", "destination_region", "long_term_retention", "time_zone") {
-		opDefinition := resourceCBRPolicyV3OpDefinition(d)
-		updateOpts.OperationDefinition = opDefinition
-	}
-
-	_, err = policies.Update(client, d.Id(), updateOpts).Extract()
-	if err != nil {
-		return fmtp.Errorf("Error updating Huaweicloud CBR policy: %s", err)
-	}
-
-	return resourceCBRPolicyV3Read(d, meta)
-}
-
-func resourceCBRPolicyV3Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.CbrV3Client(config.GetRegion(d))
-	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud CBR client: %s", err)
-	}
-
-	if err = policies.Delete(client, d.Id()).ExtractErr(); err != nil {
-		return fmtp.Errorf("Error deleting Huaweicloud CBR policy: %s", err)
-	}
-
-	d.SetId("")
-	return nil
-}
-
-func resourceCBRPolicyV3OpDefinition(d *schema.ResourceData) *policies.PolicyODCreate {
-	policyODCreate := policies.PolicyODCreate{}
-
-	if destinationProjectID, ok3 := d.GetOk("destination_project_id"); ok3 {
-		policyODCreate.DestinationProjectID = destinationProjectID.(string)
-		policyODCreate.DestinationRegion = d.Get("destination_region").(string)
-	}
-
-	//the backup_quantity and time_period are both left blank means the backups are retained permanently
-	maxBackups, ok1 := d.GetOk("backup_quantity")
-	durationDays, ok2 := d.GetOk("time_period")
-	if !ok1 && !ok2 {
-		policyODCreate.MaxBackups = -1
-		policyODCreate.RetentionDurationDays = -1
-		return &policyODCreate
-	}
-	policyODCreate.MaxBackups = maxBackups.(int)
-	policyODCreate.RetentionDurationDays = durationDays.(int)
-
-	if _, ok := d.GetOk("long_term_retention"); ok {
-		policyODCreate.DailyBackups = d.Get("long_term_retention.0.daily").(int)
-		policyODCreate.WeekBackups = d.Get("long_term_retention.0.weekly").(int)
-		policyODCreate.MonthBackups = d.Get("long_term_retention.0.monthly").(int)
-		policyODCreate.YearBackups = d.Get("long_term_retention.0.yearly").(int)
-		policyODCreate.Timezone = d.Get("time_zone").(string)
-	}
-
-	return &policyODCreate
-}
-
 func makeSchedule(frequency, backupType, duration, time string) (string, error) {
 	timeSlice := strings.Split(time, ":")
 	if len(timeSlice) != 2 {
-		return "", fmtp.Errorf("Wrong time format (%s), should be HH:MM", time)
+		return "", fmt.Errorf("invalid time format (%s), should be HH:MM", time)
 	}
 	schedule := fmt.Sprintf("FREQ=%s;%s=%s;BYHOUR=%s;BYMINUTE=%s",
 		frequency, backupType, duration, timeSlice[0], timeSlice[1])
 	return schedule, nil
 }
 
-func resourceCBRPolicyV3BackupSchedule(d *schema.ResourceData) ([]string, error) {
+func buildPolicyBackupSchedule(backupCycleRaw []interface{}) ([]string, error) {
 	var frequency, backupType, duration string
 
-	backupCycleRaw := d.Get("backup_cycle").([]interface{})
 	rawInfo := backupCycleRaw[0].(map[string]interface{})
-
-	//If 'days' is set, the value of 'interval' will be 0, relatively, the value of 'days' will be "".
+	// If 'days' is set, the value of 'interval' will be 0, relatively, the value of 'days' will be "".
 	if rawInfo["days"] != "" {
 		frequency = "WEEKLY"
 		backupType = "BYDAY"
@@ -363,59 +197,219 @@ func resourceCBRPolicyV3BackupSchedule(d *schema.ResourceData) ([]string, error)
 	return schedules, nil
 }
 
-func setCBRPolicyV3LongTermRetention(d *schema.ResourceData, resp *policies.PolicyODCreate) error {
-	if resp.DailyBackups == 0 && resp.WeekBackups == 0 && resp.MonthBackups == 0 && resp.YearBackups == 0 {
-		return nil
+func buildPolicyOpDefinition(d *schema.ResourceData) *policies.PolicyODCreate {
+	policyODCreate := policies.PolicyODCreate{}
+
+	if destinationProjectID, ok := d.GetOk("destination_project_id"); ok {
+		policyODCreate.DestinationProjectID = destinationProjectID.(string)
+		policyODCreate.DestinationRegion = d.Get("destination_region").(string)
 	}
-	result := make([]map[string]interface{}, 1)
-	retention := map[string]interface{}{
-		"daily":   resp.DailyBackups,
-		"weekly":  resp.WeekBackups,
-		"monthly": resp.MonthBackups,
-		"yearly":  resp.YearBackups,
+
+	// The backup_quantity and time_period are both left blank means the backups are retained permanently
+	maxBackups, ok1 := d.GetOk("backup_quantity")
+	durationDays, ok2 := d.GetOk("time_period")
+	if !ok1 && !ok2 {
+		policyODCreate.MaxBackups = -1
+		policyODCreate.RetentionDurationDays = -1
+		return &policyODCreate
 	}
-	result[0] = retention
-	return d.Set("long_term_retention", result)
+	policyODCreate.MaxBackups = maxBackups.(int)
+	policyODCreate.RetentionDurationDays = durationDays.(int)
+
+	if _, ok := d.GetOk("long_term_retention"); ok {
+		policyODCreate.DailyBackups = d.Get("long_term_retention.0.daily").(int)
+		policyODCreate.WeekBackups = d.Get("long_term_retention.0.weekly").(int)
+		policyODCreate.MonthBackups = d.Get("long_term_retention.0.monthly").(int)
+		policyODCreate.YearBackups = d.Get("long_term_retention.0.yearly").(int)
+		policyODCreate.Timezone = d.Get("time_zone").(string)
+	}
+
+	return &policyODCreate
 }
 
-func setCBRPolicyV3BackupCycle(d *schema.ResourceData, schedules []string) error {
+func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	schedule, err := buildPolicyBackupSchedule(d.Get("backup_cycle").([]interface{}))
+	if err != nil {
+		return diag.Errorf("error parsing the format of backup cycle: %s", err)
+	}
+	createOpts := policies.CreateOpts{
+		Name:                d.Get("name").(string),
+		OperationType:       d.Get("type").(string),
+		Enabled:             utils.Bool(d.Get("enabled").(bool)),
+		OperationDefinition: buildPolicyOpDefinition(d),
+		Trigger: &policies.Trigger{
+			Properties: policies.TriggerProperties{
+				Pattern: schedule,
+			},
+		},
+	}
+
+	cbrPolicy, err := policies.Create(client, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating CBR policy: %s", err)
+	}
+
+	d.SetId(cbrPolicy.ID)
+
+	return resourcePolicyRead(ctx, d, meta)
+}
+
+func flattenPolicyBackupCycle(schedules []string) ([]map[string]interface{}, error) {
 	schedule := make(map[string]interface{})
-	//The value obtained from API is a string containing 'days', 'interval' and 'execution_times',
-	//so it should be extracted when setting the corresponding value to state.
+	// The value obtained from API is a string containing 'days', 'interval' and 'execution_times',
+	// so it should be extracted when setting the corresponding value to state.
 	if strings.Contains(schedules[0], "WEEKLY") {
-		regexExp := regexp.MustCompile("BYDAY=([\\w,]+);")
-		result := regexExp.FindStringSubmatch(schedules[0])
-		//The right length of the string match is two, first is the match result of the regex string,
-		//second is the match result of the regex group.
+		result := regexp.MustCompile(`BYDAY=([\w,]+);`).FindStringSubmatch(schedules[0])
+		// The right length of the string match is two, first is the match result of the regex string,
+		// second is the match result of the regex group.
 		if len(result) != 2 {
-			return fmtp.Errorf("Wrong weekly days format in API response")
+			return nil, fmt.Errorf("invalid format of the weekly days in API response")
 		}
 		schedule["days"] = result[1]
 	} else {
-		regexExp := regexp.MustCompile("INTERVAL=([\\d]+);")
-		result := regexExp.FindStringSubmatch(schedules[0])
+		result := regexp.MustCompile(`INTERVAL=([\d]+);`).FindStringSubmatch(schedules[0])
 		if len(result) != 2 {
-			return fmtp.Errorf("Wrong backup interval format in API response")
+			return nil, fmt.Errorf("invalid format of backup interval in API response")
 		}
 		num, err := strconv.Atoi(result[1])
 		if err != nil {
-			return err
+			return nil, err
 		}
 		schedule["interval"] = num
 	}
 	backupTimeList := make([]string, len(schedules))
 	for i, v := range schedules {
-		regexExp := regexp.MustCompile("BYHOUR=(\\d+);BYMINUTE=(\\d+)")
-		times := regexExp.FindStringSubmatch(v)
+		times := regexp.MustCompile(`BYHOUR=(\d+);BYMINUTE=(\d+)`).FindStringSubmatch(v)
 		if len(times) != 3 {
-			return fmtp.Errorf("Wrong backup time format in API response")
+			return nil, fmt.Errorf("invalid format of backup time in API response")
 		}
 		backupTimeList[i] = strings.Join([]string{times[1], times[2]}, ":")
 	}
 	schedule["execution_times"] = backupTimeList
-	backupCycle := []map[string]interface{}{schedule}
-	if err := d.Set("backup_cycle", backupCycle); err != nil {
-		return err
+
+	return []map[string]interface{}{schedule}, nil
+}
+
+func flattenLongTermRetention(resp *policies.PolicyODCreate) []map[string]interface{} {
+	if resp.DailyBackups == 0 && resp.WeekBackups == 0 && resp.MonthBackups == 0 && resp.YearBackups == 0 {
+		return nil
 	}
+	return []map[string]interface{}{
+		{
+			"daily":   resp.DailyBackups,
+			"weekly":  resp.WeekBackups,
+			"monthly": resp.MonthBackups,
+			"yearly":  resp.YearBackups,
+		},
+	}
+}
+
+func resourcePolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.CbrV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	policyId := d.Id()
+	resp, err := policies.Get(client, policyId).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "CBR policy")
+	}
+
+	log.Printf("[DEBUG] Retrieved policy (%s): %#v", policyId, resp)
+	operationDefinition := resp.OperationDefinition
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("enabled", resp.Enabled),
+		d.Set("name", resp.Name),
+		d.Set("type", resp.OperationType),
+		d.Set("destination_region", operationDefinition.DestinationRegion),
+		d.Set("destination_project_id", operationDefinition.DestinationProjectID),
+	)
+
+	backupCycle, err := flattenPolicyBackupCycle(resp.Trigger.Properties.Pattern)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	mErr = multierror.Append(mErr, d.Set("backup_cycle", backupCycle))
+
+	if operationDefinition.MaxBackups != -1 {
+		mErr = multierror.Append(mErr,
+			d.Set("backup_quantity", operationDefinition.MaxBackups),
+			d.Set("long_term_retention", flattenLongTermRetention(operationDefinition)),
+		)
+		if operationDefinition.Timezone != "" {
+			mErr = multierror.Append(mErr, d.Set("time_zone", operationDefinition.Timezone))
+		}
+	}
+	if operationDefinition.RetentionDurationDays != -1 {
+		mErr = multierror.Append(mErr, d.Set("time_period", operationDefinition.RetentionDurationDays))
+	}
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving policy resource fields: %s", err)
+	}
+	return nil
+}
+
+func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var updateOpts policies.UpdateOpts
+
+	if d.HasChange("name") {
+		newName := d.Get("name")
+		updateOpts.Name = newName.(string)
+	}
+	if d.HasChange("enabled") {
+		enabled := d.Get("enabled").(bool)
+		updateOpts.Enabled = &enabled
+	}
+	if d.HasChange("backup_cycle") {
+		schedule, err := buildPolicyBackupSchedule(d.Get("backup_cycle").([]interface{}))
+		if err != nil {
+			return diag.Errorf("error parsing the format of backup cycle: %s", err)
+		}
+		updateOpts.Trigger = &policies.Trigger{
+			Properties: policies.TriggerProperties{
+				Pattern: schedule,
+			},
+		}
+	}
+	if d.HasChanges("backup_quantity", "time_period", "destination_region", "long_term_retention", "time_zone") {
+		updateOpts.OperationDefinition = buildPolicyOpDefinition(d)
+	}
+
+	_, err = policies.Update(client, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error updating CBR policy: %s", err)
+	}
+
+	return resourcePolicyRead(ctx, d, meta)
+}
+
+func resourcePolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	if err = policies.Delete(client, d.Id()).ExtractErr(); err != nil {
+		return diag.Errorf("error deleting CBR policy: %s", err)
+	}
+
 	return nil
 }

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -63,15 +63,17 @@ func ResourceVault() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the vault is located.",
 			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 64),
+				Description:  "The vault name.",
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -81,6 +83,7 @@ func ResourceVault() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					VaultTypeServer, VaultTypeDisk, VaultTypeTurbo,
 				}, false),
+				Description: "The vault type.",
 			},
 			"protection_type": {
 				Type:     schema.TypeString,
@@ -89,11 +92,13 @@ func ResourceVault() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"backup", "replication",
 				}, false),
+				Description: "The protection type.",
 			},
 			"size": {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validation.IntBetween(1, 10485760),
+				Description:  "The capacity of the vault, in GB.",
 			},
 			"consistent_level": {
 				Type:     schema.TypeString,
@@ -103,27 +108,32 @@ func ResourceVault() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"crash_consistent", "app_consistent",
 				}, false),
+				Description: "The consistent level (specification) of the vault.",
 			},
 			"auto_expand": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether to enable auto capacity expansion for the vault.",
 			},
 			"auto_bind": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether automatic association is supported.",
 			},
 			"bind_rules": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The rules for automatic association.",
 			},
 			"enterprise_project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The enterprise project ID to which the vault belongs.",
 			},
 			"policy": {
 				Type:     schema.TypeSet,
@@ -132,15 +142,18 @@ func ResourceVault() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The policy ID.",
 						},
 						"destination_vault_id": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The ID of destination vault to which the replication policy will associated.",
 						},
 					},
 				},
+				Description: "The policy details to associate with the CBR vault.",
 			},
 			"resources": {
 				Type:     schema.TypeSet,
@@ -149,55 +162,66 @@ func ResourceVault() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"server_id": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The ID of the ECS instance to be backed up.",
 						},
 						"excludes": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The array of disk IDs which will be excluded in the backup.",
 						},
 						"includes": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The array of disk or SFS file system IDs which will be included in the backup.",
 						},
 					},
 				},
+				Description: "The array of one or more resources to attach to the CBR vault.",
 			},
+			// Public parameters.
 			"tags":          common.TagsSchema(),
 			"charging_mode": common.SchemaChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
 			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
 			"auto_pay":      common.SchemaAutoPay(nil),
+			// Computed parameters.
 			"allocated": {
-				Type:     schema.TypeFloat,
-				Computed: true,
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "The allocated capacity, in GB.",
 			},
 			"used": {
-				Type:     schema.TypeFloat,
-				Computed: true,
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "The used capacity, in GB.",
 			},
 			"spec_code": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The specification code.",
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The vault status.",
 			},
 			"storage": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the bucket for the vault.",
 			},
 			// Deprecated arguments
 			"policy_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "schema:Deprecated; Using parameter 'policy' instead",
+				Description: "schema:Deprecated; Using parameter 'policy' instead.",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor vault and policy resources and related tests.
- repair prepaid issue (vault).
- adjust resource's functions.
- adjust acc tests.
- all parameters support description.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

##
In some tests, because the binding (unbinding) of associated resources takes a long time and there is no checking logic after the binding (unbinding) action, the associated resource queried by the resource after the resource update is completed is inconsistent with the expected associated resource

step1:  associate two volumes to manage backups and check configuration.
step2:  dissociate a volume and associate another and check configuration.

expect:
    - step1: volume number: 2
    - step2: volume number: 2

actual:
    - step1: volume number: 2
    - step2: volume number: 3

A disk is in the state of unbinding, which is considered as a bound volume.

##
When creating the prepaid vault, the resource ID is mistakenly passed into the public function of the order check as the order ID, resulting in an exception.

##
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. all parameters support description.
2. refactor vault and policy resources.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAcc -timeout 360m -parallel 4
=== RUN   TestAccDataBackup_basic
=== PAUSE TestAccDataBackup_basic
=== RUN   TestAccDataVaults_backupServer
=== PAUSE TestAccDataVaults_backupServer
=== RUN   TestAccDataVaults_replicationServer
=== PAUSE TestAccDataVaults_replicationServer
=== RUN   TestAccDataVaults_volume
=== PAUSE TestAccDataVaults_volume
=== RUN   TestAccDataVaults_backupTurbo
=== PAUSE TestAccDataVaults_backupTurbo
=== RUN   TestAccDataVaults_replicationTurbo
=== PAUSE TestAccDataVaults_replicationTurbo
=== RUN   TestAccPolicy_basic
=== PAUSE TestAccPolicy_basic
=== RUN   TestAccPolicy_retention
=== PAUSE TestAccPolicy_retention
=== RUN   TestAccPolicy_replication
=== PAUSE TestAccPolicy_replication
=== RUN   TestAccVault_backupServer
=== PAUSE TestAccVault_backupServer
=== RUN   TestAccVault_replicationServer
=== PAUSE TestAccVault_replicationServer
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== RUN   TestAccVault_volume
=== PAUSE TestAccVault_volume
=== RUN   TestAccVault_backupTurbo
=== PAUSE TestAccVault_backupTurbo
=== RUN   TestAccVault_replicationTurbo
=== PAUSE TestAccVault_replicationTurbo
=== RUN   TestAccVault_AutoBind
=== PAUSE TestAccVault_AutoBind
=== RUN   TestAccVault_bindPolicies
=== PAUSE TestAccVault_bindPolicies
=== CONT  TestAccDataBackup_basic
=== CONT  TestAccVault_backupServer
=== CONT  TestAccDataVaults_replicationTurbo
=== CONT  TestAccPolicy_retention
--- PASS: TestAccPolicy_retention (16.57s)
=== CONT  TestAccDataVaults_backupTurbo
--- PASS: TestAccDataVaults_replicationTurbo (17.19s)
=== CONT  TestAccDataVaults_volume
--- PASS: TestAccDataVaults_volume (331.47s)
=== CONT  TestAccDataVaults_replicationServer
--- PASS: TestAccDataVaults_replicationServer (13.61s)
=== CONT  TestAccDataVaults_backupServer
--- PASS: TestAccVault_backupServer (373.55s)
=== CONT  TestAccPolicy_basic
--- PASS: TestAccPolicy_basic (13.93s)
=== CONT  TestAccVault_backupTurbo
--- PASS: TestAccDataVaults_backupTurbo (518.06s)
=== CONT  TestAccVault_bindPolicies
--- PASS: TestAccVault_bindPolicies (32.46s)
=== CONT  TestAccVault_AutoBind
--- PASS: TestAccVault_AutoBind (18.12s)
=== CONT  TestAccVault_replicationTurbo
--- PASS: TestAccVault_replicationTurbo (13.90s)
=== CONT  TestAccVault_prePaidServer
--- PASS: TestAccDataBackup_basic (680.63s)
=== CONT  TestAccVault_volume
--- PASS: TestAccDataVaults_backupServer (340.27s)
=== CONT  TestAccVault_replicationServer
--- PASS: TestAccVault_replicationServer (14.41s)
=== CONT  TestAccPolicy_replication
--- PASS: TestAccPolicy_replication (7.19s)
--- PASS: TestAccVault_volume (365.30s)
--- PASS: TestAccVault_prePaidServer (522.45s)
--- PASS: TestAccVault_backupTurbo (999.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       1386.881s
```
