### PR TITLE
fix(cse/microservice): add deleted check method

### DIFF
--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -2,11 +2,13 @@ package cse
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
 	"strings"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -14,6 +16,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 )
+
+type microserviceError struct {
+	Detail    string `json:"detail"`
+	ErrorCode string `json:"errorCode"`
+	ErrorMsg  string `json:"errorMessage"`
+}
 
 func ResourceMicroservice() *schema.Resource {
 	return &schema.Resource{
@@ -127,6 +135,23 @@ func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, met
 	return resourceMicroserviceRead(ctx, d, meta)
 }
 
+func parseMicroserviceError(respErr error) error {
+	if errCode, ok := respErr.(golangsdk.ErrDefault400); ok {
+		var apiError microserviceError
+		if err := json.Unmarshal(errCode.Body, &apiError); err != nil {
+			return fmt.Errorf("the error format is incorrect: %s", err)
+		}
+		if apiError.ErrorCode == "400012" && strings.Contains(apiError.ErrorMsg, "not exist") {
+			return golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Body: []byte("the microservice engine has been deleted"),
+				},
+			}
+		}
+	}
+	return respErr
+}
+
 func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
@@ -137,7 +162,7 @@ func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ inter
 	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
 	resp, err := services.Get(client, d.Id(), token)
 	if err != nil {
-		return diag.Errorf("error getting dedicated microservice (%s): %s", d.Id(), err)
+		return common.CheckDeletedDiag(d, parseMicroserviceError(err), "CSE Microservice")
 	}
 
 	mErr := multierror.Append(nil,

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -8,12 +8,14 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The `CheckDeleteDiag` method does not decleared for CSE microservice.
```
Error: error getting dedicated microservice (f14960ba495e03f59f85aacaaafbdef3fbff3f0d): Bad request with: [GET https://123.249.31.136:30100/v4/default/registry/microservices/f14960ba495e03f59f85aacaaafbdef3fbff3f0d], error message: {"errorCode":"400012","errorMessage":"Micro-service does not exist","detail":"Service does not exist."}
│ 
│   with huaweicloud_cse_microservice.test,
│   on main.tf line 74, in resource "huaweicloud_cse_microservice" "test":
│   74: resource "huaweicloud_cse_microservice" "test" {
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add deleted check method.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
