### PR TITLE
feat(MRS): support external data sources

### DIFF
--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -431,6 +431,12 @@ The EIP must have been created and must be in the same region as the cluster.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the cluster.
 
+* `external_datasources` - (Optional, List, ForceNew) Specifies the external datasource configurations of the cluster.
+  The [object](#ExternalDatasources) structure is documented below.
+  Changing this will create a new MapReduce cluster resource.
+
+  -> Currently, this is supported only if the cluster version is **MRS 1.9.2**.
+
 The `nodes` block supports:
 
 * `group_name` - (Optional, String, ForceNew) Specifies the name of nodes for the node group.
@@ -511,6 +517,32 @@ The `configs` block supports:
 * `config_file_name` - (Required, String, ForceNew) Specifies the configuration file name of component installed.
   Changing this will create a new MapReduce cluster resource.
 
+<a name="ExternalDatasources"></a>
+The `external_datasources` block supports:
+
+* `component_name` - (Required, String, ForceNew) Specifies the component name. The valid values are `Hive` and `Ranger`.
+  Changing this will create a new MapReduce cluster resource.
+
+* `role_type` - (Required, String, ForceNew) Specifies the component role type.
+  The options are as follows:
+    + **hive_metastore**: Hive Metastore role.
+    + **ranger_data**: Ranger role.
+  
+  Changing this will create a new MapReduce cluster resource.
+
+* `source_type` - (Required, String, ForceNew) Specifies the data connection type.
+  The options are as follows:
+    + **LOCAL_DB**: Local metadata.
+    + **RDS_POSTGRES**: RDS PostgreSQL database.
+    + **RDS_MYSQL**: RDS MySQL database.
+    + **gaussdb-mysql**: GaussDB(for MySQL).
+  
+  Changing this will create a new MapReduce cluster resource.
+
+* `data_connection_id` - (Optional, String, ForceNew) Specifies the data connection ID.
+  This parameter is mandatory if `source_type` is not **LOCAL_DB**.
+  Changing this will create a new MapReduce cluster resource.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -545,7 +577,7 @@ terraform import huaweicloud_mapreduce_cluster.test b11b407c-e604-4e8d-8bc4-9239
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`manager_admin_pass`, `node_admin_pass`,`template_id`, `assigned_roles` and `component_configs`.
+`manager_admin_pass`, `node_admin_pass`,`template_id`, `assigned_roles`, `external_datasources`, and `component_configs`.
 It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.
@@ -556,7 +588,7 @@ resource "huaweicloud_mapreduce_cluster" "test" {
 
   lifecycle {
     ignore_changes = [
-      manager_admin_pass, node_admin_pass,
+      manager_admin_pass, node_admin_pass, template_id, assigned_roles, external_datasources, component_configs,
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. the acc test used a resource: huaweicloud_mapreduce_connection which is not ready currently.
2. The test result is based on some manually create resources: rds_mysql, database, mrs_connection

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccMrsMapReduceCluster_externalDataSources$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs -v

=== RUN   TestAccMrsMapReduceCluster_externalDataSources
=== PAUSE TestAccMrsMapReduceCluster_externalDataSources
=== CONT  TestAccMrsMapReduceCluster_externalDataSources
--- PASS: TestAccMrsMapReduceCluster_externalDataSources (1086.42s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs	1086.460s
```
