### PR TITLE
feat(er/instance): support data source to query instances

### DIFF
--- a/docs/data-sources/er_instances.md
+++ b/docs/data-sources/er_instances.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_instances
+
+Use this data source to filter ER instances within Huaweicloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_er_instances" "test" {
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the ER instances are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the ID used to query specified ER instance.
+
+* `name` - (Optional, String) Specifies the name used to filter the ER instances.
+  The valid length is limited from `1` to `64`, only Chinese and English letters, digits, underscores (_) and
+  hyphens (-) are allowed.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the ER instances to be queried.
+
+* `owned_by_self` - (Optional, Bool) Specifies whether resources belong to the current renant.
+
+* `status` - (Optional, String) Specifies the status used to filter the ER instances.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs used to filter the ER instances.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - All instances that match the filter parameters.  
+  The [object](#er_data_instances) structure is documented below.
+
+<a name="er_data_instances"></a>
+The `instances` block supports:
+
+* `id` - The ER instance ID.
+
+* `asn` - The BGP AS number of the ER instance.
+
+* `name` - The name of the ER instance.
+
+* `description` - The description of the ER instance.
+
+* `status` - The current status of the ER instance.
+
+* `enterprise_project_id` - The ID of enterprise project to which the ER instance belongs.
+
+* `tags` - The key/value pairs to associate with the ER instance.
+
+* `created_at` - The creation time of the ER instance.
+
+* `updated_at` - The last update time of the ER instance.
+
+* `enable_default_propagation` - Whether to enable the propagation of the default route table.
+
+* `enable_default_association` - Whether to enable the association of the default route table.
+
+* `auto_accept_shared_attachments` - Whether to automatically accept the creation of shared attachment.
+
+* `default_propagation_route_table_id` - The ID of the default propagation route table.
+
+* `default_association_route_table_id` - The ID of the default association route table.
+
+* `availability_zones` - The availability zone list where the ER instance is located.

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,17 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chnsz/golangsdk v0.0.0-20230703111548-19fd70595ff7 h1:PGaQYM2rk9/Sub+yDaPznwHdsWXKgFTfDg2alXBqpu4=
 github.com/chnsz/golangsdk v0.0.0-20230703111548-19fd70595ff7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -447,6 +447,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
+			"huaweicloud_er_instances":    er.DataSourceInstances(),
 			"huaweicloud_er_route_tables": er.DataSourceRouteTables(),
 
 			"huaweicloud_evs_volumes":      evs.DataSourceEvsVolumesV2(),

--- a/huaweicloud/services/acceptance/er/data_source_hauweicloud_er_instances_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_hauweicloud_er_instances_test.go
@@ -1,0 +1,252 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccInstancesDataSource_basic(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_instances.filter_by_name"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByName(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  name                  = "%[1]s"
+  asn                   = %[2]d
+  description           = "Created by terraform test"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo   = "bar"
+    key   = "value"
+    owner = "terraform"
+  }
+}
+`, name, bgpAsNum)
+}
+
+func testAccInstancesDataSource_filterByName(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_instances" "filter_by_name" {
+  depends_on = [
+    huaweicloud_er_instance.test,
+  ]
+
+  name = huaweicloud_er_instance.test.name
+}
+
+output "is_name_filter_useful" {
+  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_name.instances[*].id : v == huaweicloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterById(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_instances.filter_by_id"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterById(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterById(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_instances" "filter_by_id" {
+  instance_id = huaweicloud_er_instance.test.id
+}
+
+output "is_id_filter_useful" {
+  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_id.instances[*].id : v == huaweicloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterByStatus(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_instances.filter_by_status"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByStatus(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterByStatus(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_instances" "filter_by_status" {
+  status = huaweicloud_er_instance.test.status
+}
+
+output "is_status_filter_useful" {
+  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_status.instances[*].id : v == huaweicloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterByEpsId(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_instances.filter_by_eps_id"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByEpsId(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterByEpsId(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_instances" "filter_by_eps_id" {
+  depends_on = [
+    huaweicloud_er_instance.test,
+  ]
+
+  // Query all instances belonging to the default enterprise project.
+  enterprise_project_id = "0"
+}
+
+output "is_eps_id_filter_useful" {
+  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_eps_id.instances[*].id : v == huaweicloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}
+
+func TestAccInstancesDataSource_filterByTags(t *testing.T) {
+	var (
+		dName    = "data.huaweicloud_er_instances.filter_by_tags"
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSource_filterByTags(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstancesDataSource_filterByTags(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_instances" "filter_by_tags" {
+  depends_on = [
+    huaweicloud_er_instance.test,
+  ]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+output "is_tags_filter_is_useful" {
+  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_tags.instances[*].id : v == huaweicloud_er_instance.test.id])
+}
+`, testAccInstancesDataSource_base(name, bgpAsNum))
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_instances.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_instances.go
@@ -1,0 +1,252 @@
+package er
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the ER instances are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID used to query specified instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name used to filter the instances.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The enterprise project ID of the instances to be queried.`,
+			},
+			"owned_by_self": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether resources belong to the current renant.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status used to filter the instances.`,
+			},
+			"tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The key/value pairs used to filter the instances.`,
+			},
+			// Attributes
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID.`,
+						},
+						"asn": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The BGP AS number of the ER instance.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the instance.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the instance.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current status of the instance.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of enterprise project to which the instance belongs.`,
+						},
+						"tags": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The key/value pairs to associate with the instance.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the instance.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The last update time of the instance.`,
+						},
+						"enable_default_propagation": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to enable the propagation of the default route table.`,
+						},
+						"enable_default_association": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to enable the association of the default route table.`,
+						},
+						"auto_accept_shared_attachments": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to automatically accept the creation of shared attachment.`,
+						},
+						"default_propagation_route_table_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the default propagation route table.`,
+						},
+						"default_association_route_table_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the default association route table.`,
+						},
+						"availability_zones": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The availability zone list where the ER instance is located.`,
+						},
+					},
+				},
+				Description: `All instances that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+// Filter instances by name and tags.
+func filterInstances(d *schema.ResourceData, all []instances.Instance) ([]instances.Instance, error) {
+	filter := map[string]interface{}{}
+	if name, ok := d.GetOk("name"); ok {
+		filter["Name"] = name
+	}
+	filterResult, err := utils.FilterSliceWithField(all, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error filting instance list: %s", err)
+	}
+
+	result := make([]instances.Instance, 0, len(filterResult))
+	tagFilter := d.Get("tags").(map[string]interface{})
+	for _, val := range filterResult {
+		item := val.(instances.Instance)
+		tagmap := utils.TagsToMap(item.Tags)
+
+		// Filter instances list by tags, if the filter is nil, skip and return all fileterResult elements.
+		if !utils.HasMapContains(tagmap, tagFilter) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func flattenInstances(all []instances.Instance) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, instance := range all {
+		result[i] = map[string]interface{}{
+			"id":                                 instance.ID,
+			"asn":                                instance.ASN,
+			"name":                               instance.Name,
+			"description":                        instance.Description,
+			"status":                             instance.Status,
+			"enterprise_project_id":              instance.EnterpriseProjectId,
+			"tags":                               utils.TagsToMap(instance.Tags),
+			"created_at":                         instance.CreatedAt,
+			"updated_at":                         instance.UpdatedAt,
+			"enable_default_propagation":         instance.EnableDefaultPropagation,
+			"enable_default_association":         instance.EnableDefaultAssociation,
+			"auto_accept_shared_attachments":     instance.AutoAcceptSharedAttachments,
+			"default_propagation_route_table_id": instance.DefaultPropagationRouteTableId,
+			"default_association_route_table_id": instance.DefaultAssociationRouteTableId,
+			"availability_zones":                 instance.AvailabilityZoneIds,
+		}
+	}
+	return result
+}
+
+func buildSliceIgnoreEmptyElement(e string) []string {
+	if e != "" {
+		return []string{e}
+	}
+	return nil
+}
+
+func buildInstanceListOpts(d *schema.ResourceData) instances.ListOpts {
+	return instances.ListOpts{
+		EnterpriseProjectIds: buildSliceIgnoreEmptyElement(d.Get("enterprise_project_id").(string)),
+		Statuses:             buildSliceIgnoreEmptyElement(d.Get("status").(string)),
+		IDs:                  buildSliceIgnoreEmptyElement(d.Get("instance_id").(string)),
+		OwnedBySelf:          d.Get("owned_by_self").(bool),
+		SortKey:              []string{"name"},
+	}
+}
+
+func dataSourceInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	resp, err := instances.List(client, buildInstanceListOpts(d))
+	if err != nil {
+		return diag.Errorf("error retrieving instances: %s", err)
+	}
+	if resp, err = filterInstances(d, resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenInstances(resp)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving instance data source fields: %s", mErr)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/instances/requests.go
@@ -1,0 +1,55 @@
+package instances
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the instance of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The enterprise project IDs of the instance to be queried.
+	EnterpriseProjectIds []string `q:"enterprise_project_id"`
+	// The status list of the instance to be queried.
+	Statuses []string `q:"state"`
+	// The instance IDs to be queried.
+	IDs []string `q:"id"`
+	// The resource IDs corresponding to the connection.
+	ResourceIds []string `q:"resource_id"`
+	// Whether resources belong to the current renant. If this parameter is set to true, only resources belonging to the
+	// current tenant are queried, excluding shared resources. If the value is false, the current tenant and resources
+	// shared with the tenant are queried.
+	OwnedBySelf bool `q:"owned_by_self"`
+	// The list of the destinations, support for querying multiple instances.
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the instances using given parameters.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Instance, error) {
+	url := rootURL(client)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := InstancePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractInstances(pages)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/instances/results.go
@@ -1,0 +1,98 @@
+package instances
+
+import (
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// Instance is the structure that represents the details of the ER instance.
+type Instance struct {
+	// The ID of the instance.
+	ID string `json:"id"`
+	// The name of the instance.
+	Name string `json:"name"`
+	// The destination of the instance.
+	Description string `json:"description"`
+	// The current status of the instance.
+	Status string `json:"state"`
+	// The key/value pairs to associate with the instance.
+	Tags []tags.ResourceTag `json:"tags"`
+	// The creation time of the instance.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the instance.
+	UpdatedAt string `json:"updated_at"`
+	// The ID of enterprise project to which the instance belongs.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// The project ID.
+	ProjectId string `json:"project_id"`
+	// The BGP AS number of the ER instance.
+	ASN int `json:"asn"`
+	// Whether to enable the propagation of the default route table.
+	EnableDefaultPropagation bool `json:"enable_default_propagation"`
+	// Whether to enable the association of the default route table.
+	EnableDefaultAssociation bool `json:"enable_default_association"`
+	// Whether to automatically accept the creation of shared attachment.
+	AutoAcceptSharedAttachments bool `json:"auto_accept_shared_attachments"`
+	// The ID of the default propagation route table.
+	DefaultPropagationRouteTableId string `json:"default_propagation_route_table_id"`
+	// The ID of the default association route table.
+	DefaultAssociationRouteTableId string `json:"default_association_route_table_id"`
+	// The availability zone list where the ER instance is located.
+	AvailabilityZoneIds []string `json:"availability_zone_ids"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains instance list, page
+// details and the request information.
+type listResp struct {
+	// The list of the instances.
+	Instances []Instance `json:"instances"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the instances in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// InstancePage represents the response pages of the List method.
+type InstancePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no instance.
+func (r InstancePage) IsEmpty() (bool, error) {
+	resp, err := extractInstances(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r InstancePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(InstancePage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractInstances is a method which to extract the response to an instance list.
+func extractInstances(r pagination.Page) ([]Instance, error) {
+	var s listResp
+	err := r.(InstancePage).Result.ExtractInto(&s)
+	return s.Instances, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/instances/urls.go
@@ -1,0 +1,7 @@
+package instances
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("enterprise-router/instances")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,6 +156,7 @@ github.com/chnsz/golangsdk/openstack/elb/v3/monitors
 github.com/chnsz/golangsdk/openstack/elb/v3/pools
 github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects
 github.com/chnsz/golangsdk/openstack/er/v3/associations
+github.com/chnsz/golangsdk/openstack/er/v3/instances
 github.com/chnsz/golangsdk/openstack/er/v3/propagations
 github.com/chnsz/golangsdk/openstack/er/v3/routes
 github.com/chnsz/golangsdk/openstack/er/v3/routetables


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new data source to filter ER instances.
The query parameters are as follows:
- instance_id
- name
- enterprise_project_id
- status
- owned_by_self
- tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new data source to filter ER instances.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccInstancesDataSource_basic
=== PAUSE TestAccInstancesDataSource_basic
=== CONT  TestAccInstancesDataSource_basic
--- PASS: TestAccInstancesDataSource_basic (53.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        53.485s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstancesDataSource_filterById'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstancesDataSource_filterById -timeout 360m -parallel 4
=== RUN   TestAccInstancesDataSource_filterById
=== PAUSE TestAccInstancesDataSource_filterById
=== CONT  TestAccInstancesDataSource_filterById
--- PASS: TestAccInstancesDataSource_filterById (53.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        53.835s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstancesDataSource_filterByStatus'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstancesDataSource_filterByStatus -timeout 360m -parallel 4
=== RUN   TestAccInstancesDataSource_filterByStatus
=== PAUSE TestAccInstancesDataSource_filterByStatus
=== CONT  TestAccInstancesDataSource_filterByStatus
--- PASS: TestAccInstancesDataSource_filterByStatus (54.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        54.915s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstancesDataSource_filterByEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstancesDataSource_filterByEpsId -timeout 360m -parallel 4
=== RUN   TestAccInstancesDataSource_filterByEpsId
=== PAUSE TestAccInstancesDataSource_filterByEpsId
=== CONT  TestAccInstancesDataSource_filterByEpsId
--- PASS: TestAccInstancesDataSource_filterByEpsId (49.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        49.665s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstancesDataSource_filterByTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstancesDataSource_filterByTags -timeout 360m -parallel 4
=== RUN   TestAccInstancesDataSource_filterByTags
=== PAUSE TestAccInstancesDataSource_filterByTags
=== CONT  TestAccInstancesDataSource_filterByTags
--- PASS: TestAccInstancesDataSource_filterByTags (49.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        49.871s
```
