### PR TITLE
feat: add bandwidth associate resource

### DIFF
--- a/docs/resources/vpc_bandwidth_associate.md
+++ b/docs/resources/vpc_bandwidth_associate.md
@@ -1,0 +1,115 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_vpc_bandwidth_associate
+
+Associates an EIP to a specified **shared** bandwidth.
+
+-> Yearly/monthly EIPs cannot be added to a shared bandwidth. After an EIP is removed from a shared bandwidth,
+  a dedicated bandwidth will be allocated to the EIP. By default, the dedicated bandwidth will be billed by bandwidth
+  and the size is 5 Mbit/s. You can configure the bandwidth as needed.
+
+## Example Usage
+
+### Associate an EIP
+
+```hcl
+variable "public_id" {}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  eip_id       = var.public_id
+}
+```
+
+### Associate multiple EIPs
+
+```hcl
+variable "multiple_eips" {
+  type = list(string)
+}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  count = length(var.multiple_eips)
+
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  eip_id       = var.multiple_eips[count.index]
+}
+```
+
+### Associate an EIP managed by Terraform
+
+```hcl
+resource "huaweicloud_vpc_eip" "dedicated" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "dedicated"
+    size        = 5
+    charge_mode = "traffic"
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "bandwidth_1"
+  size = 100
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  eip_id       = huaweicloud_vpc_eip.dedicated.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to associate the bandwidth. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `bandwidth_id` - (Required, String, ForceNew) Specifies the shared bandwidth ID to associate.
+  Changing this creates a new resource.
+
+* `eip_id` - (Required, String) Specifies the ID of the EIP that uses the bandwidth.
+
+* `bandwidth_charge_mode` - (Optional, String) Specifies the billing mode of the dedicated bandwidth used by the EIP that
+  has been removed from a shared bandwidth. The value can be **bandwidth** or **traffic**. If not specified, the dedicated
+  bandwidth will be billed by bandwidth.
+
+* `bandwidth_size` - (Optional, Int) Specifies the size (Mbit/s) of the dedicated bandwidth used by the EIP that
+  has been removed from a shared bandwidth. The default bandwidth size is 5 Mbit/s.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format of `<bandwidth_id>/<eip_id>`.
+* `public_ip` - The EIP address.
+* `bandwidth_name` - The shared bandwidth name.
+
+## Import
+
+Bandwidth associations can be imported using the `bandwidth_id` and `eip_id` separated by a slash, e.g.:
+
+```bash
+$ terraform import huaweicloud_vpc_bandwidth_associate.eip <bandwidth_id>/<eip_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1012,9 +1012,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_vod_transcoding_template_group": vod.ResourceTranscodingTemplateGroup(),
 			"huaweicloud_vod_watermark_template":         vod.ResourceWatermarkTemplate(),
 
-			"huaweicloud_vpc_bandwidth":     eip.ResourceVpcBandWidthV2(),
-			"huaweicloud_vpc_eip":           eip.ResourceVpcEIPV1(),
-			"huaweicloud_vpc_eip_associate": eip.ResourceEIPAssociate(),
+			"huaweicloud_vpc_bandwidth":           eip.ResourceVpcBandWidthV2(),
+			"huaweicloud_vpc_bandwidth_associate": eip.ResourceBandWidthAssociate(),
+			"huaweicloud_vpc_eip":                 eip.ResourceVpcEIPV1(),
+			"huaweicloud_vpc_eip_associate":       eip.ResourceEIPAssociate(),
 
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_associate_test.go
@@ -1,0 +1,210 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getBandwidthAssociateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.NetworkingV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating bandwidth client: %s", err)
+	}
+
+	bwID := state.Primary.Attributes["bandwidth_id"]
+	return bandwidths.Get(c, bwID).Extract()
+}
+
+func TestAccBandWidthAssociate_basic(t *testing.T) {
+	var bandwidth bandwidths.BandWidth
+
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc_bandwidth_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&bandwidth,
+		getBandwidthAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBandWidthAssociate_basic(randName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_name", randName),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "huaweicloud_vpc_eip.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "huaweicloud_vpc_eip.test.0", "address"),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_basic(randName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "huaweicloud_vpc_eip.test.1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "huaweicloud_vpc_eip.test.1", "address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBandWidthAssociate_migrate(t *testing.T) {
+	var bandwidth bandwidths.BandWidth
+
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_vpc_bandwidth_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&bandwidth,
+		getBandwidthAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBandWidthAssociate_migrate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_name", randName),
+					resource.TestCheckResourceAttrPair(resourceName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "huaweicloud_vpc_eip.source", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "huaweicloud_vpc_eip.source", "address"),
+				),
+			},
+			{
+				Config: testAccBandWidthAssociate_owner(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "huaweicloud_vpc_eip.test", "address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBandWidthAssociate_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  count = 2
+  name  = "%[1]s-${count.index}"
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s-${count.index}"
+    size        = 5
+    charge_mode = "traffic"
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+`, rName)
+}
+
+func testAccBandWidthAssociate_basic(rName string, index int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  eip_id       = huaweicloud_vpc_eip.test.%d.id
+}
+`, testAccBandWidthAssociate_base(rName), index)
+}
+
+func testAccBandWidthAssociate_migrate(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_vpc_bandwidth" "source" {
+  name = "%[1]s-source"
+  size = 5
+}
+
+resource "huaweicloud_vpc_eip" "source" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type = "WHOLE"
+    id         = huaweicloud_vpc_bandwidth.source.id
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  eip_id       = huaweicloud_vpc_eip.source.id
+}
+`, rName)
+}
+
+func testAccBandWidthAssociate_owner(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type = "WHOLE"
+    id         = huaweicloud_vpc_bandwidth.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [ bandwidth ]
+  }
+}
+
+resource "huaweicloud_vpc_bandwidth_associate" "test" {
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+  eip_id       = huaweicloud_vpc_eip.test.id
+}
+`, rName)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth_associate.go
@@ -1,0 +1,281 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	bandwidthsv1 "github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/chnsz/golangsdk/openstack/networking/v2/bandwidths"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+const (
+	DefaultBandWidthChargeMode = "bandwidth"
+	DefaultBandWidthSize       = 5
+)
+
+func ResourceBandWidthAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBandWidthAssociateCreate,
+		ReadContext:   resourceBandWidthAssociateRead,
+		UpdateContext: resourceBandWidthAssociateUpdate,
+		DeleteContext: resourceBandWidthAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceBandWidthAssociationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"eip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bandwidth_charge_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The charge mode after removal bandwidth.`,
+			},
+			"bandwidth_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The size (Mbits/s) after removal bandwidth.`,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bandwidth_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceBandWidthAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bwClient, err := cfg.NetworkingV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating bandwidth client: %s", err)
+	}
+	eipClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EIP client: %s", err)
+	}
+
+	bwID := d.Get("bandwidth_id").(string)
+	eipID := d.Get("eip_id").(string)
+
+	err = insertEIPsToBandwidth(d, bwClient, eipClient, bwID, eipID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceID := fmt.Sprintf("%s/%s", bwID, eipID)
+	d.SetId(resourceID)
+	return resourceBandWidthAssociateRead(ctx, d, meta)
+}
+
+func resourceBandWidthAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	eipClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating bandwidth v1 client: %s", err)
+	}
+
+	bwID := d.Get("bandwidth_id").(string)
+	eipID := d.Get("eip_id").(string)
+
+	b, err := bandwidthsv1.Get(eipClient, bwID).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "bandwidth associate")
+	}
+
+	var eipItem *bandwidthsv1.PublicIpinfo
+	allEIPs := b.PublicipInfo
+	for i := range allEIPs {
+		if allEIPs[i].PublicipId == eipID {
+			eipItem = &allEIPs[i]
+			break
+		}
+	}
+
+	if eipItem == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("bandwidth_id", b.ID),
+		d.Set("bandwidth_name", b.Name),
+		d.Set("eip_id", eipItem.PublicipId),
+		d.Set("public_ip", eipItem.PublicipAddress),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceBandWidthAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bwClient, err := cfg.NetworkingV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating bandwidth client: %s", err)
+	}
+	eipClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EIP client: %s", err)
+	}
+
+	if d.HasChange("eip_id") {
+		bwID := d.Get("bandwidth_id").(string)
+		oldVal, newVal := d.GetChange("eip_id")
+
+		err = removeEIPsFromBandwidth(d, bwClient, eipClient, bwID, oldVal.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		err = insertEIPsToBandwidth(d, bwClient, eipClient, bwID, newVal.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// update the resource ID
+		resourceID := fmt.Sprintf("%s/%s", bwID, newVal.(string))
+		d.SetId(resourceID)
+	}
+
+	return resourceBandWidthAssociateRead(ctx, d, meta)
+}
+
+func resourceBandWidthAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bwClient, err := cfg.NetworkingV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating bandwidth v2.0 client: %s", err)
+	}
+	eipClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EIP client: %s", err)
+	}
+
+	bwID := d.Get("bandwidth_id").(string)
+	eipID := d.Get("eip_id").(string)
+
+	err = removeEIPsFromBandwidth(d, bwClient, eipClient, bwID, eipID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func insertEIPsToBandwidth(d *schema.ResourceData, bwClient, eipClient *golangsdk.ServiceClient, bwID, eipID string) error {
+	publicIp, err := eips.Get(eipClient, eipID).Extract()
+	if err != nil {
+		return fmt.Errorf("error fetching EIP %s: %s", eipID, err)
+	}
+
+	if publicIp.BandwidthShareType == "WHOLE" {
+		// the EIP is already associated to the shared bandwidth, return with success.
+		if publicIp.BandwidthID == bwID {
+			log.Printf("[DEBUG] EIP %s is already associated to shared bandwidth %s", eipID, bwID)
+			return nil
+		}
+
+		// the EIP is associated to another shared bandwidth, we should remove it first.
+		if err := removeEIPsFromBandwidth(d, bwClient, eipClient, publicIp.BandwidthID, eipID); err != nil {
+			return err
+		}
+	}
+
+	publicipOpts := []bandwidths.PublicIpInfoID{
+		{
+			PublicIPID: eipID,
+		},
+	}
+	insertOpts := bandwidths.BandWidthInsertOpts{
+		PublicipInfo: publicipOpts,
+	}
+
+	log.Printf("[DEBUG] Add EIP %s to bandwidth %s", eipID, bwID)
+	if _, err := bandwidths.Insert(bwClient, bwID, insertOpts).Extract(); err != nil {
+		return fmt.Errorf("error inserting EIP %s into bandwidth %s: %s", eipID, bwID, err)
+	}
+	return nil
+}
+
+func removeEIPsFromBandwidth(d *schema.ResourceData, bwClient, eipClient *golangsdk.ServiceClient, bwID, eipID string) error {
+	if _, err := eips.Get(eipClient, eipID).Extract(); err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			log.Printf("[WARN] unnecessary to remove the non-existent EIP %s from bandwidth %s", eipID, bwID)
+			return nil
+		}
+		return fmt.Errorf("error fetching EIP %s: %s", eipID, err)
+	}
+
+	bwChargeMode := d.Get("bandwidth_charge_mode").(string)
+	if bwChargeMode == "" {
+		bwChargeMode = DefaultBandWidthChargeMode
+	}
+
+	bwSize := d.Get("bandwidth_size").(int)
+	if bwSize == 0 {
+		bwSize = DefaultBandWidthSize
+	}
+
+	removeOpts := bandwidths.BandWidthRemoveOpts{
+		ChargeMode: bwChargeMode,
+		Size:       &bwSize,
+		PublicipInfo: []bandwidths.PublicIpInfoID{
+			{
+				PublicIPID: eipID,
+			},
+		},
+	}
+
+	log.Printf("[DEBUG] Remove EIP %s from bandwidth %s", eipID, bwID)
+	err := bandwidths.Remove(bwClient, bwID, removeOpts).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error removing EIP %s from bandwidth %s: %s", eipID, bwID, err)
+	}
+
+	return nil
+}
+
+func resourceBandWidthAssociationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want '<bandwidth_id>/<eip_id>', but '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("bandwidth_id", parts[0]),
+		d.Set("eip_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
add new resource **huaweicloud_vpc_bandwidth_associate**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccBandWidthAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccBandWidthAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccBandWidthAssociate_basic
=== PAUSE TestAccBandWidthAssociate_basic
=== CONT  TestAccBandWidthAssociate_basic
--- PASS: TestAccBandWidthAssociate_basic (46.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       46.705s

$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccBandWidthAssociate_migrate"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccBandWidthAssociate_migrate -timeout 360m -parallel 4
=== RUN   TestAccBandWidthAssociate_migrate
=== PAUSE TestAccBandWidthAssociate_migrate
=== CONT  TestAccBandWidthAssociate_migrate
--- PASS: TestAccBandWidthAssociate_migrate (60.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       60.563s
```
