### PR TITLE
feat(er/route): add static route resource

### DIFF
--- a/docs/resources/er_static_route.md
+++ b/docs/resources/er_static_route.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_static_route
+
+Manages a static route under the ER route table within HuaweiCloud.
+
+## Example Usage
+
+### Create a static route and cross the VPC
+
+```hcl
+variable "route_table_id" {}
+variable "destination_vpc_cidr" {}
+variable "source_vpc_attachment_id" {}
+
+resource "huaweicloud_er_static_route" "test" {
+  route_table_id = var.route_table_id
+  destination    = var.destination_vpc_cidr
+  attachment_id  = var.source_vpc_attachment_id
+}
+```
+
+### Create a black hole route
+
+```hcl
+variable "route_table_id" {}
+variable "destination_vpc_cidr" {}
+
+resource "huaweicloud_er_static_route" "test" {
+  route_table_id = var.route_table_id
+  destination    = var.destination_vpc_cidr
+  is_blackhole   = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the static route and related route table are
+  located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `route_table_id` - (Required, String, ForceNew) Specifies the ID of the route table to which the static route
+  belongs.  
+  Changing this parameter will create a new resource.
+
+* `destination` - (Required, String, ForceNew) Specifies the destination of the static route.  
+  Changing this parameter will create a new resource.
+
+* `attachment_id` - (Optional, String) Specifies the ID of the corresponding attachment.
+
+* `is_blackhole` - (Optional, Bool) Specifies whether route is the black hole route, defaults to `false`.  
+  + If the value is empty or `false`, the parameter `attachment_id` is required.
+  + If the value is `true`, the parameter `attachment_id` must be empty.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `type` - The type of the static route.
+
+* `status` - The current status of the static route.
+
+* `created_at` - The creation time of the static route.
+
+* `updated_at` - The latest update time of the static route.
+
+## Import
+
+Static routes can be imported using the related `route_table_id` and their `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_er_static_route.test <route_table_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -817,6 +817,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_instance":       er.ResourceInstance(),
 			"huaweicloud_er_propagation":    er.ResourcePropagation(),
 			"huaweicloud_er_route_table":    er.ResourceRouteTable(),
+			"huaweicloud_er_static_route":   er.ResourceStaticRoute(),
 			"huaweicloud_er_vpc_attachment": er.ResourceVpcAttachment(),
 
 			"huaweicloud_evs_snapshot": ResourceEvsSnapshotV2(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go
@@ -1,0 +1,246 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/routes"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getStaticRouteFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	return routes.Get(client, state.Primary.Attributes["route_table_id"], state.Primary.ID)
+}
+
+func TestAccStaticRoute_basic(t *testing.T) {
+	var (
+		obj routes.Route
+
+		sourceSelfResName = "huaweicloud_er_static_route.source_self"
+		destSelfResName   = "huaweicloud_er_static_route.destination_self"
+		crossVpcResName   = "huaweicloud_er_static_route.cross_vpc"
+		name              = acceptance.RandomAccResourceName()
+		bgpAsNum          = acctest.RandIntRange(64512, 65534)
+
+		sourceSelfRes = acceptance.InitResourceCheck(sourceSelfResName, &obj, getStaticRouteFunc)
+		destSelfRes   = acceptance.InitResourceCheck(destSelfResName, &obj, getStaticRouteFunc)
+		crossVpcRes   = acceptance.InitResourceCheck(crossVpcResName, &obj, getStaticRouteFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      sourceSelfRes.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStaticRoute_basic_step1(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					sourceSelfRes.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(sourceSelfResName, "route_table_id",
+						"huaweicloud_er_route_table.source", "id"),
+					resource.TestCheckResourceAttrPair(sourceSelfResName, "destination",
+						"huaweicloud_vpc.source", "cidr"),
+					resource.TestCheckResourceAttrPair(sourceSelfResName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.source", "id"),
+					resource.TestCheckResourceAttrSet(sourceSelfResName, "type"),
+					resource.TestCheckResourceAttrSet(sourceSelfResName, "status"),
+					resource.TestCheckResourceAttrSet(sourceSelfResName, "created_at"),
+					resource.TestCheckResourceAttrSet(sourceSelfResName, "updated_at"),
+					destSelfRes.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(destSelfResName, "route_table_id",
+						"huaweicloud_er_route_table.destination", "id"),
+					resource.TestCheckResourceAttrPair(destSelfResName, "destination",
+						"huaweicloud_vpc.destination", "cidr"),
+					resource.TestCheckResourceAttrPair(destSelfResName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.destination", "id"),
+					crossVpcRes.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(crossVpcResName, "route_table_id",
+						"huaweicloud_er_route_table.source", "id"),
+					resource.TestCheckResourceAttrPair(crossVpcResName, "destination",
+						"huaweicloud_vpc.destination", "cidr"),
+					resource.TestCheckResourceAttrPair(crossVpcResName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.source", "id"),
+				),
+			},
+			{
+				Config: testAccStaticRoute_basic_step2(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					sourceSelfRes.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(sourceSelfResName, "attachment_id",
+						"huaweicloud_er_vpc_attachment.destination", "id"),
+					destSelfRes.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(destSelfResName, "destination",
+						"huaweicloud_vpc.source", "cidr"),
+					crossVpcRes.CheckResourceExists(),
+					resource.TestCheckResourceAttr(crossVpcResName, "is_blackhole", "true"),
+				),
+			},
+			{
+				ResourceName:      sourceSelfResName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccStaticRouteImportStateFunc(sourceSelfResName),
+			},
+			{
+				ResourceName:      destSelfResName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccStaticRouteImportStateFunc(destSelfResName),
+			},
+			{
+				ResourceName:      crossVpcResName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccStaticRouteImportStateFunc(crossVpcResName),
+			},
+		},
+	})
+}
+
+func testAccStaticRouteImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var routeTableId, staticRouteId string
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) of ER static route is not found in the tfstate", rsName)
+		}
+		routeTableId = rs.Primary.Attributes["route_table_id"]
+		staticRouteId = rs.Primary.ID
+		if routeTableId == "" || staticRouteId == "" {
+			return "", fmt.Errorf("the static route is not exist or related route table ID is missing")
+		}
+		return fmt.Sprintf("%s/%s", routeTableId, staticRouteId), nil
+	}
+}
+
+func testAccStaticRoute_base(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+variable "base_vpc_cidr" {
+  type    = string
+  default = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc" "source" {
+  name = "%[1]s_source"
+  cidr = cidrsubnet(var.base_vpc_cidr, 2, 1)
+}
+
+resource "huaweicloud_vpc" "destination" {
+  name = "%[1]s_destination"
+  cidr = cidrsubnet(var.base_vpc_cidr, 2, 2)
+}
+
+resource "huaweicloud_vpc_subnet" "source" {
+  vpc_id = huaweicloud_vpc.source.id
+
+  name       = "%[1]s_source"
+  cidr       = cidrsubnet(huaweicloud_vpc.source.cidr, 2, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.source.cidr, 2, 1), 1)
+}
+
+resource "huaweicloud_vpc_subnet" "destination" {
+  vpc_id = huaweicloud_vpc.destination.id
+
+  name       = "%[1]s_destination"
+  cidr       = cidrsubnet(huaweicloud_vpc.destination.cidr, 2, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.destination.cidr, 2, 1), 1)
+}
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  name               = "%[1]s"
+  asn                = %[2]d
+}
+
+resource "huaweicloud_er_route_table" "source" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[1]s_source"
+}
+
+resource "huaweicloud_er_route_table" "destination" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[1]s_destination"
+}
+
+resource "huaweicloud_er_vpc_attachment" "source" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.source.id
+  subnet_id   = huaweicloud_vpc_subnet.source.id
+  name        = "%[1]s_source"
+}
+
+resource "huaweicloud_er_vpc_attachment" "destination" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.destination.id
+  subnet_id   = huaweicloud_vpc_subnet.destination.id
+  name        = "%[1]s_destination"
+}
+`, name, bgpAsNum)
+}
+
+func testAccStaticRoute_basic_step1(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_static_route" "source_self" {
+  route_table_id = huaweicloud_er_route_table.source.id
+  destination    = huaweicloud_vpc.source.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.source.id
+}
+
+resource "huaweicloud_er_static_route" "destination_self" {
+  route_table_id = huaweicloud_er_route_table.destination.id
+  destination    = huaweicloud_vpc.destination.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.destination.id
+}
+
+resource "huaweicloud_er_static_route" "cross_vpc" {
+  route_table_id = huaweicloud_er_route_table.source.id
+  destination    = huaweicloud_vpc.destination.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.source.id
+}
+`, testAccStaticRoute_base(name, bgpAsNum))
+}
+
+func testAccStaticRoute_basic_step2(name string, bgpAsNum int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+// Update the VPC attachment ID.
+resource "huaweicloud_er_static_route" "source_self" {
+  route_table_id = huaweicloud_er_route_table.source.id
+  destination    = huaweicloud_vpc.source.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.destination.id
+}
+
+// Update the route destination CIDR.
+resource "huaweicloud_er_static_route" "destination_self" {
+  route_table_id = huaweicloud_er_route_table.destination.id
+  destination    = huaweicloud_vpc.source.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.destination.id
+}
+
+// Change the static route to the black hole route.
+resource "huaweicloud_er_static_route" "cross_vpc" {
+  route_table_id = huaweicloud_er_route_table.source.id
+  destination    = huaweicloud_vpc.destination.cidr
+  is_blackhole   = true
+}
+`, testAccStaticRoute_base(name, bgpAsNum))
+}

--- a/huaweicloud/services/er/resource_huaweicloud_er_static_route.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_static_route.go
@@ -1,0 +1,212 @@
+package er
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/routes"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceStaticRoute() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStaticRouteCreate,
+		UpdateContext: resourceStaticRouteUpdate,
+		ReadContext:   resourceStaticRouteRead,
+		DeleteContext: resourceStaticRouteDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceStaticRouteImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the static route and related route table are located.`,
+			},
+			"route_table_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the route table to which the static route belongs.`,
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The destination of the static route.`,
+			},
+			"attachment_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the corresponding attachment.`,
+			},
+			"is_blackhole": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `Whether route is the black hole route.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the static route.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the static route.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the static route.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the static route.`,
+			},
+		},
+	}
+}
+
+func buildStaticRouteCreateOpts(d *schema.ResourceData) routes.CreateOpts {
+	return routes.CreateOpts{
+		Destination:  d.Get("destination").(string),
+		AttachmentId: d.Get("attachment_id").(string),
+		IsBlackHole:  utils.Bool(d.Get("is_blackhole").(bool)),
+	}
+}
+
+func resourceStaticRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		routeTableId = d.Get("route_table_id").(string)
+		opts         = buildStaticRouteCreateOpts(d)
+	)
+	resp, err := routes.Create(client, routeTableId, opts)
+	if err != nil {
+		return diag.Errorf("error creating static route: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	return resourceStaticRouteRead(ctx, d, meta)
+}
+
+func resourceStaticRouteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		routeTableId  = d.Get("route_table_id").(string)
+		staticRouteId = d.Id()
+	)
+
+	resp, err := routes.Get(client, routeTableId, staticRouteId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "ER static route")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("destination", resp.Destination),
+		d.Set("is_blackhole", resp.IsBlackHole),
+		// Attributes
+		d.Set("type", resp.Type),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedAt),
+		d.Set("updated_at", resp.UpdatedAt),
+	)
+
+	if len(resp.Attachments) > 0 && resp.Attachments[0].AttachmentId != "" {
+		// If the static route is not a black hole route, set related VPC attachment ID.
+		mErr = multierror.Append(mErr, d.Set("attachment_id", resp.Attachments[0].AttachmentId))
+	} else {
+		// Override 'attachment_id' while static route is the black hole route.
+		mErr = multierror.Append(mErr, d.Set("attachment_id", nil))
+	}
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving static route (%s) fields: %s", staticRouteId, mErr)
+	}
+	return nil
+}
+
+func resourceStaticRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		routeTableId  = d.Get("route_table_id").(string)
+		staticRouteId = d.Id()
+		opts          = routes.UpdateOpts{
+			AttachmentId: d.Get("attachment_id").(string),
+			IsBlackHole:  utils.Bool(d.Get("is_blackhole").(bool)),
+		}
+	)
+	_, err = routes.Update(client, routeTableId, staticRouteId, opts)
+	if err != nil {
+		return diag.Errorf("error updating static route (%s): %s", staticRouteId, err)
+	}
+
+	return resourceStaticRouteRead(ctx, d, meta)
+}
+
+func resourceStaticRouteDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	var (
+		routeTableId  = d.Get("route_table_id").(string)
+		staticRouteId = d.Id()
+	)
+	err = routes.Delete(client, routeTableId, staticRouteId)
+	if err != nil {
+		return diag.Errorf("error deleting static route (%s): %s", staticRouteId, err)
+	}
+
+	return nil
+}
+
+func resourceStaticRouteImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid format for import ID, want '<route_table_id>/<id>', but got '%s'", d.Id())
+	}
+
+	d.SetId(parts[1])
+	if err := d.Set("route_table_id", parts[0]); err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New ER resource support:
- huaweicloud_er_static_route

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add static route resource.
2. support related test and document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccStaticRoute_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccStaticRoute_basic -timeout 360m -parallel 4
=== RUN   TestAccStaticRoute_basic
=== PAUSE TestAccStaticRoute_basic
=== CONT  TestAccStaticRoute_basic
--- PASS: TestAccStaticRoute_basic (117.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        117.086s
```
