### PR TITLE
chore(ecs): add check deleted for eip associate

### DIFF
--- a/docs/resources/compute_eip_associate.md
+++ b/docs/resources/compute_eip_associate.md
@@ -128,7 +128,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-This resource can be imported by specifying all three arguments, separated by a forward slash:
+This resource can be imported using the related `eip address` or `bandwidth_id`, `instance_id` and `fixed_ip`,
+separated by slashes, e.g.
 
 ```shell
 $ terraform import huaweicloud_compute_eip_associate.bind <eip address or bandwidth_id>/<instance_id>/<fixed_ip>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


```
run acceptance tests of huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_eip_associate_test.go:
=== RUN   TestAccComputeEIPAssociate_basic
=== PAUSE TestAccComputeEIPAssociate_basic
=== RUN   TestAccComputeEIPAssociate_fixedIP
=== PAUSE TestAccComputeEIPAssociate_fixedIP
=== RUN   TestAccComputeEIPAssociate_bandwidth
=== PAUSE TestAccComputeEIPAssociate_bandwidth
=== CONT  TestAccComputeEIPAssociate_basic
=== CONT  TestAccComputeEIPAssociate_bandwidth
=== CONT  TestAccComputeEIPAssociate_fixedIP
--- PASS: TestAccComputeEIPAssociate_fixedIP (158.81s)
--- PASS: TestAccComputeEIPAssociate_basic (165.91s)
--- PASS: TestAccComputeEIPAssociate_bandwidth (224.91s)
PASS
coverage: 40.0% of statements in ./huaweicloud/services/ecs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       224.966s        coverage: 40.0% of statements in ./huaweicloud/services/ecs
```

### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ecs/resource_huaweicloud_compute_eip_associate.go (79.1%)

### [summary] 0 failed in 1 resource acceptance tests
