### PR TITLE
feat(DCS): fix dcs instance resize

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -212,6 +212,13 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of an instance.
   It is a string that contains a maximum of 1024 characters.
 
+* `deleted_nodes` - (Optional, List) Specifies the ID of the replica to delete. This parameter is mandatory when
+  you delete replicas of a master/standby DCS Redis 4.0 or 5.0 instance. Currently, only one replica can be deleted
+  at a time.
+
+* `reserved_ips` - (Optional, List) Specifies IP addresses to retain. Mandatory during cluster scale-in. If this
+  parameter is not set, the system randomly deletes unnecessary shards.
+
 The `whitelists` block supports:
 
 * `group_name` - (Required, String) Specifies the name of IP address group.

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/openstack/dcs/v2/availablezones"
+	"github.com/chnsz/golangsdk/openstack/dcs/v2/flavors"
 	"github.com/chnsz/golangsdk/openstack/dcs/v2/instances"
 	dcsTags "github.com/chnsz/golangsdk/openstack/dcs/v2/tags"
 	"github.com/chnsz/golangsdk/openstack/dcs/v2/whitelists"
@@ -264,6 +265,17 @@ func ResourceDcsInstance() *schema.Resource {
 			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
 			"auto_pay":      common.SchemaAutoPay(nil),
 			"tags":          common.TagsSchema(),
+			"deleted_nodes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MaxItems: 1,
+			},
+			"reserved_ips": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"order_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -977,21 +989,18 @@ func resizeDcsInstance(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if d.HasChanges("flavor", "capacity") {
-		specCode := d.Get("flavor").(string)
-		opts := instances.ResizeInstanceOpts{
-			SpecCode:    specCode,
-			NewCapacity: d.Get("capacity").(float64),
+		oVal, nVal := d.GetChange("flavor")
+		oldSpecCode := oVal.(string)
+		newSpecCode := nVal.(string)
+		opts, err := buildResizeInstanceOpt(client, d, oldSpecCode, newSpecCode)
+		if err != nil {
+			return err
 		}
-		if d.Get("charging_mode").(string) == chargeModePrePaid {
-			opts.BssParam = instances.DcsBssParamOpts{
-				IsAutoPay: "true",
-			}
-		}
-		log.Printf("[DEBUG] Resize DCS instance options : %#v", opts)
+		log.Printf("[DEBUG] Resize DCS instance options : %#v", *opts)
 
 		var res *instances.ResizeResponse
 		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-			res, err = instances.ResizeInstance(client, d.Id(), opts)
+			res, err = instances.ResizeInstance(client, d.Id(), *opts)
 			isRetry, err := handleOperationError(err)
 			if isRetry {
 				return resource.RetryableError(err)
@@ -1031,10 +1040,84 @@ func resizeDcsInstance(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 		if instance.SpecCode != d.Get("flavor").(string) {
 			return fmt.Errorf("change flavor failed, after changed the DCS flavor still is: %s, expected: %s",
-				instance.SpecCode, specCode)
+				instance.SpecCode, newSpecCode)
 		}
 	}
 	return nil
+}
+
+func buildResizeInstanceOpt(client *golangsdk.ServiceClient, d *schema.ResourceData, oldSpecCode,
+	newSpecCode string) (*instances.ResizeInstanceOpts, error) {
+	opts := instances.ResizeInstanceOpts{
+		SpecCode:    newSpecCode,
+		NewCapacity: d.Get("capacity").(float64),
+	}
+	if d.Get("charging_mode").(string) == chargeModePrePaid {
+		opts.BssParam = instances.DcsBssParamOpts{
+			IsAutoPay: "true",
+		}
+	}
+	if oldSpecCode == newSpecCode {
+		return nil, fmt.Errorf("the param flavor is invalid")
+	}
+	oldFlavor, err := getFlavorBySpecCode(client, oldSpecCode)
+	if err != nil {
+		return nil, err
+	}
+	newFlavor, err := getFlavorBySpecCode(client, newSpecCode)
+	if err != nil {
+		return nil, err
+	}
+	changeType := getFlavorChangeType(oldFlavor, newFlavor)
+	opts.ChangeType = changeType
+	if changeType == "createReplication" {
+		azCodes, err := getAzCode(d, client)
+		if err != nil {
+			return nil, err
+		}
+		opts.AvailableZones = azCodes
+	}
+	if changeType == "deleteReplication" {
+		if newFlavor.CacheMode == "ha" {
+			opts.NodeList = utils.ExpandToStringList(d.Get("deleted_nodes").([]interface{}))
+		} else if newFlavor.CacheMode == "cluster" {
+			azCodes, err := getAzCode(d, client)
+			if err != nil {
+				return nil, err
+			}
+			opts.ReservedIp = utils.ExpandToStringList(d.Get("reserved_ips").([]interface{}))
+			opts.AvailableZones = azCodes
+		}
+	}
+	return &opts, nil
+}
+
+func getFlavorChangeType(oldFlavor, newFlavor *flavors.Flavor) string {
+	// if the cache mode is different, it indicates the type has been changed
+	if oldFlavor.CacheMode != newFlavor.CacheMode {
+		return "instanceType"
+	}
+	// indicates the replica count increase, should add replica
+	if oldFlavor.ReplicaCount < newFlavor.ReplicaCount {
+		return "createReplication"
+	}
+	// indicates the replica count decrease, should delete replica
+	if oldFlavor.ReplicaCount > newFlavor.ReplicaCount {
+		return "deleteReplication"
+	}
+	// indicates only the capacity been changed
+	return ""
+}
+
+func getFlavorBySpecCode(client *golangsdk.ServiceClient, specCode string) (*flavors.Flavor, error) {
+	list, err := flavors.List(client, &flavors.ListOpts{SpecCode: specCode}).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("error getting dcs flavors list by specCode %s: %s", specCode, err)
+	}
+	if len(list) < 1 {
+		return nil, fmt.Errorf("the result queried by specCode(%s) is empty", specCode)
+	}
+	return &list[0], nil
 }
 
 func handleOperationError(err error) (bool, error) {
@@ -1086,6 +1169,21 @@ func resourceDcsInstancesDelete(ctx context.Context, d *schema.ResourceData, met
 
 	d.SetId("")
 	return nil
+}
+
+func getAzCode(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]string, error) {
+	var azCodes []string
+	availabilityZones, ok := d.GetOk("availability_zones")
+	if ok {
+		azCodes = utils.ExpandToStringList(availabilityZones.([]interface{}))
+	} else {
+		availableZonesCodes, err := getAvailableZoneCodeByID(client, d.Get("available_zones").([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		azCodes = availableZonesCodes
+	}
+	return azCodes, nil
 }
 
 func getAvailableZoneCodeByID(client *golangsdk.ServiceClient, azIds []interface{}) ([]string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dcs instance resize
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dcs instance resize
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dcs' TESTARGS='-run TestAccDcsInstances_'  TEST_PARALLELISM=8
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs -v -run TestAccDcsInstances_ -timeout 360m -parallel 8
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_prePaid
    acceptance.go:413: This environment does not support prepaid tests
--- SKIP: TestAccDcsInstances_prePaid (0.00s)
=== CONT  TestAccDcsInstances_proxy_change_capacity
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_proxy_to_ha
--- PASS: TestAccDcsInstances_single (107.27s)
=== CONT  TestAccDcsInstances_rw_to_proxy
--- PASS: TestAccDcsInstances_tiny (125.98s)
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_whitelists (161.14s)
=== CONT  TestAccDcsInstances_withEpsId
--- PASS: TestAccDcsInstances_basic (186.96s)
=== CONT  TestAccDcsInstances_ha_to_proxy
--- PASS: TestAccDcsInstances_rw_expand_replica (195.47s)
=== CONT  TestAccDcsInstances_rw_change_capacity
--- PASS: TestAccDcsInstances_withEpsId (129.33s)
=== CONT  TestAccDcsInstances_cluster_change_capacity
--- PASS: TestAccDcsInstances_rw_change_capacity (234.34s)
=== CONT  TestAccDcsInstances_ha_expand_replica
--- PASS: TestAccDcsInstances_cluster_expand_replica (390.65s)
=== CONT  TestAccDcsInstances_ha_change_capacity
--- PASS: TestAccDcsInstances_proxy_to_rw (598.45s)
--- PASS: TestAccDcsInstances_ha_expand_replica (193.44s)
--- PASS: TestAccDcsInstances_ha_change_capacity (167.53s)
--- PASS: TestAccDcsInstances_proxy_to_ha (711.79s)
--- PASS: TestAccDcsInstances_ha_to_proxy (532.64s)
--- PASS: TestAccDcsInstances_rw_to_proxy (625.99s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1146.41s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (1806.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       1806.664s

make testacc TEST='./huaweicloud/services/acceptance/dcs' TESTARGS='-run TestAccDcsBackup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs -v -run TestAccDcsBackup_basic -timeout 360m -parallel 4
=== RUN   TestAccDcsBackup_basic
=== PAUSE TestAccDcsBackup_basic
=== CONT  TestAccDcsBackup_basic
--- PASS: TestAccDcsBackup_basic (153.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       153.377s
```
