### PR TITLE
feat(vpc/subnet): try to get the DNS list through API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230717014129-0944d0814e48
+	github.com/chnsz/golangsdk v0.0.0-20230717075741-0fe1967a69f6
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230717014129-0944d0814e48 h1:QMDTeYpoFOjIMj1+BJObx115/SbNzbNWvK8/rZeWGQY=
-github.com/chnsz/golangsdk v0.0.0-20230717014129-0944d0814e48/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230717075741-0fe1967a69f6 h1:NWJLqDv9QjHdKSSRrrFmYNK4XNCshI/J8Te0fqGoEM8=
+github.com/chnsz/golangsdk v0.0.0-20230717075741-0fe1967a69f6/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/resource_huaweicloud_iec_vpc_subnet.go
+++ b/huaweicloud/resource_huaweicloud_iec_vpc_subnet.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
@@ -191,7 +190,7 @@ func resourceIecSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.DhcpEnable = &dhcp
 	}
 	if d.HasChange("dns_list") {
-		dnsList := vpc.ResourceSubnetDNSListV1(d, "")
+		dnsList := utils.ExpandToStringList(d.Get("dns_list").([]interface{}))
 		updateOpts.DNSList = &dnsList
 	}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments/requests.go
@@ -14,11 +14,15 @@ type ListOpts struct {
 	PageNum int `q:"page_no"`
 	// Parameter name for exact matching.
 	PreciseSearch string `q:"precise_search"`
+	// Limit number of records displayed on each page. The default value is 20.
+	Limit int `q:"limit"`
+	// Offset Page number. The default value is 1.
+	Offset int `q:"offset"`
 }
 
 // List is a method to obtain an array of one or more environments according to the query parameters.
 // Note: The list returned by the function only contains the environment of the first page. This is because the return
-//       body does not contain page number information, so the page number of the next page cannot be obtained.
+// body does not contain page number information, so the page number of the next page cannot be obtained.
 func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Environment, error) {
 	url := rootURL(c)
 	query, err := golangsdk.BuildQueryString(opts)
@@ -37,4 +41,64 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Environment, error) {
 	var s []Environment
 	err = pages.(EnvironmentPage).Result.ExtractIntoSlicePtr(&s, "envs")
 	return s, err
+}
+
+// CreateOpts allows to create a new APIG environment using given parameters
+type CreateOpts struct {
+	// Environment name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// Description of the environment, which can contain a maximum of 255 characters,
+	// and the angle brackets (< and >) are not allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new APIG shared environment using given parameters.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*Environment, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Environment
+	_, err = c.Post(rootURL(c), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// UpdateOpts allows to update an existing APIG environment using given parameters
+type UpdateOpts struct {
+	// Name of the APIG shared environment.
+	Name string `json:"name" required:"true"`
+	// Description of the APIG shared environment.
+	Description *string `json:"remark,omitempty"`
+}
+
+// Update is a method to update a APIG shared environment using given parameters.
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (*Environment, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Environment
+	_, err = c.Put(environmentURL(c, id), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Delete is a method to delete an existing APIG shared environment.
+func Delete(c *golangsdk.ServiceClient, id string) error {
+	_, err := c.Delete(environmentURL(c, id), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments/results.go
@@ -1,6 +1,8 @@
 package environments
 
-import "github.com/chnsz/golangsdk/pagination"
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
 
 type ListResp struct {
 	// Number of environments that match the query conditions.
@@ -9,6 +11,11 @@ type ListResp struct {
 	Size int `json:"size"`
 	// Environment list.
 	Environments []Environment `json:"envs"`
+}
+
+// EnvironmentPage represents the response pages of the List method.
+type EnvironmentPage struct {
+	pagination.SinglePageBase
 }
 
 type Environment struct {
@@ -20,9 +27,4 @@ type Environment struct {
 	CreateTime string `json:"create_time"`
 	// Description of the environment.
 	Description string `json:"remark"`
-}
-
-// EnvironmentPage represents the response pages of the List method.
-type EnvironmentPage struct {
-	pagination.SinglePageBase
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/shared/v1/environments/urls.go
@@ -5,3 +5,7 @@ import "github.com/chnsz/golangsdk"
 func rootURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("envs")
 }
+
+func environmentURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("envs", id)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/nameservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/nameservers/requests.go
@@ -1,0 +1,40 @@
+package nameservers
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+type ListOpts struct {
+	// Type of the name server. Value options:
+	// public: indicates a public name server.
+	// private: indicates a private name server.
+	// It is left blank by default.
+	Type string `q:"type"`
+	// Region ID. When you query a public name server, leave this parameter blank.
+	// Exact matching will work. It is left blank by default.
+	Region string `q:"region"`
+}
+
+// ToNameServersQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToNameServersQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List implements a nameserver List request.
+func List(client *golangsdk.ServiceClient, opts *ListOpts) ([]NameServer, error) {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToNameServersQuery()
+		if err != nil {
+			return nil, err
+		}
+		url += query
+	}
+
+	var s struct {
+		NameServers []NameServer `json:"nameservers"`
+	}
+	_, err := client.Get(url, &s, nil)
+	return s.NameServers, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/nameservers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/nameservers/results.go
@@ -1,0 +1,24 @@
+package nameservers
+
+// Zone represents a DNS zone.
+type NameServer struct {
+	// Type of the name server.Value options:
+	// public: indicates a public name server.
+	// private: indicates a private name server.
+	Type string `json:"type"`
+
+	// Region ID. When you query a public name server, leave this parameter blank.
+	Region string `json:"region"`
+
+	// Array of name server record objects
+	Records []Record `json:"ns_records"`
+}
+
+type Record struct {
+	// Host name. This parameter is left blank when a private name server is used.
+	HostName string `json:"hostname"`
+	// Address of the name server. When the server is a public name server, this parameter is left blank.
+	Address string `json:"address"`
+	// the priority. If the value of priority is 1, the DNS server is the first one to resolve domain names.
+	Priority int `json:"priority"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/nameservers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/nameservers/urls.go
@@ -1,0 +1,7 @@
+package nameservers
+
+import "github.com/chnsz/golangsdk"
+
+func baseURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("nameservers")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230717014129-0944d0814e48
+# github.com/chnsz/golangsdk v0.0.0-20230717075741-0fe1967a69f6
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -126,6 +126,7 @@ github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics
 github.com/chnsz/golangsdk/openstack/dms/v2/maintainwindows
 github.com/chnsz/golangsdk/openstack/dms/v2/products
 github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances
+github.com/chnsz/golangsdk/openstack/dns/v2/nameservers
 github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords
 github.com/chnsz/golangsdk/openstack/dns/v2/recordsets
 github.com/chnsz/golangsdk/openstack/dns/v2/zones


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

buildSubnetDNSList is used to obtain the DNS list according to the region in the following orders:
1. return the dns_list if it was specified;
2. return nil if primary_dns was specified, otherwise continue;
3. return the private DNS list if the region is in **privateDNSList**
4. try to get the private DNS list through API https://support.huaweicloud.com/intl/en-us/api-dns/dns_api_69001.html
5. return the public DNS if any error occurs;

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcSubnetV1_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_basic (77.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       77.380s
```
