### PR TITLE
feat(vpn): support some new parameters

### DIFF
--- a/docs/resources/vpn_gateway.md
+++ b/docs/resources/vpn_gateway.md
@@ -66,6 +66,25 @@ resource "huaweicloud_vpn_gateway" "test" {
 }
 ```
 
+### Creating a private VPN gateway with Enterprise Router
+
+```hcl
+variable "name" {}
+variable "er_id" {}
+variable "access_vpc_id" {}
+variable "access_subnet_id" {}
+
+resource "huaweicloud_vpn_gateway" "test" {
+  name               = var.name
+  network_type       = "private"
+  attachment_type    = "er"
+  er_id              = var.er_id
+  availability_zones = ["cn-north-4a", "cn-north-4b"]
+  access_vpc_id      = var.access_vpc_id
+  access_subnet_id   = var.access_subnet_id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -75,37 +94,62 @@ The following arguments are supported:
 
 * `name` - (Required, String) The name of the VPN gateway. Only letters, digits, underscores(_) and hypens(-) are supported.
 
-* `vpc_id` - (Required, String, ForceNew) The ID of the VPC to which the VPN gateway is connected.
-
-  Changing this parameter will create a new resource.
-
-* `local_subnets` - (Required, List) The list of local subnets.
-
-* `connect_subnet` - (Required, String, ForceNew) The Network ID of the VPC subnet used by the VPN gateway.
-
-  Changing this parameter will create a new resource.
-
 * `availability_zones` - (Required, List, ForceNew) The list of availability zone IDs.
-
-  Changing this parameter will create a new resource.
-
-* `master_eip` - (Required, List, ForceNew) The master EIP configurations.
-  The [object](#Gateway_CreateRequestEip) structure is documented below.
-
-  Changing this parameter will create a new resource.
-
-* `slave_eip` - (Required, List, ForceNew) The slave EIP configurations.
-  The [object](#Gateway_CreateRequestEip) structure is documented below.
-
-  Changing this parameter will create a new resource.
-
-* `attachment_type` - (Optional, String, ForceNew) The attachment type. The value can be **vpc**.
-  Defaults to **vpc**
 
   Changing this parameter will create a new resource.
 
 * `flavor` - (Optional, String, ForceNew) The flavor of the VPN gateway.
   The value can be **Basic**, **Professional1** and **Professional2**. Defaults to **Professional1**.
+
+  Changing this parameter will create a new resource.
+
+* `attachment_type` - (Optional, String, ForceNew) The attachment type. The value can be **vpc** and **er**.
+  Defaults to **vpc**.
+
+  Changing this parameter will create a new resource.
+
+* `network_type` - (Optional, String, ForceNew) The network type. The value can be **public** and **private**.
+  Defaults to **public**.
+
+  Changing this parameter will create a new resource.
+
+* `vpc_id` - (Optional, String, ForceNew) The ID of the VPC to which the VPN gateway is connected.
+  This parameter is mandatory when `attachment_type` is **vpc**.
+
+  Changing this parameter will create a new resource.
+
+* `local_subnets` - (Optional, List) The list of local subnets.
+  This parameter is mandatory when `attachment_type` is **vpc**.
+
+* `connect_subnet` - (Optional, String, ForceNew) The Network ID of the VPC subnet used by the VPN gateway.
+  This parameter is mandatory when `attachment_type` is **vpc**.
+
+  Changing this parameter will create a new resource.
+
+* `er_id` - (Optional, String, ForceNew) The enterprise router ID to attach with to VPN gateway.
+  This parameter is mandatory when `attachment_type` is **er**.
+
+  Changing this parameter will create a new resource.
+
+* `master_eip` - (Optional, List, ForceNew) The master EIP configurations.
+  This parameter is mandatory when `network_type` is **public** or left empty.
+  The [object](#Gateway_CreateRequestEip) structure is documented below.
+
+  Changing this parameter will create a new resource.
+
+* `slave_eip` - (Optional, List, ForceNew) The slave EIP configurations.
+  This parameter is mandatory when `network_type` is **public** or left empty.
+  The [object](#Gateway_CreateRequestEip) structure is documented below.
+
+  Changing this parameter will create a new resource.
+
+* `access_vpc_id` - (Optional, String, ForceNew) The access VPC ID.
+  The defaul value is the value of `vpc_id`.
+
+  Changing this parameter will create a new resource.
+
+* `access_subnet_id` - (Optional, String, ForceNew) The access subnet ID.
+  The defaul value is the value of `connect_subnet`.
 
   Changing this parameter will create a new resource.
 
@@ -133,8 +177,9 @@ The `master_eip` or `slave_eip` block supports:
 
   Changing this parameter will create a new resource.
 
-* `bandwidth_size` - (Optional, Int, ForceNew) Bandwidth size in Mbit/s. When the `flavor` is **V300**, the value
-  cannot be greater than **300**. When the `flavor` is **V1G**, the value cannot be greater than **1024**.
+* `bandwidth_size` - (Optional, Int, ForceNew) Bandwidth size in Mbit/s. When the `flavor` is **Basic**, the value
+  cannot be greater than **100**. When the `flavor` is **Professional1**, the value cannot be greater than **300**.
+  When the `flavor` is **Professional2**, the value cannot be greater than **1000**.
 
   Changing this parameter will create a new resource.
 
@@ -180,14 +225,14 @@ The `master_eip` or `slave_eip` block supports:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `update` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 
 The gateway can be imported using the `id`, e.g.
 
-```
+```bash
 $ terraform import huaweicloud_vpn_gateway.test 0ce123456a00f2591fabc00385ff1234
 ```

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_gateway.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_gateway.go
@@ -58,54 +58,12 @@ func ResourceGateway() *schema.Resource {
 					validation.StringLenBetween(1, 64),
 				),
 			},
-			"vpc_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The ID of the VPC to which the VPN gateway is connected.`,
-			},
-			"local_subnets": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    true,
-				Description: `The local subnets.`,
-			},
-			"connect_subnet": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The Network ID of the VPC subnet used by the VPN gateway.`,
-			},
 			"availability_zones": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Required:    true,
 				ForceNew:    true,
 				Description: `The availability zone IDs.`,
-			},
-			"master_eip": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Elem:     GatewayEipSchema(),
-				Required: true,
-				ForceNew: true,
-			},
-			"slave_eip": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Elem:     GatewayEipSchema(),
-				Required: true,
-				ForceNew: true,
-			},
-			"attachment_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "vpc",
-				ForceNew:    true,
-				Description: `The attachment type.`,
-				ValidateFunc: validation.StringInSlice([]string{
-					"vpc",
-				}, false),
 			},
 			"flavor": {
 				Type:        schema.TypeString,
@@ -116,6 +74,81 @@ func ResourceGateway() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"V1G", "V300", "Basic", "Professional1", "Professional2",
 				}, false),
+			},
+			"attachment_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "vpc",
+				ForceNew:    true,
+				Description: `The attachment type.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"vpc", "er",
+				}, false),
+			},
+			"network_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The network type of the VPN gateway.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The ID of the VPC to which the VPN gateway is connected.`,
+			},
+			"local_subnets": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				Description: `The local subnets.`,
+			},
+			"connect_subnet": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The Network ID of the VPC subnet used by the VPN gateway.`,
+			},
+			"er_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The enterprise router ID to attach with to VPN gateway.`,
+			},
+			"master_eip": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     GatewayEipSchema(),
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"slave_eip": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Elem:     GatewayEipSchema(),
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"access_vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The access VPC ID of the VPN gateway.`,
+			},
+			"access_subnet_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The access subnet ID of the VPN gateway.`,
 			},
 			"asn": {
 				Type:        schema.TypeInt,
@@ -303,6 +336,10 @@ func buildCreateGatewayVpnGatewayChildBody(d *schema.ResourceData, config *confi
 		"vpc_id":                utils.ValueIngoreEmpty(d.Get("vpc_id")),
 		"master_eip":            buildCreateGatewayMasterEipChildBody(d),
 		"slave_eip":             buildCreateGatewaySlaveEipChildBody(d),
+		"access_vpc_id":         utils.ValueIngoreEmpty(d.Get("access_vpc_id")),
+		"access_subnet_id":      utils.ValueIngoreEmpty(d.Get("access_subnet_id")),
+		"er_id":                 utils.ValueIngoreEmpty(d.Get("er_id")),
+		"network_type":          utils.ValueIngoreEmpty(d.Get("network_type")),
 	}
 	return params
 }
@@ -467,6 +504,10 @@ func resourceGatewayRead(ctx context.Context, d *schema.ResourceData, meta inter
 		d.Set("used_connection_group", utils.PathSearch("vpn_gateway.used_connection_group", getGatewayRespBody, nil)),
 		d.Set("used_connection_number", utils.PathSearch("vpn_gateway.used_connection_number", getGatewayRespBody, nil)),
 		d.Set("vpc_id", utils.PathSearch("vpn_gateway.vpc_id", getGatewayRespBody, nil)),
+		d.Set("access_vpc_id", utils.PathSearch("vpn_gateway.access_vpc_id", getGatewayRespBody, nil)),
+		d.Set("access_subnet_id", utils.PathSearch("vpn_gateway.access_subnet_id", getGatewayRespBody, nil)),
+		d.Set("er_id", utils.PathSearch("vpn_gateway.er_id", getGatewayRespBody, nil)),
+		d.Set("network_type", utils.PathSearch("vpn_gateway.network_type", getGatewayRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -232,7 +232,9 @@ func RemoveNil(data map[string]interface{}) map[string]interface{} {
 
 		switch v := v.(type) {
 		case map[string]interface{}:
-			withoutNil[k] = RemoveNil(v)
+			if len(v) > 0 {
+				withoutNil[k] = RemoveNil(v)
+			}
 		case []map[string]interface{}:
 			rv := make([]map[string]interface{}, 0, len(v))
 			for _, vv := range v {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new parameters network_type, er_id, access_vpc_id and access_subnet_id
2. support er in attachment_type
3. add a little improvement in RemoveNil func
4. update the doc and test cases
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpn' TESTARGS='-run TestAccGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccGateway_basic
=== PAUSE TestAccGateway_basic
=== CONT  TestAccGateway_basic
--- PASS: TestAccGateway_basic (173.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       173.810s

make testacc TEST='./huaweicloud/services/acceptance/vpn' TESTARGS='-run TestAccGateway_withER'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccGateway_withER -timeout 360m -parallel 4
=== RUN   TestAccGateway_withER
=== PAUSE TestAccGateway_withER
=== CONT  TestAccGateway_withER
--- PASS: TestAccGateway_withER (251.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       251.905s
```
