### PR TITLE
fix(RDS): fix rds test

### DIFF
--- a/huaweicloud/services/rds/common.go
+++ b/huaweicloud/services/rds/common.go
@@ -31,6 +31,7 @@ func handleMultiOperationsError(err error) (bool, error) {
 			"DBS.200047": struct{}{},
 			"DBS.200080": struct{}{},
 			"DBS.201206": struct{}{},
+			"DBS.212033": struct{}{},
 			"DBS.280011": struct{}{},
 			"DBS.280816": struct{}{},
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccRdsInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccRdsInstance_ -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_withEpsId
--- PASS: TestAccRdsInstance_withEpsId (561.15s)
=== CONT  TestAccRdsInstance_withParameters
--- PASS: TestAccRdsInstance_ha (605.66s)
=== CONT  TestAccRdsInstance_prePaid
    acceptance.go:421: This environment does not support prepaid tests
--- SKIP: TestAccRdsInstance_prePaid (0.01s)
=== CONT  TestAccRdsInstance_mysql
--- PASS: TestAccRdsInstance_basic (677.04s)
--- PASS: TestAccRdsInstance_sqlserver (804.32s)
--- PASS: TestAccRdsInstance_withParameters (1389.33s)
--- PASS: TestAccRdsInstance_mysql (1397.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2002.938s
```
