### PR TITLE
fix(vpc/secgroup): update the error message for creating security group rule

### DIFF
--- a/huaweicloud/resource_huaweicloud_networking_secgroup_rule.go
+++ b/huaweicloud/resource_huaweicloud_networking_secgroup_rule.go
@@ -194,7 +194,8 @@ func resourceNetworkingSecGroupRuleCreateV1(ctx context.Context, d *schema.Resou
 func resourceNetworkingSecGroupRuleCreateV3(ctx context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
-	v3Client, err := config.NetworkingV3Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	v3Client, err := config.NetworkingV3Client(region)
 	if err != nil {
 		return fmtp.DiagErrorf("Error creating HuaweiCloud networking v3 client: %s", err)
 	}
@@ -217,8 +218,9 @@ func resourceNetworkingSecGroupRuleCreateV3(ctx context.Context, d *schema.Resou
 	resp, err := v3Rules.Create(v3Client, opt)
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			return fmtp.DiagErrorf("The current region does not support creating security group rules through the "+
-				"ver.3 API: %#v", err)
+			return fmtp.DiagErrorf("these parameters (%v) are not support in current region (%s), please stop using "+
+				"and re-run the script. However, the 'ports' parameter can be replaced by parameter 'port_range_min' "+
+				"and parameter 'port_range_max'", utils.MarshalValue(advancedParams), region)
 		}
 		return fmtp.DiagErrorf("Error creating Security Group rule: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Ver.3 APIs are not yet supported in some regions, and we don't have a clear explanation of what users should do if this error occurs.
What we did: tell users which ver.3 parameters they were using and suggest removing them.

For example, in the `ap-southeast-1`, the APIs just support the ver.2 functions, we will return the follow message: 
```
these parameters (["ports","remote_address_group_id","action","priority"]) are not support in current region (ap-southeast-1), please stop using and re-run the script
```

If we need to test this function in the specified region, we can using these test codes:
```
func TestAccNetworkingSecGroupRule_unsupportRegion(t *testing.T) {
	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))

	resource.ParallelTest(t, resource.TestCase{
		PreCheck:     func() { testAccPreCheck(t) },
		Providers:    testAccProviders,
		CheckDestroy: testAccCheckNetworkingSecGroupRuleDestroy,
		Steps: []resource.TestStep{
			{
				Config: testAccNetworkingSecGroupRule_unsupportRegion_step1(name),
				ExpectError: regexp.MustCompile(fmt.Sprintf("the current region (%s) does not support creating security group rules through "+
					"the ver.3 API, please stop using these parameters (%v) and re-run the script to create security "+
					"group rules using the ver.2 API", HW_REGION_NAME, utils.MarshalValue(advancedParams))),
			},
			{
				Config: testAccNetworkingSecGroupRule_unsupportRegion_step2(name),
				ExpectError: regexp.MustCompile(fmt.Sprintf("the current region (%s) does not support creating security group rules through "+
					"the ver.3 API, please stop using these parameters (%v) and re-run the script to create security "+
					"group rules using the ver.2 API", HW_REGION_NAME, utils.MarshalValue(advancedParams))),
			},
			{
				Config: testAccNetworkingSecGroupRule_unsupportRegion_step3(name),
				ExpectError: regexp.MustCompile(fmt.Sprintf("the current region (%s) does not support creating security group rules through "+
					"the ver.3 API, please stop using these parameters (%v) and re-run the script to create security "+
					"group rules using the ver.2 API", HW_REGION_NAME, utils.MarshalValue(advancedParams))),
			},
			{
				Config: testAccNetworkingSecGroupRule_unsupportRegion_step4(name),
				ExpectError: regexp.MustCompile(fmt.Sprintf("the current region (%s) does not support creating security group rules through "+
					"the ver.3 API, please stop using these parameters (%v) and re-run the script to create security "+
					"group rules using the ver.2 API", HW_REGION_NAME, utils.MarshalValue(advancedParams))),
			},
		},
	})
}

func testAccNetworkingSecGroupRule_unsupportRegion_step1(name string) string {
	return fmt.Sprintf(`
%[1]s

resource "huaweicloud_networking_secgroup_rule" "test" {
  security_group_id = huaweicloud_networking_secgroup.secgroup_test.id
  direction         = "ingress"
  ethertype         = "IPv4"
  protocol          = "tcp"
  ports             = "80" // unsupport parameter for ver.2 API
  remote_ip_prefix  = "0.0.0.0/0"
}
`, testAccNetworkingSecGroupRule_base(name))
}

func testAccNetworkingSecGroupRule_unsupportRegion_step2(name string) string {
	return fmt.Sprintf(`
%[1]s

resource "huaweicloud_networking_secgroup_rule" "test" {
  security_group_id = huaweicloud_networking_secgroup.secgroup_test.id
  direction         = "ingress"
  ethertype         = "IPv4"
  protocol          = "tcp"
  port_range_min    = "80"
  port_range_max    = "80"
  priority          = 50 // unsupport parameter for ver.2 API
  remote_ip_prefix  = "0.0.0.0/0"
}
`, testAccNetworkingSecGroupRule_base(name))
}

func testAccNetworkingSecGroupRule_unsupportRegion_step3(name string) string {
	return fmt.Sprintf(`
%[1]s

resource "huaweicloud_networking_secgroup_rule" "test" {
  security_group_id = huaweicloud_networking_secgroup.secgroup_test.id
  direction         = "ingress"
  ethertype         = "IPv4"
  protocol          = "tcp"
  port_range_min    = "80"
  port_range_max    = "80"
  action            = "deny" // unsupport parameter for ver.2 API
  remote_ip_prefix  = "0.0.0.0/0"
}
`, testAccNetworkingSecGroupRule_base(name))
}

func testAccNetworkingSecGroupRule_unsupportRegion_step4(name string) string {
	return fmt.Sprintf(`
%[1]s

resource "huaweicloud_vpc_address_group" "test" {
  name = "%[2]s"
  
  addresses = [
    "192.168.10.12",
    "192.168.11.0-192.168.11.240",
  ]
}

resource "huaweicloud_networking_secgroup_rule" "test" {
  security_group_id       = huaweicloud_networking_secgroup.secgroup_test.id
  direction               = "ingress"
  ethertype               = "IPv4"
  protocol                = "tcp"
  port_range_min          = "80"
  port_range_max          = "80"
  remote_address_group_id = huaweicloud_vpc_address_group.test.id // unsupport parameter for ver.2 API
}
`, testAccNetworkingSecGroupRule_base(name), name)
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the error message for creating security group rule
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
