### PR TITLE
fix(RAM): support update principals and resource_urns

### DIFF
--- a/docs/resources/ram_resource_share.md
+++ b/docs/resources/ram_resource_share.md
@@ -37,27 +37,26 @@ The following arguments are supported:
 
 * `name` - (Required, String) Specifies the name of the resource share.
 
-* `principals` - (Required, List, ForceNew) Specifies the list of one or more principals associated with the resource
-  share. The principals could be account IDs and organization IDs. You can put account IDs and organization IDs to this
+* `principals` - (Required, List) Specifies one or more principals associated with the resource share.
+  The principals could be account IDs and organization IDs. You can put account IDs and organization IDs to this
   field together.
   + If set to account IDs, please make sure the account ID is not your owner account ID.
   + If set to organization IDs, you first need to use the RAM console to enable sharing with Organizations. Please refer
   to the [document](https://support.huaweicloud.com/intl/en-us/qs-ram/ram_02_0004.html).
 
-  Changing this parameter will create a new resource.
-
-* `resource_urns` - (Required, List, ForceNew) Specifies the list of URNs of one or more resources associated with the
+* `resource_urns` - (Required, List) Specifies one or more resources urns associated with the
   resource share. The format of URN is: `<service-name>:<region>:<account-id>:<type-name>:<resource-path>`.
   Sharable cloud services and resource types refer to
   [document](https://support.huaweicloud.com/intl/en-us/productdesc-ram/ram_01_0007.html).
 
-  Changing this parameter will create a new resource.
-
-* `permission_ids` - (Optional, List, ForceNew) Specifies the list of RAM permissions associated with the resource
+* `permission_ids` - (Optional, List) Specifies the list of RAM permissions associated with the resource
   share. A resource type can be associated with only one RAM permission. If you do not specify a permission ID,
   RAM automatically associates the default permission for each resource type.
+  
+  You can find permission IDs through data source `huaweicloud_ram_resource_permissions`.
 
-  Changing this parameter will create a new resource.
+  -> The field `permission_ids` does not support updating due to RAM API limitations. You can specify this field when
+  creating a resource, and nothing will happen when you change this field after apply.
 
 * `description` - (Optional, String) Specifies the description of the resource share.
 
@@ -97,4 +96,22 @@ The ram share can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_ram_resource_share.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `permission_ids`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_ram_resource_share" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      permission_ids,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -57,8 +57,10 @@ var (
 	HW_HIGH_COST_ALLOW      = os.Getenv("HW_HIGH_COST_ALLOW")
 	HW_SWR_SHARING_ACCOUNT  = os.Getenv("HW_SWR_SHARING_ACCOUNT")
 
-	HW_RAM_SHARE_ACCOUNT_ID   = os.Getenv("HW_RAM_SHARE_ACCOUNT_ID")
-	HW_RAM_SHARE_RESOURCE_URN = os.Getenv("HW_RAM_SHARE_RESOURCE_URN")
+	HW_RAM_SHARE_ACCOUNT_ID          = os.Getenv("HW_RAM_SHARE_ACCOUNT_ID")
+	HW_RAM_SHARE_RESOURCE_URN        = os.Getenv("HW_RAM_SHARE_RESOURCE_URN")
+	HW_RAM_SHARE_UPDATE_ACCOUNT_ID   = os.Getenv("HW_RAM_SHARE_UPDATE_ACCOUNT_ID")
+	HW_RAM_SHARE_UPDATE_RESOURCE_URN = os.Getenv("HW_RAM_SHARE_UPDATE_RESOURCE_URN")
 
 	HW_CERTIFICATE_KEY_PATH         = os.Getenv("HW_CERTIFICATE_KEY_PATH")
 	HW_CERTIFICATE_CHAIN_PATH       = os.Getenv("HW_CERTIFICATE_CHAIN_PATH")
@@ -451,8 +453,13 @@ func TestAccPreCheckSWRDomian(t *testing.T) {
 // lintignore:AT003
 func TestAccPreCheckRAM(t *testing.T) {
 	if HW_RAM_SHARE_ACCOUNT_ID == "" || HW_RAM_SHARE_RESOURCE_URN == "" {
-		t.Skip("HW_RAM_SHARE_ACCOUNT_ID and HW_RAM_SHARE_RESOURCE_URN must be set for ram tests, " +
-			"the value of HW_RAM_SHARE_ACCOUNT_ID should be another account id")
+		t.Skip("HW_RAM_SHARE_ACCOUNT_ID and HW_RAM_SHARE_RESOURCE_URN " +
+			"must be set for create ram resource tests.")
+	}
+
+	if HW_RAM_SHARE_UPDATE_ACCOUNT_ID == "" || HW_RAM_SHARE_UPDATE_RESOURCE_URN == "" {
+		t.Skip("HW_RAM_SHARE_UPDATE_ACCOUNT_ID and HW_RAM_SHARE_UPDATE_RESOURCE_URN" +
+			" must be set for update ram resource tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/ram/resource_huaweicloud_ram_resource_share_test.go
+++ b/huaweicloud/services/acceptance/ram/resource_huaweicloud_ram_resource_share_test.go
@@ -89,7 +89,6 @@ func TestAccRAMShare_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "principals.0", acceptance.HW_RAM_SHARE_ACCOUNT_ID),
 					resource.TestCheckResourceAttr(rName, "resource_urns.0", acceptance.HW_RAM_SHARE_RESOURCE_URN),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "permission_ids.#", "1"),
 					resource.TestCheckResourceAttr(rName, "associated_permissions.#", "1"),
 					resource.TestCheckResourceAttrSet(rName, "owning_account_id"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
@@ -98,18 +97,39 @@ func TestAccRAMShare_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testRAMShare_basic_update(name),
+				// update principal
+				Config: testRAMShare_basic_update(name, acceptance.HW_RAM_SHARE_UPDATE_ACCOUNT_ID,
+					acceptance.HW_RAM_SHARE_RESOURCE_URN),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
-					resource.TestCheckResourceAttr(rName, "description", "test description information update"),
+					resource.TestCheckResourceAttr(rName, "description",
+						"test description information update"),
+					resource.TestCheckResourceAttr(rName, "principals.0",
+						acceptance.HW_RAM_SHARE_UPDATE_ACCOUNT_ID),
+					resource.TestCheckResourceAttr(rName, "resource_urns.0", acceptance.HW_RAM_SHARE_RESOURCE_URN),
 					resource.TestCheckResourceAttr(rName, "tags.foo_update", "bar_update"),
+				),
+			},
+			{
+				// update resource urn
+				Config: testRAMShare_basic_update(name, acceptance.HW_RAM_SHARE_UPDATE_ACCOUNT_ID,
+					acceptance.HW_RAM_SHARE_UPDATE_RESOURCE_URN),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "principals.0",
+						acceptance.HW_RAM_SHARE_UPDATE_ACCOUNT_ID),
+					resource.TestCheckResourceAttr(rName, "resource_urns.0",
+						acceptance.HW_RAM_SHARE_UPDATE_RESOURCE_URN),
 				),
 			},
 			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permission_ids",
+				},
 			},
 		},
 	})
@@ -131,7 +151,7 @@ resource "huaweicloud_ram_resource_share" "test" {
 `, name, acceptance.HW_RAM_SHARE_ACCOUNT_ID, acceptance.HW_RAM_SHARE_RESOURCE_URN)
 }
 
-func testRAMShare_basic_update(name string) string {
+func testRAMShare_basic_update(name, accountID, resourceUrn string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_ram_resource_share" "test" {
   name        = "%[1]s_update"
@@ -144,5 +164,5 @@ resource "huaweicloud_ram_resource_share" "test" {
     foo_update = "bar_update"
   }
 }
-`, name, acceptance.HW_RAM_SHARE_ACCOUNT_ID, acceptance.HW_RAM_SHARE_RESOURCE_URN)
+`, name, accountID, resourceUrn)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
RAM resource support update principals and resource_urns.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The field `permission_ids` does not support updating. The remote `permission_ids` will change automatic when changing field `resource_urns`. So make this field valid only when creating a resource.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ram' TESTARGS='-run TestAccRAMShare_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccRAMShare_basic -timeout 360m -parallel 4 
=== RUN   TestAccRAMShare_basic 
=== PAUSE TestAccRAMShare_basic
=== CONT  TestAccRAMShare_basic
--- PASS: TestAccRAMShare_basic (16.95s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       17.015s
```
