### PR TITLE
feat(er/attachment): support new data source

### DIFF
--- a/docs/data-sources/er_attachments.md
+++ b/docs/data-sources/er_attachments.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_attachments
+
+Use this data source to filter ER attachments within Huaweicloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_er_attachments" "test" {
+  instance_id = var.instance_id
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the ER attachments are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ER instance ID to which the attachment belongs.
+
+* `attachment_id` - (Optional, String) Specifies the specified attachment ID used to query.
+
+* `type` - (Optional, String) Specifies the resource type to be filtered.  
+  The valid values are as follows:
+  + **vpc**: Virtual private cloud.
+  + **vpn**: VPN gateway.
+  + **vgw**: Virtual gateway of cloud private line.
+  + **peering**: Peering connection, through the cloud connection (CC) to load ERs in different regions to create a
+    peering connection.
+
+* `name` - (Optional, String) Specifies the name used to filter the attachments.
+
+* `status` - (Optional, String) Specifies the status used to filter the attachments.
+  The valid values are as follows:
+  + **available**
+  + **failed**
+  + **pending_acceptance**
+  + **rejected**
+
+* `tags` - (Optional, Map) The key/value pairs used to filter the attachments.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `attachments` - All attachments that match the filter parameters.  
+  The [object](#er_data_attachments) structure is documented below.
+
+<a name="er_data_attachments"></a>
+The `attachments` block supports:
+
+* `id` - The attachment ID.
+
+* `name` - The attachment name.
+
+* `description` - The description of the attachment.
+
+* `status` - The current status of the attachment.
+
+* `created_at` - The creation time of the attachment.
+
+* `updated_at` - The latest update time of the attachment.
+
+* `tags` - The key/value pairs to associate with the attachment.
+
+* `type` - The attachment type.
+
+* `route_table_id` - The associated route table ID.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb
+	github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb h1:pmgOgpgobVtoyqWTc6Xu3Jz3rKnVSbA5mgrAK5Vph0c=
-github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff h1:W/u9kd87wIW49JVhLzO8xmwvA8NB7rovrhNYWYaGCFk=
+github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -448,6 +448,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
+			"huaweicloud_er_attachments":  er.DataSourceAttachments(),
 			"huaweicloud_er_instances":    er.DataSourceInstances(),
 			"huaweicloud_er_route_tables": er.DataSourceRouteTables(),
 

--- a/huaweicloud/services/acceptance/er/data_source_hauweicloud_er_attachments_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_hauweicloud_er_attachments_test.go
@@ -1,0 +1,375 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccAttachmentsDataSource_basic(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_er_attachments.filter_by_name"
+		name  = acceptance.RandomAccResourceName()
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachmentsDataSource_filterByName(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachmentsDataSource_base(name string) string {
+	bgpAsNum := acctest.RandIntRange(64512, 65534)
+
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  name                  = "%[2]s"
+  asn                   = %[3]d
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_er_vpc_attachment" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+
+  name = "%[2]s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestVpc(name), name, bgpAsNum)
+}
+
+func testAccAttachmentsDataSource_filterByName(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_attachments" "filter_by_name" {
+  // The behavior of parameter 'name' is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  name        = huaweicloud_er_vpc_attachment.test.name
+}
+
+data "huaweicloud_er_attachments" "not_found" {
+  // Since a specified name is used, there is no dependency relationship with resource attachment, and the dependency
+  // needs to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "resource_not_found"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_name.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+}
+`, testAccAttachmentsDataSource_base(name))
+}
+
+func TestAccAttachmentsDataSource_filterById(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_er_attachments.filter_by_id"
+		name  = acceptance.RandomAccResourceName()
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachmentsDataSource_filterById(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachmentsDataSource_filterById(name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_attachments" "filter_by_id" {
+  instance_id   = huaweicloud_er_instance.test.id
+  attachment_id = huaweicloud_er_vpc_attachment.test.id
+}
+
+data "huaweicloud_er_attachments" "not_found" {
+  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id   = huaweicloud_er_instance.test.id
+  attachment_id = "%[2]s"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_id.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+}
+
+output "is_id_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+}
+`, testAccAttachmentsDataSource_base(name), randUUID)
+}
+
+func TestAccAttachmentsDataSource_filterByType(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_er_attachments.filter_by_type"
+		name  = acceptance.RandomAccResourceName()
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachmentsDataSource_filterByType(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachmentsDataSource_filterByType(name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_attachments" "filter_by_type" {
+  // Since a specified type is used, there is no dependency relationship with resource attachment, and the dependency
+  // needs to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  type        = "vpc"
+}
+
+data "huaweicloud_er_attachments" "not_found" {
+  // Since a specified type is used, there is no dependency relationship with resource attachment, and the dependency
+  // needs to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  type        = "vgw"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_type.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+}
+
+output "is_type_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+}
+`, testAccAttachmentsDataSource_base(name), randUUID)
+}
+
+func TestAccAttachmentsDataSource_filterByStatus(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_er_attachments.filter_by_status"
+		name  = acceptance.RandomAccResourceName()
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachmentsDataSource_filterByStatus(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachmentsDataSource_filterByStatus(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_attachments" "filter_by_status" {
+  instance_id = huaweicloud_er_instance.test.id
+  status      = huaweicloud_er_vpc_attachment.test.status
+}
+
+data "huaweicloud_er_attachments" "not_found" {
+  // Since a specified status is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id   = huaweicloud_er_instance.test.id
+  status        = "failed"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_status.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+}
+
+output "is_status_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+}
+`, testAccAttachmentsDataSource_base(name))
+}
+
+func TestAccAttachmentsDataSource_filterByTags(t *testing.T) {
+	var (
+		dName = "data.huaweicloud_er_attachments.filter_by_tags"
+		name  = acceptance.RandomAccResourceName()
+
+		dc = acceptance.InitDataSourceCheck(dName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckER(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachmentsDataSource_filterByTags(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachmentsDataSource_filterByTags(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_attachments" "filter_by_tags" {
+  // Since a specified key/value pair is used, there is no dependency relationship with resource attachment, and the
+  // dependency needs to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+data "huaweicloud_er_attachments" "not_found" {
+  // Since a specified key/value pair is used, there is no dependency relationship with resource attachment, and the
+  // dependency needs to be manually set.
+  depends_on = [
+    huaweicloud_er_vpc_attachment.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+
+  tags = {
+    owner = "terraform"
+  }
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_tags.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+}
+
+output "is_tags_filter_is_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+}
+`, testAccAttachmentsDataSource_base(name))
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
@@ -1,0 +1,225 @@
+package er
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/attachments"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceAttachments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAttachmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the ER attachments are located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ER instance ID to which the attachment belongs.`,
+			},
+			"attachment_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The specified attachment ID used to query.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The resource type to be filtered.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name used to filter the attachments.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status used to filter the attachments.`,
+			},
+			"tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The key/value pairs used to filter the attachments.`,
+			},
+			// Attributes
+			"attachments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The attachment ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The attachment name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the attachment.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current status of the attachment.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the attachment.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the attachment.`,
+						},
+						"tags": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The key/value pairs to associate with the attachment.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The attachment type.`,
+						},
+						"route_table_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The associated route table ID.`,
+						},
+					},
+				},
+				Description: `All attachments that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+// Filter attachments by 'name' and 'attachment_id'.
+func filterAttachments(d *schema.ResourceData, all []attachments.Attachment) ([]attachments.Attachment, error) {
+	filter := map[string]interface{}{}
+	if name, ok := d.GetOk("name"); ok {
+		filter["Name"] = name
+	}
+	if attachmentId, ok := d.GetOk("attachment_id"); ok {
+		filter["ID"] = attachmentId
+	}
+
+	if len(filter) < 1 {
+		return all, nil
+	}
+	filterResult, err := utils.FilterSliceWithField(all, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error filtering attachment list: %s", err)
+	}
+	result := make([]attachments.Attachment, 0, len(filterResult))
+	for _, val := range filterResult {
+		result = append(result, val.(attachments.Attachment))
+	}
+	return result, nil
+}
+
+func filterAttachmentsByTags(d *schema.ResourceData, all []attachments.Attachment) ([]attachments.Attachment, error) {
+	tagFilter, ok := d.GetOk("tags")
+	if !ok {
+		return all, nil
+	}
+	result := make([]attachments.Attachment, 0, len(all))
+	for _, val := range all {
+		tagmap := utils.TagsToMap(val.Tags)
+
+		// Filter attachment list by tags, if the filter is nil, skip and return all fileterResult elements.
+		if utils.HasMapContains(tagmap, tagFilter.(map[string]interface{})) {
+			result = append(result, val)
+		}
+	}
+	return result, nil
+}
+
+func flattenAttachments(all []attachments.Attachment) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, attachment := range all {
+		result[i] = map[string]interface{}{
+			"id":             attachment.ID,
+			"name":           attachment.Name,
+			"description":    attachment.Description,
+			"status":         attachment.Status,
+			"created_at":     attachment.CreatedAt,
+			"updated_at":     attachment.UpdatedAt,
+			"tags":           utils.TagsToMap(attachment.Tags),
+			"type":           attachment.ResourceType,
+			"route_table_id": attachment.RouteTableId,
+		}
+	}
+	return result
+}
+
+func buildAttachmentListOpts(d *schema.ResourceData) attachments.ListOpts {
+	return attachments.ListOpts{
+		Statuses:      buildSliceIgnoreEmptyElement(d.Get("status").(string)),
+		ResourceTypes: buildSliceIgnoreEmptyElement(d.Get("type").(string)),
+		SortKey:       []string{"name"},
+	}
+}
+
+func dataSourceAttachmentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	resp, err := attachments.List(client, instanceId, buildAttachmentListOpts(d))
+	if err != nil {
+		return diag.Errorf("error retrieving attachments: %s", err)
+	}
+	if resp, err = filterAttachments(d, resp); err != nil {
+		return diag.FromErr(err)
+	}
+	if resp, err = filterAttachmentsByTags(d, resp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("attachments", flattenAttachments(resp)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving attachments data source fields: %s", mErr)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/requests.go
@@ -1,0 +1,61 @@
+package attachments
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The next page index for the attachments query.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	Marker string `q:"marker"`
+	// The list of current status of the attachments (type of VPC, VPN, VGW and PEERING), support for querying multiple
+	// attachments.
+	Statuses []string `q:"state"`
+	// The resource types to be filtered.
+	// + vpc: virtual private cloud
+	// + vpn: vpn gateway
+	// + vgw: virtual gateway of cloud private line
+	// + peering: Peering connection, through the cloud connection (CC) to load enterprise routers in different regions
+	//   to create a peering connection
+	ResourceTypes []string `q:"resource_type"`
+	// The resource IDs corresponding to the attachment to be filtered.
+	ResourceIds []string `q:"resource_id"`
+	// The list of keyword to sort the attachments result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	// The valid values are as follows:
+	// + asc
+	// + desc
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the propagations under specified route table using given opts.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOpts) ([]Attachment, error) {
+	url := queryURL(client, instanceId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := AttachmentPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractAttachments(pages)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/results.go
@@ -1,0 +1,123 @@
+package attachments
+
+import (
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// listResp is the structure that represents the ER attachment list, page detail and the request information.
+type listResp struct {
+	// The list of the ER attachment.
+	Attachments []Attachment `json:"attachments"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo PageInfo `json:"page_info"`
+}
+
+// Attachment is the structure that represents the ER attachment (type of VPC, VPN, VGW and PEERING) details.
+type Attachment struct {
+	// The attachment ID.
+	ID string `json:"id"`
+	// The attachment name.
+	Name string `json:"name"`
+	// The attachment description.
+	Description string `json:"description"`
+	// The current status of the attachment.
+	// + pending
+	// + available
+	// + modifying
+	// + deleting
+	// + failed
+	// + pending_acceptance
+	// + rejected
+	// + initiating_request
+	// + freezed
+	Status string `json:"state"`
+	// The creation time of the attachment.
+	CreatedAt string `json:"created_at"`
+	// The latest update time of the attachment.
+	UpdatedAt string `json:"updated_at"`
+	// The tag list associated with the attachment.
+	Tags []tags.ResourceTag `json:"tags"`
+	// The project ID where the attachment is located.
+	ProjectId string `json:"project_id"`
+	// The ER instance ID to which the attachment is belongs.
+	InstanceId string `json:"er_id"`
+	// The resource ID associated with the internal connection.
+	ResourceId string `json:"resource_id"`
+	// The resource type.
+	// + vpc: virtual private cloud.
+	// + vpn: vpn gateway.
+	// + vgw: virtual gateway of cloud private line.
+	// + peering: Peering connection, through the cloud connection (CC) to load enterprise routers in different regions
+	//   to create a peering connection.
+	ResourceType string `q:"resource_type"`
+	// The project ID to which the attachment is belongs.
+	ResourceProjectId string `json:"resource_project_id"`
+	// Whether this attachment is associated.
+	Associated bool `json:"associated"`
+	// The associated route table ID.
+	RouteTableId string `json:"route_table_id"`
+}
+
+// PageInfo is the structure that represents the page information.
+type PageInfo struct {
+	// The next marker (next page index) information.
+	NextMarker string `json:"next_marker"`
+	// The number of the ER attahcment in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// AttachmentPage represents the response pages of the List method.
+type AttachmentPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if current page no ER attachment.
+func (r AttachmentPage) IsEmpty() (bool, error) {
+	resp, err := extractAttachments(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index during current page.
+func (r AttachmentPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	return resp.NextMarker, nil
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r AttachmentPage) NextPageURL() (string, error) {
+	currentURL := r.URL
+
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == "" {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*PageInfo, error) {
+	var s listResp
+	err := r.(AttachmentPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractAttachments is a method which to extract the response to an attachment list.
+func extractAttachments(r pagination.Page) ([]Attachment, error) {
+	var s listResp
+	err := r.(AttachmentPage).Result.ExtractInto(&s)
+	return s.Attachments, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/urls.go
@@ -1,0 +1,7 @@
+package attachments
+
+import "github.com/chnsz/golangsdk"
+
+func queryURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "attachments")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb
+# github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -158,6 +158,7 @@ github.com/chnsz/golangsdk/openstack/elb/v3/monitors
 github.com/chnsz/golangsdk/openstack/elb/v3/pools
 github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects
 github.com/chnsz/golangsdk/openstack/er/v3/associations
+github.com/chnsz/golangsdk/openstack/er/v3/attachments
 github.com/chnsz/golangsdk/openstack/er/v3/instances
 github.com/chnsz/golangsdk/openstack/er/v3/propagations
 github.com/chnsz/golangsdk/openstack/er/v3/routes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New data source is support: huaweicloud_er_attachments
This data source can query all kinds of ER attachments (VPN, VGW, PEERING, VPC) during follow arguments:
- attachment_id
- type
- status
- name
- tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query ER attachment.
2. support related documentation and acc tests.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_basic
=== PAUSE TestAccAttachmentsDataSource_basic
=== CONT  TestAccAttachmentsDataSource_basic
--- PASS: TestAccAttachmentsDataSource_basic (90.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        90.157s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_filterById'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_filterById -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_filterById
=== PAUSE TestAccAttachmentsDataSource_filterById
=== CONT  TestAccAttachmentsDataSource_filterById
--- PASS: TestAccAttachmentsDataSource_filterById (91.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        91.538s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_filterByType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_filterByType -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_filterByType
=== PAUSE TestAccAttachmentsDataSource_filterByType
=== CONT  TestAccAttachmentsDataSource_filterByType
--- PASS: TestAccAttachmentsDataSource_filterByType (98.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        98.175s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_filterByStatus'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_filterByStatus -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_filterByStatus
=== PAUSE TestAccAttachmentsDataSource_filterByStatus
=== CONT  TestAccAttachmentsDataSource_filterByStatus
--- PASS: TestAccAttachmentsDataSource_filterByStatus (99.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        99.348s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_filterByTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_filterByTags -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_filterByTags
=== PAUSE TestAccAttachmentsDataSource_filterByTags
=== CONT  TestAccAttachmentsDataSource_filterByTags
--- PASS: TestAccAttachmentsDataSource_filterByTags (97.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        97.580s
```
