### PR TITLE
fix(RDS): fix rds backup test

### DIFF
--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_backups_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_backups_test.go
@@ -40,7 +40,7 @@ func TestAccDatasourceBackup_basic(t *testing.T) {
 }
 
 func testAccDatasourceBackup_basic() string {
-	backupConfig := testBackup_basic(acceptance.RandomAccResourceName())
+	backupConfig := testBackup_mysql_basic(acceptance.RandomAccResourceName())
 	return fmt.Sprintf(`
 %s 
 

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
@@ -57,7 +57,7 @@ func getBackupResourceFunc(config *config.Config, state *terraform.ResourceState
 	return getBackupRespBody, nil
 }
 
-func TestAccBackup_basic(t *testing.T) {
+func TestAccBackup_mysql_basic(t *testing.T) {
 	var obj interface{}
 
 	name := acceptance.RandomAccResourceName()
@@ -75,11 +75,12 @@ func TestAccBackup_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testBackup_basic(name),
+				Config: testBackup_mysql_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
 					resource.TestCheckResourceAttrSet(rName, "begin_time"),
 					resource.TestCheckResourceAttrSet(rName, "end_time"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
@@ -96,40 +97,114 @@ func TestAccBackup_basic(t *testing.T) {
 	})
 }
 
-func testBackup_basic(name string) string {
-	rdsInstanceConfig := testAccBackupRdsInstance(name)
-	return fmt.Sprintf(`
-%s
+func TestAccBackup_sqlserver_basic(t *testing.T) {
+	var obj interface{}
 
-resource "huaweicloud_rds_backup" "test" {
-  name        = "%s"
-  instance_id = huaweicloud_rds_instance.test.id
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rds_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_sqlserver_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
 }
-`, rdsInstanceConfig, name)
+
+func TestAccBackup_pg_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rds_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_pg_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
 }
 
 // disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
-func testAccBackupRdsInstance(name string) string {
+func testBackup_mysql_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_rds_flavors" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+  group_type    = "dedicated"
+}
+
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%s"
-  flavor            = "rds.pg.n1.large.2"
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
   security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
-  fixed_ip          = "192.168.0.58"
 
   db {
     password = "Huangwei!120521"
-    type     = "PostgreSQL"
-    version  = "12"
-    port     = 8635
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
   }
   volume {
     type = "CLOUDSSD"
@@ -140,9 +215,69 @@ resource "huaweicloud_rds_instance" "test" {
     keep_days  = 0
   }
 
-  tags = {
-    key = "value"
-    foo = "bar"
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "huaweicloud_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_rds_instance.test.id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_sqlserver_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_networking_secgroup" "test" {
+  name = "default"
+}
+
+data "huaweicloud_rds_flavors" "test" {
+  db_type       = "SQLServer"
+  db_version    = "2019_SE"
+  instance_mode = "single"
+  group_type    = "dedicated"
+  vcpus         = 4
+}
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "SQLServer"
+    version  = "2019_SE"
+    port     = 8631
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 0
   }
 
   lifecycle {
@@ -150,6 +285,64 @@ resource "huaweicloud_rds_instance" "test" {
       backup_strategy,
     ]
   }
+}
+
+resource "huaweicloud_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_rds_instance.test.id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_pg_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_rds_flavors" "test" {
+  db_type       = "PostgreSQL"
+  db_version    = "14"
+  instance_mode = "single"
+  group_type    = "dedicated"
+  vcpus         = 8
+}
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  vpc_id            = huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "Huangwei!120521"
+    type     = "PostgreSQL"
+    version  = "14"
+    port     = 8632
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 0
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "huaweicloud_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_rds_instance.test.id
 }
 `, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/rds/common.go
+++ b/huaweicloud/services/rds/common.go
@@ -30,6 +30,7 @@ func handleMultiOperationsError(err error) (bool, error) {
 			"DBS.200019": struct{}{},
 			"DBS.200047": struct{}{},
 			"DBS.200080": struct{}{},
+			"DBS.201015": struct{}{},
 			"DBS.201206": struct{}{},
 			"DBS.212033": struct{}{},
 			"DBS.280011": struct{}{},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   fix rds backup test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   fix rds backup test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccBackup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccBackup_ -timeout 360m -parallel 4
=== RUN   TestAccBackup_mysql_basic
=== PAUSE TestAccBackup_mysql_basic
=== RUN   TestAccBackup_sqlserver_basic
=== PAUSE TestAccBackup_sqlserver_basic
=== RUN   TestAccBackup_pg_basic
=== PAUSE TestAccBackup_pg_basic
=== CONT  TestAccBackup_mysql_basic
=== CONT  TestAccBackup_pg_basic
=== CONT  TestAccBackup_sqlserver_basic
--- PASS: TestAccBackup_mysql_basic (797.91s)
--- PASS: TestAccBackup_pg_basic (829.44s)
--- PASS: TestAccBackup_sqlserver_basic (999.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       999.898s

make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccDatasourceBackup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccDatasourceBackup_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceBackup_basic
=== PAUSE TestAccDatasourceBackup_basic
=== CONT  TestAccDatasourceBackup_basic
--- PASS: TestAccDatasourceBackup_basic (782.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       782.417s
```
