### PR TITLE
feat(EVS): EVS support GPSSD2 and ESSD2 volume type

### DIFF
--- a/docs/data-sources/evs_volumes.md
+++ b/docs/data-sources/evs_volumes.md
@@ -68,6 +68,19 @@ The `volumes` block supports:
 
 * `description` - The disk description.
 
+* `volume_type` - The disk type. Valid values are as follows:
+  + **SAS**: High I/O type.
+  + **SSD**: Ultra-high I/O type.
+  + **GPSSD**: General purpose SSD type.
+  + **ESSD**: Extreme SSD type.
+  + **GPSSD2**: General purpose SSD V2 type.
+  + **ESSD2**: Extreme SSD V2 type.
+
+* `iops` - the IOPS(Input/Output Operations Per Second) of the volume. Only valid when `volume_type` is **GPSSD2** or
+  **ESSD2**.
+
+* `throughput` - The throughput of the system disk. Only valid when `volume_type` is **GPSSD2**.
+
 * `enterprise_project_id` - The ID of the enterprise project associated with the disk.
 
 * `name` - The disk name.

--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -51,15 +51,36 @@ The following arguments are supported:
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone for the disk. Changing this creates
   a new disk.
 
-* `volume_type` - (Required, String, ForceNew) Specifies the disk type. Currently, the value can be SAS, SSD, GPSSD or
-  ESSD.
-  + SAS: specifies the high I/O disk type.
-  + SSD: specifies the ultra-high I/O disk type.
-  + GPSSD: specifies the general purpose SSD disk type.
-  + ESSD: Extreme SSD type.
+* `volume_type` - (Required, String, ForceNew) Specifies the disk type. Changing this creates a new disk.
+  Valid values are as follows:
+  + **SAS**: High I/O type.
+  + **SSD**: Ultra-high I/O type.
+  + **GPSSD**: General purpose SSD type.
+  + **ESSD**: Extreme SSD type.
+  + **GPSSD2**: General purpose SSD V2 type.
+  + **ESSD2**: Extreme SSD V2 type.
 
-      If the specified disk type is not available in the AZ, the disk will fail to create. Changing this creates a new
-      disk.
+  -> If the specified disk type is not available in the AZ, the disk will fail to create.
+  The volume type **ESSD2** only support in postpaid charging mode.
+
+* `iops` - (Optional, Int, ForceNew) Specifies the IOPS(Input/Output Operations Per Second) for the volume.
+  The field is valid and required when `volume_type` is set to **GPSSD2** or **ESSD2**.
+
+  + If `volume_type` is set to **GPSSD2**. The field `iops` ranging from 3,000 to 128,000.
+    This IOPS must also be less than or equal to 500 multiplying the capacity.
+
+  + If `volume_type` is set to **ESSD2**. The field `iops` ranging from 100 to 256,000.
+    This IOPS must also be less than or equal to 1000 multiplying the capacity.
+
+  Changing this creates a new disk.
+
+* `throughput` - (Optional, Int, ForceNew) Specifies the throughput for the volume. The Unit is MiB/s.
+  The field is valid and required when `volume_type` is set to **GPSSD2**.
+
+  + If `volume_type` is set to **GPSSD2**. The field `throughput` ranging from 125 to 1,000.
+    This throughput must also be less than or equal to the IOPS divided by 4.
+
+  Changing this creates a new disk.
 
 * `name` - (Optional, String) Specifies the disk name. The value can contain a maximum of 255 bytes.
 

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -23,6 +23,12 @@ func TestAccEvsVolume_basic(t *testing.T) {
 	var volume cloudvolumes.Volume
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_evs_volume.test"
+	resourceName1 := "huaweicloud_evs_volume.test.0"
+	resourceName2 := "huaweicloud_evs_volume.test.1"
+	resourceName3 := "huaweicloud_evs_volume.test.2"
+	resourceName4 := "huaweicloud_evs_volume.test.3"
+	resourceName5 := "huaweicloud_evs_volume.test.4"
+	resourceName6 := "huaweicloud_evs_volume.test.5"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -38,55 +44,67 @@ func TestAccEvsVolume_basic(t *testing.T) {
 			{
 				Config: testAccEvsVolume_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(4),
+					rc.CheckMultiResourcesExists(6),
 					// Common configuration
-					resource.TestCheckResourceAttrPair("huaweicloud_evs_volume.test.0", "availability_zone",
+					resource.TestCheckResourceAttrPair(resourceName1, "availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "description", "Created by acc test script."),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "volume_type", "SSD"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "size", "100"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName1, "description",
+						"Created by acc test script."),
+					resource.TestCheckResourceAttr(resourceName1, "volume_type", "SSD"),
+					resource.TestCheckResourceAttr(resourceName1, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName1, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName1, "tags.key", "value"),
 					// Personalized configuration
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "name", rName+"_vbd_normal_volume"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "device_type", "VBD"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "multiattach", "false"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.1", "name", rName+"_vbd_share_volume"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.1", "device_type", "VBD"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.1", "multiattach", "true"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.2", "name", rName+"_scsi_normal_volume"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.2", "device_type", "SCSI"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.2", "multiattach", "false"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.3", "name", rName+"_scsi_share_volume"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.3", "device_type", "SCSI"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.3", "multiattach", "true"),
+					resource.TestCheckResourceAttr(resourceName1, "name", rName+"_vbd_normal_volume"),
+					resource.TestCheckResourceAttr(resourceName1, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName1, "multiattach", "false"),
+
+					resource.TestCheckResourceAttr(resourceName2, "name", rName+"_vbd_share_volume"),
+					resource.TestCheckResourceAttr(resourceName2, "device_type", "VBD"),
+					resource.TestCheckResourceAttr(resourceName2, "multiattach", "true"),
+
+					resource.TestCheckResourceAttr(resourceName3, "name", rName+"_scsi_normal_volume"),
+					resource.TestCheckResourceAttr(resourceName3, "device_type", "SCSI"),
+					resource.TestCheckResourceAttr(resourceName3, "multiattach", "false"),
+
+					resource.TestCheckResourceAttr(resourceName4, "name", rName+"_scsi_share_volume"),
+					resource.TestCheckResourceAttr(resourceName4, "device_type", "SCSI"),
+					resource.TestCheckResourceAttr(resourceName4, "multiattach", "true"),
+
+					resource.TestCheckResourceAttr(resourceName5, "name", rName+"_gpssd2_normal_volume"),
+					resource.TestCheckResourceAttr(resourceName5, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName5, "device_type", "SCSI"),
+					resource.TestCheckResourceAttr(resourceName5, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName5, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName5, "throughput", "500"),
+
+					resource.TestCheckResourceAttr(resourceName6, "name", rName+"_essd2_normal_volume"),
+					resource.TestCheckResourceAttr(resourceName6, "volume_type", "ESSD2"),
+					resource.TestCheckResourceAttr(resourceName6, "device_type", "SCSI"),
+					resource.TestCheckResourceAttr(resourceName6, "multiattach", "false"),
+					resource.TestCheckResourceAttr(resourceName6, "iops", "3000"),
 				),
 			},
 			{
 				Config: testAccEvsVolume_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(4),
+					rc.CheckMultiResourcesExists(6),
 					// Common configuration
-					resource.TestCheckResourceAttrPair("huaweicloud_evs_volume.test.0", "availability_zone",
+					resource.TestCheckResourceAttrPair(resourceName1, "availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "description", "Updated by acc test script."),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "volume_type", "SSD"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "size", "200"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "tags.foo1", "bar"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName1, "description",
+						"Updated by acc test script."),
+					resource.TestCheckResourceAttr(resourceName1, "volume_type", "SSD"),
+					resource.TestCheckResourceAttr(resourceName1, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName1, "tags.foo1", "bar"),
+					resource.TestCheckResourceAttr(resourceName1, "tags.key", "value1"),
 					// Personalized configuration
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "name", rName+"_vbd_normal_volume_update"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "device_type", "VBD"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.0", "multiattach", "false"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.1", "name", rName+"_vbd_share_volume_update"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.1", "device_type", "VBD"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.1", "multiattach", "true"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.2", "name", rName+"_scsi_normal_volume_update"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.2", "device_type", "SCSI"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.2", "multiattach", "false"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.3", "name", rName+"_scsi_share_volume_update"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.3", "device_type", "SCSI"),
-					resource.TestCheckResourceAttr("huaweicloud_evs_volume.test.3", "multiattach", "true"),
+					resource.TestCheckResourceAttr(resourceName1, "name", rName+"_vbd_normal_volume_update"),
+					resource.TestCheckResourceAttr(resourceName2, "name", rName+"_vbd_share_volume_update"),
+					resource.TestCheckResourceAttr(resourceName3, "name", rName+"_scsi_normal_volume_update"),
+					resource.TestCheckResourceAttr(resourceName4, "name", rName+"_scsi_share_volume_update"),
+					resource.TestCheckResourceAttr(resourceName5, "name", rName+"_gpssd2_normal_volume_update"),
+					resource.TestCheckResourceAttr(resourceName6, "name", rName+"_essd2_normal_volume_update"),
 				),
 			},
 		},
@@ -137,6 +155,8 @@ func TestAccEvsVolume_prePaid(t *testing.T) {
 	var volume cloudvolumes.Volume
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_evs_volume.test"
+	resourceName1 := "huaweicloud_evs_volume.test.0"
+	resourceName2 := "huaweicloud_evs_volume.test.1"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -155,30 +175,35 @@ func TestAccEvsVolume_prePaid(t *testing.T) {
 			{
 				Config: testAccEvsVolume_prePaid(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
-					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+					rc.CheckMultiResourcesExists(2),
+					// Common configuration
+					resource.TestCheckResourceAttrPair(resourceName1, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName1, "description",
+						"test volume for charging mode"),
+					resource.TestCheckResourceAttr(resourceName1, "size", "100"),
+
+					// Personalized configuration
+					resource.TestCheckResourceAttr(resourceName1, "volume_type", "SSD"),
+					resource.TestCheckResourceAttr(resourceName1, "name", rName+"_ssd_volume"),
+					resource.TestCheckResourceAttr(resourceName1, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName1, "auto_renew", "false"),
+
+					resource.TestCheckResourceAttr(resourceName2, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName2, "name", rName+"_gpssd2_volume"),
+					resource.TestCheckResourceAttr(resourceName2, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName2, "auto_renew", "false"),
+					resource.TestCheckResourceAttr(resourceName2, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName2, "throughput", "500"),
 				),
 			},
 			{
 				Config: testAccEvsVolume_prePaid(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+					rc.CheckMultiResourcesExists(2),
+					resource.TestCheckResourceAttr(resourceName1, "auto_renew", "true"),
+					resource.TestCheckResourceAttr(resourceName2, "auto_renew", "true"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"cascade",
-					"period_unit",
-					"period",
-					"auto_renew",
-				},
 			},
 		},
 	})
@@ -190,13 +215,60 @@ variable "volume_configuration" {
   type = list(object({
     suffix      = string
     device_type = string
+    volume_type = string
     multiattach = bool
+    iops        = number
+    throughput  = number
   }))
   default = [
-    {suffix = "vbd_normal_volume",  device_type = "VBD",  multiattach = false},
-    {suffix = "vbd_share_volume",   device_type = "VBD",  multiattach = true},
-    {suffix = "scsi_normal_volume", device_type = "SCSI", multiattach = false},
-    {suffix = "scsi_share_volume",  device_type = "SCSI", multiattach = true},
+    {
+      suffix = "vbd_normal_volume",
+      device_type = "VBD",
+      volume_type = "SSD",
+      multiattach = false,
+      iops = 0,
+      throughput = 0
+    },
+    {
+      suffix = "vbd_share_volume",
+      device_type = "VBD",
+      volume_type = "SSD",
+      multiattach = true,
+      iops = 0,
+      throughput = 0
+    },
+    {
+      suffix = "scsi_normal_volume",
+      device_type = "SCSI",
+      volume_type = "SSD",
+      multiattach = false,
+      iops = 0,
+      throughput = 0
+    },
+    {
+      suffix = "scsi_share_volume",
+      device_type = "SCSI",
+      volume_type = "SSD",
+      multiattach = true,
+      iops = 0,
+      throughput = 0
+    },
+    {
+      suffix = "gpssd2_normal_volume",
+      device_type = "SCSI",
+      volume_type = "GPSSD2",
+      multiattach = false,
+      iops = 3000,
+      throughput = 500
+    },
+    {
+      suffix = "essd2_normal_volume",
+      device_type = "SCSI",
+      volume_type = "ESSD2",
+      multiattach = false,
+      iops = 3000,
+      throughput = 0
+    },
   ]
 }
 
@@ -215,9 +287,11 @@ resource "huaweicloud_evs_volume" "test" {
   name              = "%s_${var.volume_configuration[count.index].suffix}"
   size              = 100
   description       = "Created by acc test script."
-  volume_type       = "SSD"
+  volume_type       = var.volume_configuration[count.index].volume_type
   device_type       = var.volume_configuration[count.index].device_type
   multiattach       = var.volume_configuration[count.index].multiattach
+  iops              = var.volume_configuration[count.index].iops
+  throughput        = var.volume_configuration[count.index].throughput
 
   tags = {
     foo = "bar"
@@ -238,9 +312,11 @@ resource "huaweicloud_evs_volume" "test" {
   name              = "%s_${var.volume_configuration[count.index].suffix}_update"
   size              = 200
   description       = "Updated by acc test script."
-  volume_type       = "SSD"
+  volume_type       = var.volume_configuration[count.index].volume_type
   device_type       = var.volume_configuration[count.index].device_type
   multiattach       = var.volume_configuration[count.index].multiattach
+  iops              = var.volume_configuration[count.index].iops
+  throughput        = var.volume_configuration[count.index].throughput
 
   tags = {
     foo1 = "bar"
@@ -265,21 +341,54 @@ resource "huaweicloud_evs_volume" "test" {
 `, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
+func testAccEvsVolume_prepaid_base() string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    suffix      = string
+    volume_type = string
+    iops        = number
+    throughput  = number
+  }))
+  default = [
+    {
+      suffix = "ssd_volume",
+      volume_type = "SSD",
+      iops = 0,
+      throughput = 0
+    },
+    {
+      suffix = "gpssd2_volume",
+      volume_type = "GPSSD2",
+      iops = 3000,
+      throughput = 500
+    },
+  ]
+}
+
+data "huaweicloud_availability_zones" "test" {}
+`)
+}
+
 func testAccEvsVolume_prePaid(rName string, isAutoRenew bool) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+%[1]s
 
 resource "huaweicloud_evs_volume" "test" {
-  name              = "%[1]s"
+  count = length(var.volume_configuration)
+
+  name              = "%s_${var.volume_configuration[count.index].suffix}"
   description       = "test volume for charging mode"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  volume_type       = "SSD"
   size              = 100
+  volume_type       = var.volume_configuration[count.index].volume_type
+  iops              = var.volume_configuration[count.index].iops
+  throughput        = var.volume_configuration[count.index].throughput
 
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = 1
-  auto_renew    = "%v"
+  auto_renew    = "%[3]v"
 }
-`, rName, isAutoRenew)
+`, testAccEvsVolume_prepaid_base(), rName, isAutoRenew)
 }

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
@@ -97,6 +97,18 @@ func DataSourceEvsVolumesV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"volume_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"iops": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"throughput": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"enterprise_project_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -182,6 +194,9 @@ func sourceEvsVolumes(volumes []cloudvolumes.Volume) ([]map[string]interface{}, 
 			"attachments":           sourceEvsAttachment(volume.Attachments, volume.Metadata.AttachedMode),
 			"availability_zone":     volume.AvailabilityZone,
 			"description":           volume.Description,
+			"volume_type":           volume.VolumeType,
+			"iops":                  volume.IOPS.TotalVal,
+			"throughput":            volume.Throughput.TotalVal,
 			"enterprise_project_id": volume.EnterpriseProjectID,
 			"name":                  volume.Name,
 			"service_type":          volume.ServiceType,

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
@@ -79,6 +79,10 @@ type VolumeOpts struct {
 	Tags map[string]string `json:"tags,omitempty"`
 	// the enterprise project id
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+	// The iops of evs volume. Only required when volume_type is `GPSSD2` or `ESSD2`
+	IOPS int `json:"iops,omitempty"`
+	// The throughput of evs volume. Only required when volume_type is `GPSSD2`
+	Throughput int `json:"throughput,omitempty"`
 }
 
 // SchedulerOpts contains the scheduler hints

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/results.go
@@ -59,6 +59,16 @@ type VolumeMetadata struct {
 	AttachedMode string `json:"attached_mode"`
 }
 
+// IOPSAndThroughput is the struct of IOPS and throughput
+type IOPSAndThroughput struct {
+	// The frozened mark
+	Frozened bool `json:"frozened"`
+	// The iops or throughput id
+	ID string `json:"id"`
+	// The iops or throughput value
+	TotalVal int `json:"total_val"`
+}
+
 // Link is an object that represents a link to which the disk belongs.
 type Link struct {
 	// Specifies the corresponding shortcut link.
@@ -81,6 +91,10 @@ type Volume struct {
 	Description string `json:"description"`
 	// The type of volume to create, either SATA or SSD.
 	VolumeType string `json:"volume_type"`
+	// The IOPS of the volume. Only exist when volume_type is `ESSD2` or `GPSSD2`
+	IOPS IOPSAndThroughput `json:"iops"`
+	// The throughput of the volume. Only exist when volume_type is `GPSSD2`
+	Throughput IOPSAndThroughput `json:"throughput"`
 	// AvailabilityZone is which availability zone the volume is in.
 	AvailabilityZone string `json:"availability_zone"`
 	// Instances onto which the volume is attached.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 EVS support GPSSD2 and ESSD2 volume type
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Add two parameters `iops` and `throughput`
- Change the unit test
- Change the document

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_prePaid -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_prePaid
=== PAUSE TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolume_prePaid
--- PASS: TestAccEvsVolume_prePaid (165.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       165.438s
```

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic 
=== PAUSE TestAccEvsVolume_basic 
=== CONT  TestAccEvsVolume_basic 
--- PASS: TestAccEvsVolume_basic (135.37s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       135.431s 
```
