### PR TITLE
feat(RDS): rds instance support restore

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -188,6 +188,9 @@ The following arguments are supported:
 
 * `volume` - (Required, List) Specifies the volume information. Structure is documented below.
 
+* `restore` - (Optional, List, ForceNew) Specifies the restoration information. It only supported restore to postpaid
+  instance. Structure is documented below. Changing this parameter will create a new resource.
+
 * `fixed_ip` - (Optional, String, ForceNew) Specifies an intranet floating IP address of RDS DB instance. Changing this
   parameter will create a new resource.
 
@@ -275,7 +278,7 @@ The `volume` block supports:
   + *ULTRAHIGH*: SSD storage.
   + *LOCALSSD*: local SSD storage.
   + *CLOUDSSD*: cloud SSD storage. This storage type is supported only with general-purpose and dedicated DB
-      instances.
+    instances.
   + *ESSD*: extreme SSD storage.
 
   Changing this parameter will create a new resource. For details about volume types, see
@@ -292,6 +295,17 @@ The `volume` block supports:
   + **10**
   + **15**
   + **20**
+
+The `restore` block supports:
+
+* `instance_id` - (Required, String, ForceNew) Specifies the source DB instance ID. Changing this parameter will create
+  a new resource.
+
+* `backup_id` - (Required, String, ForceNew) Specifies the ID of the backup used to restore data. Changing this
+  parameter will create a new resource.
+
+* `database_name` - (Optional, Map, ForceNew) Specifies the database to be restored. This parameter applies only to
+  Microsoft SQL Server databases. Changing this parameter will create a new resource.
 
 The `backup_strategy` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb
+	github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb h1:pmgOgpgobVtoyqWTc6Xu3Jz3rKnVSbA5mgrAK5Vph0c=
-github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff h1:W/u9kd87wIW49JVhLzO8xmwvA8NB7rovrhNYWYaGCFk=
+github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -286,6 +286,139 @@ func TestAccRdsInstance_withParameters(t *testing.T) {
 	})
 }
 
+func TestAccRdsInstance_restore_mysql(t *testing.T) {
+	var instance instances.RdsInstanceResponse
+	name := acceptance.RandomAccResourceName()
+	resourceType := "huaweicloud_rds_instance"
+	resourceName := "huaweicloud_rds_instance.test_backup"
+	pwd := acceptance.RandomPassword()
+	newPwd := acceptance.RandomPassword()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstance_restore_mysql(name, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_rds_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "400"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "15"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
+				),
+			},
+			{
+				Config: testAccRdsInstance_restore_mysql_update(name, newPwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_rds_flavors.test", "flavors.1.name"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "500"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "20"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3308"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstance_restore_sqlserver(t *testing.T) {
+	var instance instances.RdsInstanceResponse
+	name := acceptance.RandomAccResourceName()
+	resourceType := "huaweicloud_rds_instance"
+	resourceName := "huaweicloud_rds_instance.test_backup"
+	pwd := acceptance.RandomPassword()
+	newPwd := acceptance.RandomPassword()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstance_restore_sqlserver(name, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_rds_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
+				),
+			},
+			{
+				Config: testAccRdsInstance_restore_sqlserver_update(name, newPwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_rds_flavors.test", "flavors.1.name"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8636"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstance_restore_pg(t *testing.T) {
+	var instance instances.RdsInstanceResponse
+	name := acceptance.RandomAccResourceName()
+	resourceType := "huaweicloud_rds_instance"
+	resourceName := "huaweicloud_rds_instance.test_backup"
+	pwd := acceptance.RandomPassword()
+	newPwd := acceptance.RandomPassword()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstance_restore_pg(name, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_rds_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8732"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
+				),
+			},
+			{
+				Config: testAccRdsInstance_restore_pg_update(name, newPwd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_rds_flavors.test", "flavors.1.name"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8733"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRdsInstanceDestroy(rsType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
@@ -823,4 +956,262 @@ resource "huaweicloud_rds_instance" "test" {
   }
 }
 `, common.TestBaseNetwork(name), name)
+}
+
+func testAccRdsInstance_restore_mysql(name, pwd string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_vpc" "test_update" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test_update" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_networking_secgroup" "test_update" {
+  name = "default"
+}
+
+resource "huaweicloud_rds_instance" "test_backup" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id = data.huaweicloud_networking_secgroup.test_update.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test_update.id
+  vpc_id            = data.huaweicloud_vpc.test_update.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+  ssl_enable        = true  
+
+  restore {
+    instance_id = huaweicloud_rds_backup.test.instance_id
+    backup_id   = huaweicloud_rds_backup.test.id
+  }
+
+  db {
+    password = "%[3]s"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 3306
+  }
+
+  backup_strategy {
+    start_time = "08:15-09:15"
+    keep_days  = 3
+    period     = 1
+  }
+
+  volume {
+    type              = "CLOUDSSD"
+    size              = 50
+    limit_size        = 400
+    trigger_threshold = 15
+  }
+}
+`, testBackup_mysql_basic(name), name, pwd)
+}
+
+func testAccRdsInstance_restore_mysql_update(name, pwd string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_vpc" "test_update" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test_update" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_networking_secgroup" "test_update" {
+  name = "default"
+}
+
+resource "huaweicloud_rds_instance" "test_backup" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
+  security_group_id = data.huaweicloud_networking_secgroup.test_update.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test_update.id
+  vpc_id            = data.huaweicloud_vpc.test_update.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+  ssl_enable        = false
+
+  restore {
+    instance_id = huaweicloud_rds_backup.test.instance_id
+    backup_id   = huaweicloud_rds_backup.test.id
+  }
+
+  db {
+    password = "%[3]s"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 3308
+  }
+
+  backup_strategy {
+    start_time = "18:15-19:15"
+    keep_days  = 5
+    period     = 3
+  }
+
+  volume {
+    type              = "CLOUDSSD"
+    size              = 60
+    limit_size        = 500
+    trigger_threshold = 20
+  }
+}
+`, testBackup_mysql_basic(name), name, pwd)
+}
+
+func testAccRdsInstance_restore_sqlserver(name, pwd string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test_backup" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+
+  restore {
+    instance_id = huaweicloud_rds_backup.test.instance_id
+    backup_id   = huaweicloud_rds_backup.test.id
+  }
+
+  db {
+    password = "%[3]s"
+    type     = "SQLServer"
+    version  = "2019_SE"
+    port     = 8635
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testBackup_sqlserver_basic(name), name, pwd)
+}
+
+func testAccRdsInstance_restore_sqlserver_update(name, pwd string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test_backup" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+
+  restore {
+    instance_id = huaweicloud_rds_backup.test.instance_id
+    backup_id   = huaweicloud_rds_backup.test.id
+  }
+
+  db {
+    password = "%[3]s"
+    type     = "SQLServer"
+    version  = "2019_SE"
+    port     = 8636
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 60
+  }
+}
+`, testBackup_sqlserver_basic(name), name, pwd)
+}
+
+func testAccRdsInstance_restore_pg(name, pwd string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_vpc" "test_update" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test_update" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_networking_secgroup" "test_update" {
+  name = "default"
+}
+
+resource "huaweicloud_rds_instance" "test_backup" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id = data.huaweicloud_networking_secgroup.test_update.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test_update.id
+  vpc_id            = data.huaweicloud_vpc.test_update.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+
+  restore {
+    instance_id = huaweicloud_rds_backup.test.instance_id
+    backup_id   = huaweicloud_rds_backup.test.id
+  }
+
+  db {
+    password = "%[3]s"
+    type     = "PostgreSQL"
+    version  = "14"
+    port     = 8732
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testBackup_pg_basic(name), name, pwd)
+}
+
+func testAccRdsInstance_restore_pg_update(name, pwd string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_vpc" "test_update" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test_update" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_networking_secgroup" "test_update" {
+  name = "default"
+}
+
+resource "huaweicloud_rds_instance" "test_backup" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
+  security_group_id = data.huaweicloud_networking_secgroup.test_update.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test_update.id
+  vpc_id            = data.huaweicloud_vpc.test_update.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+
+  restore {
+    instance_id = huaweicloud_rds_backup.test.instance_id
+    backup_id   = huaweicloud_rds_backup.test.id
+  }
+
+  db {
+    password = "%[3]s"
+    type     = "PostgreSQL"
+    version  = "14"
+    port     = 8733
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 60
+  }
+}
+`, testBackup_pg_basic(name), name, pwd)
 }

--- a/huaweicloud/services/rds/common.go
+++ b/huaweicloud/services/rds/common.go
@@ -9,6 +9,22 @@ import (
 	"github.com/chnsz/golangsdk"
 )
 
+var (
+	// Some error codes that need to be retried coming from https://console-intl.huaweicloud.com/apiexplorer/#/errorcenter/RDS.
+	retryErrCodes = map[string]struct{}{
+		"DBS.201202": {},
+		"DBS.200011": {},
+		"DBS.200019": {},
+		"DBS.200047": {},
+		"DBS.200080": {},
+		"DBS.201015": {},
+		"DBS.201206": {},
+		"DBS.212033": {}, // http response code is 403
+		"DBS.280011": {},
+		"DBS.280816": {},
+	}
+)
+
 // The RDS instance is limited to only one operation at a time.
 // In addition to locking and waiting between multiple operations, a retry method is required to ensure that the
 // request can be executed correctly.
@@ -23,18 +39,21 @@ func handleMultiOperationsError(err error) (bool, error) {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
 		}
 
-		// Some error codes that need to be retried coming from https://console-intl.huaweicloud.com/apiexplorer/#/errorcenter/RDS.
-		retryErrCodes := map[string]struct{}{
-			"DBS.201202": struct{}{},
-			"DBS.200011": struct{}{},
-			"DBS.200019": struct{}{},
-			"DBS.200047": struct{}{},
-			"DBS.200080": struct{}{},
-			"DBS.201015": struct{}{},
-			"DBS.201206": struct{}{},
-			"DBS.212033": struct{}{},
-			"DBS.280011": struct{}{},
-			"DBS.280816": struct{}{},
+		errorCode, errorCodeErr := jmespath.Search("errCode||error_code", apiError)
+		if errorCodeErr != nil {
+			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
+		}
+
+		if _, ok = retryErrCodes[errorCode.(string)]; ok {
+			// The operation failed to execute and needs to be executed again, because other operations are
+			// currently in progress.
+			return true, err
+		}
+	}
+	if errCode, ok := err.(golangsdk.ErrDefault403); ok {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
 		}
 
 		errorCode, errorCodeErr := jmespath.Search("errCode||error_code", apiError)

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -70,6 +70,18 @@ func ExpandToStringList(v []interface{}) []string {
 	return s
 }
 
+// ExpandToStringMap takes the result for a map of string and returns a map[string]string
+func ExpandToStringMap(v map[string]interface{}) map[string]string {
+	s := make(map[string]string)
+	for key, val := range v {
+		if strVal, ok := val.(string); ok && strVal != "" {
+			s[key] = strVal
+		}
+	}
+
+	return s
+}
+
 // ExpandToStringListPointer takes the result for an array of strings and returns a pointer of the array
 func ExpandToStringListPointer(v []interface{}) *[]string {
 	s := ExpandToStringList(v)

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/requests.go
@@ -62,9 +62,71 @@ type CreateOpts struct {
 	// Only valid if action is REDIRECT_TO_LISTENER.
 	RedirectListenerID string `json:"redirect_listener_id,omitempty"`
 
+	// Requests matching this policy will be redirected to the URL.
+	// Only valid if action is REDIRECT_TO_URL.
+	RedirectUrlConfig *RedirectUrlConfig `json:"redirect_url_config,omitempty"`
+
+	// Requests matching this policy will be redirected to the configuration of the page.
+	// Only valid if action is FIXED_RESPONSE.
+	FixedResponseConfig *FixedResponseConfig `json:"fixed_response_config,omitempty"`
+
+	// The config of the redirected pool.
+	// Only valid if action is REDIRECT_TO_POOL.
+	RedirectPoolsExtendConfig *RedirectPoolsExtendConfig `json:"redirect_pools_extend_config,omitempty"`
+
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+}
+
+type RedirectUrlConfig struct {
+	// The protocol for redirection.
+	Protocol string `json:"protocol,omitempty"`
+
+	// The host name that requests are redirected to.
+	Host string `json:"host,omitempty"`
+
+	// The port that requests are redirected to.
+	Port string `json:"port,omitempty"`
+
+	// The path that requests are redirected to.
+	Path string `json:"path,omitempty"`
+
+	// The query string set in the URL for redirection.
+	Query string `json:"query"`
+
+	// The status code returned after the requests are redirected.
+	StatusCode string `json:"status_code" required:"true"`
+}
+
+type FixedResponseConfig struct {
+	// The fixed HTTP status code configured in the forwarding rule.
+	StatusCode string `json:"status_code" required:"true"`
+
+	// The format of the response body.
+	ContentType string `json:"content_type,omitempty"`
+
+	// The content of the response message body.
+	MessageBody string `json:"message_body"`
+}
+
+type RedirectPoolsExtendConfig struct {
+	// Whether the rewriter url enable
+	RewriteUrlEnable bool `json:"rewrite_url_enable,omitempty"`
+
+	// The rewriter url config
+	RewriteUrlConfig *RewriteUrlConfig `json:"rewrite_url_config,omitempty"`
+}
+
+type RewriteUrlConfig struct {
+	// The host of the rewriter url
+	Host string `json:"host,omitempty"`
+
+	// The path that requests are redirected to.
+	Path string `json:"path,omitempty"`
+
+	// The query string set in the URL for redirection.
+	Query string `json:"query"`
 }
 
 // ToL7PolicyCreateMap builds a request body from CreateOpts.
@@ -164,6 +226,9 @@ type UpdateOpts struct {
 	// The position of this policy on the listener.
 	Position int32 `json:"position,omitempty"`
 
+	// The priority of this policy on the listener.
+	Priority int32 `json:"priority,omitempty"`
+
 	// A human-readable description for the resource, empty string is allowed.
 	Description *string `json:"description,omitempty"`
 
@@ -174,6 +239,18 @@ type UpdateOpts struct {
 	// Requests matching this policy will be redirected to this LISTENER.
 	// Only valid if action is REDIRECT_TO_LISTENER.
 	RedirectListenerID *string `json:"redirect_listener_id,omitempty"`
+
+	// Requests matching this policy will be redirected to the URL.
+	// Only valid if action is REDIRECT_TO_URL.
+	RedirectUrlConfig *RedirectUrlConfig `json:"redirect_url_config,omitempty"`
+
+	// Requests matching this policy will be redirected to the configuration of the page.
+	// Only valid if action is FIXED_RESPONSE.
+	FixedResponseConfig *FixedResponseConfig `json:"fixed_response_config,omitempty"`
+
+	// The config of the redirected pool.
+	// Only valid if action is REDIRECT_TO_POOL.
+	RedirectPoolsExtendConfig *RedirectPoolsExtendConfig `json:"redirect_pools_extend_config,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/results.go
@@ -23,6 +23,9 @@ type L7Policy struct {
 	// The position of this policy on the listener.
 	Position int32 `json:"position"`
 
+	// The priority of this policy on the listener.
+	Priority int32 `json:"priority"`
+
 	// A human-readable description for the resource.
 	Description string `json:"description"`
 
@@ -37,6 +40,18 @@ type L7Policy struct {
 	// Requests matching this policy will be redirected to this Listener.
 	// Only valid if action is REDIRECT_TO_LISTENER.
 	RedirectListenerID string `json:"redirect_listener_id"`
+
+	// Requests matching this policy will be redirected to the URL.
+	// Only valid if action is REDIRECT_TO_URL.
+	RedirectUrlConfig *RedirectUrlConfig `json:"redirect_url_config"`
+
+	// Requests matching this policy will be redirected to the configuration of the page.
+	// Only valid if action is FIXED_RESPONSE.
+	FixedResponseConfig *FixedResponseConfig `json:"fixed_response_config"`
+
+	// The config of the redirected pool.
+	// Only valid if action is REDIRECT_TO_POOL.
+	RedirectPoolsExtendConfig *RedirectPoolsExtendConfig `json:"redirect_pools_extend_config"`
 
 	// The administrative state of the L7 policy, which is up (true) or down (false).
 	AdminStateUp bool `json:"admin_state_up"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/requests.go
@@ -79,6 +79,10 @@ type VolumeOpts struct {
 	Tags map[string]string `json:"tags,omitempty"`
 	// the enterprise project id
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+	// The iops of evs volume. Only required when volume_type is `GPSSD2` or `ESSD2`
+	IOPS int `json:"iops,omitempty"`
+	// The throughput of evs volume. Only required when volume_type is `GPSSD2`
+	Throughput int `json:"throughput,omitempty"`
 }
 
 // SchedulerOpts contains the scheduler hints

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes/results.go
@@ -59,6 +59,16 @@ type VolumeMetadata struct {
 	AttachedMode string `json:"attached_mode"`
 }
 
+// IOPSAndThroughput is the struct of IOPS and throughput
+type IOPSAndThroughput struct {
+	// The frozened mark
+	Frozened bool `json:"frozened"`
+	// The iops or throughput id
+	ID string `json:"id"`
+	// The iops or throughput value
+	TotalVal int `json:"total_val"`
+}
+
 // Link is an object that represents a link to which the disk belongs.
 type Link struct {
 	// Specifies the corresponding shortcut link.
@@ -81,6 +91,10 @@ type Volume struct {
 	Description string `json:"description"`
 	// The type of volume to create, either SATA or SSD.
 	VolumeType string `json:"volume_type"`
+	// The IOPS of the volume. Only exist when volume_type is `ESSD2` or `GPSSD2`
+	IOPS IOPSAndThroughput `json:"iops"`
+	// The throughput of the volume. Only exist when volume_type is `GPSSD2`
+	Throughput IOPSAndThroughput `json:"throughput"`
 	// AvailabilityZone is which availability zone the volume is in.
 	AvailabilityZone string `json:"availability_zone"`
 	// Instances onto which the volume is attached.

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/requests.go
@@ -42,3 +42,52 @@ func GetPasswordPolicy(client *golangsdk.ServiceClient, domainID string) (*Passw
 	_, err := client.Get(passwordPolicyURL(client, domainID), &resp, nil)
 	return &resp.Body, err
 }
+
+// ProtectPolicyOpts provides options used to modify the operation protection policy.
+type ProtectPolicyOpts struct {
+	// Specifies whether to enable operation protection. The value can be true or false.
+	Protection *bool `json:"operation_protection" required:"true"`
+	// Specifies the attributes IAM users can modify.
+	AllowUser *AllowUserOpts `json:"allow_user,omitempty"`
+	// Specifies whether to designate a person for verification.
+	// If this parameter is set to on, you need to specify the scene parameter to designate a person for verification.
+	// If this parameter is set to off, the designated operator is responsible for the verification.
+	AdminCheck *string `json:"admin_check,omitempty"`
+	// Specifies the verification method. This parameter is mandatory when admin_check is set to on.
+	// The optional values are mobile and email.
+	Scene *string `json:"scene,omitempty"`
+	// Specifies the mobile number used for verification. Example: 0086-123456789
+	Mobile *string `json:"mobile,omitempty"`
+	// Specifies the email address used for verification. An example value is example@email.com.
+	Email *string `json:"email,omitempty"`
+}
+
+type AllowUserOpts struct {
+	// Specifies whether to allow IAM users to manage access keys by themselves.
+	ManageAccesskey *bool `json:"manage_accesskey,omitempty"`
+	// Specifies whether to allow IAM users to change their email addresses.
+	ManageEmail *bool `json:"manage_email,omitempty"`
+	// Specifies whether to allow IAM users to change their mobile numbers.
+	ManageMobile *bool `json:"manage_mobile,omitempty"`
+	// Specifies whether to allow IAM users to change their passwords.
+	ManagePassword *bool `json:"manage_password,omitempty"`
+}
+
+// UpdateProtectPolicy can modify the operation protection policy
+func UpdateProtectPolicy(client *golangsdk.ServiceClient, opts *ProtectPolicyOpts, domainID string) (*ProtectPolicy, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "protect_policy")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ProtectPolicyResp
+	_, err = client.Put(protectPolicyURL(client, domainID), &b, &resp, nil)
+	return &resp.Body, err
+}
+
+// GetProtectPolicy retrieves details of the operation protection policy
+func GetProtectPolicy(client *golangsdk.ServiceClient, domainID string) (*ProtectPolicy, error) {
+	var resp ProtectPolicyResp
+	_, err := client.Get(protectPolicyURL(client, domainID), &resp, nil)
+	return &resp.Body, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/results.go
@@ -24,3 +24,33 @@ type PasswordPolicy struct {
 type PasswordPolicyResp struct {
 	Body PasswordPolicy `json:"password_policy"`
 }
+
+type ProtectPolicy struct {
+	// Indicates whether to enable operation protection.
+	Protection bool `json:"operation_protection"`
+	// the attributes IAM users can modify.
+	AllowUser AllowUserBody `json:"allow_user"`
+	// Indicates whether to designate a person for verification.
+	AdminCheck string `json:"admin_check"`
+	// the verification method. The optional values are mobile and email.
+	Scene string `json:"scene"`
+	// the mobile number used for verification. Example: 0086-123456789
+	Mobile string `json:"mobile"`
+	// the email address used for verification. An example value is example@email.com.
+	Email string `json:"email"`
+}
+
+type AllowUserBody struct {
+	// Indicates whether to allow IAM users to manage access keys by themselves.
+	ManageAccesskey bool `json:"manage_accesskey"`
+	// Indicates whether to allow IAM users to change their email addresses.
+	ManageEmail bool `json:"manage_email"`
+	// Indicates whether to allow IAM users to change their mobile numbers.
+	ManageMobile bool `json:"manage_mobile"`
+	// Indicates whether to allow IAM users to change their passwords.
+	ManagePassword bool `json:"manage_password"`
+}
+
+type ProtectPolicyResp struct {
+	Body ProtectPolicy `json:"protect_policy"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/security/urls.go
@@ -7,3 +7,7 @@ const rootPath = "OS-SECURITYPOLICY"
 func passwordPolicyURL(client *golangsdk.ServiceClient, domainID string) string {
 	return client.ServiceURL(rootPath, "domains", domainID, "password-policy")
 }
+
+func protectPolicyURL(client *golangsdk.ServiceClient, domainID string) string {
+	return client.ServiceURL(rootPath, "domains", domainID, "protect-policy")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -22,6 +22,7 @@ type CreateOpts struct {
 	VpcId               string             `json:"vpc_id" required:"true"`
 	SubnetId            string             `json:"subnet_id" required:"true"`
 	SecurityGroupId     string             `json:"security_group_id" required:"true"`
+	RestorePoint        *RestorePoint      `json:"restore_point,omitempty"`
 	ChargeInfo          *ChargeInfo        `json:"charge_info,omitempty"`
 	TimeZone            string             `json:"time_zone,omitempty"`
 	FixedIp             string             `json:"data_vip,omitempty"`
@@ -63,6 +64,14 @@ type BackupStrategy struct {
 type Volume struct {
 	Type string `json:"type" required:"true"`
 	Size int    `json:"size" required:"true"`
+}
+
+type RestorePoint struct {
+	InstanceId   string            `json:"instance_id" required:"true"`
+	Type         string            `json:"type" required:"true"`
+	BackupId     string            `json:"backup_id,omitempty"`
+	RestoreTime  string            `json:"restore_time,omitempty"`
+	DatabaseName map[string]string `json:"database_name,omitempty"`
 }
 
 type ChargeInfo struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230718085800-819e20e25fbb
+# github.com/chnsz/golangsdk v0.0.0-20230721033028-327ee73ae1ff
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support restore
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support restore
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsInstance_restore_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_restore_ -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_sqlserver
--- PASS: TestAccRdsInstance_restore_pg (2097.87s)
--- PASS: TestAccRdsInstance_restore_mysql (2522.02s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2690.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       5264.663s
```
