### PR TITLE
chore(Modelarts): fix lint errors and documents

### DIFF
--- a/docs/resources/modelarts_dataset.md
+++ b/docs/resources/modelarts_dataset.md
@@ -178,7 +178,7 @@ This resource provides the following timeouts configuration options:
 
 The datasets can be imported by `id`.
 
-```
+```bash
 terraform import huaweicloud_modelarts_dataset.test yiROKoTTjtwjvP71yLG
 ```
 
@@ -189,7 +189,7 @@ API response, security or some other reason. The missing attributes include: `da
 importing a dataset. You can then decide if changes should be applied to the dataset, or the resource definition
 should be updated to align with the dataset. Also you can ignore changes as below.
 
-```
+```hcl
 resource "huaweicloud_modelarts_dataset" "test" {
     ...
 

--- a/docs/resources/modelarts_dataset_version.md
+++ b/docs/resources/modelarts_dataset_version.md
@@ -89,7 +89,7 @@ This resource provides the following timeouts configuration options:
 
 The dataset versions can be imported by dataset ID and version ID, separated by a slash, e.g.
 
-```
+```bash
 terraform import huaweicloud_modelarts_dataset_version.test yiROKoTTjtwjvP71yLG/wieeeoTrtrtjvn67yLm
 ```
 
@@ -98,7 +98,7 @@ API response, security or some other reason. The missing attributes include: `ha
 recommended running `terraform plan` after importing a dataset. You can then decide if changes should be applied to the
 dataset, or the resource definition should be updated to align with the dataset. Also you can ignore changes as below.
 
-```
+```hcl
 resource "huaweicloud_modelarts_dataset_version" "test" {
     ...
 

--- a/docs/resources/modelarts_notebook.md
+++ b/docs/resources/modelarts_notebook.md
@@ -121,6 +121,6 @@ The `mount_storages` block contains:
 
 The notebook can be imported by `id`.
 
-```
+```bash
 terraform import huaweicloud_modelarts_notebook.test b11b407c-e604-4e8d-8bc4-92398320b847
 ```

--- a/docs/resources/modelarts_notebook_mount_storage.md
+++ b/docs/resources/modelarts_notebook_mount_storage.md
@@ -55,6 +55,6 @@ In addition to all arguments above, the following attributes are exported:
 The mount storage can be imported by `id`, It is composed of the ID of notebook and mount ID, separated by a slash.
  For example,
 
-```
+```bash
 terraform import huaweicloud_modelarts_notebook_mount_storage.test b11b407c-e604-4e8d-8bc4-92398320b847/4e206d3c-6831-4267-b93d-e236105cda38
 ```

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccDataSourceDatasetVersions_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccDataSourceDatasets_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccNotebookImages_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_test.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getDatesetResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ModelArtsV2Client(acceptance.HW_REGION_NAME)
+func getDatesetResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ModelArtsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return nil, fmt.Errorf("error creating ModelArts v1 client, err=%s", err)
 	}
 
 	return dataset.Get(client, state.Primary.ID, dataset.GetOpts{})

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_version_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_version_test.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
 	"github.com/chnsz/golangsdk/openstack/modelarts/v2/version"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 )
 
-func getDatasetVersionResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ModelArtsV2Client(acceptance.HW_REGION_NAME)
+func getDatasetVersionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ModelArtsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_mount_storage_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_mount_storage_test.go
@@ -4,20 +4,20 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 )
 
-func getNotebookMountResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ModelArtsV1Client(acceptance.HW_REGION_NAME)
+func getNotebookMountResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ModelArtsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return nil, fmt.Errorf("error creating ModelArts v1 client, err=%s", err)
 	}
 
 	notebookId, storageId, err := modelarts.ParseMountFromId(state.Primary.ID)

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getNotebookResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ModelArtsV1Client(acceptance.HW_REGION_NAME)
+func getNotebookResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ModelArtsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return nil, fmt.Errorf("error creating ModelArts v1 client, err=%s", err)
 	}
 
 	return notebook.Get(client, state.Primary.ID)

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_dataset_versions.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_dataset_versions.go
@@ -5,10 +5,12 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/version"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -105,9 +107,9 @@ func DataSourceDatasetVerions() *schema.Resource {
 }
 
 func dataSourceDatasetVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ModelArtsV2Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ModelArtsV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_datasets.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_datasets.go
@@ -3,14 +3,15 @@ package modelarts
 import (
 	"context"
 
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceDatasets() *schema.Resource {
@@ -156,11 +157,11 @@ func DataSourceDatasets() *schema.Resource {
 }
 
 func dataSourceDatasetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ModelArtsV2Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ModelArtsV2Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating ModelArts v2 client, err=%s", err)
+		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}
 
 	opts := dataset.ListOpts{
@@ -175,17 +176,17 @@ func dataSourceDatasetsRead(_ context.Context, d *schema.ResourceData, meta inte
 
 	page, err := dataset.List(client, opts)
 	if err != nil {
-		return fmtp.DiagErrorf("Error querying ModelArts datasets: %s ", err)
+		return diag.Errorf("error querying ModelArts datasets: %s ", err)
 	}
 
 	p, err := page.AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("Error querying ModelArts datasets: %s", err)
+		return diag.Errorf("error querying ModelArts datasets: %s", err)
 	}
 
 	datasets, err := dataset.ExtractDatasets(p)
 	if err != nil {
-		return fmtp.DiagErrorf("Error querying ModelArts datasets: %s", err)
+		return diag.Errorf("error querying ModelArts datasets: %s", err)
 	}
 
 	var rst []map[string]interface{}
@@ -210,7 +211,7 @@ func dataSourceDatasetsRead(_ context.Context, d *schema.ResourceData, meta inte
 
 	err = d.Set("datasets", rst)
 	if err != nil {
-		return fmtp.DiagErrorf("set datasets err:%s", err)
+		return diag.Errorf("set datasets err:%s", err)
 	}
 
 	d.SetId(hashcode.Strings(ids))

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset_version.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset_version.go
@@ -8,14 +8,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/version"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
+	"github.com/chnsz/golangsdk/openstack/modelarts/v2/version"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -132,11 +134,11 @@ func ResourceDatasetVersion() *schema.Resource {
 }
 
 func ResourceDatasetVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ModelArtsV2Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ModelArtsV2Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating ModelArts v2 client, err=%s", err)
+		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}
 
 	datasetId := d.Get("dataset_id").(string)
@@ -163,9 +165,9 @@ func ResourceDatasetVersionCreate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func ResourceDatasetVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ModelArtsV2Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ModelArtsV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}
@@ -201,10 +203,10 @@ func ResourceDatasetVersionRead(_ context.Context, d *schema.ResourceData, meta 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func ResourceDatasetVersionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ModelArtsV2Client(region)
+func ResourceDatasetVersionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ModelArtsV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}
@@ -216,7 +218,6 @@ func ResourceDatasetVersionDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error deleting ModelArts dataset version, ID= %s", d.Id())
 	}
 
-	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^(TestAccResourceNotebook_basic|TestAccResourceNotebook_all)$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts -v

=== RUN   TestAccResourceNotebook_basic
=== PAUSE TestAccResourceNotebook_basic
=== RUN   TestAccResourceNotebook_all
=== PAUSE TestAccResourceNotebook_all
=== CONT  TestAccResourceNotebook_basic
=== CONT  TestAccResourceNotebook_all
--- PASS: TestAccResourceNotebook_basic (62.37s)
--- PASS: TestAccResourceNotebook_all (130.81s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts	130.855s


Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccResourceNotebookMountStorage_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts -v

=== RUN   TestAccResourceNotebookMountStorage_basic
=== PAUSE TestAccResourceNotebookMountStorage_basic
=== CONT  TestAccResourceNotebookMountStorage_basic
--- PASS: TestAccResourceNotebookMountStorage_basic (76.42s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts	76.454s



Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccResourceDateset_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts -v

=== RUN   TestAccResourceDateset_basic
=== PAUSE TestAccResourceDateset_basic
=== CONT  TestAccResourceDateset_basic
--- PASS: TestAccResourceDateset_basic (92.89s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts	92.931s

Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccDatasetVersionResource_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts -v

=== RUN   TestAccDatasetVersionResource_basic
=== PAUSE TestAccDatasetVersionResource_basic
=== CONT  TestAccDatasetVersionResource_basic
--- PASS: TestAccDatasetVersionResource_basic (116.89s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts	116.929s




Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccDataSourceDatasetVersions_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts -v

=== RUN   TestAccDataSourceDatasetVersions_basic
=== PAUSE TestAccDataSourceDatasetVersions_basic
=== CONT  TestAccDataSourceDatasetVersions_basic
--- PASS: TestAccDataSourceDatasetVersions_basic (107.38s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts	107.414s

```
