### PR TITLE
chore(workflow): upload debug file in cron-ci and pre-release

### DIFF
--- a/.github/workflows/cron-ci.yml
+++ b/.github/workflows/cron-ci.yml
@@ -67,6 +67,8 @@ jobs:
       HW_ADMIN: "true"
       HW_ENTERPRISE_PROJECT_ID: "0"
       HW_ENTERPRISE_PROJECT_ID_TEST: "0"
+      TF_LOG: "DEBUG"
+      TF_LOG_PATH: "${{ github.workspace }}/acceptance.log"
 
     runs-on: ubuntu-latest
 
@@ -90,7 +92,7 @@ jobs:
           total=0
           commitID=$(git log --before="1 week ago" --pretty=format:"%h" -n 1)
           all_files=$(git diff $commitID --name-only huaweicloud | grep -v "_test.go")
-          echo -e "the following files have changed since $commitID:\n$all_files\n"
+          echo -e "the following files have changed since $commitID:\n$all_files\n" | tee -a ${{ env.TF_LOG_PATH }}
 
           for f in $all_files; do
             path=${f%/*}
@@ -106,16 +108,25 @@ jobs:
               basic_case=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk 'NR==1{print $2}' | awk -F '(' '{print $1}')
               if [ "X$basic_case" != "X" ]; then
                 total=`expr $total + 1`
-                echo -e "\nrun acceptance basic test: $basic_case"
+                echo -e "\nrun acceptance basic test: $basic_case" | tee -a ${{ env.TF_LOG_PATH }}
                 make testacc TEST="./$path" TESTARGS="-run ${basic_case}"
                 if [ $? -ne 0 ]; then
                   result=`expr $result + 1`
                 fi
               fi
             else
-              echo -e "\n[skipped] --- ./${test_file} does not exist"
+              echo -e "\n[skipped] --- ./${test_file} does not exist" | tee -a ${{ env.TF_LOG_PATH }}
             fi
           done
 
-          echo -e "\n[summary] $result failed in $total acceptance basic tests"
+          echo -e "\n[summary] $result failed in $total acceptance basic tests" | tee -a ${{ env.TF_LOG_PATH }}
           exit $result
+
+      - name: Upload acceptance log
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-ci
+          path: |
+            ${{ env.TF_LOG_PATH }}
+          if-no-files-found: ignore

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -169,6 +169,8 @@ jobs:
       HW_ADMIN: "true"
       HW_ENTERPRISE_PROJECT_ID: "0"
       HW_ENTERPRISE_PROJECT_ID_TEST: "0"
+      TF_LOG: "DEBUG"
+      TF_LOG_PATH: "${{ github.workspace }}/acceptance.log"
 
     runs-on: ubuntu-latest
     steps:
@@ -192,7 +194,7 @@ jobs:
           total=0
           last_tag=$(git tag --sort=-creatordate | sed -n 1p)
           all_files=$(git diff $last_tag --name-only huaweicloud | grep -v "_test.go")
-          echo -e "the following files have changed since $last_tag:\n$all_files\n"
+          echo -e "the following files have changed since $last_tag:\n$all_files\n" | tee -a ${{ env.TF_LOG_PATH }}
 
           for f in $all_files; do
             path=${f%/*}
@@ -208,16 +210,25 @@ jobs:
               basic_case=$(grep "^func TestAcc" ./${test_file} | grep _basic | awk 'NR==1{print $2}' | awk -F '(' '{print $1}')
               if [ "X$basic_case" != "X" ]; then
                 total=`expr $total + 1`
-                echo -e "\n[$total] `date` run acceptance basic test: $basic_case"
+                echo -e "\n[$total] `date` run acceptance basic test: $basic_case" | tee -a ${{ env.TF_LOG_PATH }}
                 make testacc TEST="./$path" TESTARGS="-run ${basic_case}"
                 if [ $? -ne 0 ]; then
                   result=`expr $result + 1`
                 fi
               fi
             else
-              echo -e "\n[skipped] --- ./${test_file} does not exist"
+              echo -e "\n[skipped] --- ./${test_file} does not exist" | tee -a ${{ env.TF_LOG_PATH }}
             fi
           done
 
-          echo -e "\n[summary] $result failed in $total acceptance basic tests"
+          echo -e "\n[summary] $result failed in $total acceptance basic tests" | tee -a ${{ env.TF_LOG_PATH }}
           exit $result
+
+      - name: Upload acceptance log
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: acceptance-release
+          path: |
+            ${{ env.TF_LOG_PATH }}
+          if-no-files-found: ignore


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

upload debug file in **cron-ci** and **pre-release**
Currently, the *acc-test* workflow does not support uploading debug file.

You can find the workflow in https://github.com/ShiChangkuo/terraform-provider-huaweicloud/actions/runs/5654126621

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
