### PR TITLE
feat(WAF): add a new resource waf geolocation access control rule

### DIFF
--- a/docs/resources/waf_rule_geolocation_access_control.md
+++ b/docs/resources/waf_rule_geolocation_access_control.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_rule_geolocation_access_control
+
+Manages a WAF rule geolocation access control resource within HuaweiCloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The geolocation access control rule resource can be used in Cloud Mode, Dedicated Mode.
+
+## Example Usage
+
+```hcl
+variable policy_id {}
+variable enterprise_project_id {}
+
+resource "huaweicloud_waf_rule_geolocation_access_control" "test" {
+  policy_id             = var.policy_id
+  enterprise_project_id = var.enterprise_project_id
+  name                  = "test_rule"
+  geolocation           = "FJ|JL|LN|GZ"
+  action                = 1
+  description           = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the policy ID.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of WAF geolocation access control rule. This parameter can contain a
+  maximum of 128 characters. Only letters, digits, hyphens (-), underscores (_), colons (:) and periods (.) are allowed.
+
+* `geolocation` - (Required, String) Specifies the locations that can be configured in the geolocation access control
+  rule. Separate multiple locations with vertical lines, such as **FJ|JL|LN|GZ**.
+
+  Valid locations are as follows:
+  **CN**: China, **CA**: Canada, **US**: The United States, **AU**: Australia, **IN**: India, **JP**: Japan,
+  **UK**: United Kingdom, **FR**: France, **DE**: Germany, **BR**: Brazil, **Thailand**: Thailand,
+  **Singapore**: Singapore,**South Africa**: South Africa, **Mexico**: Mexico, **Peru**: Peru, **Indonesia**: Indonesia,
+  **GD**: Guangdong, **FJ**: Fujian, **JL**: Jilin, **LN**: Liaoning, **TW**: Taiwan SAR, China,**GZ**: Guizhou,
+  **AH**: Anhui, **HL**: Heilongjiang, **HA**: Henan, **SC**: Sichuan, **HE**: Hebei, **YN**: Yunnan, **HB**: Hubei,
+  **HI**: Hainan, **QH**: Qinghai, **HN**: Hunan, **JX**: Jiangxi, **SX**: Shanxi, **SN**: Shaanxi, **ZJ**: Zhejiang,
+  **GS**: Gansu, **JS**: Jiangsu, **SD**: Shandong, **BJ**: Beijing, **SH**: Shanghai, **TJ**: Tianjin,
+  **CQ**: Chongqing, **MO**: Macao SAR, China, **HK**: Hong Kong SAR, China, **NX**: Ningxia, **GX**: Guangxi,
+  **XJ**: Xinjiang, **XZ**: Tibet, **NM**: Inner Mongolia.
+
+* `action` - (Required, Int) Specifies the protective action of WAF geolocation access control rule.
+  Valid values are as follows:
+  + 0: WAF blocks requests that hit the rule.
+  + 1: WAF allows requests that hit the rule.
+  + 2: WAF only record requests that hit the rule.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF geolocation access
+  control rule.
+
+  Changing this parameter will create a new resource.
+
+* `status` - (Optional, Int) Specifies the status of WAF geolocation access control rule.
+  Valid values are as follows:
+  + **0**: Disabled.
+  + **1**: Enabled.
+
+  The default value is **1**.
+
+* `description` - (Optional, String) Specifies the description of WAF geolocation access control rule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+There are two ways to import WAF rule geolocation access control state.
+
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_geolocation_access_control.test <policy_id>/<rule_id>
+```
+
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_geolocation_access_control.test <policy_id>/<rule_id>/<enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1078,6 +1078,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rule_global_protection_whitelist": waf.ResourceRuleGlobalProtectionWhitelist(),
 			"huaweicloud_waf_rule_precise_protection":          waf.ResourceRulePreciseProtection(),
 			"huaweicloud_waf_rule_web_tamper_protection":       waf.ResourceWafRuleWebTamperProtectionV1(),
+			"huaweicloud_waf_rule_geolocation_access_control":  waf.ResourceRuleGeolocation(),
 			"huaweicloud_waf_dedicated_instance":               waf.ResourceWafDedicatedInstance(),
 			"huaweicloud_waf_dedicated_domain":                 waf.ResourceWafDedicatedDomainV1(),
 			"huaweicloud_waf_instance_group":                   waf.ResourceWafInstanceGroup(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_geolocation_access_control_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_geolocation_access_control_test.go
@@ -1,0 +1,196 @@
+package waf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getRuleGeolocationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/geoip/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", state.Primary.Attributes["policy_id"])
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", state.Primary.ID)
+
+	queryParam := ""
+	if epsID := state.Primary.Attributes["enterprise_project_id"]; epsID != "" {
+		queryParam = fmt.Sprintf("?enterprise_project_id=%s", epsID)
+	}
+	getPath += queryParam
+
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving WAF geolocation access control rule: %s", err)
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccRuleGeolocation_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_geolocation_access_control.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleGeolocationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleGeolocation_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "geolocation", "FJ|JL|LN|GZ"),
+					resource.TestCheckResourceAttr(rName, "action", "1"),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+				),
+			},
+			{
+				Config: testRuleGeolocation_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "geolocation", "FJ|JL|LN|HN"),
+					resource.TestCheckResourceAttr(rName, "action", "0"),
+					resource.TestCheckResourceAttr(rName, "status", "0"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccRuleGeolocation_withEpsID(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_geolocation_access_control.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleGeolocationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleGeolocation_withEpsID(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "geolocation", "FJ|JL|LN|GZ"),
+					resource.TestCheckResourceAttr(rName, "action", "1"),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func testRuleGeolocation_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_geolocation_access_control" "test" {
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  name        = "%s"
+  geolocation = "FJ|JL|LN|GZ"
+  action      = 1
+  description = "test description"
+}
+`, testAccWafPolicyV1_basic(name), name)
+}
+
+func testRuleGeolocation_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_geolocation_access_control" "test" {
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  name        = "%s_update"
+  geolocation = "FJ|JL|LN|HN"
+  action      = 0
+  status      = 0
+}
+`, testAccWafPolicyV1_basic(name), name)
+}
+
+func testRuleGeolocation_withEpsID(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_geolocation_access_control" "test" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  name                  = "%s"
+  enterprise_project_id = "%s"
+  geolocation           = "FJ|JL|LN|GZ"
+  action                = 1
+  description           = "test description"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+		name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_geolocation_access_control.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_geolocation_access_control.go
@@ -1,0 +1,266 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product WAF
+// ---------------------------------------------------------------
+
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceRuleGeolocation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRuleGeolocationCreate,
+		UpdateContext: resourceRuleGeolocationUpdate,
+		ReadContext:   resourceRuleGeolocationRead,
+		DeleteContext: resourceRuleGeolocationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceWAFRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the policy ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of WAF geolocation access control rule.`,
+			},
+			"geolocation": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the locations that can be configured in the geolocation access control rule.`,
+			},
+			"action": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the protective action of WAF geolocation access control rule.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the enterprise project ID of WAF geolocation access control rule.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1,
+				Description: `Specifies the status of WAF geolocation access control rule.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description of WAF geolocation access control rule.`,
+			},
+		},
+	}
+}
+
+func resourceRuleGeolocationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/geoip"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", d.Get("policy_id").(string))
+	createPath += buildQueryParams(d, cfg)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildCreateBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating WAF geolocation access control rule: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("id", createRespBody)
+	if err != nil {
+		return diag.Errorf("error creating WAF geolocation access control rule: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceRuleGeolocationRead(ctx, d, meta)
+}
+
+func buildCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"geoip":       d.Get("geolocation"),
+		"white":       d.Get("action"),
+		"status":      d.Get("status"),
+		"description": d.Get("description"),
+	}
+}
+
+func resourceRuleGeolocationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/geoip/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", d.Get("policy_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", d.Id())
+	getPath += buildQueryParams(d, cfg)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF geolocation access control rule")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("policy_id", utils.PathSearch("policyid", getRespBody, nil)),
+		d.Set("geolocation", utils.PathSearch("geoip", getRespBody, nil)),
+		d.Set("action", utils.PathSearch("white", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRuleGeolocationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	updateRuleGeolocationChanges := []string{
+		"name",
+		"geolocation",
+		"action",
+		"description",
+	}
+	if d.HasChanges(updateRuleGeolocationChanges...) {
+		updatePath := client.Endpoint + "v1/{project_id}/waf/policy/{policy_id}/geoip/{rule_id}"
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
+		updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+		updatePath += buildQueryParams(d, cfg)
+		updateOpt := golangsdk.RequestOpts{
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=utf8",
+			},
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildUpdateBodyParams(d)),
+		}
+
+		_, err := client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating WAF geolocation access control rule: %s", err)
+		}
+	}
+
+	if d.HasChange("status") {
+		if err := updateRuleStatus(client, d, cfg, "geoip"); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return resourceRuleGeolocationRead(ctx, d, meta)
+}
+
+func buildUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"geoip":       d.Get("geolocation"),
+		"white":       d.Get("action"),
+		"description": d.Get("description"),
+	}
+}
+
+func resourceRuleGeolocationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/geoip/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Get("policy_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", d.Id())
+	deletePath += buildQueryParams(d, cfg)
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting WAF geolocation access control rule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource waf geolocation access control rule
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRuleGeolocation_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleGeolocation_basic -timeout 360m -parallel 4 
=== RUN   TestAccRuleGeolocation_basic 
=== PAUSE TestAccRuleGeolocation_basic
=== CONT  TestAccRuleGeolocation_basic
--- PASS: TestAccRuleGeolocation_basic (395.77s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       395.831s
```
