### PR TITLE
feat(WAF): add a new resource waf known attack source rule

### DIFF
--- a/docs/resources/waf_rule_known_attack_source.md
+++ b/docs/resources/waf_rule_known_attack_source.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_rule_known_attack_source
+
+Manages a WAF rule known attack source resource within HuaweiCloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The known attack source rule resource can be used in Cloud Mode, Dedicated Mode.
+
+## Example Usage
+
+```hcl
+variable policy_id {}
+variable enterprise_project_id {}
+
+resource "huaweicloud_waf_rule_known_attack_source" "test" {
+  policy_id             = var.policy_id
+  enterprise_project_id = var.enterprise_project_id
+  block_type            = "long_ip_block"
+  block_time            = 500
+  description           = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the policy ID.
+
+  Changing this parameter will create a new resource.
+
+* `block_type` - (Required, String, ForceNew) Specifies the type of WAF known attack source rule.
+
+  Changing this parameter will create a new resource.
+
+  Valid values are as follows:
+  + **long_ip_block**: Long-term IP address blocking.
+  + **long_cookie_block**: Long-term Cookie blocking.
+  + **long_params_block**: Long-term Params blocking.
+  + **short_ip_block**: Short-term IP address blocking.
+  + **short_cookie_block**: Short-term Cookie blocking.
+  + **short_params_block**: Short-term Params blocking.
+
+* `block_time` - (Required, Int) Specifies the blocking time in seconds.
+  + If the prefix of `block_type` is **long**, the value ranges from 301 to 1800.
+  + If the prefix of `block_type` is **short**, the value ranges from 1 to 300.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF known attack
+  source rule.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of WAF known attack source rule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+There are two ways to import WAF rule known attack source state.
+
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_known_attack_source.test <policy_id>/<rule_id>
+```
+
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_known_attack_source.test <policy_id>/<rule_id>/<enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1076,6 +1076,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_rule_cc_protection":               waf.ResourceRuleCCProtection(),
 			"huaweicloud_waf_rule_data_masking":                waf.ResourceWafRuleDataMaskingV1(),
 			"huaweicloud_waf_rule_global_protection_whitelist": waf.ResourceRuleGlobalProtectionWhitelist(),
+			"huaweicloud_waf_rule_known_attack_source":         waf.ResourceRuleKnownAttack(),
 			"huaweicloud_waf_rule_precise_protection":          waf.ResourceRulePreciseProtection(),
 			"huaweicloud_waf_rule_web_tamper_protection":       waf.ResourceWafRuleWebTamperProtectionV1(),
 			"huaweicloud_waf_dedicated_instance":               waf.ResourceWafDedicatedInstance(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_known_attack_source_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_known_attack_source_test.go
@@ -1,0 +1,186 @@
+package waf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getRuleKnownAttackResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/punishment/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", state.Primary.Attributes["policy_id"])
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", state.Primary.ID)
+
+	queryParam := ""
+	if epsID := state.Primary.Attributes["enterprise_project_id"]; epsID != "" {
+		queryParam = fmt.Sprintf("?enterprise_project_id=%s", epsID)
+	}
+	getPath += queryParam
+
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving WAF known attack source rule: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccRuleKnownAttack_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_known_attack_source.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleKnownAttackResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleKnownAttack_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "block_type", "long_ip_block"),
+					resource.TestCheckResourceAttr(rName, "block_time", "500"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+				),
+			},
+			{
+				Config: testRuleKnownAttack_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "block_time", "600"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccRuleKnownAttack_withEpsID(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_known_attack_source.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleKnownAttackResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleKnownAttack_withEpsID(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "block_type", "long_ip_block"),
+					resource.TestCheckResourceAttr(rName, "block_time", "500"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func testRuleKnownAttack_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_known_attack_source" "test" {
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  block_type  = "long_ip_block"
+  block_time  = 500
+  description = "test description"
+}
+`, testAccWafPolicyV1_basic(name))
+}
+
+func testRuleKnownAttack_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_known_attack_source" "test" {
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  block_type  = "long_ip_block"
+  block_time  = 600
+}
+`, testAccWafPolicyV1_basic(name))
+}
+
+func testRuleKnownAttack_withEpsID(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_known_attack_source" "test" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  enterprise_project_id = "%s"
+  block_type            = "long_ip_block"
+  block_time            = 500
+  description           = "test description"
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_known_attack_source.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_known_attack_source.go
@@ -1,0 +1,235 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product WAF
+// ---------------------------------------------------------------
+
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceRuleKnownAttack() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRuleKnownAttackCreate,
+		UpdateContext: resourceRuleKnownAttackUpdate,
+		ReadContext:   resourceRuleKnownAttackRead,
+		DeleteContext: resourceRuleKnownAttackDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceWAFRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the policy ID.`,
+			},
+			"block_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the type of WAF known attack source rule.`,
+			},
+			"block_time": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the blocking time in seconds.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description of WAF known attack source rule.`,
+			},
+		},
+	}
+}
+
+func resourceRuleKnownAttackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/punishment"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", d.Get("policy_id").(string))
+	createPath += buildQueryParams(d, cfg)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildRuleKnownAttackBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating WAF known attack source rule: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("id", createRespBody)
+	if err != nil {
+		return diag.Errorf("error creating WAF known attack source rule: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceRuleKnownAttackRead(ctx, d, meta)
+}
+
+func buildRuleKnownAttackBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"category":    d.Get("block_type"),
+		"block_time":  d.Get("block_time"),
+		"description": d.Get("description"),
+	}
+}
+
+func resourceRuleKnownAttackRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/punishment/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", d.Get("policy_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", d.Id())
+	getPath += buildQueryParams(d, cfg)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF known attack source rule")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("policy_id", utils.PathSearch("policyid", getRespBody, nil)),
+		d.Set("block_time", utils.PathSearch("block_time", getRespBody, nil)),
+		d.Set("block_type", utils.PathSearch("category", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRuleKnownAttackUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/punishment/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+	updatePath += buildQueryParams(d, cfg)
+	updateOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildRuleKnownAttackBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating WAF known attack source rule: %s", err)
+	}
+
+	return resourceRuleKnownAttackRead(ctx, d, meta)
+}
+
+func resourceRuleKnownAttackDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/punishment/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Get("policy_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", d.Id())
+	deletePath += buildQueryParams(d, cfg)
+
+	deleteRuleKnownAttackOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteRuleKnownAttackOpt)
+	if err != nil {
+		return diag.Errorf("error deleting WAF known attack source rule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource waf known attack source rule
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRuleKnownAttack_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleKnownAttack_basic -timeout 360m -parallel 4 
=== RUN   TestAccRuleKnownAttack_basic 
=== PAUSE TestAccRuleKnownAttack_basic
=== CONT  TestAccRuleKnownAttack_basic
--- PASS: TestAccRuleKnownAttack_basic (400.66s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       400.726s
```
