### PR TITLE
chore: fix lint issues for IAM group

### DIFF
--- a/docs/data-sources/identity_group.md
+++ b/docs/data-sources/identity_group.md
@@ -6,7 +6,7 @@ subcategory: "Identity and Access Management (IAM)"
 
 Use this data source to get details of the specified IAM user group.
 
-~> You *must* have IAM read privileges to use this data source.
+-> **NOTE:** You *must* have IAM read privileges to use this data source.
 
 ## Example Usage
 
@@ -32,16 +32,16 @@ data "huaweicloud_identity_group" "group" {
 
 The `users` block contains:
 
-* `name` - Indicates the IAM user name.
+* `id` - Indicates the ID of the IAM user.
 
-* `id` - Indicates the ID of the User.
+* `name` - Indicates the IAM user name.
 
 * `description` - Indicates the description of the IAM user.
 
 * `enabled` - Indicates the whether the IAM user is enabled.
 
 * `password_expires_at` - Indicates the time when the password will expire.
-  Null indicates that the password has unlimited validity.
+  If this value is not set, the password will not expire.
 
 * `password_status` - Indicates the password status. True means that the password needs to be changed,
   and false means that the password is normal.

--- a/docs/data-sources/identity_users.md
+++ b/docs/data-sources/identity_users.md
@@ -6,7 +6,7 @@ subcategory: "Identity and Access Management (IAM)"
 
 Use this data source to query the IAM user list within HuaweiCloud.
 
-~> You *must* have IAM read privileges to use this data source.
+-> **NOTE:** You *must* have IAM read privileges to use this data source.
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ The `users` block contains:
 * `groups` - Indicates the user groups to which an IAM user belongs.
 
 * `password_expires_at` - Indicates the time when the password will expire.
-  Null indicates that the password has unlimited validity.
+  If this value is not set, the password will not expire.
 
 * `password_status` - Indicates the password status. True means that the password needs to be changed,
   and false means that the password is normal.

--- a/docs/resources/identity_group.md
+++ b/docs/resources/identity_group.md
@@ -4,9 +4,9 @@ subcategory: "Identity and Access Management (IAM)"
 
 # huaweicloud_identity_group
 
-Manages a User Group resource within HuaweiCloud IAM service.
+Manages an IAM user group resource within HuaweiCloud.
 
-Note: You *must* have admin privileges in your HuaweiCloud cloud to use this resource.
+-> **NOTE:** You *must* have admin privileges to use this resource.
 
 ## Example Usage
 
@@ -21,7 +21,7 @@ resource "huaweicloud_identity_group" "group_1" {
 
 The following arguments are supported:
 
-* `name` - (Required, String) Specifies the name of the group.The length is less than or equal to 64 bytes.
+* `name` - (Required, String) Specifies the name of the group. The length is less than or equal to 64 bytes.
 
 * `description` - (Optional, String) Specifies the description of the group.
 
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A resource ID in UUID format.
+* `id` - The resource ID in UUID format.
 
 ## Import
 

--- a/docs/resources/identity_group_membership.md
+++ b/docs/resources/identity_group_membership.md
@@ -4,9 +4,9 @@ subcategory: "Identity and Access Management (IAM)"
 
 # huaweicloud_identity_group_membership
 
-Manages a User Group Membership resource within HuaweiCloud IAM service.
+Manages an IAM group membership resource within HuaweiCloud.
 
-Note: You *must* have admin privileges in your HuaweiCloud cloud to use this resource.
+-> **NOTE:** You *must* have admin privileges to use this resource.
 
 ## Example Usage
 
@@ -41,12 +41,12 @@ resource "huaweicloud_identity_group_membership" "membership_1" {
 
 The following arguments are supported:
 
-* `group` - (Required, String, ForceNew) The group ID of this membership.
+* `group` - (Required, String, ForceNew) Specifies the group ID of this membership.
 
-* `users` - (Required, List) A List of user IDs to associate to the group.
+* `users` - (Required, List) Specifies a list of IAM user IDs to associate to the group.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - The resource ID in UUID format.

--- a/docs/resources/identity_user.md
+++ b/docs/resources/identity_user.md
@@ -4,9 +4,9 @@ subcategory: "Identity and Access Management (IAM)"
 
 # huaweicloud_identity_user
 
-Manages a User resource within HuaweiCloud IAM service.
+Manages an IAM user resource within HuaweiCloud.
 
-Note: You *must* have admin privileges in your HuaweiCloud cloud to use this resource.
+-> **NOTE:** You *must* have admin privileges to use this resource.
 
 ## Example Usage
 
@@ -45,9 +45,9 @@ The following arguments are supported:
 * `enabled` - (Optional, Bool) Specifies whether the user is enabled or disabled. Valid values are `true` and `false`.
 
 * `access_type` - (Optional, String) Specifies the access type of the user. Available values are:
-  + default: support both programmatic and management console access.
-  + programmatic: only support programmatic access.
-  + console: only support management console access.
+  + **default**: support both programmatic and management console access.
+  + **programmatic**: only support programmatic access.
+  + **console**: only support management console access.
 
 ## Attributes Reference
 
@@ -71,13 +71,13 @@ $ terraform import huaweicloud_identity_user.user_1 89c60255-9bd6-460c-822a-e2b9
 
 But due to the security reason, `password` can not be imported, you can ignore it as below.
 
-```
+```hcl
 resource "huaweicloud_identity_user" "user_1" {
   ...
 
   lifecycle {
     ignore_changes = [
-      "password",
+      password,
     ]
   }
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -872,7 +872,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_access_key":            iam.ResourceIdentityKey(),
 			"huaweicloud_identity_acl":                   iam.ResourceIdentityACL(),
 			"huaweicloud_identity_agency":                iam.ResourceIAMAgencyV3(),
-			"huaweicloud_identity_group":                 iam.ResourceIdentityGroupV3(),
+			"huaweicloud_identity_group":                 iam.ResourceIdentityGroup(),
 			"huaweicloud_identity_group_membership":      iam.ResourceIdentityGroupMembershipV3(),
 			"huaweicloud_identity_group_role_assignment": iam.ResourceIdentityGroupRoleAssignment(),
 			"huaweicloud_identity_project":               iam.ResourceIdentityProjectV3(),
@@ -1191,7 +1191,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_project_v3":          iam.ResourceIdentityProjectV3(),
 			"huaweicloud_identity_role_assignment_v3":  iam.ResourceIdentityGroupRoleAssignment(),
 			"huaweicloud_identity_user_v3":             iam.ResourceIdentityUserV3(),
-			"huaweicloud_identity_group_v3":            iam.ResourceIdentityGroupV3(),
+			"huaweicloud_identity_group_v3":            iam.ResourceIdentityGroup(),
 			"huaweicloud_identity_group_membership_v3": iam.ResourceIdentityGroupMembershipV3(),
 			"huaweicloud_identity_provider_conversion": iam.ResourceIAMProviderConversion(),
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -878,7 +878,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_project":               iam.ResourceIdentityProjectV3(),
 			"huaweicloud_identity_role":                  iam.ResourceIdentityRole(),
 			"huaweicloud_identity_role_assignment":       iam.ResourceIdentityGroupRoleAssignment(),
-			"huaweicloud_identity_user":                  iam.ResourceIdentityUserV3(),
+			"huaweicloud_identity_user":                  iam.ResourceIdentityUser(),
 			"huaweicloud_identity_user_role_assignment":  iam.ResourceIdentityUserRoleAssignment(),
 			"huaweicloud_identity_provider":              iam.ResourceIdentityProvider(),
 			"huaweicloud_identity_password_policy":       iam.ResourceIdentityPasswordPolicy(),
@@ -1190,7 +1190,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_identity_project_v3":          iam.ResourceIdentityProjectV3(),
 			"huaweicloud_identity_role_assignment_v3":  iam.ResourceIdentityGroupRoleAssignment(),
-			"huaweicloud_identity_user_v3":             iam.ResourceIdentityUserV3(),
+			"huaweicloud_identity_user_v3":             iam.ResourceIdentityUser(),
 			"huaweicloud_identity_group_v3":            iam.ResourceIdentityGroup(),
 			"huaweicloud_identity_group_membership_v3": iam.ResourceIdentityGroupMembershipV3(),
 			"huaweicloud_identity_provider_conversion": iam.ResourceIAMProviderConversion(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -873,7 +873,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_acl":                   iam.ResourceIdentityACL(),
 			"huaweicloud_identity_agency":                iam.ResourceIAMAgencyV3(),
 			"huaweicloud_identity_group":                 iam.ResourceIdentityGroup(),
-			"huaweicloud_identity_group_membership":      iam.ResourceIdentityGroupMembershipV3(),
+			"huaweicloud_identity_group_membership":      iam.ResourceIdentityGroupMembership(),
 			"huaweicloud_identity_group_role_assignment": iam.ResourceIdentityGroupRoleAssignment(),
 			"huaweicloud_identity_project":               iam.ResourceIdentityProjectV3(),
 			"huaweicloud_identity_role":                  iam.ResourceIdentityRole(),
@@ -1192,7 +1192,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_role_assignment_v3":  iam.ResourceIdentityGroupRoleAssignment(),
 			"huaweicloud_identity_user_v3":             iam.ResourceIdentityUser(),
 			"huaweicloud_identity_group_v3":            iam.ResourceIdentityGroup(),
-			"huaweicloud_identity_group_membership_v3": iam.ResourceIdentityGroupMembershipV3(),
+			"huaweicloud_identity_group_membership_v3": iam.ResourceIdentityGroupMembership(),
 			"huaweicloud_identity_provider_conversion": iam.ResourceIAMProviderConversion(),
 
 			"huaweicloud_cdm_cluster_v1": cdm.ResourceCdmCluster(),

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_group_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_group_test.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccIdentityGroupDataSource_basic(t *testing.T) {
-	resourceName := "data.huaweicloud_identity_group.test"
+	dataSourceName := "data.huaweicloud_identity_group.test"
 	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(resourceName)
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -25,7 +25,34 @@ func TestAccIdentityGroupDataSource_basic(t *testing.T) {
 				Config: testAccIdentityGroupDataSource_by_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "users.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityGroupDataSource_with_user(t *testing.T) {
+	dataSourceName := "data.huaweicloud_identity_group.test"
+	rName := acceptance.RandomAccResourceName()
+	password := acceptance.RandomPassword()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityGroupDataSource_with_user(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "users.#", "2"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.id"),
 				),
 			},
 		},
@@ -34,17 +61,46 @@ func TestAccIdentityGroupDataSource_basic(t *testing.T) {
 
 func testAccIdentityGroupDataSource_by_name(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_group" "group_1" {
+resource "huaweicloud_identity_group" "test" {
   name        = "%s"
-  description = "A ACC test group"
+  description = "An ACC test group"
 }
 
 data "huaweicloud_identity_group" "test" {
-  name = huaweicloud_identity_group.group_1.name
+  name = huaweicloud_identity_group.test.name
   
   depends_on = [
-    huaweicloud_identity_group.group_1
+    huaweicloud_identity_group.test
   ]
 }
 `, rName)
+}
+
+func testAccIdentityGroupDataSource_with_user(rName, password string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_group" "test" {
+  name        = "%[1]s"
+  description = "An ACC test group"
+}
+
+resource "huaweicloud_identity_user" "test" {
+  count    = 2
+  name     = "%[1]s-${count.index}"
+  password = "%[2]s"
+  enabled  = true
+}
+
+resource "huaweicloud_identity_group_membership" "test" {
+  group = huaweicloud_identity_group.test.id
+  users = huaweicloud_identity_user.test.*.id
+}
+
+data "huaweicloud_identity_group" "test" {
+  name = huaweicloud_identity_group.test.name
+
+  depends_on = [
+    huaweicloud_identity_group_membership.test
+  ]
+}
+`, rName, password)
 }

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_users_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_users_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_group_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_group_test.go
@@ -4,27 +4,26 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/identity/v3/groups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func getIdentityGroupResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.IdentityV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("Error creating HuaweiCloud IAM client: %s", err)
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 	return groups.Get(client, state.Primary.ID).Extract()
 }
 
-func TestAccIdentityV3Group_basic(t *testing.T) {
+func TestAccIdentityGroup_basic(t *testing.T) {
 	var group groups.Group
-	var groupName = acceptance.RandomAccResourceName()
+	groupName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_identity_group.group_1"
 
 	rc := acceptance.InitResourceCheck(
@@ -42,11 +41,11 @@ func TestAccIdentityV3Group_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityV3Group_basic(groupName),
+				Config: testAccIdentityGroup_basic(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(resourceName, "description", "A ACC test group"),
+					resource.TestCheckResourceAttr(resourceName, "description", "An ACC test group"),
 				),
 			},
 			{
@@ -55,31 +54,31 @@ func TestAccIdentityV3Group_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIdentityV3Group_update(groupName),
+				Config: testAccIdentityGroup_update(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(resourceName, "description", "Some Group"),
+					resource.TestCheckResourceAttr(resourceName, "description", "An ACC update group"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityV3Group_basic(groupName string) string {
+func testAccIdentityGroup_basic(groupName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_group" "group_1" {
   name        = "%s"
-  description = "A ACC test group"
+  description = "An ACC test group"
 }
 `, groupName)
 }
 
-func testAccIdentityV3Group_update(groupName string) string {
+func testAccIdentityGroup_update(groupName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_group" "group_1" {
   name        = "%s"
-  description = "Some Group"
+  description = "An ACC update group"
 }
 `, groupName)
 }

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_users.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_users.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/groups"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/users"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -119,7 +120,7 @@ func flattenIAMUserList(client *golangsdk.ServiceClient, userList []users.User) 
 		if groupNames, err := getUserOwnGroups(client, val.ID); err == nil {
 			result[i]["groups"] = groupNames
 		} else {
-			log.Printf("[WARN] faied to get groups to which the user belongs: %s", err)
+			log.Printf("[WARN] faied to get groups to which the user %s belongs: %s", val.Name, err)
 		}
 	}
 	return result, ids


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityUser_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityUser_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_basic (19.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       19.383s

$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityGroupDataSource_with_user"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityGroupDataSource_with_user -timeout 360m -parallel 4
=== RUN   TestAccIdentityGroupDataSource_with_user
=== PAUSE TestAccIdentityGroupDataSource_with_user
=== CONT  TestAccIdentityGroupDataSource_with_user
--- PASS: TestAccIdentityGroupDataSource_with_user (12.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       12.830s

$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityGroupDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityGroupDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityGroupDataSource_basic
=== PAUSE TestAccIdentityGroupDataSource_basic
=== CONT  TestAccIdentityGroupDataSource_basic
--- PASS: TestAccIdentityGroupDataSource_basic (11.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       11.445s

$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityGroupMembership_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityGroupMembership_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityGroupMembership_basic
=== PAUSE TestAccIdentityGroupMembership_basic
=== CONT  TestAccIdentityGroupMembership_basic
--- PASS: TestAccIdentityGroupMembership_basic (33.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       33.303s
```
