### PR TITLE
feat(identitycenter): add permission set resource

### DIFF
--- a/docs/incubating/identitycenter_permission_set.md
+++ b/docs/incubating/identitycenter_permission_set.md
@@ -1,0 +1,55 @@
+---
+subcategory: "IAM Identity Center"
+---
+
+# huaweicloud_identitycenter_permission_set
+
+Manages an Identity Center permission set resource within HuaweiCloud.  
+
+## Example Usage
+
+```hcl
+data "huaweicloud_identitycenter_instance" "system" {}
+
+resource "huaweicloud_identitycenter_permission_set" "demo" {
+  instance_id      = data.huaweicloud_identitycenter_instance.system.id
+  name             = "demo"
+  session_duration = "PT8H"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the IAM Identity Center instance.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the permission set.
+  Changing this parameter will create a new resource.
+
+* `session_duration` - (Required, String) Specifies the length of time that the user sessions are valid in the
+  ISO-8601 standard, e.g. **PT4H**.
+
+* `relay_state` - (Optional, String) Specifies the relay state URL used to redirect users within the application during
+  the federation authentication process.
+
+* `description` - (Optional, String) Specifies the description of the permission set.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `urn` - The Uniform Resource Name of the permission set.
+
+* `created_at` - The date the permission set was created in RFC3339 format.
+
+## Import
+
+The Identity Center permission set can be imported using the `instance_id` and `id` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_identitycenter_permission_set.demo <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -887,7 +887,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_password_policy":       iam.ResourceIdentityPasswordPolicy(),
 			"huaweicloud_identity_protection_policy":     iam.ResourceIdentityProtectionPolicy(),
 
-			"huaweicloud_identitycenter_user": identitycenter.ResourceIdentityCenterUser(),
+			"huaweicloud_identitycenter_user":           identitycenter.ResourceIdentityCenterUser(),
+			"huaweicloud_identitycenter_permission_set": identitycenter.ResourcePermissionSet(),
 
 			"huaweicloud_iec_eip":                 resourceIecNetworkEip(),
 			"huaweicloud_iec_keypair":             resourceIecKeypair(),

--- a/huaweicloud/services/acceptance/identitycenter/resource_huaweicloud_identitycenter_permission_set_test.go
+++ b/huaweicloud/services/acceptance/identitycenter/resource_huaweicloud_identitycenter_permission_set_test.go
@@ -1,0 +1,150 @@
+package identitycenter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getPermissionSetResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	getPermissionSetClient, err := cfg.NewServiceClient("identitycenter", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Identity Center client: %s", err)
+	}
+
+	getPermissionSetHttpUrl := "v1/instances/{instance_id}/permission-sets/{id}"
+	getPermissionSetPath := getPermissionSetClient.Endpoint + getPermissionSetHttpUrl
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{id}", state.Primary.ID)
+
+	getPermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getPermissionSetResp, err := getPermissionSetClient.Request("GET", getPermissionSetPath, &getPermissionSetOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving permission set: %s", err)
+	}
+
+	return utils.FlattenResponse(getPermissionSetResp)
+}
+
+func TestAccPermissionSet_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_identitycenter_permission_set.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPermissionSetResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testPermissionSet_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "session_duration", "PT8H"),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttrSet(rName, "urn"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"data.huaweicloud_identitycenter_instance.system", "id"),
+				),
+			},
+			{
+				Config: testPermissionSet_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "session_duration", "PT4H"),
+					resource.TestCheckResourceAttr(rName, "description", "updated by terraform"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateIdFunc: testPermissionSetImportState(rName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testPermissionSet_without_desc(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "session_duration", "PT4H"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+				),
+			},
+		},
+	})
+}
+
+func testPermissionSetImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		if instanceID == "" {
+			return "", fmt.Errorf("attribute (instance_id) of resource (%s) not found: %s", name, rs)
+		}
+
+		return instanceID + "/" + rs.Primary.ID, nil
+	}
+}
+
+func testPermissionSet_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_identitycenter_instance" "system" {}
+
+resource "huaweicloud_identitycenter_permission_set" "test" {
+  instance_id      = data.huaweicloud_identitycenter_instance.system.id
+  name             = "%s"
+  session_duration = "PT8H"
+  description      = "created by terraform"
+}
+`, name)
+}
+
+func testPermissionSet_update(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_identitycenter_instance" "system" {}
+
+resource "huaweicloud_identitycenter_permission_set" "test" {
+  instance_id      = data.huaweicloud_identitycenter_instance.system.id
+  name             = "%s"
+  session_duration = "PT4H"
+  description      = "updated by terraform"
+}
+`, name)
+}
+
+func testPermissionSet_without_desc(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_identitycenter_instance" "system" {}
+
+resource "huaweicloud_identitycenter_permission_set" "test" {
+  instance_id      = data.huaweicloud_identitycenter_instance.system.id
+  name             = "%s"
+  session_duration = "PT4H"
+}
+`, name)
+}

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_permission_set.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_permission_set.go
@@ -1,0 +1,256 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product IdentityCenter
+// ---------------------------------------------------------------
+
+package identitycenter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourcePermissionSet() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePermissionSetCreate,
+		UpdateContext: resourcePermissionSetUpdate,
+		ReadContext:   resourcePermissionSetRead,
+		DeleteContext: resourcePermissionSetDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePermissionSetImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"session_duration": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"relay_state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePermissionSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		createPermissionSetHttpUrl = "v1/instances/{instance_id}/permission-sets"
+		createPermissionSetProduct = "identitycenter"
+	)
+	createPermissionSetClient, err := cfg.NewServiceClient(createPermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Identity Center client: %s", err)
+	}
+
+	createPermissionSetPath := createPermissionSetClient.Endpoint + createPermissionSetHttpUrl
+	createPermissionSetPath = strings.ReplaceAll(createPermissionSetPath, "{instance_id}", d.Get("instance_id").(string))
+
+	createPermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createPermissionSetOpt.JSONBody = utils.RemoveNil(buildCreatePermissionSetBodyParams(d))
+	createPermissionSetResp, err := createPermissionSetClient.Request("POST", createPermissionSetPath, &createPermissionSetOpt)
+	if err != nil {
+		return diag.Errorf("error creating permission set: %s", err)
+	}
+
+	createPermissionSetRespBody, err := utils.FlattenResponse(createPermissionSetResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("permission_set.permission_set_id", createPermissionSetRespBody)
+	if err != nil {
+		return diag.Errorf("error creating permission set: ID is not found in API response")
+	}
+
+	d.SetId(id.(string))
+	return resourcePermissionSetRead(ctx, d, meta)
+}
+
+func buildCreatePermissionSetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":             utils.ValueIngoreEmpty(d.Get("name")),
+		"session_duration": utils.ValueIngoreEmpty(d.Get("session_duration")),
+		"description":      utils.ValueIngoreEmpty(d.Get("description")),
+		"relay_state":      utils.ValueIngoreEmpty(d.Get("relay_state")),
+	}
+	return bodyParams
+}
+
+func resourcePermissionSetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		getPermissionSetHttpUrl = "v1/instances/{instance_id}/permission-sets/{id}"
+		getPermissionSetProduct = "identitycenter"
+	)
+	getPermissionSetClient, err := cfg.NewServiceClient(getPermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Identity Center client: %s", err)
+	}
+
+	getPermissionSetPath := getPermissionSetClient.Endpoint + getPermissionSetHttpUrl
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{instance_id}", d.Get("instance_id").(string))
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{id}", d.Id())
+
+	getPermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getPermissionSetResp, err := getPermissionSetClient.Request("GET", getPermissionSetPath, &getPermissionSetOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving permission set")
+	}
+
+	getPermissionSetRespBody, err := utils.FlattenResponse(getPermissionSetResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	timeStamp := utils.PathSearch("permission_set.created_date", getPermissionSetRespBody, 0).(float64)
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("permission_set.name", getPermissionSetRespBody, nil)),
+		d.Set("session_duration", utils.PathSearch("permission_set.session_duration", getPermissionSetRespBody, nil)),
+		d.Set("relay_state", utils.PathSearch("permission_set.relay_state", getPermissionSetRespBody, nil)),
+		d.Set("description", utils.PathSearch("permission_set.description", getPermissionSetRespBody, nil)),
+		d.Set("urn", utils.PathSearch("permission_set.permission_urn", getPermissionSetRespBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(timeStamp)/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePermissionSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updatePermissionSetChanges := []string{
+		"session_duration",
+		"description",
+		"relay_state",
+	}
+
+	if d.HasChanges(updatePermissionSetChanges...) {
+		var (
+			updatePermissionSetHttpUrl = "v1/instances/{instance_id}/permission-sets/{id}"
+			updatePermissionSetProduct = "identitycenter"
+		)
+		updatePermissionSetClient, err := cfg.NewServiceClient(updatePermissionSetProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating Identity Center client: %s", err)
+		}
+
+		updatePermissionSetPath := updatePermissionSetClient.Endpoint + updatePermissionSetHttpUrl
+		updatePermissionSetPath = strings.ReplaceAll(updatePermissionSetPath, "{instance_id}", d.Get("instance_id").(string))
+		updatePermissionSetPath = strings.ReplaceAll(updatePermissionSetPath, "{id}", d.Id())
+
+		updatePermissionSetOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		updatePermissionSetOpt.JSONBody = utils.RemoveNil(buildUpdatePermissionSetBodyParams(d))
+		_, err = updatePermissionSetClient.Request("PUT", updatePermissionSetPath, &updatePermissionSetOpt)
+		if err != nil {
+			return diag.Errorf("error updating permission set: %s", err)
+		}
+	}
+
+	return resourcePermissionSetRead(ctx, d, meta)
+}
+
+func buildUpdatePermissionSetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"session_duration": utils.ValueIngoreEmpty(d.Get("session_duration")),
+		"relay_state":      utils.ValueIngoreEmpty(d.Get("relay_state")),
+		// the description parameter can be cleared
+		"description": d.Get("description"),
+	}
+	return bodyParams
+}
+
+func resourcePermissionSetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		deletePermissionSetHttpUrl = "v1/instances/{instance_id}/permission-sets/{id}"
+		deletePermissionSetProduct = "identitycenter"
+	)
+	deletePermissionSetClient, err := cfg.NewServiceClient(deletePermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating Identity Center client: %s", err)
+	}
+
+	deletePermissionSetPath := deletePermissionSetClient.Endpoint + deletePermissionSetHttpUrl
+	deletePermissionSetPath = strings.ReplaceAll(deletePermissionSetPath, "{instance_id}", d.Get("instance_id").(string))
+	deletePermissionSetPath = strings.ReplaceAll(deletePermissionSetPath, "{id}", d.Id())
+
+	deletePermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	_, err = deletePermissionSetClient.Request("DELETE", deletePermissionSetPath, &deletePermissionSetOpt)
+	if err != nil {
+		return diag.Errorf("error deleting permission set: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePermissionSetImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		err := fmt.Errorf("invalid format: the format must be <instance id>/<permission set id>")
+		return nil, err
+	}
+
+	instanceID := parts[0]
+	psID := parts[1]
+
+	d.SetId(psID)
+	d.Set("instance_id", instanceID)
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* add new resource **huaweicloud_identitycenter_permission_set**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 go test -v .\huaweicloud\services\acceptance\identitycenter -v -run TestAccPermissionSet_basic
=== RUN   TestAccPermissionSet_basic
=== PAUSE TestAccPermissionSet_basic
=== CONT  TestAccPermissionSet_basic
--- PASS: TestAccPermissionSet_basic (35.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/identitycenter    35.237s
```
