### PR TITLE
fix(cce/node): fix the keypair reference

### DIFF
--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_v3_test.go
@@ -57,7 +57,7 @@ resource "huaweicloud_cce_node_pool" "test" {
   flavor_id                = "s6.large.2"
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
-  key_pair                 = huaweicloud_compute_keypair.test.name
+  key_pair                 = huaweicloud_kps_keypair.test.name
   scall_enable             = false
   min_node_count           = 0
   max_node_count           = 0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
during the full test, there are some problems have been found:
```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccAddonTemplateDataSource_basic
=== PAUSE TestAccAddonTemplateDataSource_basic
=== RUN   TestAccCCEClusterV3DataSource_basic
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== RUN   TestAccCCEClustersDataSource_basic
=== PAUSE TestAccCCEClustersDataSource_basic
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== RUN   TestAccNodeDataSource_basic
=== PAUSE TestAccNodeDataSource_basic
=== RUN   TestAccNodesDataSource_basic
=== PAUSE TestAccNodesDataSource_basic
=== RUN   TestAccAddon_basic
=== PAUSE TestAccAddon_basic
=== RUN   TestAccAddon_values
=== PAUSE TestAccAddon_values
=== RUN   TestAccCluster_basic
=== PAUSE TestAccCluster_basic
=== RUN   TestAccCluster_prePaid
=== PAUSE TestAccCluster_prePaid
=== RUN   TestAccCluster_withEip
=== PAUSE TestAccCluster_withEip
=== RUN   TestAccCluster_withEpsId
=== PAUSE TestAccCluster_withEpsId
=== RUN   TestAccCluster_turbo
=== PAUSE TestAccCluster_turbo
=== RUN   TestAccCluster_hibernate
=== PAUSE TestAccCluster_hibernate
=== RUN   TestAccCluster_multiContainerNetworkCidrs
=== PAUSE TestAccCluster_multiContainerNetworkCidrs
=== RUN   TestAccCluster_secGroup
=== PAUSE TestAccCluster_secGroup
=== RUN   TestAccCCENamespaceV1_basic
=== PAUSE TestAccCCENamespaceV1_basic
=== RUN   TestAccCCENamespaceV1_generateName
=== PAUSE TestAccCCENamespaceV1_generateName
=== RUN   TestAccNodeAttach_basic
=== PAUSE TestAccNodeAttach_basic
=== RUN   TestAccNodeAttach_prePaid
=== PAUSE TestAccNodeAttach_prePaid
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== RUN   TestAccNode_basic
=== PAUSE TestAccNode_basic
=== RUN   TestAccNode_eip
=== PAUSE TestAccNode_eip
=== RUN   TestAccNode_volume_encryption
=== PAUSE TestAccNode_volume_encryption
=== RUN   TestAccNode_prePaid
=== PAUSE TestAccNode_prePaid
=== RUN   TestAccNode_password
=== PAUSE TestAccNode_password
=== RUN   TestAccNode_storage
=== PAUSE TestAccNode_storage
=== RUN   TestAccCCEPartition_basic
=== PAUSE TestAccCCEPartition_basic
=== RUN   TestAccCcePersistentVolumeClaimsV1_basic
=== PAUSE TestAccCcePersistentVolumeClaimsV1_basic
=== RUN   TestAccCcePersistentVolumeClaimsV1_obs
=== PAUSE TestAccCcePersistentVolumeClaimsV1_obs
=== RUN   TestAccCcePersistentVolumeClaimsV1_sfs
=== PAUSE TestAccCcePersistentVolumeClaimsV1_sfs
=== CONT  TestAccAddonTemplateDataSource_basic
=== CONT  TestAccNodeAttach_prePaid
=== CONT  TestAccNode_eip
=== CONT  TestAccCCEPartition_basic
=== NAME  TestAccNodeAttach_prePaid
    acceptance.go:430: This environment does not support prepaid tests
--- SKIP: TestAccNodeAttach_prePaid (0.00s)
=== CONT  TestAccNode_basic
=== NAME  TestAccCCEPartition_basic
    acceptance.go:726: Skip the interface acceptance test because of the cce partition az is missing.
--- SKIP: TestAccCCEPartition_basic (0.12s)
=== CONT  TestAccCcePersistentVolumeClaimsV1_sfs
--- PASS: TestAccAddonTemplateDataSource_basic (549.53s)
=== CONT  TestAccCcePersistentVolumeClaimsV1_obs
--- PASS: TestAccCcePersistentVolumeClaimsV1_sfs (849.31s)
=== CONT  TestAccCcePersistentVolumeClaimsV1_basic
--- PASS: TestAccNode_basic (860.08s)
=== CONT  TestAccNode_password
--- PASS: TestAccNode_eip (1232.59s)
=== CONT  TestAccNode_storage
--- PASS: TestAccCcePersistentVolumeClaimsV1_obs (861.32s)
=== CONT  TestAccNode_prePaid
    acceptance.go:430: This environment does not support prepaid tests
--- SKIP: TestAccNode_prePaid (0.01s)
=== CONT  TestAccCluster_withEip
--- PASS: TestAccCcePersistentVolumeClaimsV1_basic (863.19s)
=== CONT  TestAccNodeAttach_basic
--- PASS: TestAccNode_password (883.72s)
=== CONT  TestAccCCENamespaceV1_generateName
--- PASS: TestAccCluster_withEip (607.66s)
=== CONT  TestAccCCENamespaceV1_basic
--- PASS: TestAccNode_storage (843.63s)
=== CONT  TestAccCluster_secGroup
--- PASS: TestAccCCENamespaceV1_generateName (860.89s)
=== CONT  TestAccCluster_multiContainerNetworkCidrs
--- PASS: TestAccCluster_secGroup (573.06s)
=== CONT  TestAccCluster_hibernate
--- PASS: TestAccCCENamespaceV1_basic (820.09s)
=== CONT  TestAccCluster_turbo
--- PASS: TestAccNodeAttach_basic (1253.01s)
=== CONT  TestAccCluster_withEpsId
    acceptance.go:281: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccCluster_withEpsId (0.01s)
=== CONT  TestAccNodePool_prePaid
    acceptance.go:430: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.01s)
=== CONT  TestAccNodePool_storage
--- PASS: TestAccCluster_multiContainerNetworkCidrs (521.38s)
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccCluster_turbo (586.39s)
=== CONT  TestAccNodePool_SecurityGroups
    resource_huaweicloud_cce_node_pool_test.go:583: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating CCE node pool: Bad request with: [POST https://cce.cn-north-4.myhuaweicloud.com/api/v3/projects/0970dd7a1300f5672ff2c003c60ae115/clusters/e4d70ccc-2f5a-11ee-afc9-0255ac10024a/nodepools], error message: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","code":400,"errorCode":"CCE.01400001","errorMessage":"Invalid request.","error_code":"CCE_CM.0004","error_msg":"Request is invalid","message":"Check nodepool flavor error: Flavor [s6.large.2] 's subeni quota is 0, Eni network is not supported ","reason":"BadRequest"}
        
          with huaweicloud_cce_node_pool.test,
          on terraform_plugin_test.tf line 117, in resource "huaweicloud_cce_node_pool" "test":
         117: resource "huaweicloud_cce_node_pool" "test" {
        
--- PASS: TestAccCluster_hibernate (1292.62s)
=== CONT  TestAccNode_volume_encryption
    acceptance.go:612: This environment does not support KMS tests
--- SKIP: TestAccNode_volume_encryption (0.01s)
=== CONT  TestAccNodePool_tagsLabelsTaints
--- FAIL: TestAccNodePool_SecurityGroups (528.37s)
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:612: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.01s)
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_storage (997.60s)
=== CONT  TestAccNodesDataSource_basic
--- PASS: TestAccNodePool_serverGroup (931.46s)
=== CONT  TestAccCluster_prePaid
    acceptance.go:430: This environment does not support prepaid tests
--- SKIP: TestAccCluster_prePaid (0.02s)
=== CONT  TestAccCluster_basic
--- PASS: TestAccCluster_basic (556.19s)
=== CONT  TestAccAddon_values
    acceptance.go:619: HW_PROJECT_ID must be set for acceptance tests
--- SKIP: TestAccAddon_values (0.01s)
=== CONT  TestAccAddon_basic
--- PASS: TestAccNodesDataSource_basic (818.95s)
=== CONT  TestAccCCENodePoolV3DataSource_basic
    data_source_huaweicloud_cce_node_pool_v3_test.go:19: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: Reference to undeclared resource
        
          on terraform_plugin_test.tf line 40, in resource "huaweicloud_cce_node_pool" "test":
          40:   key_pair                 = huaweicloud_compute_keypair.test.name
        
        A managed resource "huaweicloud_compute_keypair" "test" has not been declared
        in the root module.
--- FAIL: TestAccCCENodePoolV3DataSource_basic (0.79s)
=== CONT  TestAccNodeDataSource_basic
--- PASS: TestAccNodePool_tagsLabelsTaints (885.76s)
=== CONT  TestAccCCEClustersDataSource_basic
--- PASS: TestAccNodePool_basic (1577.62s)
=== CONT  TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccAddon_basic (936.19s)
--- PASS: TestAccNodeDataSource_basic (801.18s)
--- PASS: TestAccCCEClustersDataSource_basic (976.76s)
--- PASS: TestAccCCEClusterV3DataSource_basic (539.19s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce    6070.310s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the keypair reference, from 'compute_keypair' to 'kps_keypair'.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccCCENodePoolV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run=TestAccCCENodePoolV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCCENodePoolV3DataSource_basic
=== PAUSE TestAccCCENodePoolV3DataSource_basic
=== CONT  TestAccCCENodePoolV3DataSource_basic
--- PASS: TestAccCCENodePoolV3DataSource_basic (913.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       913.363s
```
