### PR TITLE
fix(VPC): change vpc subnet resource delete timeouts

### DIFF
--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -123,5 +123,5 @@ $ terraform import huaweicloud_vpc_subnet 4779ab1c-7c1a-44b1-a02e-93dfc361b32d
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
+* `create` - Default is 5 minute.
 * `delete` - Default is 10 minute.

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -104,7 +104,7 @@ func ResourceVpcSubnetV1() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{ // request and response parameters


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Change vpc subnet resource delete timeouts from 5min to 10min.
- When deleting SFS Turbo resource, it takes more than five minutes to successfully delete the subnet.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcSubnetV1_'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1_ -timeout 360m -parallel 4 
=== RUN   TestAccVpcSubnetV1_basic 
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== RUN   TestAccVpcSubnetV1_dhcp
=== PAUSE TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_dhcp
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_dhcp (64.93s) 
--- PASS: TestAccVpcSubnetV1_basic (67.07s) 
--- PASS: TestAccVpcSubnetV1_ipv6 (73.77s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       73.833s
```
