### PR TITLE
feat(SFS): SFS Turbo support hpc and hpc cache share type

### DIFF
--- a/docs/resources/sfs_turbo.md
+++ b/docs/resources/sfs_turbo.md
@@ -8,13 +8,15 @@ Provides an Shared File System (SFS) Turbo resource.
 
 ## Example Usage
 
+### Create a STANDARD Shared File System (SFS) Turbo
+
 ```hcl
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "secgroup_id" {}
 variable "test_az" {}
 
-resource "huaweicloud_sfs_turbo" "sfs-turbo-1" {
+resource "huaweicloud_sfs_turbo" "test" {
   name              = "sfs-turbo-1"
   size              = 500
   share_proto       = "NFS"
@@ -30,6 +32,48 @@ resource "huaweicloud_sfs_turbo" "sfs-turbo-1" {
 }
 ```
 
+### Create an HPC Shared File System (SFS) Turbo
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "secgroup_id" {}
+variable "test_az" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  name              = "sfs-turbo-1"
+  size              = 3686
+  share_proto       = "NFS"
+  share_type        = "HPC"
+  hpc_bandwidth     = "40M"
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.secgroup_id
+  availability_zone = var.test_az
+}
+```
+
+### Create an HPC CACHE Shared File System (SFS) Turbo
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "secgroup_id" {}
+variable "test_az" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  name                = "sfs-turbo-1"
+  size                = 4096
+  share_proto         = "NFS"
+  share_type          = "HPC_CACHE"
+  hpc_cache_bandwidth = "2G"
+  vpc_id              = var.vpc_id
+  subnet_id           = var.subnet_id
+  security_group_id   = var.secgroup_id
+  availability_zone   = var.test_az
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -40,14 +84,30 @@ The following arguments are supported:
 * `name` - (Required, String, ForceNew) Specifies the name of an SFS Turbo file system. The value contains 4 to 64
   characters and must start with a letter. Changing this will create a new resource.
 
-* `size` - (Required, Int) Specifies the capacity of a common file system, in GB. The value ranges from 500 to 32768,
-  and must be large than 10240 for an enhanced file system.
+* `size` - (Required, Int) Specifies the capacity of a sharing file system, in GB.
+  + If `share_type` is set to **STANDARD** or **PERFORMANCE**, the value ranges from 500 to 32768, and ranges from
+  10240 to 327680 for an enhanced file system.
+
+  + If `share_type` is set to **HPC**, the value ranges from 3686 to 1048576 when `hpc_bandwidth` is set to **20M**,
+  and ranges from 1228 to 1048576 when `hpc_bandwidth` is set to **40M**, **125M**, **250M**, **500M** or **1000M**.
+  The capacity must be a multiple of 1.2TiB, which needs to be rounded down after converting to GiB.
+  Such as 3.6TiB->3686GiB, 4.8TiB->4915GiB, 8.4TiB->8601GiB.
+
+  + If `share_type` is set to **HPC_CACHE**, the value ranges from 4096 to 1048576, and the step size is 1024.
+  The minimum capacity(GB) should be equal to 2048 multiplying the HPC cache bandwidth size(GB/s).
+  Such as the minimum capacity is 4096 when `hpc_cache_bandwidth` is set to **2G**, the minimum capacity is 8192 when
+  `hpc_cache_bandwidth` is set to **4G**, the minimum capacity is 16384 when `hpc_cache_bandwidth` is set to **8G**.
+
+  -> The file system capacity can only be expanded, not reduced.
 
 * `share_proto` - (Optional, String, ForceNew) Specifies the protocol for sharing file systems. The valid value is NFS.
   Changing this will create a new resource.
 
-* `share_type` - (Optional, String, ForceNew) Specifies the file system type. The valid values are STANDARD and
-  PERFORMANCE Changing this will create a new resource.
+* `share_type` - (Optional, String, ForceNew) Specifies the file system type. Changing this will create a new resource.
+  Valid values are **STANDARD**, **PERFORMANCE**, **HPC** and **HPC_CACHE**.
+  Defaults to **STANDARD**.
+
+  -> The share type **HPC_CACHE** only support in postpaid charging mode.
 
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone where the file system is located.
   Changing this will create a new resource.
@@ -62,6 +122,16 @@ The following arguments are supported:
 
 * `enhanced` - (Optional, Bool, ForceNew) Specifies whether the file system is enhanced or not. Changing this will
   create a new resource.
+
+  This parameter is valid only when `share_type` is set to **STANDARD** or **PERFORMANCE**.
+
+* `hpc_bandwidth` - (Optional, String, ForceNew) Specifies the HPC bandwidth. Changing this will create a new resource.
+  This parameter is valid and required when `share_type` is set to **HPC**.
+  Valid values are: **20M**, **40M**, **125M**, **250M**, **500M** and **1000M**.
+
+* `hpc_cache_bandwidth` - (Optional, String) Specifies the HPC cache bandwidth(GB/s).
+  This parameter is valid and required when `share_type` is set to **HPC_CACHE**.
+  Valid values are: **2G**, **4G**, **8G**, **16G**, **24G**, **32G** and **48G**.
 
 * `crypt_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key to encrypt the file system. Changing this
   will create a new resource.
@@ -118,8 +188,8 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 30 minutes.
-* `update` - Default is 15 minutes.
+* `create` - Default is 60 minutes.
+* `update` - Default is 60 minutes.
 * `delete` - Default is 10 minutes.
 
 ## Import

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230727092028-373895eceb28
+	github.com/chnsz/golangsdk v0.0.0-20230731060807-4433f6122143
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230727092028-373895eceb28 h1:zpDtYdur688Mvalj0U4HfRt7dePa8STScEWU3nG56Is=
-github.com/chnsz/golangsdk v0.0.0-20230727092028-373895eceb28/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230731060807-4433f6122143 h1:dvy8WGrVTlDrr4F6+5N5UrjeLuXk+ivsTDjNKXBQ24I=
+github.com/chnsz/golangsdk v0.0.0-20230731060807-4433f6122143/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/resource_huaweicloud_sfs_turbo_test.go
+++ b/huaweicloud/resource_huaweicloud_sfs_turbo_test.go
@@ -2,12 +2,15 @@ package huaweicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -136,6 +139,151 @@ func TestAccSFSTurbo_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "size", "600"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccSFSTurbo_hpcShareType(t *testing.T) {
+	name := fmt.Sprintf("sfs-turbo-acc-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_sfs_turbo.test"
+	var turbo shares.Turbo
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSTurboDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurbo_shareTypeHpc(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(resourceName, "share_type", "HPC"),
+					resource.TestCheckResourceAttr(resourceName, "hpc_bandwidth", "40M"),
+					resource.TestCheckResourceAttr(resourceName, "size", "1228"),
+					resource.TestCheckResourceAttr(resourceName, "status", "200"),
+				),
+			},
+			{
+				Config: testAccSFSTurbo_shareTypeHpc_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "size", "4915"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSFSTurbo_hpcCacheShareType(t *testing.T) {
+	name := fmt.Sprintf("sfs-turbo-acc-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_sfs_turbo.test"
+	var turbo shares.Turbo
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSTurboDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurbo_shareTypeHpcCache(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(resourceName, "share_type", "HPC_CACHE"),
+					resource.TestCheckResourceAttr(resourceName, "hpc_cache_bandwidth", "2G"),
+					resource.TestCheckResourceAttr(resourceName, "size", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "status", "200"),
+				),
+			},
+			{
+				Config: testAccSFSTurbo_shareTypeHpcCache_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "hpc_cache_bandwidth", "2G"),
+					resource.TestCheckResourceAttr(resourceName, "size", "8192"),
+				),
+			},
+			{
+				Config: testAccSFSTurbo_shareTypeHpcCache_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "hpc_cache_bandwidth", "4G"),
+					resource.TestCheckResourceAttr(resourceName, "size", "8192"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSFSTurbo_checkError(t *testing.T) {
+	name := fmt.Sprintf("sfs-turbo-acc-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSTurboDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSFSTurbo_checkError1(name),
+				ExpectError: regexp.MustCompile("`hpc_bandwidth` is required when share type is HPC"),
+			},
+			{
+				Config:      testAccSFSTurbo_checkError2(name),
+				ExpectError: regexp.MustCompile("`hpc_cache_bandwidth` is required when share type is HPC_CACHE"),
+			},
+			{
+				Config:      testAccSFSTurbo_checkError3(name),
+				ExpectError: regexp.MustCompile("HPC_CACHE share type only support in postpaid charging mode"),
+			},
+			{
+				Config: testAccSFSTurbo_checkError4(name),
+				ExpectError: regexp.MustCompile("`hpc_bandwidth` and `hpc_cache_bandwidth` cannot be set" +
+					" when share type is STANDARD or PERFORMANCE"),
+			},
+		},
+	})
+}
+
+func TestAccSFSTurbo_checkUpdateError(t *testing.T) {
+	name := fmt.Sprintf("sfs-turbo-acc-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_sfs_turbo.test"
+	var turbo shares.Turbo
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSTurboDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurbo_checkUpdateErrorBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSTurboExists(resourceName, &turbo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(resourceName, "share_type", "PERFORMANCE"),
+					resource.TestCheckResourceAttr(resourceName, "size", "500"),
+				),
+			},
+			{
+				Config:      testAccSFSTurbo_checkUpdateErrorBasic_update(name),
+				ExpectError: regexp.MustCompile("only `HPC_CACHE` share type support updating HPC cache bandwidth"),
 			},
 		},
 	})
@@ -343,6 +491,228 @@ resource "huaweicloud_sfs_turbo" "test" {
   period_unit   = "month"
   period        = 1
   auto_renew    = true
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_shareTypeHpc(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[2]s"
+  size              = 1228
+  share_proto       = "NFS"
+  share_type        = "HPC"
+  hpc_bandwidth     = "40M"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_shareTypeHpc_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[2]s"
+  size              = 4915
+  share_proto       = "NFS"
+  share_type        = "HPC"
+  hpc_bandwidth     = "40M"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_shareTypeHpcCache(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  name                = "%[2]s"
+  size                = 4096
+  share_proto         = "NFS"
+  share_type          = "HPC_CACHE"
+  hpc_cache_bandwidth = "2G"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_shareTypeHpcCache_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  name                = "%[2]s"
+  size                = 8192
+  share_proto         = "NFS"
+  share_type          = "HPC_CACHE"
+  hpc_cache_bandwidth = "2G"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_shareTypeHpcCache_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  name                = "%[2]s"
+  size                = 8192
+  share_proto         = "NFS"
+  share_type          = "HPC_CACHE"
+  hpc_cache_bandwidth = "4G"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_checkError1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[2]s"
+  size              = 1228
+  share_proto       = "NFS"
+  share_type        = "HPC"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_checkError2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[2]s"
+  size              = 1228
+  share_proto       = "NFS"
+  share_type        = "HPC_CACHE"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_checkError3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  name                = "%[2]s"
+  size                = 4096
+  share_proto         = "NFS"
+  share_type          = "HPC_CACHE"
+  hpc_cache_bandwidth = "2G"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = false
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_checkError4(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  name                = "%[2]s"
+  size                = 500
+  share_proto         = "NFS"
+  hpc_cache_bandwidth = "2G"
+
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_checkUpdateErrorBasic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  name              = "%[2]s"
+  size              = 500
+  share_proto       = "NFS"
+  share_type        = "PERFORMANCE"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccSFSTurbo_checkUpdateErrorBasic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  vpc_id              = huaweicloud_vpc.test.id
+  subnet_id           = huaweicloud_vpc_subnet.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  name                = "%[2]s"
+  size                = 500
+  share_proto         = "NFS"
+  share_type          = "PERFORMANCE"
+  hpc_cache_bandwidth = "2G"
 }
 `, common.TestBaseNetwork(name), name)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares/requests.go
@@ -60,6 +60,7 @@ type Metadata struct {
 	MasterDedicatedHostID string `json:"master_dedicated_host_id,omitempty"`
 	SlaveDedicatedHostID  string `json:"slave_dedicated_host_id,omitempty"`
 	DedicatedStorageID    string `json:"dedicated_storage_id,omitempty"`
+	HpcBw                 string `json:"hpc_bw,omitempty"`
 }
 
 // BssParam is an object that represents the prepaid configuration.
@@ -199,6 +200,8 @@ type BssParamExtend struct {
 type ExtendOpts struct {
 	// Specifies the post-expansion capacity (GB) of the shared file system.
 	NewSize int `json:"new_size" required:"true"`
+	// New bandwidth of the file system, in GB/s. This parameter is only supported for HPC Cache file systems.
+	NewBandwidth int `json:"new_bandwidth,omitempty"`
 	// The configuration of pre-paid billing mode.
 	BssParam *BssParamExtend `json:"bss_param,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares/results.go
@@ -66,6 +66,8 @@ type Turbo struct {
 	CreatedAt time.Time `json:"-"`
 	// The enterprise project ID
 	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// The bandwidth of the HPC file system.
+	HpcBw string `json:"hpc_bw"`
 }
 
 type TurboExpandResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230727092028-373895eceb28
+# github.com/chnsz/golangsdk v0.0.0-20230731060807-4433f6122143
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -166,11 +166,9 @@ github.com/chnsz/golangsdk/openstack/er/v3/routetables
 github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
-github.com/chnsz/golangsdk/openstack/fgs/v2/aliases
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies
 github.com/chnsz/golangsdk/openstack/fgs/v2/function
 github.com/chnsz/golangsdk/openstack/fgs/v2/trigger
-github.com/chnsz/golangsdk/openstack/fgs/v2/versions
 github.com/chnsz/golangsdk/openstack/geminidb/v3/backups
 github.com/chnsz/golangsdk/openstack/geminidb/v3/configurations
 github.com/chnsz/golangsdk/openstack/geminidb/v3/flavors


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
SFS Turbo support hpc and hpc cache share type
- Change field `size` documents.
- Add new types for field `share_type`.
- Add two new field `hpc_bandwidth`, `hpc_cache_bandwidth`.
- Add Four new test function for new share type.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- This PR depends on #3243

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccSFSTurbo_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccSFSTurbo_ -timeout 360m -parallel 4
=== RUN   TestAccSFSTurbo_basic
=== PAUSE TestAccSFSTurbo_basic
=== RUN   TestAccSFSTurbo_crypt
=== PAUSE TestAccSFSTurbo_crypt
=== RUN   TestAccSFSTurbo_withEpsId
=== PAUSE TestAccSFSTurbo_withEpsId
=== RUN   TestAccSFSTurbo_prePaid
=== PAUSE TestAccSFSTurbo_prePaid
=== RUN   TestAccSFSTurbo_hpcShareType
=== PAUSE TestAccSFSTurbo_hpcShareType
=== RUN   TestAccSFSTurbo_hpcCacheShareType
=== PAUSE TestAccSFSTurbo_hpcCacheShareType
=== RUN   TestAccSFSTurbo_checkError
=== PAUSE TestAccSFSTurbo_checkError
=== RUN   TestAccSFSTurbo_checkUpdateError
=== PAUSE TestAccSFSTurbo_checkUpdateError
=== CONT  TestAccSFSTurbo_basic
=== CONT  TestAccSFSTurbo_hpcShareType
=== CONT  TestAccSFSTurbo_checkUpdateError
=== CONT  TestAccSFSTurbo_withEpsId
--- PASS: TestAccSFSTurbo_withEpsId (321.02s)
=== CONT  TestAccSFSTurbo_prePaid
--- PASS: TestAccSFSTurbo_basic (524.09s) 
=== CONT  TestAccSFSTurbo_crypt 
--- PASS: TestAccSFSTurbo_checkUpdateError (543.71s) 
=== CONT  TestAccSFSTurbo_checkError 
--- PASS: TestAccSFSTurbo_checkError (55.24s) 
=== CONT  TestAccSFSTurbo_hpcCacheShareType 
--- PASS: TestAccSFSTurbo_crypt (305.64s) 
--- PASS: TestAccSFSTurbo_prePaid (755.36s) 
--- PASS: TestAccSFSTurbo_hpcShareType (1150.90s) 
--- PASS: TestAccSFSTurbo_hpcCacheShareType (2157.31s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       2756.318s
```

