### PR TITLE
fix(EVS): EVS resource support job status refresh

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -585,6 +585,10 @@ func (c *Config) AosV1Client(region string) (*golangsdk.ServiceClient, error) {
 }
 
 // ********** client for Storage **********
+func (c *Config) BlockStorageV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("evsv1", region)
+}
+
 func (c *Config) BlockStorageV21Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("evsv21", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -23,7 +23,7 @@ var multiCatalogKeys = map[string][]string{
 	"iam":          {"identity", "iam_no_version"},
 	"bss":          {"bssv2"},
 	"ecs":          {"ecsv21", "ecsv11"},
-	"evs":          {"evsv21"},
+	"evs":          {"evsv21", "evsv1"},
 	"cce":          {"ccev1", "cce_addon"},
 	"cci":          {"cciv1_bata"},
 	"vpc":          {"networkv2", "vpcv3", "fwv2"},
@@ -222,6 +222,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	},
 
 	// ******* catalog for storage ******
+	"evsv1": {
+		Name:    "evs",
+		Version: "v1",
+		Product: "EVS",
+	},
 	"evs": {
 		Name:    "evs",
 		Version: "v2",

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v1/jobs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v1/jobs/requests.go
@@ -1,0 +1,12 @@
+package jobs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// GetJobDetails retrieves the Job with the provided jobID. To extract the Job object
+// from the response, call the ExtractJob method on the GetResult.
+func GetJobDetails(client *golangsdk.ServiceClient, jobID string) (r GetResult) {
+	_, r.Err = client.Get(jobURL(client, jobID), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v1/jobs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v1/jobs/results.go
@@ -1,0 +1,45 @@
+package jobs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Job object contains the response to a Get request
+type Job struct {
+	Status     string    `json:"status"`
+	Entities   JobEntity `json:"entities"`
+	JobID      string    `json:"job_id"`
+	JobType    string    `json:"job_type"`
+	ErrorCode  string    `json:"error_code"`
+	FailReason string    `json:"fail_reason"`
+	Error      ErrorInfo `json:"error"`
+	BeginTime  string    `json:"begin_time"`
+	EndTime    string    `json:"end_time"`
+}
+
+// JobEntity contains the response to the job task
+type JobEntity struct {
+	Name       string `json:"name"`
+	Size       int    `json:"size"`
+	VolumeID   string `json:"volume_id"`
+	VolumeType string `json:"volume_type"`
+	SubJobs    []Job  `json:"sub_jobs"`
+}
+
+// ErrorInfo contains the error message returned when an error occurs
+type ErrorInfo struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+// GetResult contains the response body and error from a Get request
+type GetResult struct {
+	golangsdk.Result
+}
+
+// ExtractJob will get the *Job object out of the GetResult
+func (r GetResult) ExtractJob() (*Job, error) {
+	var job Job
+	err := r.ExtractInto(&job)
+	return &job, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v1/jobs/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v1/jobs/urls.go
@@ -1,0 +1,7 @@
+package jobs
+
+import "github.com/chnsz/golangsdk"
+
+func jobURL(c *golangsdk.ServiceClient, jobID string) string {
+	return c.ServiceURL("jobs", jobID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,6 +164,7 @@ github.com/chnsz/golangsdk/openstack/er/v3/propagations
 github.com/chnsz/golangsdk/openstack/er/v3/routes
 github.com/chnsz/golangsdk/openstack/er/v3/routetables
 github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments
+github.com/chnsz/golangsdk/openstack/evs/v1/jobs
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
 github.com/chnsz/golangsdk/openstack/fgs/v2/aliases


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

EVS resource support job status refresh

- This PR has been tested on Huawei Cloud.
- This PR has been tested on G42 Cloud.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_basic
--- PASS: TestAccEvsVolume_basic (452.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       452.960s
```

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_withEpsId'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_withEpsId -timeout 360m -parallel 4 
=== RUN   TestAccEvsVolume_withEpsId 
=== PAUSE TestAccEvsVolume_withEpsId 
=== CONT  TestAccEvsVolume_withEpsId 
--- PASS: TestAccEvsVolume_withEpsId (47.67s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       47.723s
```

```
make testacc TEST='./huaweicloud/services/acceptance/evs' TESTARGS='-run TestAccEvsVolume_prePaid'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_prePaid -timeout 360m -parallel 4 
=== RUN   TestAccEvsVolume_prePaid 
=== PAUSE TestAccEvsVolume_prePaid
=== CONT  TestAccEvsVolume_prePaid
--- PASS: TestAccEvsVolume_prePaid (155.53s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       155.604s
```

- G42 unit test
```
make testacc TEST='./g42cloud' TESTARGS='-run TestAccEvsStorageV3Volume_'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./g42cloud -v -run TestAccEvsStorageV3Volume_ -timeout 360m -parallel=4 
=== RUN   TestAccEvsStorageV3Volume_basic 
=== PAUSE TestAccEvsStorageV3Volume_basic 
=== RUN   TestAccEvsStorageV3Volume_image
=== PAUSE TestAccEvsStorageV3Volume_image
=== CONT  TestAccEvsStorageV3Volume_basic
=== CONT  TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (55.54s) 
--- PASS: TestAccEvsStorageV3Volume_basic (60.52s) 
PASS
ok      github.com/g42cloud-terraform/terraform-provider-g42cloud/g42cloud      60.569s
```

