### PR TITLE
fix(cts): create system tracker if it does not exist

### DIFF
--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -67,7 +68,7 @@ func testAccCTSTrackerImportState(name string) resource.ImportStateIdFunc {
 	}
 }
 
-func testAccCheckCTSTrackerDestroy(s *terraform.State) error {
+func testAccCheckCTSTrackerDestroy(_ *terraform.State) error {
 	// the system tracker always exists
 	return nil
 }

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
@@ -131,10 +131,8 @@ func testAccCheckCTSTrackerDestroy(s *terraform.State) error {
 
 		allTrackers := *response.Trackers
 		ctsTracker := allTrackers[0]
-		if ctsTracker.Status != nil {
-			if ctsTracker.Status.Value() != "disabled" {
-				return fmt.Errorf("can not disable the CTS tracker %s", name)
-			}
+		if ctsTracker.Status != nil && ctsTracker.Status.Value() != "disabled" {
+			return fmt.Errorf("can not disable the CTS tracker %s", name)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

we do the following efforts on CTS **system** tracker:
+ extract functions to get and update status of system tracker
+ disable system tracker when destroying
+ create system tracker if it does not exist

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSTracker_basic
=== PAUSE TestAccCTSTracker_basic
=== CONT  TestAccCTSTracker_basic
--- PASS: TestAccCTSTracker_basic (26.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       26.249s
```
