### PR TITLE
fix(VPCEP): fix vpcep approval resource test duplicate resource name …

### DIFF
--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_approval_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_approval_test.go
@@ -59,27 +59,11 @@ func testAccVPCEndpointApproval_Base(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_vpcep_service" "test" {
-  name        = "%s"
-  server_type = "VM"
-  vpc_id      = data.huaweicloud_vpc.myvpc.id
-  port_id     = huaweicloud_compute_instance.ecs.network[0].port
-  approval    = true
-
-  port_mapping {
-    service_port  = 8080
-    terminal_port = 80
-  }
-  tags = {
-    owner = "tf-acc"
-  }
-}
-
 resource "huaweicloud_vpcep_endpoint" "test" {
-  service_id  = huaweicloud_vpcep_service.test.id
-  vpc_id      = data.huaweicloud_vpc.myvpc.id
-  network_id  = data.huaweicloud_vpc_subnet.test.id
-  enable_dns  = true
+  service_id = huaweicloud_vpcep_service.test.id
+  vpc_id     = data.huaweicloud_vpc.myvpc.id
+  network_id = data.huaweicloud_vpc_subnet.test.id
+  enable_dns = true
 
   tags = {
     owner = "tf-acc"
@@ -88,7 +72,7 @@ resource "huaweicloud_vpcep_endpoint" "test" {
     ignore_changes = [enable_dns]
   }
 }
-`, testAccVPCEndpoint_Precondition(rName), rName)
+`, testAccVPCEndpoint_Precondition(rName))
 }
 
 func testAccVPCEndpointApproval_Basic(rName string) string {


### PR DESCRIPTION
…error

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix vpcep approval resource test duplicate resource name error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEndpointApproval_Basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpointApproval_Basic -timeout 360m -parallel 4 
=== RUN   TestAccVPCEndpointApproval_Basic 
=== PAUSE TestAccVPCEndpointApproval_Basic
=== CONT  TestAccVPCEndpointApproval_Basic
--- PASS: TestAccVPCEndpointApproval_Basic (209.30s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     209.355s
```
