### PR TITLE
fix(DCS): fix dcs test and wait status

### DIFF
--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func getDcsResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -941,9 +940,15 @@ func TestAccDcsInstances_prePaid(t *testing.T) {
 
 func testAccDcsV1Instance_basic(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode     = "ha"
@@ -958,8 +963,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6388
   capacity           = 0.125
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
@@ -985,14 +990,20 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     key   = "value"
     owner = "terraform"
   }
-}`, common.TestVpc(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_updated(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode     = "ha"
@@ -1007,8 +1018,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 1
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
@@ -1034,14 +1045,20 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     key   = "value_update"
     owner = "terraform_update"
   }
-}`, common.TestVpc(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_ha(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1057,20 +1074,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6388
   capacity           = 1
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
   maintain_end       = "02:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_ha_expand_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1086,20 +1109,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_ha_reduce_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1115,20 +1144,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 1
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_ha_expand_replica(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1144,20 +1179,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 1
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_ha_to_proxy(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1173,20 +1214,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_rw(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1202,20 +1249,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6388
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
   maintain_end       = "02:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_rw_expand_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1231,20 +1284,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 16
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_rw_reduce_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1260,20 +1319,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_rw_expand_replica(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1289,20 +1354,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_rw_to_proxy(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1318,20 +1389,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_proxy(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1347,20 +1424,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6388
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
   maintain_end       = "02:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_proxy_expand_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1376,20 +1459,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 16
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_proxy_reduce_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1405,20 +1494,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_proxy_to_ha(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1434,20 +1529,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_proxy_to_rw(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1463,20 +1564,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_cluster(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1492,20 +1599,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6388
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
   maintain_end       = "02:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_cluster_expand_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1521,20 +1634,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 8
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_cluster_reduce_capacity(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1550,20 +1669,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_cluster_expand_replica(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   engine         = "Redis"
@@ -1579,20 +1704,26 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine             = "Redis"
   port               = 6389
   capacity           = 4
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "10:00:00"
-}`, common.TestBaseNetwork(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_epsId(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode = "ha"
@@ -1605,8 +1736,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   capacity           = 0.125
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
 
@@ -1618,14 +1749,20 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     save_days   = 1
   }
   enterprise_project_id = "%s"
-}`, common.TestVpc(instanceName), instanceName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}`, instanceName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccDcsV1Instance_tiny(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode = "ha"
@@ -1638,8 +1775,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   capacity           = 0.125
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   
@@ -1650,14 +1787,20 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     backup_at   = [1]
     save_days   = 1
   }
-}`, common.TestVpc(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_single(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode = "single"
@@ -1670,18 +1813,24 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   capacity           = 2
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
-}`, common.TestVpc(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_whitelists(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode = "ha"
@@ -1694,8 +1843,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   capacity           = 2
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   
@@ -1711,14 +1860,20 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     group_name = "test-group1"
     ip_address = ["192.168.10.100", "192.168.0.0/24"]
   }
-}`, common.TestVpc(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_whitelists_update(instanceName string) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode = "ha"
@@ -1731,8 +1886,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   password           = "Huawei_test"
   engine             = "Redis"
   capacity           = 2
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   
@@ -1748,14 +1903,20 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     group_name = "test-group2"
     ip_address = ["172.16.10.100", "172.16.0.0/24"]
   }
-}`, common.TestVpc(instanceName), instanceName)
+}`, instanceName)
 }
 
 func testAccDcsInstance_prePaid(instanceName string, isAutoRenew bool) string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode = "ha"
@@ -1763,8 +1924,8 @@ data "huaweicloud_dcs_flavors" "test" {
 }
 
 resource "huaweicloud_dcs_instance" "test" {
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), [])
   name               = "%s"
   engine             = "Redis"
@@ -1777,5 +1938,5 @@ resource "huaweicloud_dcs_instance" "test" {
   period_unit   = "month"
   period        = 1
   auto_renew    = "%v"
-}`, common.TestVpc(instanceName), instanceName, isAutoRenew)
+}`, instanceName, isAutoRenew)
 }

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -689,12 +689,13 @@ func waitForOrderComplete(ctx context.Context, d *schema.ResourceData, cfg *conf
 func waitForDcsInstanceCompleted(ctx context.Context, c *golangsdk.ServiceClient, id string, timeout time.Duration,
 	padding []string, target []string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:      padding,
-		Target:       target,
-		Refresh:      refreshDcsInstanceState(c, id),
-		Timeout:      timeout,
-		Delay:        10 * time.Second,
-		PollInterval: 10 * time.Second,
+		Pending:                   padding,
+		Target:                    target,
+		Refresh:                   refreshDcsInstanceState(c, id),
+		Timeout:                   timeout,
+		Delay:                     10 * time.Second,
+		PollInterval:              10 * time.Second,
+		ContinuousTargetOccurence: 2,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
@@ -1038,7 +1039,7 @@ func resizeDcsInstance(ctx context.Context, d *schema.ResourceData, meta interfa
 
 		// wait for dcs instance change
 		err = waitForDcsInstanceCompleted(ctx, client, d.Id(), d.Timeout(schema.TimeoutUpdate),
-			[]string{"EXTENDING"}, []string{"RUNNING"})
+			[]string{"EXTENDING", "RESTARTING"}, []string{"RUNNING"})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dcs test and wait status
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dcs test and wait status
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dcs' TESTARGS='-run TestAccDcsInstances_'  TEST_PARALLELISM=8
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs -v -run TestAccDcsInstances_ -timeout 360m -parallel 8
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_rw_change_capacity
=== CONT  TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_withEpsId
=== CONT  TestAccDcsInstances_proxy_to_ha
=== CONT  TestAccDcsInstances_prePaid
    acceptance.go:440: This environment does not support prepaid tests
--- SKIP: TestAccDcsInstances_prePaid (0.03s)
=== CONT  TestAccDcsInstances_ha_to_proxy
--- PASS: TestAccDcsInstances_withEpsId (101.85s)
=== CONT  TestAccDcsInstances_ha_expand_replica
--- PASS: TestAccDcsInstances_basic (132.37s)
=== CONT  TestAccDcsInstances_ha_change_capacity
--- PASS: TestAccDcsInstances_whitelists (142.13s)
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_rw_expand_replica (232.03s)
=== CONT  TestAccDcsInstances_cluster_change_capacity
--- PASS: TestAccDcsInstances_ha_expand_replica (181.27s)
=== CONT  TestAccDcsInstances_single
--- PASS: TestAccDcsInstances_rw_change_capacity (317.69s)
=== CONT  TestAccDcsInstances_tiny
--- PASS: TestAccDcsInstances_single (55.27s)
=== CONT  TestAccDcsInstances_proxy_change_capacity
--- PASS: TestAccDcsInstances_ha_change_capacity (224.39s)
=== CONT  TestAccDcsInstances_rw_to_proxy
--- PASS: TestAccDcsInstances_tiny (75.39s)
--- PASS: TestAccDcsInstances_proxy_to_ha (559.97s)
--- PASS: TestAccDcsInstances_ha_to_proxy (580.36s)
--- PASS: TestAccDcsInstances_cluster_expand_replica (439.67s)
--- PASS: TestAccDcsInstances_proxy_to_rw (597.80s)
--- PASS: TestAccDcsInstances_rw_to_proxy (490.22s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1095.35s)

--- PASS: TestAccDcsInstances_proxy_change_capacity (1773.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       2111.536s
```
