### PR TITLE
test(apig): remove the output and use attribute reference to instead.

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -72,7 +72,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "func_graph_policy.#", "0"),
 					resource.TestCheckResourceAttrPair(rName, "web.0.authorizer_id",
 						"huaweicloud_apig_custom_authorizer.test", "id"),
-					resource.TestCheckOutput("policy_backend_params", "3"),
+					resource.TestCheckResourceAttr(rName, "web_policy.0.backend_params.#", "3"),
 				),
 			},
 			{
@@ -100,7 +100,7 @@ func TestAccApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "func_graph.#", "0"),
 					resource.TestCheckResourceAttr(rName, "mock_policy.#", "0"),
 					resource.TestCheckResourceAttr(rName, "func_graph_policy.#", "0"),
-					resource.TestCheckOutput("policy_backend_params", "3"),
+					resource.TestCheckResourceAttr(rName, "web_policy.0.backend_params.#", "3"),
 				),
 			},
 			{
@@ -311,10 +311,6 @@ resource "huaweicloud_apig_api" "test" {
     }
   }
 }
-
-output "policy_backend_params" {
-  value = length(tolist(huaweicloud_apig_api.test.web_policy)[0].backend_params)
-}
 `, relatedConfig, name)
 }
 
@@ -413,10 +409,6 @@ resource "huaweicloud_apig_api" "test" {
       value      = "Administrator"
     }
   }
-}
-
-output "policy_backend_params" {
-  value = length(tolist(huaweicloud_apig_api.test.web_policy)[0].backend_params)
 }
 `, relatedConfig, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The progress will throw a error while import an APIG output.
```
=== NAME  TestAccApiPublishment_basic
    testing_new_import_state.go:125: unexpected output type: <nil>
```
The publishment resource refer the API basic content, and throws the output import is nil for type, but they are no have any behaviors call type, so, it is the reference issue.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove the output and use attribute reference to instead.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApi_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApi_basic -timeout 360m -parallel 4
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== CONT  TestAccApi_basic
--- PASS: TestAccApi_basic (506.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      506.281s
```
