### PR TITLE
feat: support pre-paid charging mode for bandwidth

### DIFF
--- a/docs/resources/vpc_bandwidth.md
+++ b/docs/resources/vpc_bandwidth.md
@@ -35,6 +35,22 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the Shared Bandwidth.
   Changing this creates a new bandwidth.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the Shared Bandwidth.
+  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**. Changing this will create a new bandwidth.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the Shared Bandwidth.
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this will create a new bandwidth.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the Shared Bandwidth.
+  + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
+  + If `period_unit` is set to **year**, the value ranges from `1` to `3`.
+
+  This parameter is mandatory if `charging_mode` is set to **prePaid**. Changing this will create a new bandwidth.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
+  Valid values are **true** and **false**. Defaults to **false**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -57,9 +73,9 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `update` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 
@@ -67,4 +83,22 @@ Shared Bandwidths can be imported using the `id`, e.g.
 
 ```
 $ terraform import huaweicloud_vpc_bandwidth.bandwidth_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```
+
+Note that the imported state may not be identical to your resource definition, due to payment attributes missing from
+the API response.
+The missing attributes include: `period_unit`, `period`, `auto_renew`.
+It is generally recommended running `terraform plan` after importing a Shared Bandwidth.
+You can ignore changes as below.
+
+```hcl
+resource "huaweicloud_vpc_bandwidth" "bandwidth_1" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      period_unit, period, auto_renew,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
@@ -334,11 +334,10 @@ func waitForBandwidth(client *golangsdk.ServiceClient, id string) resource.State
 }
 
 func normalizeChargingMode(billing string) string {
-	mode := "postPaid"
 	if billing != "" {
-		mode = "prePaid"
+		return "prePaid"
 	}
-	return mode
+	return "postPaid"
 }
 
 func flattenPublicIPs(band bandwidthsv1.BandWidth) []map[string]interface{} {

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/structs"
 	bandwidthsv1 "github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/bandwidths"
 
@@ -61,6 +62,10 @@ func ResourceVpcBandWidthV2() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"charging_mode": common.SchemaChargingMode(nil),
+			"period_unit":   common.SchemaPeriodUnit(nil),
+			"period":        common.SchemaPeriod(nil),
+			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
 
 			"share_type": {
 				Type:     schema.TypeString,
@@ -132,7 +137,7 @@ func resourceVpcBandWidthV2Create(ctx context.Context, d *schema.ResourceData, m
 		createOpts.EnterpriseProjectId = epsID
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	log.Printf("[DEBUG] bandwidth create options: %#v", createOpts)
 	b, err := bandwidths.Create(networkingClient, createOpts).Extract()
 	if err != nil {
 		return diag.Errorf("error creating bandwidth: %s", err)
@@ -156,6 +161,35 @@ func resourceVpcBandWidthV2Create(ctx context.Context, d *schema.ResourceData, m
 			b.ID, err)
 	}
 
+	if d.Get("charging_mode").(string) == "prePaid" {
+		// we can not create a bandwidth with pre-paid directly due to the API does not support
+		// call the change-to-period API as a workaround
+		bssClient, err := cfg.BssV2Client(region)
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+
+		changeOpts := bandwidths.ChangeToPeriodOpts{
+			BandwidthIDs: []string{b.ID},
+			ExtendParam: structs.ChargeInfo{
+				ChargeMode:  d.Get("charging_mode").(string),
+				PeriodType:  d.Get("period_unit").(string),
+				PeriodNum:   d.Get("period").(int),
+				IsAutoRenew: d.Get("auto_renew").(string),
+				IsAutoPay:   "true",
+			},
+		}
+		orderID, err := bandwidths.ChangeToPeriod(networkingClient, changeOpts).Extract()
+		if err != nil {
+			return diag.Errorf("error changing bandwidth (%s) to pre-paid billing mode: %s",
+				b.ID, err)
+		}
+
+		if err := common.WaitOrderComplete(ctx, bssClient, orderID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceVpcBandWidthV2Read(ctx, d, meta)
 }
 
@@ -167,6 +201,11 @@ func resourceVpcBandWidthV2Update(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating networking client: %s", err)
 	}
 
+	bssClient, err := cfg.BssV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating BSS V2 client: %s", err)
+	}
+
 	bwID := d.Id()
 	if d.HasChanges("name", "size") {
 		updateOpts := bandwidths.UpdateOpts{
@@ -175,9 +214,30 @@ func resourceVpcBandWidthV2Update(ctx context.Context, d *schema.ResourceData, m
 				Size: d.Get("size").(int),
 			},
 		}
-		_, err := bandwidths.Update(networkingClient, bwID, updateOpts).Extract()
+
+		// ExtendParam is valid and mandatory when changing size field in pre-paid billing mode
+		if d.HasChange("size") && d.Get("charging_mode").(string) == "prePaid" {
+			updateOpts.ExtendParam = &bandwidths.ExtendParam{
+				IsAutoPay: "true",
+			}
+		}
+
+		log.Printf("[DEBUG] bandwidth update options: %#v", updateOpts)
+		resp, err := bandwidths.Update(networkingClient, bwID, updateOpts).Extract()
 		if err != nil {
 			return diag.Errorf("error updating bandwidth (%s): %s", bwID, err)
+		}
+
+		if resp.OrderID != "" {
+			if err := common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if d.HasChange("auto_renew") {
+		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), bwID); err != nil {
+			return diag.Errorf("error updating the auto-renew of the bandwidth (%s): %s", bwID, err)
 		}
 	}
 
@@ -202,10 +262,10 @@ func resourceVpcBandWidthV2Read(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("size", b.Size),
 		d.Set("charge_mode", b.ChargeMode),
 		d.Set("enterprise_project_id", b.EnterpriseProjectID),
-
 		d.Set("share_type", b.ShareType),
 		d.Set("bandwidth_type", b.BandwidthType),
 		d.Set("status", b.Status),
+		d.Set("charging_mode", normalizeChargingMode(b.BillingInfo)),
 		d.Set("publicips", flattenPublicIPs(b)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
@@ -230,9 +290,14 @@ func resourceVpcBandWidthV2Delete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	bwID := d.Id()
-	err = bandwidths.Delete(networkingClient, bwID).ExtractErr()
-	if err != nil {
-		return diag.Errorf("error deleting bandwidth: %s", err)
+	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
+		if err := common.UnsubscribePrePaidResource(d, cfg, []string{bwID}); err != nil {
+			return diag.Errorf("error unsubscribe bandwidth: %s", err)
+		}
+	} else {
+		if err := bandwidths.Delete(networkingClient, bwID).ExtractErr(); err != nil {
+			return diag.Errorf("error deleting bandwidth: %s", err)
+		}
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -240,8 +305,8 @@ func resourceVpcBandWidthV2Delete(ctx context.Context, d *schema.ResourceData, m
 		Target:     []string{"DELETED"},
 		Refresh:    waitForBandwidth(bwClient, bwID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      3 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)
@@ -266,6 +331,14 @@ func waitForBandwidth(client *golangsdk.ServiceClient, id string) resource.State
 		log.Printf("[DEBUG] the current status of bandwidth (%s) is %s", b.ID, b.Status)
 		return b, b.Status, nil
 	}
+}
+
+func normalizeChargingMode(billing string) string {
+	mode := "postPaid"
+	if billing != "" {
+		mode = "prePaid"
+	}
+	return mode
 }
 
 func flattenPublicIPs(band bandwidthsv1.BandWidth) []map[string]interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

support pre-paid charging mode for bandwidth

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcBandWidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcBandWidth_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== CONT  TestAccVpcBandWidth_basic
--- PASS: TestAccVpcBandWidth_basic (27.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       27.592s

$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcBandWidth_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcBandWidth_prePaid -timeout 360m -parallel 4
=== RUN   TestAccVpcBandWidth_prePaid
=== PAUSE TestAccVpcBandWidth_prePaid
=== CONT  TestAccVpcBandWidth_prePaid
--- PASS: TestAccVpcBandWidth_prePaid (103.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       103.764s
```
