### PR TITLE
fix(provider): set the default auth_url with region field

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1402,11 +1402,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 		identityEndpoint = v.(string)
 	} else {
 		// use cloud as basis for identityEndpoint
-		if isGlobalIamEndpoint(cloud, region, isRegional) {
-			identityEndpoint = fmt.Sprintf("https://iam.%s:443/v3", cloud)
-		} else {
-			identityEndpoint = fmt.Sprintf("https://iam.%s.%s:443/v3", region, cloud)
-		}
+		identityEndpoint = fmt.Sprintf("https://iam.%s.%s:443/v3", region, cloud)
 	}
 
 	config := config.Config{
@@ -1513,12 +1509,4 @@ func getCloudDomain(cloud, region string) string {
 		return defaultEuropeCloud
 	}
 	return defaultCloud
-}
-
-func isGlobalIamEndpoint(domain, region string, isRegional bool) bool {
-	if !isRegional && domain == defaultCloud && !strings.HasPrefix(region, "eu-west-1") {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

set the default auth_url with region field: 
The Identity authentication URL. If omitted, the HW_AUTH_URL environment variable is used. Defaults to https://iam.{{region}}.{{cloud}}:443/v3.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccEcsFlavorsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccEcsFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEcsFlavorsDataSource_basic
=== PAUSE TestAccEcsFlavorsDataSource_basic
=== CONT  TestAccEcsFlavorsDataSource_basic
--- PASS: TestAccEcsFlavorsDataSource_basic (12.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       12.441s
```
