### PR TITLE
feat(ecs): add iops and throughput to disk

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -234,10 +234,15 @@ The following arguments are supported:
   For details about disk types, see
   [Disk Types and Disk Performance](https://support.huaweicloud.com/en-us/productdesc-evs/en-us_topic_0014580744.html).
   Available options are:
-  + `SAS`: high I/O disk type.
-  + `SSD`: ultra-high I/O disk type.
-  + `GPSSD`: general purpose SSD disk type.
+  + `SAS`: High I/O disk type.
+  + `SSD`: Ultra-high I/O disk type.
+  + `GPSSD`: General purpose SSD disk type.
   + `ESSD`: Extreme SSD type.
+  + `GPSSD2`: General purpose SSD V2 type.
+  + `ESSD2`: Extreme SSD V2 type.
+
+  -> If the specified disk type is not available in the AZ, the disk will fail to create.
+  The disk type **ESSD2** only support in postpaid charging mode.
 
 * `system_disk_size` - (Optional, Int) Specifies the system disk size in GB, The value range is 1 to 1024.
   Shrinking the disk is not supported.
@@ -247,6 +252,25 @@ The following arguments are supported:
 
   -> **NOTE:** This parameter is only supported in some regions, such as ap-southeast-3.
     If not supported, please contact technical support.
+
+* `system_disk_iops` - (Optional, Int, ForceNew) Specifies the IOPS(Input/Output Operations Per Second) for the disk.
+  The field is valid and required when `system_disk_type` is set to **GPSSD2** or **ESSD2**.
+
+  + If `system_disk_type` is set to **GPSSD2**. The field `system_disk_iops` ranging from 3,000 to 128,000.
+    This IOPS must also be less than or equal to 500 multiplying the capacity.
+
+  + If `system_disk_type` is set to **ESSD2**. The field `system_disk_iops` ranging from 100 to 256,000.
+    This IOPS must also be less than or equal to 1000 multiplying the capacity.
+
+  Changing this creates a new instance.
+
+* `system_disk_throughput` - (Optional, Int, ForceNew) Specifies the throughput for the disk. The Unit is MiB/s.
+  The field is valid and required when `system_disk_type` is set to **GPSSD2**.
+
+  + If `system_disk_type` is set to **GPSSD2**. The field `system_disk_throughput` ranging from 125 to 1,000.
+    This throughput must also be less than or equal to the IOPS divided by 4.
+
+  Changing this creates a new instance.
 
 * `data_disks` - (Optional, List, ForceNew) Specifies an array of one or more data disks to attach to the instance.
   The data_disks object structure is documented below. Changing this creates a new instance.
@@ -353,8 +377,20 @@ The `network` block supports:
 
 The `data_disks` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the ECS data disk type, which must be one of available disk types,
-  contains of *SSD*, *GPSSD* and *SAS*. Changing this creates a new instance.
+* `type` - (Required, String, ForceNew) Specifies the ECS data disk type. Changing this creates a new instance.
+
+  For details about disk types, see
+  [Disk Types and Disk Performance](https://support.huaweicloud.com/en-us/productdesc-evs/en-us_topic_0014580744.html).
+  Available options are:
+  + `SAS`: High I/O disk type.
+  + `SSD`: Ultra-high I/O disk type.
+  + `GPSSD`: General purpose SSD disk type.
+  + `ESSD`: Extreme SSD type.
+  + `GPSSD2`: General purpose SSD V2 type.
+  + `ESSD2`: Extreme SSD V2 type.
+
+  -> If the specified disk type is not available in the AZ, the disk will fail to create.
+  The disk type **ESSD2** only support in postpaid charging mode.
 
 * `size` - (Required, Int, ForceNew) Specifies the data disk size, in GB. The value ranges form 10 to 32768.
   Changing this creates a new instance.
@@ -363,6 +399,25 @@ The `data_disks` block supports:
   the full-ECS image. Changing this creates a new instance.
 
 * `kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key. This is used to encrypt the disk.
+  Changing this creates a new instance.
+
+* `iops` - (Optional, Int, ForceNew) Specifies the IOPS(Input/Output Operations Per Second) for the disk.
+  The field is valid and required when `type` is set to **GPSSD2** or **ESSD2**.
+
+  + If `type` is set to **GPSSD2**. The field `iops` ranging from 3,000 to 128,000.
+    This IOPS must also be less than or equal to 500 multiplying the capacity.
+
+  + If `type` is set to **ESSD2**. The field `iops` ranging from 100 to 256,000.
+    This IOPS must also be less than or equal to 1000 multiplying the capacity.
+
+  Changing this creates a new instance.
+
+* `throughput` - (Optional, Int, ForceNew) Specifies the throughput for the disk. The Unit is MiB/s.
+  The field is valid and required when `type` is set to **GPSSD2**.
+
+  + If `type` is set to **GPSSD2**. The field `throughput` ranging from 125 to 1,000.
+    This throughput must also be less than or equal to the IOPS divided by 4.
+
   Changing this creates a new instance.
 
 The `bandwidth` block supports:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230808033823-57d659bc8ebd
+	github.com/chnsz/golangsdk v0.0.0-20230810012948-bfb45ca78484
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230808033823-57d659bc8ebd h1:NA/z5iA9aHQyyl7RU+w72C15d2/dcikHEpTX7lsLW5E=
-github.com/chnsz/golangsdk v0.0.0-20230808033823-57d659bc8ebd/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230810012948-bfb45ca78484 h1:GHN0aiLGYzKSx/TSv0E3tB0fO7ZRZR/2PgmSnlcJALg=
+github.com/chnsz/golangsdk v0.0.0-20230810012948-bfb45ca78484/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -130,6 +130,11 @@ type RootVolume struct {
 
 	Size int `json:"size,omitempty"`
 
+	// The iops of evs volume. Only required when volume_type is `GPSSD2` or `ESSD2`
+	IOPS int `json:"iops,omitempty"`
+	// The throughput of evs volume. Only required when volume_type is `GPSSD2`
+	Throughput int `json:"throughput,omitempty"`
+
 	ExtendParam *VolumeExtendParam `json:"extendparam,omitempty"`
 
 	Metadata *VolumeMetadata `json:"metadata,omitempty"`
@@ -143,6 +148,11 @@ type DataVolume struct {
 	MultiAttach *bool `json:"multiattach,omitempty"`
 
 	PassThrough *bool `json:"hw:passthrough,omitempty"`
+
+	// The iops of evs volume. Only required when volume_type is `GPSSD2` or `ESSD2`
+	IOPS int `json:"iops,omitempty"`
+	// The throughput of evs volume. Only required when volume_type is `GPSSD2`
+	Throughput int `json:"throughput,omitempty"`
 
 	Extendparam *VolumeExtendParam `json:"extendparam,omitempty"`
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/requests.go
@@ -293,14 +293,14 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 // CreateRuleOpts is the common options struct used in this package's CreateRule
 // operation.
 type CreateRuleOpts struct {
-	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	// The L7 rule type. One of HOST_NAME, PATH, METHOD, HEADER, QUERY_STRING, or SOURCE_IP.
 	RuleType RuleType `json:"type" required:"true"`
 
-	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	// The comparison type for the L7 rule. One of EQUAL_TO, REGEX, or STARTS_WITH.
 	CompareType CompareType `json:"compare_type" required:"true"`
 
-	// The value to use for the comparison. For example, the file type to compare.
-	Value string `json:"value" required:"true"`
+	// The value to use for the comparison.
+	Value string `json:"value,omitempty"`
 
 	// TenantID is the UUID of the tenant who owns the rule in octavia.
 	// Only administrative users can specify a project UUID other than their own.
@@ -316,6 +316,18 @@ type CreateRuleOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The matching conditions of the forwarding rule.
+	// This parameter is available only when enhance_l7policy_enable of the listener is set to true.
+	Conditions []Condition `json:"conditions,omitempty"`
+}
+
+type Condition struct {
+	// The key of the match item.
+	Key string `json:"key,omitempty"`
+
+	// The value of the match item.
+	Value string `json:"value" required:"true"`
 }
 
 // ToRuleCreateMap builds a request body from CreateRuleOpts.
@@ -403,13 +415,13 @@ type UpdateRuleOptsBuilder interface {
 // UpdateRuleOpts is the common options struct used in this package's Update
 // operation.
 type UpdateRuleOpts struct {
-	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	// The L7 rule type. One of HOST_NAME, PATH, METHOD, HEADER, QUERY_STRING, or SOURCE_IP.
 	RuleType RuleType `json:"type,omitempty"`
 
-	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	// The comparison type for the L7 rule. One of EQUAL_TO, REGEX, or STARTS_WITH.
 	CompareType CompareType `json:"compare_type,omitempty"`
 
-	// The value to use for the comparison. For example, the file type to compare.
+	// The value to use for the comparison.
 	Value string `json:"value,omitempty"`
 
 	// The key to use for the comparison. For example, the name of the cookie to evaluate.
@@ -422,6 +434,10 @@ type UpdateRuleOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The matching conditions of the forwarding rule.
+	// This parameter is available only when enhance_l7policy_enable of the listener is set to true.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // ToRuleUpdateMap builds a request body from UpdateRuleOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/results.go
@@ -76,10 +76,10 @@ type Rule struct {
 	// The unique ID for the L7 rule.
 	ID string `json:"id"`
 
-	// The L7 rule type. One of COOKIE, FILE_TYPE, HEADER, HOST_NAME, or PATH.
+	// The L7 rule type. One of HOST_NAME, PATH, METHOD, HEADER, QUERY_STRING, or SOURCE_IP.
 	RuleType string `json:"type"`
 
-	// The comparison type for the L7 rule. One of CONTAINS, ENDS_WITH, EQUAL_TO, REGEX, or STARTS_WITH.
+	// The comparison type for the L7 rule. One of EQUAL_TO, REGEX, or STARTS_WITH.
 	CompareType string `json:"compare_type"`
 
 	// The value to use for the comparison. For example, the file type to compare.
@@ -109,6 +109,16 @@ type Rule struct {
 	// This field seems to only be returned during a call to a load balancer's /status
 	// see: https://github.com/gophercloud/gophercloud/issues/1362
 	OperatingStatus string `json:"operating_status"`
+
+	// The matching conditions of the forwarding rule.
+	// This parameter is available only when enhance_l7policy_enable of the listener is set to true.
+	Conditions []Condition `json:"conditions"`
+
+	// The creation time.
+	CreatedAt string `json:"created_at"`
+
+	// The updated time.
+	UpdatedAt string `json:"updated_at"`
 }
 
 type commonResult struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230808033823-57d659bc8ebd
+# github.com/chnsz/golangsdk v0.0.0-20230810012948-bfb45ca78484
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/ecs/ TESTARGS='-run=TestAccComputeInstance_diskIopsThroughput'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs/ -v -run=TestAccComputeInstance_diskIopsThroughput -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_diskIopsThroughput
=== PAUSE TestAccComputeInstance_diskIopsThroughput
=== CONT  TestAccComputeInstance_diskIopsThroughput
--- PASS: TestAccComputeInstance_diskIopsThroughput (247.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       247.485s
```
