### PR TITLE
feat(WAF): add a new resource WAF rule anti crawler

### DIFF
--- a/docs/resources/waf_rule_anti_crawler.md
+++ b/docs/resources/waf_rule_anti_crawler.md
@@ -1,0 +1,111 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_rule_anti_crawler
+
+Manages a WAF rule anti crawler resource within HuaweiCloud.
+
+-> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
+used. The anti crawler rule resource can be used in Cloud Mode, Dedicated Mode.
+
+## Example Usage
+
+```hcl
+variable policy_id {}
+variable enterprise_project_id {}
+
+resource "huaweicloud_waf_rule_anti_crawler" "test" {
+  policy_id             = var.policy_id
+  enterprise_project_id = var.enterprise_project_id
+  name                  = "test_name"
+  protection_mode       = "anticrawler_specific_url"
+  priority              = 100
+  description           = "test description"
+
+  conditions {
+    field   = "user-agent"
+    logic   = "contain"
+    content = "TR"
+  }
+
+  conditions {
+    field   = "url"
+    logic   = "equal"
+    content = "/test/path"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the policy ID.
+
+  Changing this parameter will create a new resource.
+
+* `protection_mode` - (Required, String, ForceNew) Specifies the protection mode of WAF anti crawler rule.
+  Changing this parameter will create a new resource. Valid values are as follows:
+    + **anticrawler_specific_url**: Used to protect a specific path specified by the rule.
+    + **anticrawler_except_url**: Used to protect all paths except the one specified by the rule.
+
+  -> All rules in the current mode will take effect, while rules in another mode will become invalid.
+
+* `name` - (Required, String) Specifies the rule name. The value should be a maximum of 128 characters. Only letters,
+  digits, hyphens (-), underscores (_), colons (:) and periods (.) are allowed.
+
+* `priority` - (Required, Int) Specifies the priority. A smaller value indicates a higher priority. If the value is
+  the same, the rule is created earlier and the priority is higher. Value ranges from **0** to **65535**.
+
+* `conditions` - (Required, List) Specifies the match condition list.
+  The [conditions](#RuleAntiCrawler_conditions) structure is documented below.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF anti crawler rule.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the rule description.
+
+<a name="RuleAntiCrawler_conditions"></a>
+The `conditions` block supports:
+
+* `field` - (Required, String) Specifies the field type. The valid values are **url** and **user-agent**.
+
+* `logic` - (Required, String) Specifies the logic for matching the condition. The valid values are **contain**,
+  **not_contain**, **equal**, **not_equal**, **prefix**, **not_prefix**, **suffix**, **not_suffix**, **contain_any**,
+  **not_contain_all**, **equal_any**, **not_equal_all**, **prefix_any**, **not_prefix_all**, **suffix_any** and
+  **not_suffix_all**.
+
+* `content` - (Optional, String) Specifies the content of the condition.
+  It is valid and required when the `logic` does not end with `any` or `all`.
+
+* `reference_table_id` - (Optional, String) Specifies the reference table ID.
+  It is valid and required when the `logic` end with `any` or `all`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The rule status.
+
+## Import
+
+There are two ways to import WAF rule anti crawler state.
+
+* Using `policy_id` and `rule_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_anti_crawler.test <policy_id>/<rule_id>
+```
+
+* Using `policy_id`, `rule_id` and `enterprise_project_id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_rule_anti_crawler.test <policy_id>/<rule_id>/<enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1086,6 +1086,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_cloud_instance":                      waf.ResourceCloudInstance(),
 			"huaweicloud_waf_domain":                              waf.ResourceWafDomainV1(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicyV1(),
+			"huaweicloud_waf_rule_anti_crawler":                   waf.ResourceRuleAntiCrawler(),
 			"huaweicloud_waf_rule_blacklist":                      waf.ResourceWafRuleBlackListV1(),
 			"huaweicloud_waf_rule_cc_protection":                  waf.ResourceRuleCCProtection(),
 			"huaweicloud_waf_rule_data_masking":                   waf.ResourceWafRuleDataMaskingV1(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_anti_crawler_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_anti_crawler_test.go
@@ -1,0 +1,369 @@
+package waf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getRuleAntiCrawlerResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/anticrawler/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", state.Primary.Attributes["policy_id"])
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", state.Primary.ID)
+
+	queryParam := ""
+	if epsID := state.Primary.Attributes["enterprise_project_id"]; epsID != "" {
+		queryParam = fmt.Sprintf("?enterprise_project_id=%s", epsID)
+	}
+	getPath += queryParam
+
+	getRuleOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getRuleResp, err := client.Request("GET", getPath, &getRuleOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving WAF anti crawler rule: %s", err)
+	}
+	return utils.FlattenResponse(getRuleResp)
+}
+
+func TestAccRuleAntiCrawler_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_anti_crawler.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleAntiCrawlerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleAntiCrawler_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "protection_mode", "anticrawler_specific_url"),
+					resource.TestCheckResourceAttr(rName, "priority", "0"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.field", "user-agent"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.logic", "contain"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.content", "TR"),
+					resource.TestCheckResourceAttr(rName, "conditions.1.field", "url"),
+					resource.TestCheckResourceAttr(rName, "conditions.1.logic", "equal"),
+					resource.TestCheckResourceAttr(rName, "conditions.1.content", "/test/path"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				Config: testRuleAntiCrawler_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "priority", "65535"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.field", "user-agent"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.logic", "suffix_any"),
+					resource.TestCheckResourceAttrPair(rName, "conditions.0.reference_table_id",
+						"huaweicloud_waf_reference_table.ref_table", "id"),
+					resource.TestCheckResourceAttr(rName, "conditions.1.field", "user-agent"),
+					resource.TestCheckResourceAttr(rName, "conditions.1.logic", "prefix"),
+					resource.TestCheckResourceAttr(rName, "conditions.1.content", "RF"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccRuleAntiCrawler_exceptProtectionMode(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_anti_crawler.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleAntiCrawlerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleAntiCrawler_excepProtectionMode(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "protection_mode", "anticrawler_except_url"),
+					resource.TestCheckResourceAttr(rName, "priority", "500"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.field", "url"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.logic", "not_contain_all"),
+					resource.TestCheckResourceAttrPair(rName, "conditions.0.reference_table_id",
+						"huaweicloud_waf_reference_table.ref_table", "id"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				Config: testRuleAntiCrawler_excepProtectionMode_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "priority", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.field", "user-agent"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.logic", "contain"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.content", "TR"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccRuleAntiCrawler_withEpsID(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_anti_crawler.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleAntiCrawlerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRuleAntiCrawler_withEpsID(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_waf_policy.policy_1", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "protection_mode", "anticrawler_except_url"),
+					resource.TestCheckResourceAttr(rName, "priority", "500"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.field", "user-agent"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.logic", "contain"),
+					resource.TestCheckResourceAttr(rName, "conditions.0.content", "TR"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func testRuleAntiCrawler_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_anti_crawler" "test" {
+  policy_id       = huaweicloud_waf_policy.policy_1.id
+  name            = "%s"
+  protection_mode = "anticrawler_specific_url"
+  priority        = 0
+  description     = "test description"
+
+  conditions {
+    field   = "user-agent"
+    logic   = "contain"
+    content = "TR"
+  }
+
+  conditions {
+    field   = "url"
+    logic   = "equal"
+    content = "/test/path"
+  }
+}
+`, testAccWafPolicyV1_basic(name), name)
+}
+
+func testRuleAntiCrawler_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_reference_table" "ref_table" {
+  name        = "%s"
+  type        = "user-agent"
+  description = "test user agent"
+
+  conditions = [
+    "UA"
+  ]
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+
+resource "huaweicloud_waf_rule_anti_crawler" "test" {
+  policy_id       = huaweicloud_waf_policy.policy_1.id
+  name            = "%s_update"
+  protection_mode = "anticrawler_specific_url"
+  priority        = 65535
+  description     = "test description update"
+
+  conditions {
+    field              = "user-agent"
+    logic              = "suffix_any"
+    reference_table_id = huaweicloud_waf_reference_table.ref_table.id
+  }
+
+  conditions {
+    field   = "user-agent"
+    logic   = "prefix"
+    content = "RF"
+  }
+}
+`, testAccWafPolicyV1_basic(name), name, name)
+}
+
+func testRuleAntiCrawler_excepProtectionMode(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_reference_table" "ref_table" {
+  name        = "%s"
+  type        = "url"
+  description = "test url"
+
+  conditions = [
+    "/test/path"
+  ]
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+
+resource "huaweicloud_waf_rule_anti_crawler" "test" {
+  policy_id       = huaweicloud_waf_policy.policy_1.id
+  name            = "%s"
+  protection_mode = "anticrawler_except_url"
+  priority        = 500
+  description     = "test description"
+
+  conditions {
+    field              = "url"
+    logic              = "not_contain_all"
+    reference_table_id = huaweicloud_waf_reference_table.ref_table.id
+  }
+}
+`, testAccWafPolicyV1_basic(name), name, name)
+}
+
+func testRuleAntiCrawler_excepProtectionMode_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_anti_crawler" "test" {
+  policy_id       = huaweicloud_waf_policy.policy_1.id
+  name            = "%s_update"
+  protection_mode = "anticrawler_except_url"
+  priority        = 1000
+  description     = "test description update"
+
+  conditions {
+    field   = "user-agent"
+    logic   = "contain"
+    content = "TR"
+  }
+}
+`, testAccWafPolicyV1_basic(name), name)
+}
+
+func testRuleAntiCrawler_withEpsID(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_anti_crawler" "test" {
+  policy_id             = huaweicloud_waf_policy.policy_1.id
+  name                  = "%s"
+  protection_mode       = "anticrawler_except_url"
+  priority              = 500
+  description           = "test description"
+  enterprise_project_id = "%s"
+
+  conditions {
+    field   = "user-agent"
+    logic   = "contain"
+    content = "TR"
+  }
+}
+`, testAccWafPolicyV1_basic_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name,
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_anti_crawler.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_anti_crawler.go
@@ -1,0 +1,356 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product WAF
+// ---------------------------------------------------------------
+
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceRuleAntiCrawler() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAntiCrawlerRuleCreate,
+		UpdateContext: resourceAntiCrawlerRuleUpdate,
+		ReadContext:   resourceAntiCrawlerRuleRead,
+		DeleteContext: resourceAntiCrawlerRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceWAFRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the policy ID.`,
+			},
+			"protection_mode": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the protection mode of WAF anti crawler rule.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the rule name.`,
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the priority.`,
+			},
+			"conditions": {
+				Type:        schema.TypeList,
+				Elem:        ruleAntiCrawlerConditionsSchema(),
+				Required:    true,
+				Description: `Specifies the match condition list.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the rule description.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The rule status.`,
+			},
+		},
+	}
+}
+
+func ruleAntiCrawlerConditionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"field": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the field type.`,
+			},
+			"logic": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the logic for matching the condition.`,
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the content of the condition.`,
+			},
+			"reference_table_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the reference table ID.`,
+			},
+		},
+	}
+}
+
+func updateAntiCrawlerProtectionMode(client *golangsdk.ServiceClient, httpPath, protectionMode string) error {
+	updateOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"anticrawler_type": protectionMode,
+		},
+	}
+
+	_, err := client.Request("PUT", httpPath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating WAF anti crawler rule protection mode: %s", err)
+	}
+	return nil
+}
+
+func createAntiCrawlerRule(client *golangsdk.ServiceClient, httpPath string, d *schema.ResourceData) error {
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildCreateOrUpdateRuleBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", httpPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("error creating WAF anti crawler rule: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return err
+	}
+
+	id, err := jmespath.Search("id", createRespBody)
+	if err != nil {
+		return fmt.Errorf("error creating WAF anti crawler rule: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+	return nil
+}
+
+func resourceAntiCrawlerRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/anticrawler"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	httpPath := client.Endpoint + httpUrl
+	httpPath = strings.ReplaceAll(httpPath, "{project_id}", client.ProjectID)
+	httpPath = strings.ReplaceAll(httpPath, "{policy_id}", d.Get("policy_id").(string))
+	httpPath += buildQueryParams(d, cfg)
+
+	// update WAF anti crawler protection mode first
+	if err := updateAntiCrawlerProtectionMode(client, httpPath, d.Get("protection_mode").(string)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := createAntiCrawlerRule(client, httpPath, d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceAntiCrawlerRuleRead(ctx, d, meta)
+}
+
+func buildCreateOrUpdateRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"type":        d.Get("protection_mode"),
+		"priority":    d.Get("priority"),
+		"description": d.Get("description"),
+		"conditions":  buildRuleAntiCrawlerConditions(d.Get("conditions")),
+	}
+	return bodyParams
+}
+
+func buildRuleAntiCrawlerConditions(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"category":        raw["field"],
+				"logic_operation": raw["logic"],
+			}
+			if content := raw["content"].(string); content != "" {
+				rst[i]["contents"] = []string{content}
+			}
+			if referenceTableId := raw["reference_table_id"].(string); referenceTableId != "" {
+				rst[i]["value_list_id"] = referenceTableId
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceAntiCrawlerRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/anticrawler/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", d.Get("policy_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", d.Id())
+	getPath += buildQueryParams(d, cfg)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF anti crawler rule")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("policy_id", utils.PathSearch("policyid", getRespBody, nil)),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("protection_mode", utils.PathSearch("type", getRespBody, nil)),
+		d.Set("priority", utils.PathSearch("priority", getRespBody, nil)),
+		d.Set("conditions", flattenRuleAntiCrawlerConditions(getRespBody)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRuleAntiCrawlerConditions(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("conditions", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, len(curArray))
+	for i, v := range curArray {
+		rst[i] = map[string]interface{}{
+			"field":              utils.PathSearch("category", v, nil),
+			"logic":              utils.PathSearch("logic_operation", v, nil),
+			"content":            utils.PathSearch("contents|[0]", v, nil),
+			"reference_table_id": utils.PathSearch("value_list_id", v, nil),
+		}
+	}
+	return rst
+}
+
+func resourceAntiCrawlerRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/anticrawler/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", d.Get("policy_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+	updatePath += buildQueryParams(d, cfg)
+	updateOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildCreateOrUpdateRuleBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating WAF anti crawler rule: %s", err)
+	}
+
+	return resourceAntiCrawlerRuleRead(ctx, d, meta)
+}
+
+func resourceAntiCrawlerRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/policy/{policy_id}/anticrawler/{rule_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF Client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", d.Get("policy_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", d.Id())
+	deletePath += buildQueryParams(d, cfg)
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting WAF anti crawler rule: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource WAF rule anti crawler
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRuleAntiCrawler_'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleAntiCrawler_ -timeout 360m -parallel 4 
=== RUN   TestAccRuleAntiCrawler_basic 
=== PAUSE TestAccRuleAntiCrawler_basic
=== RUN   TestAccRuleAntiCrawler_exceptProtectionMode
=== PAUSE TestAccRuleAntiCrawler_exceptProtectionMode
=== RUN   TestAccRuleAntiCrawler_withEpsID
=== PAUSE TestAccRuleAntiCrawler_withEpsID
=== CONT  TestAccRuleAntiCrawler_basic
=== CONT  TestAccRuleAntiCrawler_withEpsID
=== CONT  TestAccRuleAntiCrawler_exceptProtectionMode
--- PASS: TestAccRuleAntiCrawler_basic (348.15s) 
--- PASS: TestAccRuleAntiCrawler_withEpsID (350.22s) 
--- PASS: TestAccRuleAntiCrawler_exceptProtectionMode (352.06s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       352.137s
```
