### PR TITLE
chore: fix lint issues for IAM resources

### DIFF
--- a/docs/resources/identity_acl.md
+++ b/docs/resources/identity_acl.md
@@ -4,10 +4,10 @@ subcategory: "Identity and Access Management (IAM)"
 
 # huaweicloud_identity_acl
 
-Manages a ACL resource within HuaweiCloud IAM service. The ACL allowing user access only from specified IP address
+Manages an ACL resource within HuaweiCloud IAM service. The ACL allowing user access only from specified IP address
 ranges and IPv4 CIDR blocks. The ACL take effect for IAM users under the Domain account rather than the account itself.
 
-Note: You *must* have admin privileges in your HuaweiCloud cloud to use this resource.
+-> **NOTE:** You *must* have admin privileges to use this resource.
 
 ## Example Usage
 
@@ -30,15 +30,18 @@ resource "huaweicloud_identity_acl" "acl" {
 
 The following arguments are supported:
 
-* `type` - (Required, String, ForceNew) Specifies the ACL is created through the Console or API. valid value are '
-  console' and 'api'. Changing this parameter will create a new ACL.
+* `type` - (Required, String, ForceNew) Specifies the ACL is created through the Console or API.
+  Valid values are **console** and **api**. Changing this parameter will create a new ACL.
 
 * `ip_cidrs` - (Optional, List) Specifies the IPv4 CIDR blocks from which console access or api access is allowed.
-  The `ip_cidrs` cannot repeat. The structure is documented below.
+  The `ip_cidrs` cannot repeat. The [object](#ip_cidrs_object) structure is documented below.
 
 * `ip_ranges` - (Optional, List) Specifies the IP address ranges from which console access or api access is allowed.
-  The `ip_ranges` cannot repeat. The structure is documented below.
+  The `ip_ranges` cannot repeat. The [object](#ip_ranges_object) structure is documented below.
 
+-> **NOTE:** Up to 200 `ip_cidrs` and `ip_ranges` can be created in total for each access method.
+
+<a name="ip_cidrs_object"></a>
 The `ip_cidrs` block supports:
 
 * `cidr` - (Required, String) Specifies the IPv4 CIDR block, for example, **192.168.0.0/24**.
@@ -46,6 +49,7 @@ The `ip_cidrs` block supports:
 * `description` - (Optional, String) Specifies a description about an IPv4 CIDR block. This parameter can contain a
   maximum of 255 characters and the following characters are not allowed:**@#%^&*<>\\**.
 
+<a name="ip_ranges_object"></a>
 The `ip_ranges` block supports:
 
 * `range` - (Required, String) Specifies the Ip address range, for example, **0.0.0.0-255.255.255.0**.
@@ -53,18 +57,8 @@ The `ip_ranges` block supports:
 * `description` - (Optional, String) Specifies a description about an IP address range. This parameter can contain a
   maximum of 255 characters and the following characters are not allowed:**@#%^&*<>\\**.
 
-->**NOTE:** Up to 200 `ip_cidrs` and `ip_ranges` can be created in total for each access method.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of identity acl.
-
-## Timeouts
-
-This resource provides the following timeouts configuration options:
-
-* `create` - Default is 5 minute.
-* `update` - Default is 5 minute.
-* `delete` - Default is 3 minute.
+* `id` - The ID of identity ACL.

--- a/docs/resources/identity_agency.md
+++ b/docs/resources/identity_agency.md
@@ -4,7 +4,9 @@ subcategory: "Identity and Access Management (IAM)"
 
 # huaweicloud_identity_agency
 
-Manages an agency resource within huawei cloud.
+Manages an agency resource within HuaweiCloud.
+
+-> **NOTE:** You *must* have admin privileges to use this resource.
 
 ## Example Usage
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
@@ -4,20 +4,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/identity/v3.0/credentials"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func getIdentityAccessKeyResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	iamClient, err := c.IAMV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("Error creating HuaweiCloud identity client: %s", err)
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 
 	found, err := credentials.Get(iamClient, state.Primary.ID).Extract()
@@ -26,7 +25,7 @@ func getIdentityAccessKeyResourceFunc(c *config.Config, state *terraform.Resourc
 	}
 
 	if found.AccessKey != state.Primary.ID {
-		return nil, fmtp.Errorf("Access Key not found")
+		return nil, fmt.Errorf("Access Key not found")
 	}
 	return found, nil
 }

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
@@ -22,13 +22,13 @@ func getIdentityAgencyResourceFunc(c *config.Config, state *terraform.ResourceSt
 }
 
 func TestAccIdentityAgency_basic(t *testing.T) {
-	var agency agency.Agency
+	var object agency.Agency
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_identity_agency.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
-		&agency,
+		&object,
 		getIdentityAgencyResourceFunc,
 	)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

* this is the **last** PR to fix lint issues for IAM service.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentitACL"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentitACL -timeout 360m -parallel 4
=== RUN   TestAccIdentitACL_basic
=== PAUSE TestAccIdentitACL_basic
=== RUN   TestAccIdentitACL_apiAccess
=== PAUSE TestAccIdentitACL_apiAccess
=== CONT  TestAccIdentitACL_basic
=== CONT  TestAccIdentitACL_apiAccess
--- PASS: TestAccIdentitACL_basic (11.27s)
--- PASS: TestAccIdentitACL_apiAccess (11.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       11.318s

$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityAccessKey"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityAccessKey -timeout 360m -parallel 4
=== RUN   TestAccIdentityAccessKey_basic
=== PAUSE TestAccIdentityAccessKey_basic
=== RUN   TestAccIdentityAccessKey_secret
=== PAUSE TestAccIdentityAccessKey_secret
=== CONT  TestAccIdentityAccessKey_basic
=== CONT  TestAccIdentityAccessKey_secret
--- PASS: TestAccIdentityAccessKey_secret (6.99s)
--- PASS: TestAccIdentityAccessKey_basic (11.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       11.412s
```
