### PR TITLE
refactor(utils): improve on RemoveNil and PasswordEncrypt test case

### DIFF
--- a/huaweicloud/utils/password_encrypt.go
+++ b/huaweicloud/utils/password_encrypt.go
@@ -7,6 +7,8 @@ import (
 	"io"
 
 	"github.com/GehirnInc/crypt"
+
+	// call init function to register sha512 crypt
 	_ "github.com/GehirnInc/crypt/sha512_crypt"
 )
 
@@ -20,9 +22,10 @@ func Salt(size int) ([]byte, error) {
 		return nil, fmt.Errorf("error generating salt: %s", err)
 	}
 
+	max := uint8(len(letters))
 	arc := uint8(0)
 	for i, x := range salt {
-		arc = x % 62
+		arc = x % max
 		salt[i] = letters[arc]
 	}
 	return salt, nil

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -23,13 +23,14 @@ func yellow(str interface{}) string {
 func TestAccFunction_RemoveNil(t *testing.T) {
 	var (
 		testInput = map[string]interface{}{
-			"level_one_index_zero": nil,
+			"level_one_index_zero": map[string]interface{}{},
 			"level_one_index_one": []map[string]interface{}{
 				{
 					"level_two_index_zero": nil,
 				},
 				{
 					"level_two_index_one": "192.168.0.1",
+					"level_two_index_two": nil,
 				},
 			},
 			"level_one_index_two": []map[string]interface{}{
@@ -50,8 +51,9 @@ func TestAccFunction_RemoveNil(t *testing.T) {
 		}
 	)
 
-	if !reflect.DeepEqual(RemoveNil(testInput), expected) {
-		t.Fatalf("The processing result of RemoveNil method is not as expected, want %s, but %s", green(expected), yellow(testInput))
+	testOutput := RemoveNil(testInput)
+	if !reflect.DeepEqual(testOutput, expected) {
+		t.Fatalf("The processing result of RemoveNil method is not as expected, want %s, but %s", green(expected), yellow(testOutput))
 	}
 	t.Logf("The processing result of RemoveNil method meets expectation: %s", green(expected))
 }
@@ -80,4 +82,21 @@ func TestAccFunction_jsonStringsEqual(t *testing.T) {
 			"but got '%v'", green(true), yellow(false))
 	}
 	t.Logf("The processing result of function 'JSONStringsEqual' meets expectation: %s", green(true))
+}
+
+func TestAccFunction_PasswordEncrypt(t *testing.T) {
+	var password = "Test@123!"
+	encrypted, err := PasswordEncrypt(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("The encrypted string of %s is %s", password, green(encrypted))
+
+	newEncrypted, err := TryPasswordEncrypt(encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newEncrypted != encrypted {
+		t.Fatalf("The encrypted string is not as expected, want %s, but %s", green(encrypted), yellow(newEncrypted))
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ go test -v ./huaweicloud/utils/ -run TestAccFunction_RemoveNil
=== RUN   TestAccFunction_RemoveNil
    utils_test.go:58: The processing result of RemoveNil method meets expectation: map[string]interface {}{"level_one_index_one":[]map[string]interface {}{map[string]interface {}{"level_two_index_one":"192.168.0.1"}}, "level_one_index_three":"172.16.0.237"}
--- PASS: TestAccFunction_RemoveNil (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.011s

$ go test -v ./huaweicloud/utils/ -run TestAccFunction_PasswordEncrypt
=== RUN   TestAccFunction_PasswordEncrypt
    utils_test.go:93: The encrypted string of Test@123! is "JDYkQTRWc3E3aTJ3QXdOSjU0cyQyODRmZ1dQdXRaUnhac1BmeWh3YW14M*******************LcktSdDRYNFVDL3NDWXpvSmdqdVYuWjlnU1RTWGNKNk1tMA=="
--- PASS: TestAccFunction_PasswordEncrypt (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.012s
```
