### PR TITLE
feat: chore(apig): support APPCODE resource and update the old parameter

### DIFF
--- a/docs/resources/apig_application_code.md
+++ b/docs/resources/apig_application_code.md
@@ -1,0 +1,71 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_appcode
+
+Manages an APPCODE in application resource within HuaweiCloud.
+
+## Example Usage
+
+### Auto generate APPCODE
+
+```hcl
+variable "instance_id" {}
+variable "application_id" {}
+
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = var.instance_id
+  application_id = var.application_id
+}
+```
+
+### Manually configure APPCODE
+
+```hcl
+variable "instance_id" {}
+variable "application_id" {}
+variable "app_code" {}
+
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = var.instance_id
+  application_id = var.application_id
+  value          = var.app_code
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the application and APPCODE are located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the application
+  and APPCODE belong.  
+  Changing this will create a new resource.
+
+* `application_id` - (Required, String, ForceNew) Specifies the ID of application to which the APPCODE belongs.
+  Changing this will create a new resource.
+
+* `value` - (Optional, String, ForceNew) Specifies the APPCODE value (content).
+  The value can contain `64` to `180` characters, starting with a letter, plus sign (+), or slash (/). Only letters and
+  the following special characters are allowed: `+_!@#$%/=`.
+  If omitted, a random value will be generated.
+  Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The APPCODE ID.
+
+* `created_at` - The creation time of the APPCODE.
+
+## Import
+
+APPCODEs can be imported using related `instance_id`, `application_id` and their `id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_appcode.test <instance_id>/<application_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -676,6 +676,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_signature":                   apig.ResourceSignature(),
 			"huaweicloud_apig_throttling_policy_associate": apig.ResourceThrottlingPolicyAssociate(),
 			"huaweicloud_apig_throttling_policy":           apig.ResourceApigThrottlingPolicyV2(),
+			"huaweicloud_apig_appcode":                     apig.ResourceAppcode(),
 
 			"huaweicloud_as_configuration":    as.ResourceASConfiguration(),
 			"huaweicloud_as_group":            as.ResourceASGroup(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_appcode_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_appcode_test.go
@@ -1,0 +1,158 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAppcodeFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+	}
+	return applications.GetAppCode(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["application_id"], state.Primary.ID).Extract()
+}
+
+// Auto generate APPCODE.
+func TestAccAppcode_basic(t *testing.T) {
+	var (
+		appCode applications.AppCode
+
+		rName = "huaweicloud_apig_appcode.test"
+		rc    = acceptance.InitResourceCheck(rName, &appCode, getAppcodeFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppcode_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppcodeImportIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccAppcodeImportIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rName := "huaweicloud_apig_appcode.test"
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", rName, rs)
+		}
+		instanceId := rs.Primary.Attributes["instance_id"]
+		appId := rs.Primary.Attributes["application_id"]
+		appCodeId := rs.Primary.ID
+		if instanceId == "" || appId == "" || appCodeId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', but got '%s/%s/%s'",
+				instanceId, appId, appCodeId)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, appId, appCodeId), nil
+	}
+}
+
+func testAccApigAppcode_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccAppcode_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = huaweicloud_apig_instance.test.id
+  application_id = huaweicloud_apig_application.test.id
+}
+`, testAccApigAppcode_base())
+}
+
+// Manually configure APPCODE.
+func TestAccAppcode_manuallyConfig(t *testing.T) {
+	var (
+		appCode applications.AppCode
+
+		rName = "huaweicloud_apig_appcode.test"
+		rc    = acceptance.InitResourceCheck(rName, &appCode, getAppcodeFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppcode_manuallyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppcodeImportIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccAppcode_manuallyConfig() string {
+	code := utils.Base64EncodeString(acctest.RandString(64))
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = huaweicloud_apig_instance.test.id
+  application_id = huaweicloud_apig_application.test.id
+  value          = "%[2]s"
+}
+`, testAccApigAppcode_base(), code)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_appcode.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_appcode.go
@@ -1,0 +1,171 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceAppcode() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppcodeCreate,
+		ReadContext:   resourceAppcodeRead,
+		DeleteContext: resourceAppcodeDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAppcodeImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the application and APPCODE are located.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the dedicated instance to which the application and APPCODE belong.",
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the application to which the APPCODE belongs.",
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The APPCODE value (content).",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the APPCODE.",
+			},
+		},
+	}
+}
+
+func resourceAppcodeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		resp *applications.AppCode
+
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+		appCode    = d.Get("value").(string)
+	)
+	client, err := cfg.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	if appCode != "" {
+		opt := applications.AppCodeOpts{
+			AppCode: appCode,
+		}
+		resp, err = applications.CreateAppCode(client, instanceId, appId, opt).Extract()
+		if err != nil {
+			return diag.Errorf("generating APPCODE failed: %s", err)
+		}
+	} else {
+		resp, err = applications.AutoGenerateAppCode(client, instanceId, appId).Extract()
+		if err != nil {
+			return diag.Errorf("auto generating APPCODE failed: %s", err)
+		}
+	}
+
+	d.SetId(resp.Id)
+
+	return resourceAppcodeRead(ctx, d, meta)
+}
+
+func resourceAppcodeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+		appCodeId  = d.Id()
+	)
+	client, err := cfg.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	resp, err := applications.GetAppCode(client, instanceId, appId, appCodeId).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error querying APPCODE (%s) from specified application (%s) under dedicated instance (%s)",
+				appCodeId, appId, instanceId))
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("value", resp.Code),
+		d.Set("created_at", resp.CreateTime),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving APPCODE resource fields: %s", err)
+	}
+	return nil
+}
+
+func resourceAppcodeDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+		appCodeId  = d.Id()
+	)
+	client, err := cfg.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	err = applications.RemoveAppCode(client, instanceId, appId, appCodeId).ExtractErr()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error deleting APPCODE (%s) from specified application (%s) under dedicated instance (%s)",
+				appCodeId, appId, instanceId))
+	}
+	return nil
+}
+
+func resourceAppcodeImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', "+
+			"but got '%s'", importedId)
+	}
+	d.SetId(parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("application_id", parts[1]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error saving APPCODE resource fields during import: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -73,6 +73,7 @@ func ResourceApigApplicationV2() *schema.Resource {
 			"app_codes": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				MaxItems: 5,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a resource to manage APPCODE.
Update the parameter `app_codes` of the application resource and ignore changes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support the APPCODE resource for APIG service.
2. support related documentation and acceptance test.
3. update parameter `app_codes` behavior.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

1. Auto generate APPCODE test
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccAppcode_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccAppcode_basic -timeout 360m -parallel 4
=== RUN   TestAccAppcode_basic
=== PAUSE TestAccAppcode_basic
=== CONT  TestAccAppcode_basic
--- PASS: TestAccAppcode_basic (465.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig    465.666s
```
2. Manually configure APPCODE test
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccAppcode_manuallyConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccAppcode_manuallyConfig -timeout 360m -parallel 4
=== RUN   TestAccAppcode_manuallyConfig
=== PAUSE TestAccAppcode_manuallyConfig
=== CONT  TestAccAppcode_manuallyConfig
--- PASS: TestAccAppcode_manuallyConfig (471.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      471.891s
```
3. Manually destroy and refresh state
![销毁并刷新](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/467c3c03-07af-4627-8d62-4df6819ba6a5)
4. Manually destroy when destroying APPCODE and before confirm
![删除时销毁](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/53bc8a00-a29a-434f-bae7-58204c771ced)
