### PR TITLE
feat(iam): support IAM user SSO type for identity provider

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -77,7 +77,7 @@ The following arguments are supported:
   + **iam_user_sso**: After a federated user logs in to HuaweiCloud, the system automatically maps the external identity
     ID to an IAM user so that the federated user has the permissions of the mapped IAM user.
 
-  The default value is virtual_user_sso. For details about how to choose an SSO type,
+  The default value is **virtual_user_sso**. For details about how to choose an SSO type,
   see [Application Scenarios of Virtual User SSO and IAM User SSO](https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_08_0251.html).
   Changing this creates a new resource.
 

--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -6,7 +6,8 @@ subcategory: "Identity and Access Management (IAM)"
 
 Manages the identity providers within HuaweiCloud IAM service.
 
--> **NOTE:** You can create up to 10 identity providers.
+-> **NOTE:** 1. You *must* have admin privileges to use this resource.
+  <br/>2. You can create up to 10 identity providers.
 
 ## Example Usage
 
@@ -63,12 +64,29 @@ The following arguments are supported:
   Changing this creates a new resource.
 
 * `protocol` - (Required, String, ForceNew) Specifies the protocol of the identity provider.
-  Valid values are *saml* and *oidc*.
-  Changing this creates a new resource.
+  Valid values are **saml** and **oidc**. Changing this creates a new resource.
 
 * `status` - (Optional, Bool) Enabled status for the identity provider. Defaults to true.
 
 * `description` - (Optional, String) Specifies the description of the identity provider.
+
+* `sso_type` - (Optional, String, ForceNew) Specifies the single sign-on type of the identity provider.
+  Valid values are as follows:
+  + **virtual_user_sso**: After a federated user logs in to HuaweiCloud, the system automatically creates a virtual user
+    and assigns permissions to the user based on identity conversion rules.
+  + **iam_user_sso**: After a federated user logs in to HuaweiCloud, the system automatically maps the external identity
+    ID to an IAM user so that the federated user has the permissions of the mapped IAM user.
+
+  The default value is virtual_user_sso. For details about how to choose an SSO type,
+  see [Application Scenarios of Virtual User SSO and IAM User SSO](https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_08_0251.html).
+  Changing this creates a new resource.
+
+  -> **NOTE:** 1. Only one SSO type of identity provider can be created under an account.
+    <br/>2. The identity provider with OIDC protocol only supports virtual user SSO type.
+    <br/>3. An account can create multiple identity providers with virtual user SSO type.
+    <br/>4. An account can create only one identity provider with IAM user SSO type.
+    <br/>5. When you use IAM user SSO type, make sure that you have set **IAM_SAML_Attributes_xUserId** in the IDP
+      and External Identity ID in the SP to the same value.
 
 * `metadata` - (Optional, String) Specifies the metadata of the IDP(Identity Provider) server.
   To obtain the metadata file of your enterprise IDP, contact the enterprise administrator.
@@ -125,8 +143,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - A resource ID which equals the identity provider name.
 
 * `login_link` - The login link of the identity provider.
-
-* `sso_type` - The single sign-on type of the identity provider.
 
 * `conversion_rules` - The identity conversion rules of the identity provider.
   The [object](#conversion_rules) structure is documented below

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
@@ -56,6 +56,12 @@ func ResourceIdentityProvider() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{protocolSAML, protocolOIDC}, false),
 			},
+			"sso_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -168,10 +174,6 @@ func ResourceIdentityProvider() *schema.Resource {
 					},
 				},
 			},
-			"sso_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"login_link": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -191,6 +193,7 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 	opts := providers.CreateProviderOpts{
 		Enabled:     d.Get("status").(bool),
 		Description: d.Get("description").(string),
+		SsoType:     d.Get("sso_type").(string),
 	}
 	name := d.Get("name").(string)
 	log.Printf("[DEBUG] Create identity options %s : %#v", name, opts)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

we can create an identity provider with **IAM user SSO** type

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityProvider_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityProvider_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityProvider_basic
=== PAUSE TestAccIdentityProvider_basic
=== CONT  TestAccIdentityProvider_basic
--- PASS: TestAccIdentityProvider_basic (13.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       13.461s
```
