### PR TITLE
refactor(cce): replace extend_param with extend_params in cluster

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -248,7 +248,8 @@ The following arguments are supported:
   + **ipvs**: Optimized kube-proxy mode with higher throughput and faster speed. This mode supports incremental updates
     and can keep connections uninterrupted during service updates. It is suitable for large-sized clusters.
 
-* `extend_param` - (Optional, Map, ForceNew) Specifies the extended parameter.
+* `extend_params` - (Optional, List, ForceNew) Specifies the extended parameter.
+  The [object](#cce_cluster_extend_params) structure is documented below.
   Changing this parameter will create a new cluster resource.
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CCE cluster.
@@ -296,6 +297,50 @@ The following arguments are supported:
 The `masters` block supports:
 
 * `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone of the master node.
+  Changing this parameter will create a new cluster resource.
+
+<a name="cce_cluster_extend_params"></a>
+The `extend_params` block supports:
+
+* `cluster_az` - (Optional, String, ForceNew) Specifies the AZ of master nodes in the cluster. The value can be:
+  + **multi_az**: The cluster will span across AZs. This field is configurable only for high-availability clusters.
+  + **AZ of the dedicated cloud computing pool**: The cluster will be deployed in the AZ of Dedicated Cloud (DeC).
+  This parameter is mandatory for dedicated CCE clusters.
+
+  Changing this parameter will create a new cluster resource.
+
+* `dss_master_volumes` - (Optional, String, ForceNew) Specifies whether the system and data disks of a master node
+  use dedicated distributed storage. If left unspecified, EVS disks are used by default.
+  This parameter is mandatory for dedicated CCE clusters.
+  It is in the following format:
+
+  ```bash
+  <rootVol.dssPoolID>.<rootVol.volType>;<dataVol.dssPoolID>.<dataVol.volType>
+  ```
+
+  Changing this parameter will create a new cluster resource.
+
+* `fix_pool_mask` - (Optional, String, ForceNew) Specifies the number of mask bits of the fixed IP address pool
+  of the container network model. This field can only be used when `container_network_type` is set to **vpc-router**.
+  Changing this parameter will create a new cluster resource.
+
+* `dec_master_flavor` - (Optional, String, ForceNew) Specifies the specifications of the master node
+  in the dedicated hybrid cluster.
+  Changing this parameter will create a new cluster resource.
+
+* `docker_umask_mode` - (Optional, String, ForceNew) Specifies the default UmaskMode configuration of Docker in a
+  cluster. The value can be **secure** or **normal**, defaults to normal.
+  Changing this parameter will create a new cluster resource.
+
+* `cpu_manager_policy` - (Optional, String, ForceNew) Specifies the cluster CPU management policy.
+  The value can be:
+  + **none**: CPU cores will not be exclusively allocated to workload pods.
+    Select this value if you want a large pool of shareable CPU cores.
+  + **static**: CPU cores can be exclusively allocated to workload pods.
+    Select this value if your workload is sensitive to latency in CPU cache and scheduling.In a CCE Turbo cluster,
+    this setting is valid only for nodes where common containers, not Kata containers, run.
+
+  Defaults to none.  
   Changing this parameter will create a new cluster resource.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster -timeout 360m -parallel 4
=== RUN   TestAccCluster_basic
=== PAUSE TestAccCluster_basic
=== RUN   TestAccCluster_prePaid
=== PAUSE TestAccCluster_prePaid
=== RUN   TestAccCluster_withEip
=== PAUSE TestAccCluster_withEip
=== RUN   TestAccCluster_withEpsId
=== PAUSE TestAccCluster_withEpsId
=== RUN   TestAccCluster_turbo
=== PAUSE TestAccCluster_turbo
=== RUN   TestAccCluster_hibernate
=== PAUSE TestAccCluster_hibernate
=== RUN   TestAccCluster_multiContainerNetworkCidrs
=== PAUSE TestAccCluster_multiContainerNetworkCidrs
=== RUN   TestAccCluster_secGroup
=== PAUSE TestAccCluster_secGroup
=== CONT  TestAccCluster_basic
=== CONT  TestAccCluster_turbo
=== CONT  TestAccCluster_withEip
=== CONT  TestAccCluster_prePaid
--- PASS: TestAccCluster_turbo (535.89s)
=== CONT  TestAccCluster_withEpsId
--- PASS: TestAccCluster_basic (555.96s)
=== CONT  TestAccCluster_multiContainerNetworkCidrs
--- PASS: TestAccCluster_withEip (609.38s)
=== CONT  TestAccCluster_secGroup
--- PASS: TestAccCluster_prePaid (739.74s)
=== CONT  TestAccCluster_hibernate
--- PASS: TestAccCluster_multiContainerNetworkCidrs (538.00s)
--- PASS: TestAccCluster_withEpsId (594.82s)
--- PASS: TestAccCluster_secGroup (525.95s)
--- PASS: TestAccCluster_hibernate (1262.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       2002.600s
```
