### PR TITLE
fix(sms): fix panic in target_server_disks block

### DIFF
--- a/docs/resources/sms_task.md
+++ b/docs/resources/sms_task.md
@@ -83,7 +83,7 @@ The `target_server_disks` block supports:
 * `device_type` - (Required, String, ForceNew) Specifies the disk type. The value can be **NORMAL** and **BOOT**.
   Changing this parameter will create a new resource.
 
-* `disk_id` - (Optional, String, ForceNew) Specifies the disk index, e.g. "0".
+* `disk_id` - (Required, String, ForceNew) Specifies the disk index, e.g. "0".
   Changing this parameter will create a new resource.
 
 * `used_size` - (Optional, Int, ForceNew) Specifies the used space in MB. Changing this parameter will create a new resource.

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
@@ -111,10 +111,11 @@ func ResourceMigrateTask() *schema.Resource {
 							ForceNew: true,
 						},
 						"disk_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: "schema: Required",
 						},
 						"used_size": {
 							Type:     schema.TypeInt,

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
@@ -284,13 +284,13 @@ func buildTargetServerPVRequest(raw []interface{}) []tasks.PVRequest {
 		idx := item["index"].(int)
 		pvs[i] = tasks.PVRequest{
 			Name:       item["name"].(string),
-			Size:       convertMBtoBytes(item["size"].(int64)),
+			Size:       convertMBtoBytes(int64(item["size"].(int))),
+			UsedSize:   convertMBtoBytes(int64(item["used_size"].(int))),
 			DeviceType: item["device_type"].(string),
 			FileSystem: item["file_system"].(string),
 			MountPoint: item["mount_point"].(string),
 			Index:      &idx,
 			UUID:       item["uuid"].(string),
-			UsedSize:   convertMBtoBytes(item["used_size"].(int64)),
 		}
 	}
 
@@ -310,8 +310,8 @@ func buildTargetServerDiskRequest(d *schema.ResourceData, cfg *config.Config, si
 		disks[i] = tasks.DiskRequest{
 			Name:            item["name"].(string),
 			DeviceType:      item["device_type"].(string),
-			Size:            convertMBtoBytes(item["size"].(int64)),
-			UsedSize:        convertMBtoBytes(item["used_size"].(int64)),
+			Size:            convertMBtoBytes(int64(item["size"].(int))),
+			UsedSize:        convertMBtoBytes(int64(item["used_size"].(int))),
 			DiskId:          item["disk_id"].(string),
 			PhysicalVolumes: buildTargetServerPVRequest(item["physical_volumes"].([]interface{})),
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

1. fix panic in target_server_disks block
fixes #3324 

2. mark the disk_id as required
the API will return an error without `disk_id`.
```
huaweicloud_sms_task.task: Creating...
╷
│ Error: error creating SMS migrate task: Bad request with: [POST https://sms.ap-southeast-1.myhuaweicloud.com/v3/tasks],
   request_id: 4e39a546fd5b3ade5f1c23edd********,
   error message: {"error_code":"SMS.6103","error_param":[],"error_msg":"Missing diskId in disk node!"}
│
│   with huaweicloud_sms_task.task,
│   on main.tf line 14, in resource "huaweicloud_sms_task" "task":
│   14: resource "huaweicloud_sms_task" "task" {
│
╵
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```bash
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - huaweicloud/huaweicloud in /home/devops01/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
data.huaweicloud_sms_source_servers.source: Reading...
huaweicloud_sms_server_template.test: Refreshing state... [id=7d26ba17-****-****-****-2c9e4689b1dd]
data.huaweicloud_sms_source_servers.source: Read complete after 0s [id=444698b8-****-****-****-77a35ce9b6f2]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # huaweicloud_sms_task.task will be created
  + resource "huaweicloud_sms_task" "task" {
      + action                = "start"
      + enterprise_project_id = (known after apply)
      + id                    = (known after apply)
      + migrate_speed         = (known after apply)
      + migration_ip          = "192.168.0.232"
      + os_type               = "LINUX"
      + project_id            = (known after apply)
      + region                = (known after apply)
      + source_server_id      = "444698b8-****-****-****-77a35ce9b6f2"
      + start_target_server   = true
      + state                 = (known after apply)
      + target_server_id      = "3c204ca1-****-****-****-6e9c1289d31a"
      + target_server_name    = (known after apply)
      + type                  = "MIGRATE_FILE"
      + use_public_ip         = false

      + target_server_disks {
          + device_type = "BOOT"
          + disk_id     = "0"
          + name        = "/dev/sda"
          + size        = 40960
          + used_size   = (known after apply)

          + physical_volumes {
              + device_type = "OS"
              + file_system = "ext4"
              + index       = 0
              + mount_point = "/"
              + name        = "/dev/sda1"
              + size        = 40012
              + used_size   = (known after apply)
              + uuid        = "92414257-****-****-****-66c415ee7358"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

huaweicloud_sms_task.task: Creating...
huaweicloud_sms_task.task: Creation complete after 6s [id=a75100e8-****-****-****-88b4409f39be]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
