### PR TITLE
fix: feat(WAF): WAF policy fix lint error and support new fields

### DIFF
--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -14,11 +14,25 @@ used. The policy resource can be used in Cloud Mode, Dedicated Mode and ELB Mode
 ```hcl
 variable "enterprise_project_id" {}
 
-resource "huaweicloud_waf_policy" "policy_1" {
-  name                  = "policy_1"
+resource "huaweicloud_waf_policy" "test" {
+  name                  = "test_policy"
   protection_mode       = "log"
+  robot_action          = "block"
   level                 = 2
   enterprise_project_id = var.enterprise_project_id
+
+  options {
+    crawler_scanner                = true
+    crawler_script                 = true
+    false_alarm_masking            = true
+    general_check                  = true
+    geolocation_access_control     = true
+    information_leakage_prevention = true
+    known_attack_source            = true
+    precise_protection             = true
+    web_tamper_protection          = true
+    webshell                       = true
+  }
 }
 ```
 
@@ -32,18 +46,81 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the policy name. The maximum length is 256 characters. Only digits, letters,
   underscores(_), and hyphens(-) are allowed.
 
-* `protection_mode` - (Optional, String) Specifies the protective action after a rule is matched. Defaults to `log`.
-  Valid values are:
-  + `block`: WAF blocks and logs detected attacks.
-  + `log`: WAF logs detected attacks only.
-
-* `level` - (Optional, Int) Specifies the protection level. Defaults to `2`. Valid values are:
-  + `1`: low
-  + `2`: medium
-  + `3`: high
-
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF policy.
   Changing this parameter will create a new resource.
+
+* `full_detection` - (Optional, Bool) Specifies the detection mode in precise protection. Defaults to **false**.
+  + **false**: Instant detection. When a request hits the blocking conditions in precise protection, WAF terminates
+    checks and blocks the request immediately.
+  + **true**: Full detection. If a request hits the blocking conditions in precise protection, WAF does not block the
+    request immediately. Instead, it blocks the requests until other checks are finished.
+
+* `protection_mode` - (Optional, String) Specifies the protective action after a rule is matched. Defaults to **log**.
+  Valid values are:
+  + **block**: WAF blocks and logs detected attacks.
+  + **log**: WAF logs detected attacks only.
+
+* `robot_action` - (Optional, String) Specifies the protective actions for each rule in anti-crawler protection.
+  Defaults to **log**. Valid values are:
+  + **block**: WAF blocks discovered attacks.
+  + **log**: WAF only logs discovered attacks.
+
+* `level` - (Optional, Int) Specifies the protection level. Defaults to **2**. Valid values are:
+  + **1**: Low. At this protection level, WAF blocks only requests with obvious attack features. If a large number of
+    false alarms have been reported, this value is recommended.
+  + **2**: Medium. This protection level meets web protection requirements in most scenarios.
+  + **3**: High. At this protection level, WAF provides the finest granular protection and can intercept attacks with
+    complex bypass features, such as Jolokia cyber attacks, common gateway interface (CGI) vulnerability detection,
+    and Druid SQL injection attacks.
+
+* `options` - (Optional, List) Specifies the switch options of the protection item in the policy.
+  The [options](#Policy_Options) structure is documented below.
+
+<a name="Policy_Options"></a>
+The `options` block supports:
+
+* `basic_web_protection` - (Optional, Bool) Specifies whether basic web protection is enabled. Defaults to **false**.
+
+* `general_check` - (Optional, Bool) Specifies whether the general check in basic web protection is enabled.
+  Defaults to **false**.
+
+* `webshell` - (Optional, Bool) Specifies whether the webshell detection in basic web protection is enabled.
+  Defaults to **false**.
+
+* `crawler_engine` - (Optional, Bool) Specifies whether the search engine is enabled. Defaults to **false**.
+
+* `crawler_scanner` - (Optional, Bool) Specifies whether the anti-crawler detection is enabled. Defaults to **false**.
+
+* `crawler_script` - (Optional, Bool) Specifies whether the script tool is enabled. Defaults to **false**.
+
+* `crawler_other` - (Optional, Bool) Specifies whether other crawler check is enabled. Defaults to **false**.
+
+* `cc_attack_protection` - (Optional, Bool) Specifies whether the cc attack protection rules are enabled.
+  Defaults to **false**.
+
+* `precise_protection` - (Optional, Bool) Specifies whether the precise protection is enabled. Defaults to **false**.
+
+* `blacklist` - (Optional, Bool) Specifies whether the blacklist and whitelist protection is enabled.
+  Defaults to **false**.
+
+* `data_masking` - (Optional, Bool) Specifies whether data masking is enabled. Defaults to **false**.
+
+* `false_alarm_masking` - (Optional, Bool) Specifies whether false alarm masking is enabled. Defaults to **false**.
+
+* `web_tamper_protection` - (Optional, Bool) Specifies whether the web tamper protection is enabled.
+  Defaults to **false**.
+
+* `geolocation_access_control` - (Optional, Bool) Specifies whether the geolocation access control is enabled.
+  Defaults to **false**.
+
+* `information_leakage_prevention` - (Optional, Bool) Specifies whether the information leakage prevention is enabled.
+  Defaults to **false**.
+
+* `bot_enable` - (Optional, Bool) Specifies whether the anti-crawler protection is enabled. Defaults to **false**.
+
+* `known_attack_source` - (Optional, Bool) Specifies whether the known attack source is enabled. Defaults to **false**.
+
+* `anti_crawler` - (Optional, Bool) Specifies whether the javascript anti-crawler is enabled. Defaults to **false**.
 
 ## Attribute Reference
 
@@ -51,43 +128,24 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The policy ID in UUID format.
 
-* `full_detection` - The detection mode in Precise Protection.
-  + `true`: full detection, Full detection finishes all threat detections before blocking requests that meet Precise
-      Protection specified conditions.
-  + `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that
-      meets Precise Protection specified conditions.
+* `deep_inspection` - The deep inspection in basic web protection.
 
-* `options` - The protection switches. The options object structure is documented below.
+* `header_inspection` - The header inspection in basic web protection.
 
-The `options` block supports:
+* `shiro_decryption_check` - The shiro decryption check in basic web protection.
 
-* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
+* `bind_hosts` - The protection switches. The options object structure is documented below.
 
-* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
+The `bind_hosts` block supports:
 
-* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+* `id` - The domain name ID.
 
-* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
+* `hostname` - The domain name.
 
-* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
+* `waf_type` - The deployment mode of WAF instance that is used for the domain name. The value can be **cloud** for
+  cloud WAF or **premium** for dedicated WAF instances.
 
-* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
-
-* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
-
-* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
-
-* `cc_attack_protection` - Indicates whether CC Attack Protection is enabled.
-
-* `precise_protection` - Indicates whether Precise Protection is enabled.
-
-* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
-
-* `data_masking` - Indicates whether Data Masking is enabled.
-
-* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
-
-* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
+* `mode` - The special domain name mode. This attribute is only valid for dedicated mode.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_policy_test.go
@@ -48,15 +48,84 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "level", "1"),
 					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "protection_mode", "log"),
+					resource.TestCheckResourceAttr(resourceName, "robot_action", "log"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.basic_web_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.general_check", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_engine", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_scanner", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_script", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_other", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.webshell", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.cc_attack_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.precise_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.blacklist", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.data_masking", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.false_alarm_masking", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.web_tamper_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.geolocation_access_control", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.information_leakage_prevention", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.bot_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.known_attack_source", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.anti_crawler", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_hosts.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "deep_inspection"),
+					resource.TestCheckResourceAttrSet(resourceName, "header_inspection"),
+					resource.TestCheckResourceAttrSet(resourceName, "shiro_decryption_check"),
 				),
 			},
 			{
-				Config: testAccWafPolicyV1_update(randName),
+				Config: testAccWafPolicyV1_update1(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName+"_updated"),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "true"),
 					resource.TestCheckResourceAttr(resourceName, "protection_mode", "block"),
 					resource.TestCheckResourceAttr(resourceName, "level", "3"),
+					resource.TestCheckResourceAttr(resourceName, "robot_action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.basic_web_protection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.general_check", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_engine", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_scanner", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_script", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_other", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.webshell", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.cc_attack_protection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.precise_protection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.blacklist", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.data_masking", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.false_alarm_masking", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.web_tamper_protection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.geolocation_access_control", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.information_leakage_prevention", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.bot_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.known_attack_source", "true"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.anti_crawler", "true"),
+				),
+			},
+			{
+				Config: testAccWafPolicyV1_update2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.basic_web_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.general_check", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_engine", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_scanner", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_script", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.crawler_other", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.webshell", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.cc_attack_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.precise_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.blacklist", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.data_masking", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.false_alarm_masking", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.web_tamper_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.geolocation_access_control", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.information_leakage_prevention", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.bot_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.known_attack_source", "false"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.anti_crawler", "false"),
 				),
 			},
 			{
@@ -134,14 +203,57 @@ resource "huaweicloud_waf_policy" "policy_1" {
 `, testAccWafDedicatedInstanceV1_conf(name), name)
 }
 
-func testAccWafPolicyV1_update(name string) string {
+func testAccWafPolicyV1_update1(name string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "huaweicloud_waf_policy" "policy_1" {
   name            = "%s_updated"
+  full_detection  = true
   protection_mode = "block"
   level           = 3
+  robot_action    = "block"
+
+  options {
+    anti_crawler                   = true
+    basic_web_protection           = true
+    blacklist                      = true
+    bot_enable                     = true
+    cc_attack_protection           = true
+    crawler_engine                 = true
+    crawler_other                  = true
+    crawler_scanner                = true
+    false_alarm_masking            = true
+    general_check                  = true
+    geolocation_access_control     = true
+    information_leakage_prevention = true
+    known_attack_source            = true
+    precise_protection             = true
+    web_tamper_protection          = true
+    webshell                       = true
+  }
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstanceV1_conf(name), name)
+}
+
+func testAccWafPolicyV1_update2(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_policy" "policy_1" {
+  name            = "%s_updated"
+  full_detection  = false
+  protection_mode = "block"
+  level           = 3
+  robot_action    = "block"
+
+  options {
+    
+  }
 
   depends_on = [
     huaweicloud_waf_dedicated_instance.instance_1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix WAF resource policy lint error: replace deprecated function, fix format errors, modify log message and some error handling.
- WAF policy resource support new feature: 
  - add new fields `robot_action`, `bind_hosts`, `deep_inspection`, `header_inspection`, `shiro_decryption_check` and `options switch`.
  - mark field `crawler` deprecated.



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- If the switch in field `options` is not specified, make them default to false.
- The API URL is : https://support.huaweicloud.com/api-waf/UpdatePolicy.html

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafPolicyV1_basic 
=== PAUSE TestAccWafPolicyV1_basic 
=== CONT  TestAccWafPolicyV1_basic 
--- PASS: TestAccWafPolicyV1_basic (368.86s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       368.923s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafPolicyV1_withEpsID'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1_withEpsID -timeout 360m -parallel 4 
=== RUN   TestAccWafPolicyV1_withEpsID 
=== PAUSE TestAccWafPolicyV1_withEpsID
=== CONT  TestAccWafPolicyV1_withEpsID
--- PASS: TestAccWafPolicyV1_withEpsID (352.33s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       352.387s
```
