### PR TITLE
feat: add new data source to query the current account

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -5,8 +5,7 @@ Use this data source to get information about the current account.
 ## Example Usage
 
 ```hcl
-data "huaweicloud_account" "current" {
-}
+data "huaweicloud_account" "current" {}
 
 output "current_account_id" {
   value = data.huaweicloud_account.current.id

--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -1,0 +1,26 @@
+# huaweicloud_account
+
+Use this data source to get information about the current account.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_account" "current" {
+}
+
+output "current_account_id" {
+  value = data.huaweicloud_account.current.id
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The account ID.
+
+* `name` - The account name.

--- a/huaweicloud/data_source_huaweicloud_account.go
+++ b/huaweicloud/data_source_huaweicloud_account.go
@@ -1,0 +1,58 @@
+package huaweicloud
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3/domains"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func DataSourceAccount() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAccountRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAccountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	identityClient, err := cfg.IdentityV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating IAM client: %s", err)
+	}
+
+	// ResourceBase: https://iam.{CLOUD}/v3/auth/
+	identityClient.ResourceBase += "auth/"
+	allPages, err := domains.List(identityClient, nil).AllPages()
+	if err != nil {
+		return diag.Errorf("failed to query account: %s", err)
+	}
+
+	accounts, err := domains.ExtractDomains(allPages)
+	if err != nil {
+		return diag.Errorf("failed to extract details of account: %s", err)
+	}
+
+	if len(accounts) == 0 {
+		return diag.Errorf("failed to query account: you are not authorized to perform the action")
+	}
+
+	result := accounts[0]
+	d.SetId(result.ID)
+
+	mErr := multierror.Append(nil,
+		d.Set("name", result.Name),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/data_source_huaweicloud_account_test.go
+++ b/huaweicloud/data_source_huaweicloud_account_test.go
@@ -1,0 +1,46 @@
+package huaweicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDatasourceAccount_basic(t *testing.T) {
+	rName := "data.huaweicloud_account.current"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceAccount_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountDataSourceID(rName),
+					resource.TestCheckResourceAttrSet(rName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAccountDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find the account data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("the account data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccDatasourceAccount_basic = `
+data "huaweicloud_account" "current" {}
+`

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -392,6 +392,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_as_configurations": as.DataSourceASConfigurations(),
 			"huaweicloud_as_groups":         as.DataSourceASGroups(),
 
+			"huaweicloud_account":            DataSourceAccount(),
 			"huaweicloud_availability_zones": DataSourceAvailabilityZones(),
 
 			"huaweicloud_bms_flavors": bms.DataSourceBmsFlavors(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

Add new data source **huaweicloud_account**

**Note:** this data source is global, so there is no subcategory in docs.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud" TESTARGS="-run TestAccDatasourceAccount_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccDatasourceAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAccount_basic
=== PAUSE TestAccDatasourceAccount_basic
=== CONT  TestAccDatasourceAccount_basic
--- PASS: TestAccDatasourceAccount_basic (6.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       6.499s
```
