### PR TITLE
feat(RDS): add rds instance params and fix deletion method

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -241,6 +241,13 @@ The following arguments are supported:
 
 * `ssl_enable` - (Optional, Bool) Specifies whether to enable the SSL for MySQL database.
 
+* `description` - (Optional, String) Specifies the description of the instance. The value consists of 0 to 64
+  characters, including letters, digits, periods (.), underscores (_), and hyphens (-).
+
+* `dss_pool_id` - (Optional, String) Specifies the exclusive storage ID for Dec users. It is different for each az
+  configuration. When creating an instance for Dec users, it is needed to be specified for all nodes of the instance
+  and separated by commas if database instance type is not standalone or read-only.
+
 * `tags` - (Optional, Map) A mapping of tags to assign to the RDS instance. Each tag is represented by one key-value
   pair.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. add params of description and dss_pool_id
2. add wait process to deletion method

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add params of description and dss_pool_id
2. add wait process to deletion method
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_withEpsId
=== CONT  TestAccRdsInstance_ha
--- PASS: TestAccRdsInstance_ha (622.10s)
--- PASS: TestAccRdsInstance_withEpsId (624.68s)
--- PASS: TestAccRdsInstance_basic (707.45s)
--- PASS: TestAccRdsInstance_prePaid (1002.40s)
--- PASS: TestAccRdsInstance_sqlserver (1010.19s)
--- PASS: TestAccRdsInstance_withParameters (1495.81s)
--- PASS: TestAccRdsInstance_mysql (1681.74s)
--- PASS: TestAccRdsInstance_restore_pg (2194.22s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2377.40s)
--- PASS: TestAccRdsInstance_restore_mysql (2690.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2803.394s
```
