### PR TITLE
fix(nat): add Computed to port_id and private_ip

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_dnat_rule.go
@@ -92,11 +92,13 @@ func ResourcePublicDnatRule() *schema.Resource {
 				Type:         schema.TypeString,
 				ExactlyOneOf: []string{"port_id", "private_ip"},
 				Optional:     true,
+				Computed:     true,
 				Description:  "The port ID of network.",
 			},
 			"private_ip": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The private IP address of a user.",
 			},
 


### PR DESCRIPTION
As port_id and private_ip are both set with api response value, but only one of them can be configured, so needs Computed here to avoid reset it to empty after next plan.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/nat/ TESTARGS='-run=TestAccPublicDnatRule_withPort'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat/ -v -run=TestAccPublicDnatRule_withPort -timeout 360m -parallel 4
=== RUN   TestAccPublicDnatRule_withPort
=== PAUSE TestAccPublicDnatRule_withPort
=== CONT  TestAccPublicDnatRule_withPort
--- PASS: TestAccPublicDnatRule_withPort (225.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat
```
