### PR TITLE
refactor(cce/node_pool): remove out of date arguments in update request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230822105821-bf46bf479421
+	github.com/chnsz/golangsdk v0.0.0-20230823070852-9f656cc09d94
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230822105821-bf46bf479421 h1:CYvqdBX2WLu5h3BecTBBWPPdgjad6WJA9Ael/onx+KA=
-github.com/chnsz/golangsdk v0.0.0-20230822105821-bf46bf479421/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230823070852-9f656cc09d94 h1:xJ8C/5f/x7eySlXSybHkFtndDONPx1Bi+BwdiGkpgss=
+github.com/chnsz/golangsdk v0.0.0-20230823070852-9f656cc09d94/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -621,14 +621,7 @@ func flattenStorage(storageRaw *nodes.StorageSpec) []map[string]interface{} {
 }
 
 func buildNodePoolUpdateOpts(d *schema.ResourceData) (*nodepools.UpdateOpts, error) {
-	loginSpec, err := buildResourceNodeLoginSpec(d)
-	if err != nil {
-		return nil, err
-	}
-
 	updateOpts := nodepools.UpdateOpts{
-		Kind:       "NodePool",
-		ApiVersion: "v3",
 		Metadata: nodepools.UpdateMetaData{
 			Name: d.Get("name").(string),
 		},
@@ -641,19 +634,12 @@ func buildNodePoolUpdateOpts(d *schema.ResourceData) (*nodepools.UpdateOpts, err
 				ScaleDownCooldownTime: d.Get("scale_down_cooldown_time").(int),
 				Priority:              d.Get("priority").(int),
 			},
-			NodeTemplate: nodes.Spec{
-				Flavor:                d.Get("flavor_id").(string),
-				Az:                    d.Get("availability_zone").(string),
-				Login:                 loginSpec,
-				RootVolume:            buildResourceNodeRootVolume(d),
-				DataVolumes:           buildResourceNodeDataVolume(d),
-				Count:                 1,
+			NodeTemplate: nodepools.UpdateNodeTemplate{
 				UserTags:              utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 				K8sTags:               buildResourceNodeK8sTags(d),
 				Taints:                buildResourceNodeTaint(d),
 				InitializedConditions: utils.ExpandToStringList(d.Get("initialized_conditions").([]interface{})),
 			},
-			Type: d.Get("type").(string),
 		},
 	}
 	return &updateOpts, nil

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
 )
 
 var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
@@ -171,9 +172,9 @@ type UpdateOptsBuilder interface {
 // UpdateOpts contains all the values needed to update a new node pool
 type UpdateOpts struct {
 	// API type, fixed value Node
-	Kind string `json:"kind" required:"true"`
+	Kind string `json:"kind,omitempty"`
 	// API version, fixed value v3
-	ApiVersion string `json:"apiversion" required:"true"`
+	ApiVersion string `json:"apiversion,omitempty"`
 	// Metadata required to update a Node Pool
 	Metadata UpdateMetaData `json:"metadata" required:"true"`
 	// specifications to update a Node Pool
@@ -186,12 +187,56 @@ type UpdateMetaData struct {
 	Name string `json:"name" required:"true"`
 }
 
+type UpdateNodeTemplate struct {
+	// Node specifications
+	Flavor string `json:"flavor,omitempty"`
+	// The value of the available partition name
+	Az string `json:"az,omitempty"`
+	// The OS of the node
+	Os string `json:"os,omitempty"`
+	// ID of the dedicated host to which nodes will be scheduled
+	DedicatedHostID string `json:"dedicatedHostId,omitempty"`
+	// Node login parameters
+	Login *nodes.LoginSpec `json:"login,omitempty"`
+	// System disk parameter of the node
+	RootVolume *nodes.VolumeSpec `json:"rootVolume,omitempty"`
+	// The data disk parameter of the node must currently be a disk
+	DataVolumes []nodes.VolumeSpec `json:"dataVolumes,omitempty"`
+	// Disk initialization configuration management parameters
+	// If omit, disk management is performed according to the DockerLVMConfigOverride parameter in extendParam
+	Storage *nodes.StorageSpec `json:"storage,omitempty"`
+	// Elastic IP parameters of the node
+	PublicIP *nodes.PublicIPSpec `json:"publicIP,omitempty"`
+	// The billing mode of the node: the value is 0 (on demand)
+	BillingMode int `json:"billingMode,omitempty"`
+	// Number of nodes when creating in batch
+	Count int `json:"count,omitempty"`
+	// The node nic spec
+	NodeNicSpec *nodes.NodeNicSpec `json:"nodeNicSpec,omitempty"`
+	// Extended parameter
+	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
+	// UUID of an ECS group
+	EcsGroupID string `json:"ecsGroupId,omitempty"`
+	// Tag of a VM, key value pair format
+	UserTags []tags.ResourceTag `json:"userTags,omitempty"`
+	// Tag of a Kubernetes node, key value pair format
+	K8sTags map[string]string `json:"k8sTags,omitempty"`
+	// The runtime spec
+	RunTime *nodes.RunTimeSpec `json:"runtime,omitempty"`
+	// taints to created nodes to configure anti-affinity
+	Taints []nodes.TaintSpec `json:"taints,omitempty"`
+	// The name of the created partition
+	Partition string `json:"partition,omitempty"`
+	// The initialized conditions
+	InitializedConditions []string `json:"initializedConditions,omitempty"`
+}
+
 // UpdateSpec describes Node pools update specification
 type UpdateSpec struct {
 	// Node type. Currently, only VM nodes are supported.
 	Type string `json:"type,omitempty"`
 	// Node template
-	NodeTemplate nodes.Spec `json:"nodeTemplate"`
+	NodeTemplate UpdateNodeTemplate `json:"nodeTemplate"`
 	// Initial number of expected nodes
 	InitialNodeCount *int `json:"initialNodeCount" required:"true"`
 	// Auto scaling parameters

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230822105821-bf46bf479421
+# github.com/chnsz/golangsdk v0.0.0-20230823070852-9f656cc09d94
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool_basic -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_basic (1623.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1623.730s
```
