### PR TITLE
chore(antiddos): move antiddos data source to deprecated

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -385,8 +385,6 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"huaweicloud_antiddos": dataSourceAntiDdosV1(),
-
 			"huaweicloud_apig_environments": apig.DataSourceEnvironments(),
 
 			"huaweicloud_as_configurations": as.DataSourceASConfigurations(),
@@ -597,8 +595,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_product_v1":        dms.DataSourceDmsProduct(),
 			"huaweicloud_dms_maintainwindow_v1": dms.DataSourceDmsMaintainWindow(),
 
-			"huaweicloud_antiddos_v1": dataSourceAntiDdosV1(),
-
 			"huaweicloud_dcs_maintainwindow_v1": dcs.DataSourceDcsMaintainWindow(),
 
 			"huaweicloud_dds_flavors_v3":   dds.DataSourceDDSFlavorV3(),
@@ -621,6 +617,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_route_ids_v2": vpc.DataSourceVpcRouteIdsV2(),
 
 			// Deprecated
+			"huaweicloud_antiddos":                      deprecated.DataSourceAntiDdosV1(),
+			"huaweicloud_antiddos_v1":                   deprecated.DataSourceAntiDdosV1(),
 			"huaweicloud_compute_availability_zones_v2": deprecated.DataSourceComputeAvailabilityZonesV2(),
 			"huaweicloud_csbs_backup":                   deprecated.DataSourceCSBSBackupV1(),
 			"huaweicloud_csbs_backup_policy":            deprecated.DataSourceCSBSBackupPolicyV1(),

--- a/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_antiddos_v1_test.go
+++ b/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_antiddos_v1_test.go
@@ -1,20 +1,21 @@
-package huaweicloud
+package deprecated
 
 import (
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccAntiDdosV1DataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_antiddos.antiddos"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:  func() { acceptance.TestAccPreCheckDeprecated(t) },
+		Providers: acceptance.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAntiDdosV1DataSource_basic,

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_antiddos_v1.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_antiddos_v1.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package deprecated
 
 import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
-func dataSourceAntiDdosV1() *schema.Resource {
+func DataSourceAntiDdosV1() *schema.Resource {
 	return &schema.Resource{
 		Read:               dataSourceAntiDdosV1Read,
 		DeprecationMessage: "this is deprecated",
@@ -109,8 +109,8 @@ func dataSourceAntiDdosV1() *schema.Resource {
 }
 
 func dataSourceAntiDdosV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	antiddosClient, err := config.AntiDDosV1Client(GetRegion(d, config))
+	cfg := meta.(*config.Config)
+	antiddosClient, err := cfg.AntiDDosV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmtp.Errorf("Error creating antiddos client: %s", err)
 	}
@@ -147,7 +147,7 @@ func dataSourceAntiDdosV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("network_type", ddosStatus.NetworkType)
 	d.Set("status", ddosStatus.Status)
 
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", cfg.GetRegion(d))
 
 	traffic, err := antiddos.DailyReport(antiddosClient, ddosStatus.FloatingIpId).Extract()
 	logp.Printf("traffic %#v", traffic)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/deprecated/ TESTARGS='-run=TestAccAntiDdosV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated/ -v -run=TestAccAntiDdosV1DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccAntiDdosV1DataSource_basic
=== PAUSE TestAccAntiDdosV1DataSource_basic
=== CONT  TestAccAntiDdosV1DataSource_basic
--- PASS: TestAccAntiDdosV1DataSource_basic (73.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        73.299s
```
