### PR TITLE
chore: refactor(cfw): update some parameter's behavior

### DIFF
--- a/docs/resources/cfw_address_group_member.md
+++ b/docs/resources/cfw_address_group_member.md
@@ -31,10 +31,6 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the address name.
-
-  Changing this parameter will create a new resource.
-
 * `address` - (Required, String, ForceNew) Specifies the IP address.
 
   Changing this parameter will create a new resource.

--- a/docs/resources/cfw_black_white_list.md
+++ b/docs/resources/cfw_black_white_list.md
@@ -55,12 +55,13 @@ The following arguments are supported:
   + **58**: indicates ICMPv6;
   + **-1**: indicates any protocol;
 
-* `port` - (Required, String) Specifies the destination port.
-
 * `address_type` - (Required, Int) Specifies the IP address type.
   The options are **0** (ipv4), **1** (ipv6) and **2** (domain).
 
 * `address` - (Required, String) Specifies the address.
+
+* `port` - (Optional, String) Specifies the destination port.
+  Required and only available if protocol is **TCP** or **UDP**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_address_group_member_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_address_group_member_test.go
@@ -71,7 +71,6 @@ func TestAccAddressGroupMember_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_cfw_address_group.test", "id"),
-					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "address", "192.168.0.1"),
 					resource.TestCheckResourceAttr(rName, "address_type", "0"),
 				),
@@ -92,10 +91,9 @@ func testAddressGroupMember_basic(name string) string {
 
 resource "huaweicloud_cfw_address_group_member" "test" {
   group_id = huaweicloud_cfw_address_group.test.id
-  name     = "%s"
   address  = "192.168.0.1"
 }
-`, testAddressGroup_basic(name), name)
+`, testAddressGroup_basic(name))
 }
 
 func testAddressGroupMemberImportState(name string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_black_white_list_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_black_white_list_test.go
@@ -105,7 +105,7 @@ func TestAccBlackWhiteList_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "list_type", "4"),
 					resource.TestCheckResourceAttr(rName, "direction", "1"),
 					resource.TestCheckResourceAttr(rName, "protocol", "-1"),
-					resource.TestCheckResourceAttr(rName, "port", "80"),
+					resource.TestCheckResourceAttr(rName, "port", ""),
 					resource.TestCheckResourceAttr(rName, "address_type", "0"),
 					resource.TestCheckResourceAttr(rName, "address", "2.2.2.2"),
 				),
@@ -145,7 +145,6 @@ resource "huaweicloud_cfw_black_white_list" "test" {
   list_type    = 4
   direction    = 1
   protocol     = -1
-  port         = "80"
   address_type = 0
   address      = "2.2.2.2"
 }

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_address_group_member.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_address_group_member.go
@@ -44,12 +44,6 @@ func ResourceAddressGroupMember() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the ID of the IP address group.`,
 			},
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `Specifies the address name.`,
-			},
 			"address": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -71,6 +65,13 @@ func ResourceAddressGroupMember() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: `Specifies address description.`,
+			},
+			// Deprecated
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `schema: Deprecated; Specifies the address name.`,
 			},
 		},
 	}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_black_white_list.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_black_white_list.go
@@ -64,7 +64,8 @@ func ResourceBlackWhiteList() *schema.Resource {
 			},
 			"port": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: `Specifies the destination port.`,
 			},
 			"address_type": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For group member resource, the name parameter has been deprecated, and the API no longer returns it.
For black/white list resource, if the protocol is `ANY` or `ICMP`, the port should be empty (no value is available).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deprecate name parameter for member resource.
2. update port parameter's behavior for black/white list resource.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cfw' TESTARGS='-run=TestAccAddressGroupMember_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run=TestAccAddressGroupMember_basic -timeout 360m -parallel 4
=== RUN   TestAccAddressGroupMember_basic
=== PAUSE TestAccAddressGroupMember_basic
=== CONT  TestAccAddressGroupMember_basic
--- PASS: TestAccAddressGroupMember_basic (15.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       15.455s
```
```
make testacc TEST='./huaweicloud/services/acceptance/cfw' TESTARGS='-run=TestAccBlackWhiteList_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run=TestAccBlackWhiteList_basic -timeout 360m -parallel 4
=== RUN   TestAccBlackWhiteList_basic
=== PAUSE TestAccBlackWhiteList_basic
=== CONT  TestAccBlackWhiteList_basic
--- PASS: TestAccBlackWhiteList_basic (23.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       23.677s
```
