### PR TITLE
feat(RDS): add rds mysql account params and rewrite for all

### DIFF
--- a/docs/resources/rds_mysql_account.md
+++ b/docs/resources/rds_mysql_account.md
@@ -34,26 +34,55 @@ The following arguments are supported:
 
 * `password` - (Required, String) Specifies the password of the db account. The parameter must be 8 to 32 characters
   long and contain only letters(case-sensitive), digits, and special characters(~!@#$%^*-_=+?,()&). The value must be
-  different from name or name spelled backwards.
+  different from `name` or `name` spelled backwards.
+
+* `hosts` - (Optional, List, ForceNew) Specifies the IP addresses that are allowed to access your DB instance.
+  + If the IP address is set to %, all IP addresses are allowed to access your instance.
+  + If the IP address is set to 10.10.10.%, all IP addresses in the subnet 10.10.10.X are allowed to access
+    your instance.
+  + Multiple IP addresses can be added.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies remarks of the database account. The parameter must be 1 to 512
+  characters long and is supported only for MySQL 8.0.25 and later versions.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID of account which is formatted `<instance_id>/<account_name>`.
+* `id` - The resource ID of account which is formatted `<instance_id>/<name>`.
 
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minutes.
-* `update` - Default is 10 minutes.
-* `delete` - Default is 10 minutes.
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
 
 ## Import
 
-RDS account can be imported using the `instance id` and `account name`, e.g.:
+RDS account can be imported using the `instance_id` and `name` separated by a slash, e.g.:
 
+```bash
+$ terraform import huaweicloud_rds_mysql_account.account_1 <instance_id>/<name>
 ```
-$ terraform import huaweicloud_rds_mysql_account.user_1 instance_id/account_name
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`. It is generally recommended
+running `terraform plan` after importing the RDS Mysql account. You can then decide if changes should be applied to
+the RDS Mysql account, or the resource definition should be updated to align with the RDS Mysql account. Also you
+can ignore changes as below.
+
+```hcl
+resource "huaweicloud_rds_mysql_account" "account_1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      password
+    ]
+  }
+}
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1007,7 +1007,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_ram_resource_share": ram.ResourceRAMShare(),
 
-			"huaweicloud_rds_mysql_account":            rds.ResourceRdsAccount(),
+			"huaweicloud_rds_mysql_account":            rds.ResourceMysqlAccount(),
 			"huaweicloud_rds_mysql_database":           rds.ResourceRdsDatabase(),
 			"huaweicloud_rds_mysql_database_privilege": rds.ResourceRdsDatabasePrivilege(),
 			"huaweicloud_rds_instance":                 rds.ResourceRdsInstance(),
@@ -1182,7 +1182,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_smn_topic_v2":        smn.ResourceTopic(),
 			"huaweicloud_smn_subscription_v2": smn.ResourceSubscription(),
 
-			"huaweicloud_rds_account":            rds.ResourceRdsAccount(),
+			"huaweicloud_rds_account":            rds.ResourceMysqlAccount(),
 			"huaweicloud_rds_database":           rds.ResourceRdsDatabase(),
 			"huaweicloud_rds_database_privilege": rds.ResourceRdsDatabasePrivilege(),
 			"huaweicloud_rds_instance_v3":        rds.ResourceRdsInstance(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_privilege_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -33,6 +34,9 @@ func getRdsDatabasePrivilegeFunc(conf *config.Config, state *terraform.ResourceS
 func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_rds_mysql_database_privilege.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
+		acctest.RandIntRange(10, 99))
+
 	var users []model.UserWithPrivilege
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -46,7 +50,7 @@ func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsDatabasePrivilege_basic(rName),
+				Config: testAccRdsDatabasePrivilege_basic(rName, dbPwd),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "users.0.name",
@@ -63,7 +67,7 @@ func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 	})
 }
 
-func testAccRdsDatabasePrivilege_basic(rName string) string {
+func testAccRdsDatabasePrivilege_basic(rName, dbPwd string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -81,5 +85,5 @@ resource "huaweicloud_rds_mysql_database_privilege" "test" {
     name = huaweicloud_rds_mysql_account.test.name
   }
 }
-`, testRdsDatabase_basic(rName, rName), rName)
+`, testRdsDatabase_basic(rName, dbPwd, rName), rName)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_test.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -36,6 +38,8 @@ func TestAccRdsDatabase_basic(t *testing.T) {
 	description := "test database"
 	descriptionUpdate := "test database update"
 	resourceName := "huaweicloud_rds_mysql_database.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
+		acctest.RandIntRange(10, 99))
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -49,7 +53,7 @@ func TestAccRdsDatabase_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testRdsDatabase_basic(rName, description),
+				Config: testRdsDatabase_basic(rName, dbPwd, description),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -58,7 +62,7 @@ func TestAccRdsDatabase_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testRdsDatabase_basic(rName, descriptionUpdate),
+				Config: testRdsDatabase_basic(rName, dbPwd, descriptionUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -70,7 +74,7 @@ func TestAccRdsDatabase_basic(t *testing.T) {
 	})
 }
 
-func testRdsDatabase_basic(rName, description string) string {
+func testRdsDatabase_basic(rName, dbPwd, description string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -80,5 +84,5 @@ resource "huaweicloud_rds_mysql_database" "test" {
   character_set = "utf8"
   description   = "%s"
 }
-`, testRdsAccount_base(rName), rName, description)
+`, testAccRdsInstance_mysql_step1(rName, dbPwd), rName, description)
 }

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_account.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_account.go
@@ -2,34 +2,38 @@ package rds
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model"
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func ResourceRdsAccount() *schema.Resource {
+func ResourceMysqlAccount() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRdsAccountCreate,
-		UpdateContext: resourceRdsAccountUpdate,
-		DeleteContext: resourceRdsAccountDelete,
-		ReadContext:   resourceRdsAccountRead,
+		CreateContext: resourceMysqlAccountCreate,
+		UpdateContext: resourceMysqlAccountUpdate,
+		ReadContext:   resourceMysqlAccountRead,
+		DeleteContext: resourceMysqlAccountDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -40,182 +44,313 @@ func ResourceRdsAccount() *schema.Resource {
 				Computed: true,
 			},
 			"instance_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the RDS Mysql instance.`,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the username of the DB account.`,
 			},
 			"password": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: `Specifies the password of the DB account.`,
+			},
+			"hosts": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the IP addresses that are allowed to access your DB instance.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies remarks of the DB account.`,
 			},
 		},
 	}
 }
 
-func resourceRdsAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.HcRdsV3Client(c.GetRegion(d))
+func resourceMysqlAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createMysqlAccount: create RDS Mysql account.
+	var (
+		createMysqlAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user"
+		createMysqlAccountProduct = "rds"
+	)
+	createMysqlAccountClient, err := cfg.NewServiceClient(createMysqlAccountProduct, region)
 	if err != nil {
-		return fmtp.DiagErrorf("error creating RDS client: %s", err)
+		return diag.Errorf("error creating RDS client: %s", err)
 	}
 
-	dbUser := d.Get("name").(string)
 	instanceId := d.Get("instance_id").(string)
+	createMysqlAccountPath := createMysqlAccountClient.Endpoint + createMysqlAccountHttpUrl
+	createMysqlAccountPath = strings.ReplaceAll(createMysqlAccountPath, "{project_id}",
+		createMysqlAccountClient.ProjectID)
+	createMysqlAccountPath = strings.ReplaceAll(createMysqlAccountPath, "{instance_id}", instanceId)
 
-	config.MutexKV.Lock(instanceId)
-	defer config.MutexKV.Unlock(instanceId)
-
-	createOpts := &model.CreateDbUserRequest{
-		InstanceId: instanceId,
-		Body: &model.UserForCreation{
-			Name:     dbUser,
-			Password: d.Get("password").(string),
-		},
+	createMysqlAccountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
+	requestBody := buildCreateMysqlAccountBodyParams(d)
+	log.Printf("[DEBUG] Create RDS Mysql account options: %#v", createMysqlAccountOpt)
+	requestBody["password"] = utils.ValueIngoreEmpty(d.Get("password"))
+	createMysqlAccountOpt.JSONBody = utils.RemoveNil(requestBody)
 
-	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		_, err = client.CreateDbUser(createOpts)
-		retryable, err := handleMultiOperationsError(err)
-		if retryable {
-			return resource.RetryableError(err)
-		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = createMysqlAccountClient.Request("POST", createMysqlAccountPath, &createMysqlAccountOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(createMysqlAccountClient, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
 	})
 	if err != nil {
-		return diag.Errorf("error creating RDS database user: %s", err)
+		return diag.Errorf("error creating RDS Mysql account: %s", err)
 	}
 
-	id := instanceId + "/" + dbUser
-	d.SetId(id)
-	return resourceRdsAccountRead(ctx, d, meta)
+	accountName := d.Get("name").(string)
+	d.SetId(instanceId + "/" + accountName)
+
+	return resourceMysqlAccountRead(ctx, d, meta)
 }
 
-func resourceRdsAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.HcRdsV3Client(c.GetRegion(d))
+func buildCreateMysqlAccountBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":    utils.ValueIngoreEmpty(d.Get("name")),
+		"comment": utils.ValueIngoreEmpty(d.Get("description")),
+		"hosts":   utils.ValueIngoreEmpty(d.Get("hosts")),
+	}
+	return bodyParams
+}
+
+func resourceMysqlAccountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getMysqlAccount: query RDS Mysql account
+	var (
+		getMysqlAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/detail?page=1&limit=100"
+		getMysqlAccountProduct = "rds"
+	)
+	getMysqlAccountClient, err := cfg.NewServiceClient(getMysqlAccountProduct, region)
 	if err != nil {
-		return fmtp.DiagErrorf("error creating RDS client: %s", err)
+		return diag.Errorf("error creating RDS client: %s", err)
 	}
 
 	// Split instance_id and user from resource id
-	parts := strings.SplitN(d.Id(), "/", 2)
+	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
-		return fmtp.DiagErrorf("invalid id format, must be <instance_id>/<user>")
+		return diag.Errorf("invalid id format, must be <instance_id>/<name>")
 	}
 	instanceId := parts[0]
-	dbUser := parts[1]
+	accountName := parts[1]
 
-	// items on every page, [1, 100]
-	limit := int32(100)
-	// List all db users
-	request := &model.ListDbUsersRequest{
-		InstanceId: instanceId,
-		Limit:      limit,
-		Page:       int32(1),
+	getMysqlAccountPath := getMysqlAccountClient.Endpoint + getMysqlAccountHttpUrl
+	getMysqlAccountPath = strings.ReplaceAll(getMysqlAccountPath, "{project_id}", getMysqlAccountClient.ProjectID)
+	getMysqlAccountPath = strings.ReplaceAll(getMysqlAccountPath, "{instance_id}", instanceId)
+
+	getMysqlAccountResp, err := pagination.ListAllItems(
+		getMysqlAccountClient,
+		"page",
+		getMysqlAccountPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving RDS Mysql account")
 	}
 
-	for {
-		response, err := client.ListDbUsers(request)
-		if err != nil {
-			return common.CheckDeletedDiag(d, err, "error listing RDS db users")
-		}
-		users := *response.Users
-		if len(users) == 0 {
-			break
-		}
-		request.Page += 1
-		for _, user := range users {
-			if user.Name == dbUser {
-				d.Set("instance_id", instanceId)
-				d.Set("name", dbUser)
-				return nil
-			}
-		}
+	getMysqlAccountRespJson, err := json.Marshal(getMysqlAccountResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getMysqlAccountRespBody interface{}
+	err = json.Unmarshal(getMysqlAccountRespJson, &getMysqlAccountRespBody)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	// DB user deleted
-	d.SetId("")
-	log.Printf("[WARN] failed to fetch RDS db user %s: deleted", dbUser)
+	account := utils.PathSearch(fmt.Sprintf("users[?name=='%s']|[0]", accountName), getMysqlAccountRespBody, nil)
 
+	if account == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("name", utils.PathSearch("name", account, nil)),
+		d.Set("description", utils.PathSearch("comment", account, nil)),
+		d.Set("hosts", utils.PathSearch("hosts", account, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceMysqlAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateMysqlAccountClient, err := cfg.NewServiceClient("rds", region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	if err = updateMysqlAccountPassword(ctx, d, updateMysqlAccountClient); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = updateMysqlAccountDescription(d, updateMysqlAccountClient); err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceMysqlAccountRead(ctx, d, meta)
+}
+
+func updateMysqlAccountPassword(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChange("password") {
+		return nil
+	}
+	// updateMysqlAccount: update RDS Mysql account password
+	updateMysqlAccountHttpUrl := "v3/{project_id}/instances/{instance_id}/db_user/resetpwd"
+
+	updateMysqlAccountPath := client.Endpoint + updateMysqlAccountHttpUrl
+	updateMysqlAccountPath = strings.ReplaceAll(updateMysqlAccountPath, "{project_id}", client.ProjectID)
+	updateMysqlAccountPath = strings.ReplaceAll(updateMysqlAccountPath, "{instance_id}",
+		d.Get("instance_id").(string))
+
+	updateMysqlAccountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	updateMysqlAccountOpt.JSONBody = utils.RemoveNil(buildUpdateMysqlAccountPasswordBodyParams(d))
+
+	instanceId := d.Get("instance_id").(string)
+	retryFunc := func() (interface{}, bool, error) {
+		_, err := client.Request("POST", updateMysqlAccountPath, &updateMysqlAccountOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error updating Mysql account password: %s", err)
+	}
 	return nil
 }
 
-func resourceRdsAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.HcRdsV3Client(c.GetRegion(d))
-	if err != nil {
-		return fmtp.DiagErrorf("error creating RDS client: %s", err)
+func updateMysqlAccountDescription(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChange("description") {
+		return nil
+	}
+	// updateMysqlAccount: update RDS Mysql account password
+	updateMysqlAccountHttpUrl := "v3/{project_id}/instances/{instance_id}/db-users/{user_name}/comment"
+
+	updateMysqlAccountPath := client.Endpoint + updateMysqlAccountHttpUrl
+	updateMysqlAccountPath = strings.ReplaceAll(updateMysqlAccountPath, "{project_id}", client.ProjectID)
+	updateMysqlAccountPath = strings.ReplaceAll(updateMysqlAccountPath, "{instance_id}",
+		d.Get("instance_id").(string))
+	updateMysqlAccountPath = strings.ReplaceAll(updateMysqlAccountPath, "{user_name}", d.Get("name").(string))
+
+	updateMysqlAccountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	instanceId := d.Get("instance_id").(string)
-	config.MutexKV.Lock(instanceId)
-	defer config.MutexKV.Unlock(instanceId)
+	updateMysqlAccountOpt.JSONBody = utils.RemoveNil(buildUpdateMysqlAccountDescriptionBodyParams(d))
 
-	updateOpts := &model.SetDbUserPwdRequest{
-		InstanceId: instanceId,
-		Body: &model.DbUserPwdRequest{
-			Name:     d.Get("name").(string),
-			Password: d.Get("password").(string),
+	log.Printf("[DEBUG] Update RDS Mysql account description options: %#v", updateMysqlAccountOpt)
+	_, err := client.Request("PUT", updateMysqlAccountPath, &updateMysqlAccountOpt)
+	if err != nil {
+		return fmt.Errorf("error updating Mysql account description: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateMysqlAccountPasswordBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":     utils.ValueIngoreEmpty(d.Get("name")),
+		"password": utils.ValueIngoreEmpty(d.Get("password")),
+	}
+	return bodyParams
+}
+
+func buildUpdateMysqlAccountDescriptionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"comment": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourceMysqlAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteMysqlAccount: delete RDS Mysql account
+	var (
+		deleteMysqlAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/{user_name}"
+		deleteMysqlAccountProduct = "rds"
+	)
+	deleteMysqlAccountClient, err := cfg.NewServiceClient(deleteMysqlAccountProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	deleteMysqlAccountPath := deleteMysqlAccountClient.Endpoint + deleteMysqlAccountHttpUrl
+	deleteMysqlAccountPath = strings.ReplaceAll(deleteMysqlAccountPath, "{project_id}",
+		deleteMysqlAccountClient.ProjectID)
+	deleteMysqlAccountPath = strings.ReplaceAll(deleteMysqlAccountPath, "{instance_id}",
+		d.Get("instance_id").(string))
+	deleteMysqlAccountPath = strings.ReplaceAll(deleteMysqlAccountPath, "{user_name}", d.Get("name").(string))
+
+	deleteMysqlAccountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
 		},
 	}
 
-	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-		_, err = client.SetDbUserPwd(updateOpts)
-		retryable, err := handleMultiOperationsError(err)
-		if retryable {
-			return resource.RetryableError(err)
-		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-	if err != nil {
-		return diag.Errorf("error updating RDS database user: %s", err)
-	}
-
-	return resourceRdsAccountRead(ctx, d, meta)
-}
-
-func resourceRdsAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.HcRdsV3Client(c.GetRegion(d))
-	if err != nil {
-		return fmtp.DiagErrorf("error creating RDS client: %s", err)
-	}
+	log.Printf("[DEBUG] Delete RDS Mysql account options: %#v", deleteMysqlAccountOpt)
 
 	instanceId := d.Get("instance_id").(string)
-	config.MutexKV.Lock(instanceId)
-	defer config.MutexKV.Unlock(instanceId)
-
-	deleteOpts := &model.DeleteDbUserRequest{
-		InstanceId: instanceId,
-		UserName:   d.Get("name").(string),
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = deleteMysqlAccountClient.Request("DELETE", deleteMysqlAccountPath, &deleteMysqlAccountOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
 	}
-
-	log.Printf("[DEBUG] Delete RDS db user options: %#v", deleteOpts)
-	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		_, err = client.DeleteDbUser(deleteOpts)
-		retryable, err := handleMultiOperationsError(err)
-		if retryable {
-			return resource.RetryableError(err)
-		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(deleteMysqlAccountClient, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
 	})
 	if err != nil {
-		return diag.Errorf("error deleting RDS database user: %s", err)
+		return diag.Errorf("error deleting RDS Mysql account: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1.   rewrite for all
2.  add params description and hosts

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds mysql account params and rewrite for all
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccMysqlAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlAccount_basic
--- PASS: TestAccMysqlAccount_basic (561.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       561.834s
```
