### PR TITLE
fix(provider): unset port number in default auth_url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -193,7 +193,7 @@ The following arguments are supported:
   `HW_CLOUD` environment variable is used. Defaults to `myhuaweicloud.com`.
 
 * `auth_url` - (Optional, Required before 1.14.0) The Identity authentication URL. If omitted, the
-  `HW_AUTH_URL` environment variable is used. Defaults to `https://iam.{{region}}.{{cloud}}:443/v3`.
+  `HW_AUTH_URL` environment variable is used. Defaults to `https://iam.{{region}}.{{cloud}}/v3`.
 
 * `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
   `HW_INSECURE` environment variable is used.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1414,7 +1414,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 		identityEndpoint = v.(string)
 	} else {
 		// use cloud as basis for identityEndpoint
-		identityEndpoint = fmt.Sprintf("https://iam.%s.%s:443/v3", region, cloud)
+		identityEndpoint = fmt.Sprintf("https://iam.%s.%s/v3", region, cloud)
 	}
 
 	config := config.Config{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

curently, the default auth url is "https://iam.{region}.myhuaweicloud.com:443/v3".

Although the default port of HTTPS is **443**, but we can not guarantee the port will not be changed, so it's better to unset it in default `auth_url`.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (266.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       266.225s
```
