### PR TITLE
feat(RocketMQ): fix rocketmq instance params access_key and secret_key

### DIFF
--- a/docs/resources/dms_rocketmq_user.md
+++ b/docs/resources/dms_rocketmq_user.md
@@ -42,10 +42,18 @@ The following arguments are supported:
 * `instance_id` - (Required, String, ForceNew) Specifies the ID of the rocketMQ instance.
   Changing this parameter will create a new resource.
 
-* `access_key` - (Required, String, ForceNew) Specifies the access key of the user.
+* `access_key` - (Required, String, ForceNew) Specifies the name of the user, which starts with a letter, consists of 7
+  to 64 characters and can contain only letters, digits, hyphens (-), and underscores (_).
   Changing this parameter will create a new resource.
 
-* `secret_key` - (Required, String, ForceNew) Specifies the secret key of the user.
+* `secret_key` - (Required, String, ForceNew) Specifies the password of the user. Use 8 to 32 characters. Contain at
+  least three of the following character types:
+  + Uppercase letters.
+  + Lowercase letters.
+  + Digits.
+  + Special characters \`~!@#$%^&*()-_=+\|[{}];:'"",<.>/?. Cannot be the `access_key` or the `access_key` spelled
+    backwards.
+  
   Changing this parameter will create a new resource.
 
 * `white_remote_address` - (Optional, String) Specifies the IP address whitelist.
@@ -80,8 +88,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The rocketmq user can be imported using the rocketMQ instance ID and user access key separated by a slash, e.g.
+The rocketmq user can be imported using the rocketMQ `instance_id` and user `access_key` separated by a slash, e.g.
 
-```
-$ terraform import huaweicloud_dms_rocketmq_user.test c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/access_key
+```bash
+$ terraform import huaweicloud_dms_rocketmq_user.test <instance_id>/<access_key>
 ```

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_user_test.go
@@ -90,10 +90,9 @@ func TestAccDmsRocketMQUser_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"access_key", "secret_key"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
@@ -3,13 +3,11 @@ package dms
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
@@ -47,18 +45,12 @@ func ResourceDmsRocketMQUser() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `Specifies the access key of the user.`,
-				ValidateFunc: validation.All(
-					validation.StringMatch(regexp.MustCompile(`^[A-Za-z]*$`),
-						"Only support letters"),
-					validation.StringLenBetween(7, 64),
-				),
 			},
 			"secret_key": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Description:  `Specifies the secret key of the user.`,
-				ValidateFunc: validation.StringLenBetween(8, 32),
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the secret key of the user.`,
 			},
 			"white_remote_address": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  replace rocketmq user ak sk with name and password
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  replace rocketmq user ak sk with name and password
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dms/' TESTARGS='-run TestAccDmsRocketMQUser_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQUser_ -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQUser_basic
=== PAUSE TestAccDmsRocketMQUser_basic
=== RUN   TestAccDmsRocketMQUser_with_name
=== PAUSE TestAccDmsRocketMQUser_with_name
=== CONT  TestAccDmsRocketMQUser_basic
=== CONT  TestAccDmsRocketMQUser_with_name
--- PASS: TestAccDmsRocketMQUser_basic (601.34s)
--- PASS: TestAccDmsRocketMQUser_with_name (694.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       694.684s
```
