### PR TITLE
fix(cce/node_attach): add initialized_conditions as an attribute

### DIFF
--- a/docs/resources/cce_node_attach.md
+++ b/docs/resources/cce_node_attach.md
@@ -103,6 +103,7 @@ In addition to all arguments above, the following attributes are exported:
 * `ecs_group_id` - The Ecs group ID.
 * `subnet_id` - The ID of the subnet to which the NIC belongs.
 * `charging_mode` - The charging mode of the CCE node. Valid values are *prePaid* and *postPaid*.
+* `initialized_conditions` - The custom initialization flags.
 
 * `root_volume` - The configuration of the system disk.
   + `size` - The disk size in GB.

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
@@ -265,6 +265,11 @@ func ResourceNodeAttach() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"initialized_conditions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
the node attach resource use the Read func of node, missing initialized_conditions will cause panic
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodeAttach_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodeAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccNodeAttach_basic
=== PAUSE TestAccNodeAttach_basic
=== CONT  TestAccNodeAttach_basic
--- PASS: TestAccNodeAttach_basic (1216.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1216.637s
```
