### PR TITLE
feat(CodeArts): add a new resource codearts deploy group

### DIFF
--- a/docs/resources/codearts_deploy_group.md
+++ b/docs/resources/codearts_deploy_group.md
@@ -1,0 +1,142 @@
+---
+subcategory: "CodeArts Deploy"
+---
+
+# huaweicloud_codearts_deploy_group
+
+Manages a CodeArts deploy group resource within HuaweiCloud.
+
+## Example Usage
+
+### Using proxy access mode
+
+```hcl
+variable "project_id" {}
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id  = var.project_id
+  name        = "test_group"
+  os_type     = "linux"
+  description = "test description"
+}
+```
+
+### Without using proxy access mode
+
+```hcl
+variable "project_id" {}
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id    = var.project_id
+  name          = "test_group"
+  os_type       = "linux"
+  description   = "test description"
+  is_proxy_mode = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the group name. The name consists of 3 to 128 characters, including letters,
+  digits, chinese characters or `-_.` symbols.
+
+* `project_id` - (Required, String, ForceNew) Specifies the project ID for CodeArts service.
+
+  Changing this parameter will create a new resource.
+
+* `os_type` - (Required, String, ForceNew) Specifies the operating system. Valid values are **windows** and **linux**.
+
+  Changing this parameter will create a new resource.
+
+* `resource_pool_id` - (Optional, String) Specifies the resource pool ID. A resource pool is a collection of physical
+  environments that execute deployment commands when deploying software packages.
+  If not specified, the resource pool hosted by HuaweiCloud will be used.
+  If you want to use your own servers as resource pools, please fill your own resource pool ID.
+
+  -> Please refer to the following documents to create your own resource pool:
+  [Creating an Agent Pool](https://support.huaweicloud.com/intl/en-us/usermanual-devcloud/devcloud_01_0016.html) and
+  [Creating an Agent](https://support.huaweicloud.com/intl/en-us/usermanual-devcloud/devcloud_01_0017.html).
+
+* `description` - (Optional, String) Specifies the description.
+
+* `is_proxy_mode` - (Optional, Int, ForceNew) Specifies whether the host is in agent access mode.
+  Changing this parameter will create a new resource. Valid values are as follows:
+  + **1**: Using proxy access mode.
+  + **0**: Without using proxy access mode.
+
+  Defaults to 1.
+
+  -> The scenes to use agent access mode: If the target host cannot connect to the public network, you need to select a
+  host bound with an EIP as the proxy host to connect CodeArts to the target host.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (group ID).
+
+* `created_at` - The create time.
+
+* `updated_at` - The update time.
+
+* `host_count` - The host number in a group.
+
+* `created_by` - The creator information.
+  The [object](#DeployGroup_user) structure is documented below.
+
+* `updated_by` - The editor information.
+  The [object](#DeployGroup_user) structure is documented below.
+
+* `permission` - The group permission detail.
+  The [permission](#DeployGroup_permission) structure is documented below.
+
+<a name="DeployGroup_user"></a>
+The `object` block supports:
+
+* `user_id` - The user ID.
+
+* `user_name` - The user name.
+
+<a name="DeployGroup_permission"></a>
+The `permission` block supports:
+
+* `can_view` - Indicates whether the user has the view permission.
+
+* `can_edit` - Indicates whether the user has the edit permission.
+
+* `can_delete` - Indicates whether the user has the deletion permission.
+
+* `can_add_host` - Indicates whether the user has the permission to add hosts.
+
+* `can_manage` - Indicates whether the user has the management permission.
+
+## Import
+
+The CodeArts deploy group resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_deploy_group.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `is_proxy_mode`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_codearts_deploy_group" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      is_proxy_mode,
+    ]
+  }
+}
+```

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -789,6 +789,12 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Product: "ProjectMan",
 	},
 
+	"codearts_deploy": {
+		Name:    "codearts-deploy",
+		Version: "v2",
+		Product: "CodeArtsDeploy",
+	},
+
 	// catalog for Data Security Center
 	"dsc": {
 		Name:    "sdg",

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1119,8 +1119,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpts_task":    cpts.ResourceTask(),
 
 			// CodeArts
-			"huaweicloud_codearts_project":    codearts.ResourceProject(),
-			"huaweicloud_codearts_repository": codearts.ResourceRepository(),
+			"huaweicloud_codearts_project":      codearts.ResourceProject(),
+			"huaweicloud_codearts_repository":   codearts.ResourceRepository(),
+			"huaweicloud_codearts_deploy_group": codearts.ResourceDeployGroup(),
 
 			"huaweicloud_dsc_instance":  dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_asset_obs": dsc.ResourceAssetObs(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -172,6 +172,8 @@ var (
 	HW_NEW_CERTIFICATE_CONTENT     = os.Getenv("HW_NEW_CERTIFICATE_CONTENT")
 	HW_NEW_CERTIFICATE_PRIVATE_KEY = os.Getenv("HW_NEW_CERTIFICATE_PRIVATE_KEY")
 	HW_NEW_CERTIFICATE_ROOT_CA     = os.Getenv("HW_NEW_CERTIFICATE_ROOT_CA")
+
+	HW_CODEARTS_RESOURCE_POOL_ID = os.Getenv("HW_CODEARTS_RESOURCE_POOL_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -774,5 +776,12 @@ func TestAccPreCheckCertificateFull(t *testing.T) {
 	TestAccPreCheckCertificateWithoutRootCA(t)
 	if HW_CERTIFICATE_ROOT_CA == "" || HW_NEW_CERTIFICATE_ROOT_CA == "" {
 		t.Skip("HW_CERTIFICATE_ROOT_CA and HW_NEW_CERTIFICATE_ROOT_CA must be set for root CA validation")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCodeArtsDeploy(t *testing.T) {
+	if HW_CODEARTS_RESOURCE_POOL_ID == "" {
+		t.Skip("HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_group_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_group_test.go
@@ -1,0 +1,270 @@
+package codearts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDeployGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/host-groups/{group_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{group_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CodeArts deploy group: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+	errorCode := utils.PathSearch("error_code", getRespBody, "")
+	if errorCode == "Deploy.00021104" {
+		// 'Deploy.00021104' means the group is not exist
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	if errorCode != "" {
+		errorMsg := utils.PathSearch("error_msg", getRespBody, "")
+		return nil, fmt.Errorf("error retrieving CodeArts deploy group: error code: %s, error message: %s",
+			errorCode, errorMsg)
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccDeployGroup_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeployGroup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "project_id",
+						"huaweicloud_codearts_project.test", "id"),
+					resource.TestCheckResourceAttr(rName, "os_type", "linux"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "is_proxy_mode", "1"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "host_count"),
+					resource.TestCheckResourceAttrSet(rName, "created_by.#"),
+					resource.TestCheckResourceAttrSet(rName, "updated_by.#"),
+					resource.TestCheckResourceAttrSet(rName, "permission.#"),
+				),
+			},
+			{
+				Config: testDeployGroup_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_proxy_mode",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDeployGroup_resourcePoolId(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCodeArtsDeploy(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeployGroup_resourcePoolId(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "project_id",
+						"huaweicloud_codearts_project.test", "id"),
+					resource.TestCheckResourceAttr(rName, "os_type", "windows"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "is_proxy_mode", "0"),
+					resource.TestCheckResourceAttr(rName, "resource_pool_id", acceptance.HW_CODEARTS_RESOURCE_POOL_ID),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "host_count"),
+					resource.TestCheckResourceAttrSet(rName, "created_by.#"),
+					resource.TestCheckResourceAttrSet(rName, "updated_by.#"),
+					resource.TestCheckResourceAttrSet(rName, "permission.#"),
+				),
+			},
+			{
+				Config: testDeployGroup_resourcePoolId_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "resource_pool_id", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_proxy_mode",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDeployGroup_errorCheck(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCodeArtsDeploy(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testDeployGroup_errorCheck(name),
+				ExpectError: regexp.MustCompile(`error creating CodeArts deploy group: error code:`),
+			},
+		},
+	})
+}
+
+func testDeployGroup_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id  = huaweicloud_codearts_project.test.id
+  name        = "%s"
+  os_type     = "linux"
+  description = "test description"
+}
+`, testProject_basic(name), name)
+}
+
+func testDeployGroup_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id  = huaweicloud_codearts_project.test.id
+  name        = "%s_update"
+  os_type     = "linux"
+  description = "test description update"
+}
+`, testProject_basic(name), name)
+}
+
+func testDeployGroup_resourcePoolId(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id       = huaweicloud_codearts_project.test.id
+  name             = "%s"
+  os_type          = "windows"
+  description      = "test description"
+  is_proxy_mode    = 0
+  resource_pool_id = "%s"
+}
+`, testProject_basic(name), name, acceptance.HW_CODEARTS_RESOURCE_POOL_ID)
+}
+
+func testDeployGroup_resourcePoolId_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id    = huaweicloud_codearts_project.test.id
+  name          = "%s_update"
+  os_type       = "windows"
+  description   = "test description update"
+  is_proxy_mode = 0
+}
+`, testProject_basic(name), name)
+}
+
+func testDeployGroup_errorCheck(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id    = huaweicloud_codearts_project.test.id
+  name          = "%s"
+  os_type       = "error_type"
+  description   = "test description"
+  is_proxy_mode = 0
+}
+`, testProject_basic(name), name)
+}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go
@@ -1,0 +1,411 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CodeArts
+// ---------------------------------------------------------------
+
+package codearts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	groupNotFound = "Deploy.00021104"
+)
+
+func ResourceDeployGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeployGroupCreate,
+		UpdateContext: resourceDeployGroupUpdate,
+		ReadContext:   resourceDeployGroupRead,
+		DeleteContext: resourceDeployGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the group name.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the project ID.`,
+			},
+			"os_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the operating system.`,
+			},
+			"resource_pool_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the resource pool ID.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description.`,
+			},
+			"is_proxy_mode": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1,
+				ForceNew:    true,
+				Description: `Specifies whether the host is in agent access mode.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The create time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time.`,
+			},
+			"host_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The host number in a group.`,
+			},
+			"created_by": {
+				Type:     schema.TypeList,
+				Elem:     deployGroupUserSchema(),
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeList,
+				Elem:     deployGroupUserSchema(),
+				Computed: true,
+			},
+			"permission": {
+				Type:     schema.TypeList,
+				Elem:     deployGroupPermissionSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func deployGroupUserSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user name.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func deployGroupPermissionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"can_view": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the view permission.`,
+			},
+			"can_edit": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the edit permission.`,
+			},
+			"can_delete": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the deletion permission.`,
+			},
+			"can_add_host": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the permission to add hosts.`,
+			},
+			"can_manage": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the management permission.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDeployGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: buildCreateDeployGroupBodyParams(d, region),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy group: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(createRespBody, groupNotFound); err != nil {
+		return diag.Errorf("error creating CodeArts deploy group: %s", err)
+	}
+
+	id, err := jmespath.Search("group_id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating CodeArts deploy group: ID is not found in API response")
+	}
+
+	d.SetId(id.(string))
+
+	return resourceDeployGroupRead(ctx, d, meta)
+}
+
+func buildCreateDeployGroupBodyParams(d *schema.ResourceData, region string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":             d.Get("name"),
+		"region_name":      region,
+		"project_id":       d.Get("project_id"),
+		"os":               d.Get("os_type"),
+		"is_proxy_mode":    d.Get("is_proxy_mode"),
+		"slave_cluster_id": d.Get("resource_pool_id"),
+		"description":      d.Get("description"),
+	}
+}
+
+func resourceDeployGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups/{group_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{group_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CodeArts deploy group: %s", err)
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(getRespBody, groupNotFound); err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts deploy group")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("project_id", utils.PathSearch("project_id", getRespBody, nil)),
+		d.Set("os_type", utils.PathSearch("os", getRespBody, nil)),
+		d.Set("resource_pool_id", utils.PathSearch("slave_cluster_id", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("created_time", getRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_time", getRespBody, nil)),
+		d.Set("host_count", utils.PathSearch("host_count", getRespBody, nil)),
+		d.Set("created_by", flattenDeployGroupCreateOrUpdateUser(getRespBody, "created_by")),
+		d.Set("updated_by", flattenDeployGroupCreateOrUpdateUser(getRespBody, "updated_by")),
+		d.Set("permission", flattenDeployGroupPermission(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDeployGroupCreateOrUpdateUser(resp interface{}, expression string) []interface{} {
+	curJson, err := jmespath.Search(expression, resp)
+	if err != nil {
+		log.Printf("[ERROR] error flatten %s, cause this field is not found in API response", expression)
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"user_id":   utils.PathSearch("user_id", curJson, nil),
+			"user_name": utils.PathSearch("user_name", curJson, nil),
+		},
+	}
+}
+
+func flattenDeployGroupPermission(resp interface{}) []interface{} {
+	curJson, err := jmespath.Search("permission", resp)
+	if err != nil {
+		log.Printf("[ERROR] error flatten permission, cause this field is not found in API response")
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"can_view":     utils.PathSearch("can_view", curJson, nil),
+			"can_edit":     utils.PathSearch("can_edit", curJson, nil),
+			"can_delete":   utils.PathSearch("can_delete", curJson, nil),
+			"can_add_host": utils.PathSearch("can_add_host", curJson, nil),
+			"can_manage":   utils.PathSearch("can_manage", curJson, nil),
+		},
+	}
+}
+
+func resourceDeployGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups/{group_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{group_id}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: buildUpdateDeployGroupBodyParams(d),
+	}
+	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating CodeArts deploy group: %s", err)
+	}
+
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(updateRespBody, groupNotFound); err != nil {
+		return diag.Errorf("error updating CodeArts deploy group: %s", err)
+	}
+
+	return resourceDeployGroupRead(ctx, d, meta)
+}
+
+func buildUpdateDeployGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":             d.Get("name"),
+		"description":      d.Get("description"),
+		"slave_cluster_id": d.Get("resource_pool_id"),
+	}
+}
+
+func resourceDeployGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups/{group_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{group_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CodeArts deploy group: %s", err)
+	}
+
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(deleteRespBody, groupNotFound); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting CodeArts deploy group")
+	}
+
+	return nil
+}
+
+// checkResponseError use to check whether the CodeArts deploy API response body contains error code.
+// Parameter 'respBody' is the response body and 'notFoundCode' is the error code when the resource is not found.
+// An example of an error response body is as follows: {"error_code": "XXX", "error_msg": "XXX", "status": "XXX"}
+func checkResponseError(respBody interface{}, notFoundCode string) error {
+	errorCode := utils.PathSearch("error_code", respBody, "")
+	if errorCode == "" {
+		return nil
+	}
+
+	errorMsg := utils.PathSearch("error_msg", respBody, "")
+	err := fmt.Errorf("error code: %s, error message: %s", errorCode, errorMsg)
+	if errorCode != notFoundCode {
+		return err
+	}
+
+	return golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte(err.Error()),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add a new resource codearts deploy group

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The field `is_proxy_mode` does not have response value.
- The Create\Update\Delete function need to add Header `"Content-Type": "application/json;charset=utf-8"`
- Even if the API response code is 200, the result may still be wrong, we need to parse the response body to check whether the request is success. 
- I have verified `CheckDeletedDiag`：
  - Step1: Use  terraform create a group resource.
  - Step2: Delete this group from console.
  - Step3: Run `terraform destroy` in terraform.





**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup_basic -timeout 360m -parallel 4 
=== RUN   TestAccDeployGroup_basic 
=== PAUSE TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_basic
--- PASS: TestAccDeployGroup_basic (14.98s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  15.028s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup_resourcePoolId'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup_resourcePoolId -timeout 360m -parallel 4 
=== RUN   TestAccDeployGroup_resourcePoolId 
=== PAUSE TestAccDeployGroup_resourcePoolId
=== CONT  TestAccDeployGroup_resourcePoolId
--- PASS: TestAccDeployGroup_resourcePoolId (21.19s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  21.245s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup_errorCheck'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup_errorCheck -timeout 360m -parallel 4 
=== RUN   TestAccDeployGroup_errorCheck 
=== PAUSE TestAccDeployGroup_errorCheck 
=== CONT  TestAccDeployGroup_errorCheck
--- PASS: TestAccDeployGroup_errorCheck (4.69s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  4.736s
```
