### PR TITLE
fix(provider): validate region when using customizing endpoints

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -256,6 +256,9 @@ func (c *Config) NewServiceClient(srv, region string) (*golangsdk.ServiceClient,
 	}
 
 	if endpoint, ok := c.Endpoints[srv]; ok {
+		if region != c.Region {
+			return nil, fmt.Errorf("Resource-level region must be the same as Provider-level region when using customizing endpoints")
+		}
 		return c.newServiceClientByEndpoint(client, srv, endpoint)
 	}
 	return c.newServiceClientByName(client, serviceCatalog, region)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

The following tf script will run fail because the regions between provider and resource are different and the **endpoint** is customizing.

```hcl
provider "huaweicloud" {
  region      = "cn-north-4"

  endpoints = {
    lts = "https://lts.cn-east-3.myhuaweicloud.com"
    vpc = "https://vpc.cn-east-3.myhuaweicloud.com"
  }
}


resource "huaweicloud_lts_group" "group_1" {
  region = "cn-east-3"
  ...
}

resource "huaweicloud_vpc" "vpc" {
  region = "cn-east-3"
  ...
}
```

```bash
│ Error: error creating VPC: Bad request with: [POST https://vpc.cn-east-3.myhuaweicloud.com/v1/0970dd7a1300f5672ff******115/vpcs], request_id: 749d27ffd313d41c1b24ee7****0b74, 
error message: {"code":"VPC.0105","message":"{\"NeutronError\":{\"message\":\"The project name cn-north-4 carried by the token from IAM contains region information. Only token issued for setting region could pass the authentication.\",\"type\":\"BadRequest\",\"detail\":\"\"}}"}
│
│   with huaweicloud_vpc.vpc,
│   on main.tf line 23, in resource "huaweicloud_vpc" "vpc":
│   23: resource "huaweicloud_vpc" "vpc" {
```

It's better to add an validation when the the regions between provider and resource are different.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
│ Error: error creating LTS client: Resource-level region must be the same as Provider-level region when using customizing endpoints
│
│   with huaweicloud_lts_group.group_1,
│   on main.tf line 17, in resource "huaweicloud_lts_group" "group_1":
│   17: resource "huaweicloud_lts_group" "group_1" {
│
╵
╷
│ Error: error creating VPC client: Resource-level region must be the same as Provider-level region when using customizing endpoints
│
│   with huaweicloud_vpc.vpc,
│   on main.tf line 23, in resource "huaweicloud_vpc" "vpc":
│   23: resource "huaweicloud_vpc" "vpc" {

```
