### PR TITLE
fix(WAF): fix the WAF group test error

### DIFF
--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_associate_test.go
@@ -25,6 +25,8 @@ func TestAccWafInsGroupAssociate_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// The WAF group APIs do not support general user usage. Skip the WAF group test.
+			acceptance.TestAccPrecheckWafInstance(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_instance_group_test.go
@@ -66,19 +66,11 @@ func testAccWafInstanceGroup_conf(baseName, groupName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_availability_zones" "test" {}
-
-data "huaweicloud_compute_flavors" "flavors" {
-  availability_zone = data.huaweicloud_availability_zones.zones.names[1]
-  performance_type  = "normal"
-  cpu_core_count    = 2
-}
-
 resource "huaweicloud_waf_dedicated_instance" "instance_1" {
   name               = "%s"
-  available_zone     = data.huaweicloud_availability_zones.test.names[1]
+  available_zone     = data.huaweicloud_availability_zones.test.names[0]
   specification_code = "waf.instance.professional"
-  ecs_flavor         = data.huaweicloud_compute_flavors.flavors.ids[0]
+  ecs_flavor         = data.huaweicloud_compute_flavors.test.ids[0]
   vpc_id             = huaweicloud_vpc.test.id
   subnet_id          = huaweicloud_vpc_subnet.test.id
   
@@ -93,5 +85,5 @@ resource "huaweicloud_waf_instance_group" "group_1" {
 
   depends_on = [huaweicloud_waf_dedicated_instance.instance_1]
 }
-`, common.TestBaseNetwork(baseName), baseName, groupName)
+`, common.TestBaseComputeResources(baseName), baseName, groupName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- fix the WAF group test error
  - Fix test function `TestAccWafInstanceGroup_basic` error. Cause the script referenced an undefined datasource.
  - Skip test function `TestAccWafInsGroupAssociate_basic`. Cause The WAF group APIs do not support general user usage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafInsGroupAssociate_basic'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafInsGroupAssociate_basic -timeout 360m -parallel 4 
=== RUN   TestAccWafInsGroupAssociate_basic 
=== PAUSE TestAccWafInsGroupAssociate_basic
=== CONT  TestAccWafInsGroupAssociate_basic
    acceptance.go:379: Jump the WAF acceptance tests.
--- SKIP: TestAccWafInsGroupAssociate_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       0.073s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafInstanceGroup_basic'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafInstanceGroup_basic -timeout 360m -parallel 4 
=== RUN   TestAccWafInstanceGroup_basic 
=== PAUSE TestAccWafInstanceGroup_basic
=== CONT  TestAccWafInstanceGroup_basic
--- PASS: TestAccWafInstanceGroup_basic (405.82s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       405.859s
```
