### PR TITLE
feat(account): add region attribute to account data source

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -23,3 +23,5 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The account ID.
 
 * `name` - The account name.
+
+* `region` - The region name.

--- a/huaweicloud/data_source_huaweicloud_account.go
+++ b/huaweicloud/data_source_huaweicloud_account.go
@@ -20,13 +20,18 @@ func DataSourceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func dataSourceAccountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	identityClient, err := cfg.IdentityV3Client(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+	identityClient, err := cfg.IdentityV3Client(region)
 	if err != nil {
 		return diag.Errorf("Error creating IAM client: %s", err)
 	}
@@ -52,6 +57,7 @@ func dataSourceAccountRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	mErr := multierror.Append(nil,
 		d.Set("name", result.Name),
+		d.Set("region", region),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/data_source_huaweicloud_account_test.go
+++ b/huaweicloud/data_source_huaweicloud_account_test.go
@@ -20,6 +20,7 @@ func TestAccDatasourceAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountDataSourceID(rName),
 					resource.TestCheckResourceAttrSet(rName, "name"),
+					resource.TestCheckResourceAttrSet(rName, "region"),
 				),
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some users need to get the region information of the execution environment.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ TESTARGS='-run=TestAccDatasourceAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run=TestAccDatasourceAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAccount_basic
=== PAUSE TestAccDatasourceAccount_basic
=== CONT  TestAccDatasourceAccount_basic
--- PASS: TestAccDatasourceAccount_basic (27.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       27.829s
```
