### PR TITLE
fix: get project_id from caller when migrating EPS

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -67,7 +67,7 @@ func GetEnterpriseProjectID(d *schema.ResourceData, config *config.Config) strin
 	return config.EnterpriseProjectID
 }
 
-func MigrateEnterpriseProject(client *golangsdk.ServiceClient, region, targetEPSId, resourceType, resourceID string) error {
+func MigrateEnterpriseProject(client *golangsdk.ServiceClient, targetEPSId string, migrateOpts enterpriseprojects.MigrateResourceOpts) error {
 	if targetEPSId == "" {
 		targetEPSId = "0"
 	} else {
@@ -77,15 +77,9 @@ func MigrateEnterpriseProject(client *golangsdk.ServiceClient, region, targetEPS
 		}
 	}
 
-	migrateOpts := enterpriseprojects.MigrateResourceOpts{
-		RegionId:     region,
-		ProjectId:    client.ProjectID,
-		ResourceType: resourceType,
-		ResourceId:   resourceID,
-	}
 	migrateResult := enterpriseprojects.Migrate(client, migrateOpts, targetEPSId)
 	if err := migrateResult.Err; err != nil {
-		return fmt.Errorf("failed to migrate %s to enterprise project %s, err: %s", resourceID, targetEPSId, err)
+		return fmt.Errorf("failed to migrate %s to enterprise project %s, err: %s", migrateOpts.ResourceId, targetEPSId, err)
 	}
 
 	return nil

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
 	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -443,11 +444,10 @@ func resourceObsBucketUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("error creating EPS client: %s", err)
 		}
-		if epsClient.ProjectID == "" {
-			epsClient.ProjectID = conf.GetProjectID(region)
-		}
 
-		if err := resourceObsBucketEnterpriseProjectIdUpdate(ctx, d, obsClient, epsClient, region); err != nil {
+		// API Limitations: still requires `project_id` field when migrating the EPS of OBS bucket
+		projectID := conf.GetProjectID(region)
+		if err := resourceObsBucketEnterpriseProjectIdUpdate(ctx, d, obsClient, epsClient, region, projectID); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -949,11 +949,18 @@ func resourceObsBucketCorsUpdate(obsClient *obs.ObsClient, d *schema.ResourceDat
 }
 
 func resourceObsBucketEnterpriseProjectIdUpdate(ctx context.Context, d *schema.ResourceData,
-	obsClient *obs.ObsClient, epsClient *golangsdk.ServiceClient, region string) error {
+	obsClient *obs.ObsClient, epsClient *golangsdk.ServiceClient, region, projectID string) error {
 	bucket := d.Get("bucket").(string)
 	targetEPSId := d.Get("enterprise_project_id").(string)
 
-	if err := common.MigrateEnterpriseProject(epsClient, region, targetEPSId, "bucket", bucket); err != nil {
+	migrateOpts := enterpriseprojects.MigrateResourceOpts{
+		RegionId:     region,
+		ProjectId:    projectID,
+		ResourceType: "bucket",
+		ResourceId:   bucket,
+	}
+
+	if err := common.MigrateEnterpriseProject(epsClient, targetEPSId, migrateOpts); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

Currently, we set the `project_id` field from EPS client when migrating the EPS of resources, but we can not sure the project_id in EPS client is always non-empty, so we should get it by caller.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (285.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       285.148s

$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_withEPS"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_withEPS -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_withEPS
=== PAUSE TestAccComputeInstance_withEPS
=== CONT  TestAccComputeInstance_withEPS
--- PASS: TestAccComputeInstance_withEPS (174.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       174.220s

$ make testacc TEST="./huaweicloud/services/acceptance/obs" TESTARGS="-run TestAccObsBucket_withEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucket_withEpsId (75.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       75.216s

$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafDedicatedInstance_withEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_withEpsId
=== PAUSE TestAccWafDedicatedInstance_withEpsId
=== CONT  TestAccWafDedicatedInstance_withEpsId
--- PASS: TestAccWafDedicatedInstance_withEpsId (406.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       406.988s
```
