### PR TITLE
fix(provider): support HW_ASSUME_ROLE env without assume_role block

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 
@@ -1453,7 +1454,15 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 
 	// get assume role
 	assumeRoleList := d.Get("assume_role").([]interface{})
-	if len(assumeRoleList) == 1 {
+	if len(assumeRoleList) == 0 {
+		// without assume_role block in provider
+		delegatedAgencyName := os.Getenv("HW_ASSUME_ROLE_AGENCY_NAME")
+		delegatedDomianName := os.Getenv("HW_ASSUME_ROLE_DOMAIN_NAME")
+		if delegatedAgencyName != "" && delegatedDomianName != "" {
+			config.AssumeRoleAgency = delegatedAgencyName
+			config.AssumeRoleDomain = delegatedDomianName
+		}
+	} else {
 		assumeRole := assumeRoleList[0].(map[string]interface{})
 		config.AssumeRoleAgency = assumeRole["agency_name"].(string)
 		config.AssumeRoleDomain = assumeRole["domain_name"].(string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

According to the following docs:

```md
The `assume_role` block supports:

* `agency_name` - (Required) The name of the agency for assume role.
  If omitted, the `HW_ASSUME_ROLE_AGENCY_NAME` environment variable is used.

* `domain_name` - (Required) The name of the agency domain for assume role.
  If omitted, the `HW_ASSUME_ROLE_DOMAIN_NAME` environment variable is used.
```

but the following config will **not** take effect with **HW_ASSUME_ROLE_AGENCY_NAME** and **HW_ASSUME_ROLE_DOMAIN_NAME**
```hcl
provider "huaweicloud" {
  ...
}
```

we should add an empty `assume_role` block in provider
```hcl
provider "huaweicloud" {
  ...
  assume_role {}
}
```

Let's support both of them.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
