### PR TITLE
feat(RDS): rds instance support update fixed ip

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -191,8 +191,7 @@ The following arguments are supported:
 * `restore` - (Optional, List, ForceNew) Specifies the restoration information. It only supported restore to postpaid
   instance. Structure is documented below. Changing this parameter will create a new resource.
 
-* `fixed_ip` - (Optional, String, ForceNew) Specifies an intranet floating IP address of RDS DB instance. Changing this
-  parameter will create a new resource.
+* `fixed_ip` - (Optional, String) Specifies an intranet floating IP address of RDS DB instance.
 
 * `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230828021417-8dd96c78b724
+	github.com/chnsz/golangsdk v0.0.0-20230830011208-da996030bf8d
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230828021417-8dd96c78b724 h1:9VAYPPHF/9o6mIAxe6xCjTAffFpTk6p53h8YXwK2NSU=
-github.com/chnsz/golangsdk v0.0.0-20230828021417-8dd96c78b724/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230830011208-da996030bf8d h1:Q5AzScAMYPE8pz7TYdY4MvTq7Izldk7Q8usYrzg++7k=
+github.com/chnsz/golangsdk v0.0.0-20230830011208-da996030bf8d/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -42,7 +42,8 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
-					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.58"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.52"),
+					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.52"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
@@ -59,6 +60,8 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_updated"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.62"),
+					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.62"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8636"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
@@ -160,6 +163,8 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "400"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "15"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.57"),
+					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.57"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
 				),
@@ -175,6 +180,8 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "500"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "20"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.67"),
+					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.67"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3308"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
 				),
@@ -205,13 +212,27 @@ func TestAccRdsInstance_sqlserver(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_sqlserver(name, pwd),
+				Config: testAccRdsInstance_sqlserver(name, pwd, "192.168.0.56"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "collation", "Chinese_PRC_CI_AS"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.56"),
+					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.56"),
+				),
+			},
+			{
+				Config: testAccRdsInstance_sqlserver(name, pwd, "192.168.0.66"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "collation", "Chinese_PRC_CI_AS"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.66"),
+					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.66"),
 				),
 			},
 		},
@@ -499,7 +520,7 @@ resource "huaweicloud_rds_instance" "test" {
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
-  fixed_ip          = "192.168.0.58"
+  fixed_ip          = "192.168.0.52"
 
   db {
     password = "%s"
@@ -539,6 +560,7 @@ resource "huaweicloud_rds_instance" "test" {
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
+  fixed_ip          = "192.168.0.62"
 
   db {
     password = "%s"
@@ -674,6 +696,7 @@ resource "huaweicloud_rds_instance" "test" {
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable        = true  
+  fixed_ip          = "192.168.0.57"
 
   db {
     password = "%[2]s"
@@ -729,6 +752,7 @@ resource "huaweicloud_rds_instance" "test" {
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable        = false
+  fixed_ip          = "192.168.0.67"
 
   db {
     password = "%[2]s"
@@ -784,6 +808,7 @@ resource "huaweicloud_rds_instance" "test" {
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable        = false
+  fixed_ip          = "192.168.0.67"
 
   db {
     password = "%[2]s"
@@ -800,7 +825,7 @@ resource "huaweicloud_rds_instance" "test" {
 `, name, pwd)
 }
 
-func testAccRdsInstance_sqlserver(name, pwd string) string {
+func testAccRdsInstance_sqlserver(name, pwd, fixedIp string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -825,12 +850,13 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name                = "%s"
-  flavor              = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id   = data.huaweicloud_networking_secgroup.test.id
-  subnet_id           = data.huaweicloud_vpc_subnet.test.id
-  vpc_id              = data.huaweicloud_vpc.test.id
-  collation           = "Chinese_PRC_CI_AS"
+  name              = "%s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  collation         = "Chinese_PRC_CI_AS"
+  fixed_ip          = "%s"
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0],
@@ -848,7 +874,7 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, name, pwd)
+`, name, fixedIp, pwd)
 }
 
 func testAccRdsInstance_prePaid(name, pwd string, isAutoRenew bool) string {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/requests.go
@@ -168,6 +168,8 @@ type AddNodeSpec struct {
 	Lifecycle *Lifecycle `json:"lifecycle,omitempty"`
 	// Extended parameter
 	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
+	// The initialized conditions
+	InitializedConditions []string `json:"initializedConditions,omitempty"`
 }
 
 type ServerConfig struct {
@@ -187,6 +189,8 @@ type RootVolume struct {
 type VolumeConfig struct {
 	// Docker data disk configurations
 	LvmConfig string `json:"lvmConfig,omitempty"`
+	// Disk initialization configuration management parameters
+	Storage *StorageSpec `json:"storage,omitempty"`
 }
 
 type RuntimeConfig struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/securities/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/securities/requests.go
@@ -108,3 +108,38 @@ func UpdateSecGroup(client *golangsdk.ServiceClient, instanceId string, opts Sec
 
 	return
 }
+
+// DataIpOpts is a struct which will be used to fix the data IP(private IP).
+type DataIpOpts struct {
+	// Specifies the new private ip.
+	NewIp string `json:"new_ip" required:"true"`
+}
+
+// DataIpOptsBuilder is an interface which to support request body build of
+// the data IP of the specifies database.
+type DataIpOptsBuilder interface {
+	ToDataIpOptsMap() (map[string]interface{}, error)
+}
+
+// ToDataIpOptsMap is a method which to build a request body by the DataIpOpts.
+func (opts DataIpOpts) ToDataIpOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateDataIp is a method to update the data IP of the database.
+func UpdateDataIp(client *golangsdk.ServiceClient, instanceId string, opts DataIpOptsBuilder) (r commonResult) {
+	b, err := opts.ToDataIpOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "ip"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230828021417-8dd96c78b724
+# github.com/chnsz/golangsdk v0.0.0-20230830011208-da996030bf8d
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support update fixed ip
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support update fixed ip
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_withEpsId
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_prePaid
    acceptance.go:456: This environment does not support prepaid tests
--- SKIP: TestAccRdsInstance_prePaid (0.02s)
--- PASS: TestAccRdsInstance_ha (600.14s)
--- PASS: TestAccRdsInstance_withEpsId (617.94s)
--- PASS: TestAccRdsInstance_basic (716.59s)
--- PASS: TestAccRdsInstance_sqlserver (1115.41s)
--- PASS: TestAccRdsInstance_withParameters (1411.31s)
--- PASS: TestAccRdsInstance_mysql (1678.59s)
--- PASS: TestAccRdsInstance_restore_pg (2190.37s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2563.76s)
--- PASS: TestAccRdsInstance_restore_mysql (2643.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2643.688s
```
