### PR TITLE
feat(CodeArts): add a new resource codearts deploy host

### DIFF
--- a/docs/resources/codearts_deploy_host.md
+++ b/docs/resources/codearts_deploy_host.md
@@ -1,0 +1,193 @@
+---
+subcategory: "CodeArts Deploy"
+---
+
+# huaweicloud_codearts_deploy_host
+
+Manages a CodeArts deploy host resource within HuaweiCloud.
+
+-> The servers need to be prepared first. Please refer to the following documents to complete your server configuration:
+[Preparations](https://support.huaweicloud.com/intl/en-us/usermanual-deployman/deployman_hlp_0018.html),
+[Security Configuration](https://support.huaweicloud.com/intl/en-us/usermanual-deployman/deployman_hlp_1103.html),
+[Target Host Configuration](https://support.huaweicloud.com/intl/en-us/usermanual-deployman/deployman_hlp_1101.html) and
+[Proxy Host Configuring](https://support.huaweicloud.com/intl/en-us/usermanual-deployman/deployman_hlp_1102.html).
+
+## Example Usage
+
+### Creating a proxy host
+
+```hcl
+variable "group_id" {}
+variable "group_os_type" {}
+variable "ip_address" {}
+variable "port" {}
+variable "username" {}
+variable "password" {}
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id   = var.group_id
+  ip_address = var.ip_address
+  port       = var.port
+  username   = var.username
+  password   = var.password
+  os_type    = var.group_os_type
+  name       = "test_proxy_host"
+  as_proxy   = true
+}
+```
+
+### Creating a target host with proxy access mode
+
+```hcl
+variable "group_id" {}
+variable "group_os_type" {}
+variable "ip_address" {}
+variable "port" {}
+variable "username" {}
+variable "password" {}
+variable "proxy_host_id" {}
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id      = var.group_id
+  ip_address    = var.ip_address
+  port          = var.port
+  username      = var.username
+  password      = var.password
+  os_type       = var.group_os_type
+  proxy_host_id = var.proxy_host_id
+  name          = "test_hostname"
+}
+```
+
+### Creating a target host without proxy access mode
+
+```hcl
+variable "group_id" {}
+variable "group_os_type" {}
+variable "ip_address" {}
+variable "port" {}
+variable "username" {}
+variable "password" {}
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id   = var.group_id
+  ip_address = var.ip_address
+  port       = var.port
+  username   = var.username
+  password   = var.password
+  os_type    = var.group_os_type
+  name       = "test_hostname"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `group_id` - (Required, String, ForceNew) Specifies the CodeArts deploy group ID.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the host name. The name consists of 3 to 128 characters, including letters,
+  digits, chinese characters or `-_.` symbols.
+
+* `ip_address` - (Required, String) Specifies the IP address of your server.
+  + When creating a proxy host, only public IPv4 addresses are supported.
+  + When creating a target host with proxy access mode, both public and private IPv4 addresses are supported.
+  + When creating a target host without proxy access mode, only public IPv4 addresses are supported.
+
+* `port` - (Required, Int) Specifies the SSH port of your server. The value ranges from 1 to 65535.
+
+* `os_type` - (Required, String, ForceNew) Specifies the operating system. Valid values are **windows** and **linux**.
+  The value must be consistent with the CodeArts deploy group.
+
+  Changing this parameter will create a new resource.
+
+* `username` - (Required, String) Specifies the username of your server.
+
+* `password` - (Optional, String) Specifies the password of your server.
+
+* `private_key` - (Optional, String) Specifies the private key of your server.
+
+-> The parameter `username`, `password` and `private_key` are used for login authentication. At least one of
+`private_key` and `password` must be set. And the field `private_key` and `password` can not be set together.
+
+* `as_proxy` - (Optional, Bool, ForceNew) Specifies whether the host is an agent host. Defaults to **false**.
+
+  Changing this parameter will create a new resource.
+
+* `proxy_host_id` - (Optional, String) Specifies the proxy host ID. A proxy host ID can be assigned to multiple target
+  hosts. This field is required only when creating a target host with proxy access mode.
+
+* `install_icagent` - (Optional, Bool) Specifies whether to enable Application Operations Management (AOM) for free
+  to provide metric monitoring, log query and alarm functions. Defaults to **false**.
+
+* `sync` - (Optional, Bool) Specifies whether to synchronize the password of the current host to the hosts with the
+  same IP address, username and port number in other group in the same project. Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - The create time.
+
+* `updated_at` - The update time.
+
+* `lastest_connection_at` - The last connection time.
+
+* `connection_status` - The connection status. Valid values are **success**, **failed** and **pending**.
+
+  -> The host can be used only when `connection_status` is **success**. If the field is **failed**, please refer to the
+  following documents to check your servers:
+  [The hosts FAQs](https://support.huaweicloud.com/intl/en-us/deployman_faq/deployman_faq_0000.html) and
+  [The environment FAQs](https://support.huaweicloud.com/intl/en-us/deployman_faq/deployman_faq_00001.html)
+
+* `permission` - The host permission detail.
+  The [permission](#DeployHost_permission) structure is documented below.
+
+<a name="DeployHost_permission"></a>
+The `permission` block supports:
+
+* `can_view` - Indicates whether the user has the view permission.
+
+* `can_edit` - Indicates whether the user has the edit permission.
+
+* `can_delete` - Indicates whether the user has the deletion permission.
+
+* `can_add_host` - Indicates whether the user has the permission to add hosts.
+
+* `can_connection_test` - Indicates whether to test the host connectivity permission.
+
+## Import
+
+The CodeArts deploy host resource can be imported using `group_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_deploy_host.test <group_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`, `private_key`, `install_icagent`
+and `sync`. It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_codearts_deploy_host" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      password,
+      private_key,
+      install_icagent,
+      sync,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1127,6 +1127,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_project":      codearts.ResourceProject(),
 			"huaweicloud_codearts_repository":   codearts.ResourceRepository(),
 			"huaweicloud_codearts_deploy_group": codearts.ResourceDeployGroup(),
+			"huaweicloud_codearts_deploy_host":  codearts.ResourceDeployHost(),
 
 			"huaweicloud_dsc_instance":  dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_asset_obs": dsc.ResourceAssetObs(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -176,6 +176,7 @@ var (
 	HW_NEW_CERTIFICATE_ROOT_CA     = os.Getenv("HW_NEW_CERTIFICATE_ROOT_CA")
 
 	HW_CODEARTS_RESOURCE_POOL_ID = os.Getenv("HW_CODEARTS_RESOURCE_POOL_ID")
+	HW_CODEARTS_ENABLE_FLAG      = os.Getenv("HW_CODEARTS_ENABLE_FLAG")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -380,14 +381,14 @@ func RandomPassword() string {
 // lintignore:AT003
 func TestAccPrecheckWafInstance(t *testing.T) {
 	if HW_WAF_ENABLE_FLAG == "" {
-		t.Skip("Jump the WAF acceptance tests.")
+		t.Skip("Skip the WAF acceptance tests.")
 	}
 }
 
 // lintignore:AT003
 func TestAccPreCheckCNADInstance(t *testing.T) {
 	if HW_CNAD_ENABLE_FLAG == "" {
-		t.Skip("Jump the CNAD acceptance tests.")
+		t.Skip("Skip the CNAD acceptance tests.")
 	}
 }
 
@@ -401,7 +402,7 @@ func TestAccPreCheckCNADProtectedObject(t *testing.T) {
 // lintignore:AT003
 func TestAccPreCheckOmsInstance(t *testing.T) {
 	if HW_OMS_ENABLE_FLAG == "" {
-		t.Skip("Jump the OMS acceptance tests.")
+		t.Skip("Skip the OMS acceptance tests.")
 	}
 }
 
@@ -415,7 +416,7 @@ func TestAccPreCheckAdminOnly(t *testing.T) {
 // lintignore:AT003
 func TestAccPreCheckReplication(t *testing.T) {
 	if HW_DEST_REGION == "" || HW_DEST_PROJECT_ID == "" {
-		t.Skip("Jump the replication policy acceptance tests.")
+		t.Skip("Skip the replication policy acceptance tests.")
 	}
 }
 
@@ -785,6 +786,13 @@ func TestAccPreCheckCertificateFull(t *testing.T) {
 func TestAccPreCheckCodeArtsDeploy(t *testing.T) {
 	if HW_CODEARTS_RESOURCE_POOL_ID == "" {
 		t.Skip("HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCodeArtsEnableFlag(t *testing.T) {
+	if HW_CODEARTS_ENABLE_FLAG == "" {
+		t.Skip("Skip the CodeArts acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go
@@ -1,0 +1,386 @@
+package codearts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDeployHostResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/host-groups/{group_id}/hosts/{host_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating codearts client: %s", err)
+	}
+
+	getHostPath := client.Endpoint + httpUrl
+	getHostPath = strings.ReplaceAll(getHostPath, "{group_id}", state.Primary.Attributes["group_id"])
+	getHostPath = strings.ReplaceAll(getHostPath, "{host_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getHostPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CodeArts deploy host: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	errorCode := utils.PathSearch("error_code", getRespBody, "")
+	if errorCode == "Deploy.00021108" {
+		// 'Deploy.00021108' means the host is not exist
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	if errorCode != "" {
+		errorMsg := utils.PathSearch("error_msg", getRespBody, "")
+		return nil, fmt.Errorf("error retrieving CodeArts deploy host: error code: %s, error message: %s",
+			errorCode, errorMsg)
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccDeployHost_withProxyMode(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	proxyName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_host.test"
+	proxyRName := "huaweicloud_codearts_deploy_host.test_proxy"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployHostResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCodeArtsEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeployHost_withProxyMode(proxyName, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "group_id",
+						"huaweicloud_codearts_deploy_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "ip_address",
+						"huaweicloud_compute_instance.test.1", "public_ip"),
+					resource.TestCheckResourceAttrPair(rName, "proxy_host_id",
+						"huaweicloud_codearts_deploy_host.test_proxy", "id"),
+					resource.TestCheckResourceAttr(rName, "port", "22"),
+					resource.TestCheckResourceAttr(rName, "username", "root"),
+					resource.TestCheckResourceAttr(rName, "password", "Test@123"),
+					resource.TestCheckResourceAttr(rName, "os_type", "linux"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "install_icagent", "true"),
+					resource.TestCheckResourceAttr(rName, "sync", "true"),
+					resource.TestCheckResourceAttr(rName, "as_proxy", "false"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "lastest_connection_at"),
+					resource.TestCheckResourceAttrSet(rName, "connection_status"),
+					resource.TestCheckResourceAttrSet(rName, "permission.#"),
+
+					resource.TestCheckResourceAttrPair(proxyRName, "ip_address",
+						"huaweicloud_compute_instance.test.0", "public_ip"),
+					resource.TestCheckResourceAttr(proxyRName, "as_proxy", "true"),
+				),
+			},
+			{
+				Config: testDeployHost_withProxyMode_update(proxyName, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "ip_address",
+						"huaweicloud_compute_instance.test.1", "access_ip_v4"),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "install_icagent", "false"),
+					resource.TestCheckResourceAttr(rName, "sync", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDeployHostImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"private_key",
+					"install_icagent",
+					"sync",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDeployHost_withoutProxyMode(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_host.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployHostResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCodeArtsEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeployHost_withoutProxyMode(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "group_id",
+						"huaweicloud_codearts_deploy_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "ip_address",
+						"huaweicloud_compute_instance.test.1", "public_ip"),
+					resource.TestCheckResourceAttr(rName, "port", "22"),
+					resource.TestCheckResourceAttr(rName, "username", "root"),
+					resource.TestCheckResourceAttr(rName, "password", "Test@123"),
+					resource.TestCheckResourceAttr(rName, "os_type", "windows"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "install_icagent", "true"),
+					resource.TestCheckResourceAttr(rName, "sync", "true"),
+					resource.TestCheckResourceAttr(rName, "as_proxy", "false"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "lastest_connection_at"),
+					resource.TestCheckResourceAttrSet(rName, "connection_status"),
+					resource.TestCheckResourceAttrSet(rName, "permission.#"),
+				),
+			},
+			{
+				Config: testDeployHost_withoutProxyMode_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "install_icagent", "false"),
+					resource.TestCheckResourceAttr(rName, "sync", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDeployHostImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"private_key",
+					"install_icagent",
+					"sync",
+				},
+			},
+		},
+	})
+}
+
+func testComputedInstance(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  count = 2
+
+  name                        = "%[2]s"
+  image_id                    = data.huaweicloud_images_image.test.id
+  flavor_id                   = "sn3.large.2"
+  availability_zone           = data.huaweicloud_availability_zones.test.names[0]
+  admin_pass                  = "Test@123"
+  delete_disks_on_termination = true
+  
+  system_disk_type = "SAS"
+  system_disk_size = 40
+  
+  eip_type = "5_bgp"
+  bandwidth {
+    share_type  = "PER"
+    size        = 1
+    charge_mode = ""
+  }
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      image_id, tags, name
+    ]
+  }
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testDeployHost_base_withProxyMode(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id  = huaweicloud_codearts_project.test.id
+  name        = "%[3]s"
+  os_type     = "linux"
+  description = "test description"
+}
+`, testComputedInstance(name), testProject_basic(name), name)
+}
+
+func testDeployHost_base_withoutProxyMode(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_codearts_deploy_group" "test" {
+  project_id    = huaweicloud_codearts_project.test.id
+  name          = "%[3]s"
+  os_type       = "windows"
+  description   = "test description"
+  is_proxy_mode = 0
+}
+`, testComputedInstance(name), testProject_basic(name), name)
+}
+
+func testDeployHost_withProxyMode(proxyName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_host" "test_proxy" {
+  group_id   = huaweicloud_codearts_deploy_group.test.id
+  ip_address = huaweicloud_compute_instance.test[0].public_ip
+  port       = 22
+  username   = "root"
+  password   = "Test@123"
+  os_type    = "linux"
+  name       = "%[2]s"
+  as_proxy   = true
+}
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id        = huaweicloud_codearts_deploy_group.test.id
+  ip_address      = huaweicloud_compute_instance.test[1].public_ip
+  port            = 22
+  username        = "root"
+  password        = "Test@123"
+  os_type         = "linux"
+  proxy_host_id   = huaweicloud_codearts_deploy_host.test_proxy.id
+  name            = "%[3]s"
+  install_icagent = true
+  sync            = true
+}
+`, testDeployHost_base_withProxyMode(name), proxyName, name)
+}
+
+func testDeployHost_withProxyMode_update(proxyName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_host" "test_proxy" {
+  group_id   = huaweicloud_codearts_deploy_group.test.id
+  ip_address = huaweicloud_compute_instance.test[0].public_ip
+  port       = 22
+  username   = "root"
+  password   = "Test@123"
+  os_type    = "linux"
+  name       = "%[2]s"
+  as_proxy   = true
+}
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id        = huaweicloud_codearts_deploy_group.test.id
+  ip_address      = huaweicloud_compute_instance.test[1].access_ip_v4
+  port            = 22
+  username        = "root"
+  password        = "Test@123"
+  os_type         = "linux"
+  proxy_host_id   = huaweicloud_codearts_deploy_host.test_proxy.id
+  name            = "%[3]s_update"
+  install_icagent = false
+  sync            = false
+}
+`, testDeployHost_base_withProxyMode(name), proxyName, name)
+}
+
+func testDeployHost_withoutProxyMode(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id        = huaweicloud_codearts_deploy_group.test.id
+  ip_address      = huaweicloud_compute_instance.test[1].public_ip
+  port            = 22
+  username        = "root"
+  password        = "Test@123"
+  os_type         = "windows"
+  name            = "%[2]s"
+  install_icagent = true
+  sync            = true
+}
+`, testDeployHost_base_withoutProxyMode(name), name)
+}
+
+func testDeployHost_withoutProxyMode_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_deploy_host" "test" {
+  group_id        = huaweicloud_codearts_deploy_group.test.id
+  ip_address      = huaweicloud_compute_instance.test[1].public_ip
+  port            = 22
+  username        = "root"
+  password        = "Test@123"
+  os_type         = "windows"
+  name            = "%[2]s_update"
+  install_icagent = false
+  sync            = false
+}
+`, testDeployHost_base_withoutProxyMode(name), name)
+}
+
+// testDeployHostImportState use to return an ID with format <group_id>/<id>
+func testDeployHostImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		groupID := rs.Primary.Attributes["group_id"]
+		if groupID == "" {
+			return "", fmt.Errorf("attribute (group_id) of Resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", groupID, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go
@@ -1,0 +1,453 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CodeArts
+// ---------------------------------------------------------------
+
+package codearts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	hostNotFound = "Deploy.00021108"
+)
+
+func ResourceDeployHost() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeployHostCreate,
+		UpdateContext: resourceDeployHostUpdate,
+		ReadContext:   resourceDeployHostRead,
+		DeleteContext: resourceDeployHostDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDeployHostImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the CodeArts deploy group ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the host name.`,
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the IP address.`,
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the SSH port.`,
+			},
+			"os_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the operating system.`,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the username.`,
+			},
+			"password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ExactlyOneOf: []string{"password", "private_key"},
+				Description:  `Specifies the password.`,
+			},
+			"private_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `Specifies the private key.`,
+			},
+			"as_proxy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether the host is an agent host.`,
+			},
+			"proxy_host_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the agent ID.`,
+			},
+			"install_icagent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: `Specifies whether to enable Application Operations Management (AOM) for free to provide
+metric monitoring, log query and alarm functions.`,
+			},
+			"sync": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: `Specifies whether to synchronize the password of the current host to the hosts with the
+same IP address, username and port number in other group in the same project.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The create time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time.`,
+			},
+			"lastest_connection_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The last connection time.`,
+			},
+			"connection_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The connection status.`,
+			},
+			"permission": {
+				Type:     schema.TypeList,
+				Elem:     deployHostPermissionSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func deployHostPermissionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"can_view": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the view permission.`,
+			},
+			"can_edit": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the edit permission.`,
+			},
+			"can_delete": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the deletion permission.`,
+			},
+			"can_add_host": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the permission to add hosts.`,
+			},
+			"can_connection_test": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether to test the host connectivity permission.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDeployHostCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups/{group_id}/hosts"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{group_id}", d.Get("group_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: buildCreateDeployHostBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy host: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(createRespBody, hostNotFound); err != nil {
+		return diag.Errorf("error creating CodeArts deploy host: %s", err)
+	}
+
+	id, err := jmespath.Search("host_id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating CodeArts deploy host: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	if d.Get("sync").(bool) {
+		if err := updateDeployHost(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceDeployHostRead(ctx, d, meta)
+}
+
+func buildCreateDeployHostBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"host_name":       d.Get("name"),
+		"ip":              d.Get("ip_address"),
+		"port":            d.Get("port"),
+		"os":              d.Get("os_type"),
+		"as_proxy":        d.Get("as_proxy"),
+		"install_icagent": d.Get("install_icagent"),
+		"authorization":   buildAuthorizationBodyParam(d),
+	}
+
+	if v, ok := d.GetOk("proxy_host_id"); ok {
+		bodyParams["proxy_host_id"] = v
+	}
+
+	return bodyParams
+}
+
+func buildAuthorizationBodyParam(d *schema.ResourceData) map[string]interface{} {
+	// Use password authentication
+	if v, ok := d.GetOk("password"); ok {
+		return map[string]interface{}{
+			"username":     d.Get("username"),
+			"password":     v,
+			"trusted_type": 0,
+		}
+	}
+	// Use key authentication
+	return map[string]interface{}{
+		"username":     d.Get("username"),
+		"private_key":  d.Get("private_key"),
+		"trusted_type": 1,
+	}
+}
+
+func resourceDeployHostRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups/{group_id}/hosts/{host_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{group_id}", d.Get("group_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{host_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CodeArts deploy host: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(getRespBody, hostNotFound); err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts deploy host")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("group_id", utils.PathSearch("group_id", getRespBody, nil)),
+		d.Set("name", utils.PathSearch("host_name", getRespBody, nil)),
+		d.Set("ip_address", utils.PathSearch("ip", getRespBody, nil)),
+		d.Set("port", utils.PathSearch("port", getRespBody, nil)),
+		d.Set("os_type", utils.PathSearch("os", getRespBody, nil)),
+		d.Set("as_proxy", utils.PathSearch("as_proxy", getRespBody, nil)),
+		d.Set("proxy_host_id", utils.PathSearch("proxy_host_id", getRespBody, nil)),
+		d.Set("username", utils.PathSearch("authorization.username", getRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", getRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", getRespBody, nil)),
+		d.Set("lastest_connection_at", utils.PathSearch("lastest_connection_time", getRespBody,
+			nil)),
+		d.Set("connection_status", utils.PathSearch("connection_status", getRespBody, nil)),
+		d.Set("permission", flattenDeployHostPermission(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDeployHostPermission(resp interface{}) []interface{} {
+	curJson, err := jmespath.Search("permission", resp)
+	if err != nil {
+		log.Printf("[ERROR] error flatten permission, cause this field is not found in API response")
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"can_view":            utils.PathSearch("can_view", curJson, nil),
+			"can_edit":            utils.PathSearch("can_edit", curJson, nil),
+			"can_delete":          utils.PathSearch("can_delete", curJson, nil),
+			"can_add_host":        utils.PathSearch("can_add_host", curJson, nil),
+			"can_connection_test": utils.PathSearch("can_connection_test", curJson, nil),
+		},
+	}
+}
+
+func resourceDeployHostUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("codearts_deploy", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	if err := updateDeployHost(client, d); err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceDeployHostRead(ctx, d, meta)
+}
+
+func updateDeployHost(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	updatePath := client.Endpoint + "v2/host-groups/{group_id}/hosts/{host_id}"
+	updatePath = strings.ReplaceAll(updatePath, "{group_id}", d.Get("group_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{host_id}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: buildUpdateDeployHostBodyParams(d),
+	}
+
+	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating CodeArts deploy host: %s", err)
+	}
+
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return err
+	}
+
+	if err := checkResponseError(updateRespBody, hostNotFound); err != nil {
+		return fmt.Errorf("error updating CodeArts deploy host: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateDeployHostBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"host_name":       d.Get("name"),
+		"ip":              d.Get("ip_address"),
+		"port":            d.Get("port"),
+		"as_proxy":        d.Get("as_proxy"),
+		"install_icagent": d.Get("install_icagent"),
+		"sync":            d.Get("sync"),
+		"authorization":   buildAuthorizationBodyParam(d),
+	}
+
+	if v, ok := d.GetOk("proxy_host_id"); ok {
+		bodyParams["proxy_host_id"] = v
+	}
+
+	return bodyParams
+}
+
+func resourceDeployHostDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/host-groups/{group_id}/hosts/{host_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{group_id}", d.Get("group_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{host_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CodeArts deploy host: %s", err)
+	}
+
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(deleteRespBody, hostNotFound); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting CodeArts deploy host")
+	}
+
+	return nil
+}
+
+func resourceDeployHostImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID,"+
+			" must be <group_id>/<id> but got %s", d.Id())
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("group_id", parts[0]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("failed to set value to state when import CodeArts deploy host, %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource codearts deploy host


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The field `password`, `private_key`, `install_icagent` and `sync` does not have response value.
- The Create\Update\Delete function need to add Header "Content-Type": "application/json;charset=utf-8"
- Even if the API response code is 200, the result may still be wrong, we need to parse the response body to check whether the request is success.
- If the host resource is not found, the response body will contain error code `Deploy.00021108`.
- I have verified `CheckDeletedDiag`：
  - Step1: Use  terraform create a host resource.
  - Step2: Delete this host from console.
  - Step3: Run `terraform destroy` in terraform.
- The test case lacks verification of private_key, but I have verified this scene.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost_withProxyMode'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost_withProxyMode -timeout 360m -parallel 4 
=== RUN   TestAccDeployHost_withProxyMode 
=== PAUSE TestAccDeployHost_withProxyMode
=== CONT  TestAccDeployHost_withProxyMode
--- PASS: TestAccDeployHost_withProxyMode (194.43s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  194.473s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost_withoutProxyMode'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost_withoutProxyMode -timeout 360m -parallel 4 
=== RUN   TestAccDeployHost_withoutProxyMode 
=== PAUSE TestAccDeployHost_withoutProxyMode
=== CONT  TestAccDeployHost_withoutProxyMode
--- PASS: TestAccDeployHost_withoutProxyMode (192.09s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  192.137s
```
