### PR TITLE
test(cce): update the test cases of node pool

### DIFF
--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_v3_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_node_pool_v3_test.go
@@ -53,8 +53,8 @@ func testAccCCENodePoolV3DataSource_basic(name string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_addon_test.go
@@ -84,7 +84,7 @@ func testAccAddon_Base(rName string) string {
 resource "huaweicloud_cce_node" "test" {
   cluster_id        = huaweicloud_cce_cluster.test.id
   name              = "%[2]s"
-  flavor_id         = "c7.large.4"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   key_pair          = huaweicloud_kps_keypair.test.name
 
@@ -168,8 +168,8 @@ func testAccAddon_values_base(name string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id         = huaweicloud_cce_cluster.test.id
   name               = "%[2]s"
-  os                 = "EulerOS 2.5"
-  flavor_id          = "c7.large.4"
+  os                 = "EulerOS 2.9"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count = 4
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
   key_pair           = huaweicloud_kps_keypair.test.name

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -94,6 +94,13 @@ func testAccNodePool_base(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
 resource "huaweicloud_kps_keypair" "test" {
   name = "%[2]s"
 }
@@ -116,8 +123,8 @@ func testAccNodePool_basic_step1(name, baseConfig string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -155,8 +162,8 @@ func testAccNodePool_basic_step2(name, baseConfig string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 2
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -200,8 +207,8 @@ func testAccNodePool_basic_step3(name, baseConfig string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -330,8 +337,8 @@ func testAccNodePool_tagsLabelsTaints_step1(name string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -378,8 +385,8 @@ func testAccNodePool_tagsLabelsTaints_step2(name string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -471,8 +478,8 @@ resource "huaweicloud_kms_key" "test" {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -538,8 +545,8 @@ func testAccNodePool_prePaid(rName string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -607,6 +614,13 @@ func testAccNodePool_SecurityGroups(name string) string {
 %[1]s
 
 data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "computingv3"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
 
 resource "huaweicloud_kps_keypair" "test" {
   name = "%[2]s"
@@ -685,8 +699,8 @@ resource "huaweicloud_networking_secgroup_rule" "rule7" {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -765,8 +779,8 @@ resource "huaweicloud_compute_servergroup" "test" {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name
@@ -836,8 +850,8 @@ resource "huaweicloud_kms_key" "test" {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.5"
-  flavor_id                = "s6.large.2"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]
   key_pair                 = huaweicloud_kps_keypair.test.name


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== CONT  TestAccNodePool_basic
=== CONT  TestAccNodePool_SecurityGroups
=== CONT  TestAccNodePool_storage
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNodePool_SecurityGroups (1425.45s)
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:640: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.00s)
=== CONT  TestAccNodePool_prePaid
    acceptance.go:458: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.00s)
=== CONT  TestAccNodePool_tagsLabelsTaints
--- PASS: TestAccNodePool_storage (1441.35s)
--- PASS: TestAccNodePool_serverGroup (1442.27s)
--- PASS: TestAccNodePool_basic (1923.66s)
--- PASS: TestAccNodePool_tagsLabelsTaints (1990.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       3415.949s
```
