### PR TITLE
chore: add SchemaDesc and update parseExtentAttribute

### DIFF
--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -518,3 +518,27 @@ func JSONStringsEqual(s1, s2 string) bool {
 
 	return jsonBytesEqual(b1.Bytes(), b2.Bytes())
 }
+
+type SchemaDescInput struct {
+	Internal   bool     `json:"Internal,omitempty"`
+	Deprecated bool     `json:"Deprecated,omitempty"`
+	Required   bool     `json:"Required,omitempty"`
+	Optional   bool     `json:"Optional,omitempty"`
+	Computed   bool     `json:"Computed,omitempty"`
+	ForceNew   bool     `json:"ForceNew,omitempty"`
+	Unscope    []string `json:"Unscope,omitempty"`
+	UsedBy     []string `json:"UsedBy,omitempty"`
+}
+
+func SchemaDesc(description string, schemaDescInput SchemaDescInput) string {
+	if os.Getenv("HW_SCHEMA") == "" {
+		return description
+	}
+
+	b, err := json.Marshal(schemaDescInput)
+	if err == nil && string(b) != "" {
+		return "schema:" + string(b) + ";" + description
+	}
+
+	return description
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add SchemaDesc to make the definition of parameter more clear, you can add some special settings in SchemaDesc
and you can use environment variable HW_SCHEMA to hide the special settings from common users

here is an example:
```go
"name": {
	Type:     schema.TypeString,
	Required: true,
	Description: utils.SchemaDesc(
	         "test description",
	          utils.SchemaDescInput{
			Deprecated: true,
			Optional:   true,
			Unscope:    []string{"FE"},
			UsedBy:     []string{"CBG"},
	}),
},
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
