### PR TITLE
feat(apig/instance): support new param vpcep_service_name

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -106,6 +106,12 @@ The following arguments are supported:
 
   Changing this will create a new resource.
 
+* `vpcep_service_name` - (Optional, String) Specifies the name of the VPC endpoint service.
+  It can contain a maximum of 16 characters, including letters, digits, underscores (_), and hyphens (-).
+
+  -> This parameter is only available if the `loadbalancer_provider` is **elb**.
+     Only enable and update operations are supported, and disable operation is not supported.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the dedicated instance.
 
 ## Attribute Reference
@@ -120,6 +126,9 @@ In addition to all arguments above, the following attributes are exported:
 * `supported_features` - The supported features of the APIG dedicated instance.
 * `created_at` - Time when the dedicated instance is created, in RFC-3339 format.
 * `status` - Status of the dedicated instance.
+* `vpcep_service_address` -  The address (full name) of the VPC endpoint service, in the
+  "{region}.{vpcep_service_name}.{service_id}" format. If this parameter is not specified, the system automatically
+  generates a name in the "{region}.apig.{service_id}" format.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The instance resource support new parameter: vpcep_service_name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new parameter 'vpcep_service_name'.
2. update related acceptance tests.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccInstance_ -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== RUN   TestAccInstance_egress
=== PAUSE TestAccInstance_egress
=== RUN   TestAccInstance_ingress
=== PAUSE TestAccInstance_ingress
=== CONT  TestAccInstance_basic
=== CONT  TestAccInstance_ingress
=== CONT  TestAccInstance_egress
--- PASS: TestAccInstance_basic (563.02s)
--- PASS: TestAccInstance_egress (572.05s)
--- PASS: TestAccInstance_ingress (587.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      587.489s
```
