### PR TITLE
refactor(RDS): rds instance extract public method

### DIFF
--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
@@ -212,7 +212,7 @@ resource "huaweicloud_rds_instance" "test" {
   }
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days  = 0
+    keep_days  = 1
   }
 
   lifecycle {
@@ -277,7 +277,7 @@ resource "huaweicloud_rds_instance" "test" {
   }
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days  = 0
+    keep_days  = 1
   }
 
   lifecycle {
@@ -330,7 +330,7 @@ resource "huaweicloud_rds_instance" "test" {
   }
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days  = 0
+    keep_days  = 1
   }
 
   lifecycle {

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -163,8 +163,6 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "400"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "15"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
-					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.57"),
-					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.57"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
 				),
@@ -696,7 +694,6 @@ resource "huaweicloud_rds_instance" "test" {
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable        = true  
-  fixed_ip          = "192.168.0.57"
 
   db {
     password = "%[2]s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance extract public method
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance extract public method
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_withEpsId
--- PASS: TestAccRdsInstance_withEpsId (628.32s)
--- PASS: TestAccRdsInstance_ha (662.54s)
--- PASS: TestAccRdsInstance_basic (795.00s)
--- PASS: TestAccRdsInstance_prePaid (1047.02s)
--- PASS: TestAccRdsInstance_sqlserver (1206.32s)
--- PASS: TestAccRdsInstance_mysql (1400.02s)
--- PASS: TestAccRdsInstance_withParameters (1525.78s)
--- PASS: TestAccRdsInstance_restore_pg (2250.47s)
--- PASS: TestAccRdsInstance_restore_mysql (2624.02s)
--- PASS: TestAccRdsInstance_restore_sqlserver (3194.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3194.311s

make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccBackup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccBackup_ -timeout 360m -parallel 4
=== RUN   TestAccBackup_mysql_basic
=== PAUSE TestAccBackup_mysql_basic
=== RUN   TestAccBackup_sqlserver_basic
=== PAUSE TestAccBackup_sqlserver_basic
=== RUN   TestAccBackup_pg_basic
=== PAUSE TestAccBackup_pg_basic
=== CONT  TestAccBackup_mysql_basic
=== CONT  TestAccBackup_pg_basic
=== CONT  TestAccBackup_sqlserver_basic
--- PASS: TestAccBackup_pg_basic (812.55s)
--- PASS: TestAccBackup_mysql_basic (965.89s)
--- PASS: TestAccBackup_sqlserver_basic (1377.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1377.045s
```
