### PR TITLE
fix(iam): check whether the user group exists in membership

### DIFF
--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/v3/groups"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/users"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -67,9 +68,15 @@ func resourceIdentityGroupMembershipRead(_ context.Context, d *schema.ResourceDa
 	groupID := d.Get("group").(string)
 	userList := d.Get("users").(*schema.Set)
 
+	// check whether the user group exists
+	_, err = groups.Get(identityClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "unable to query group")
+	}
+
 	allPages, err := users.ListInGroup(identityClient, groupID, nil).AllPages()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "unable to query groups")
+		return common.CheckDeletedDiag(d, err, "unable to query group membership")
 	}
 
 	allUsers, err := users.ExtractUsers(allPages)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

when the group does not exist, the API response code is `403` rather than `404`, so the CheckDeletedDiag method does not work, and the error message is too confusing.

```json
GET https://iam.cn-north-4.myhuaweicloud.com/v3/groups/5a0a09bc67d94e83a5d34xxxx/users

API Response Code: 403
API Response Body: 
{
  "error": {
    "code": 403,
    "message": "You are not authorized to perform the requested action.",
    "title": "Forbidden"
  }
}
```

To fix this issue, we can check whether the user group exists in membership, then the membership resource will removed in state.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ terraform refresh
huaweicloud_identity_user.user_1: Refreshing state... [id=cd46642b015340799816c4b90c7687a8]
huaweicloud_identity_group.group_1: Refreshing state... [id=5a0a09bc67d94e83a5d34b83efcf6a60]
huaweicloud_identity_group_membership.membership_1: Refreshing state... [id=5a0a09bc67d94e83a5d34b83efcf6a60]
╷
│ Warning: Resource not found
│
│   with huaweicloud_identity_group.group_1,
│   on main.tf line 17, in resource "huaweicloud_identity_group" "group_1":
│   17: resource "huaweicloud_identity_group" "group_1" {
│
│ the resource 5a0a09bc67d94e83a5d34b83efcf6a60 is gone and will be removed in Terraform state.
│
│ (and one more similar warning elsewhere)
```
