### PR TITLE
refactor(CodeArts): modify CodeArts create and read API and modify so…

### DIFF
--- a/docs/resources/codearts_deploy_group.md
+++ b/docs/resources/codearts_deploy_group.md
@@ -84,12 +84,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The update time.
 
-* `host_count` - The host number in a group.
-
 * `created_by` - The creator information.
-  The [object](#DeployGroup_user) structure is documented below.
-
-* `updated_by` - The editor information.
   The [object](#DeployGroup_user) structure is documented below.
 
 * `permission` - The group permission detail.
@@ -117,26 +112,8 @@ The `permission` block supports:
 
 ## Import
 
-The CodeArts deploy group resource can be imported using the `id`, e.g.
+The CodeArts deploy group resource can be imported using the `project_id` and `id`, separated by a slash, e.g.
 
 ```bash
-$ terraform import huaweicloud_codearts_deploy_group.test <id>
-```
-
-Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `is_proxy_mode`.
-It is generally recommended running `terraform plan` after importing a resource.
-You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
-with the resource. Also, you can ignore changes as below.
-
-```hcl
-resource "huaweicloud_codearts_deploy_group" "test" {
-  ...
-  
-  lifecycle {
-    ignore_changes = [
-      is_proxy_mode,
-    ]
-  }
-}
+$ terraform import huaweicloud_codearts_deploy_group.test <project_id>/<id>
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -783,7 +783,7 @@ func TestAccPreCheckCertificateFull(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckCodeArtsDeploy(t *testing.T) {
+func TestAccPreCheckCodeArtsDeployResourcePoolID(t *testing.T) {
 	if HW_CODEARTS_RESOURCE_POOL_ID == "" {
 		t.Skip("HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test")
 	}


### PR DESCRIPTION
…me fields

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

modify CodeArts create and read API and modify some fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:


- Change the create and read API to the latest version.
- The response body has an additional `result` structure.
- The import id change to `<project_id>/<id>`
- The 404 error_code has changed to `Deploy.00021423`
```
{
    "error":{
        "code":"Deploy.00021423",
        "message":"主机集群不存在",
        "reason":"主机集群不存在"
    },
    "error_code":"Deploy.00021423",
    "error_msg":"主机集群不存在",
    "status":"failed"
}
``` 
![20230911-1](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/ef03d9e4-f33f-4a81-9f76-01dad9ca3da8)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup_basic -timeout 360m -parallel 4 
=== RUN   TestAccDeployGroup_basic 
=== PAUSE TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_basic
--- PASS: TestAccDeployGroup_basic (15.23s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  15.274s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup_resourcePoolId'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup_resourcePoolId -timeout 360m -parallel 4 
=== RUN   TestAccDeployGroup_resourcePoolId 
=== PAUSE TestAccDeployGroup_resourcePoolId
=== CONT  TestAccDeployGroup_resourcePoolId
--- PASS: TestAccDeployGroup_resourcePoolId (14.62s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  14.672s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup_errorCheck'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup_errorCheck -timeout 360m -parallel 4 
=== RUN   TestAccDeployGroup_errorCheck 
=== PAUSE TestAccDeployGroup_errorCheck
=== CONT  TestAccDeployGroup_errorCheck
--- PASS: TestAccDeployGroup_errorCheck (8.13s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  8.177s
```
