### PR TITLE
refactor(CodeArts): modify CodeArts host create and read API and modi…

### DIFF
--- a/docs/resources/codearts_deploy_host.md
+++ b/docs/resources/codearts_deploy_host.md
@@ -161,7 +161,7 @@ The `permission` block supports:
 
 * `can_add_host` - Indicates whether the user has the permission to add hosts.
 
-* `can_connection_test` - Indicates whether to test the host connectivity permission.
+* `can_copy` - Indicates whether the user has the permission to copy hosts.
 
 ## Import
 


### PR DESCRIPTION
…fy some fields

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

modify CodeArts host create and read API and modify some fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

This PR depends on #3393

- Change the create and read API to the latest version.
- The response body has an additional result structure.
- The 404 error code example:
```
{
    "error":{
        "code":"Deploy.00021108",
        "message":"主机不存在",
        "reason":"主机不存在"
    },
    "error_code":"Deploy.00021108",
    "error_msg":"主机不存在",
    "status":"failed"
}
```

![20230911-2](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/6ab5cb8c-2bb7-412a-baa5-5f077e1854c0)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost_withProxyMode'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost_withProxyMode -timeout 360m -parallel 4 
=== RUN   TestAccDeployHost_withProxyMode 
=== PAUSE TestAccDeployHost_withProxyMode
=== CONT  TestAccDeployHost_withProxyMode
--- PASS: TestAccDeployHost_withProxyMode (218.64s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  218.683s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost_withoutProxyMode'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost_withoutProxyMode -timeout 360m -parallel 4 
=== RUN   TestAccDeployHost_withoutProxyMode 
=== PAUSE TestAccDeployHost_withoutProxyMode
=== CONT  TestAccDeployHost_withoutProxyMode 
--- PASS: TestAccDeployHost_withoutProxyMode (194.10s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  194.282s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost_errorCheck'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost_errorCheck -timeout 360m -parallel 4 
=== RUN   TestAccDeployHost_errorCheck 
=== PAUSE TestAccDeployHost_errorCheck 
=== CONT  TestAccDeployHost_errorCheck
--- PASS: TestAccDeployHost_errorCheck (184.93s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  185.003s
```
