### PR TITLE
refactor(vpc): move secgroup and secgroup rule to services

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -517,7 +517,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_gateway": nat.DataSourcePublicGateway(),
 
 			"huaweicloud_networking_port":      vpc.DataSourceNetworkingPortV2(),
-			"huaweicloud_networking_secgroup":  DataSourceNetworkingSecGroup(),
+			"huaweicloud_networking_secgroup":  vpc.DataSourceNetworkingSecGroup(),
 			"huaweicloud_networking_secgroups": vpc.DataSourceNetworkingSecGroups(),
 
 			"huaweicloud_modelarts_datasets":         modelarts.DataSourceDatasets(),
@@ -582,7 +582,7 @@ func Provider() *schema.Provider {
 			// Legacy
 			"huaweicloud_images_image_v2":        ims.DataSourceImagesImageV2(),
 			"huaweicloud_networking_port_v2":     vpc.DataSourceNetworkingPortV2(),
-			"huaweicloud_networking_secgroup_v2": DataSourceNetworkingSecGroup(),
+			"huaweicloud_networking_secgroup_v2": vpc.DataSourceNetworkingSecGroup(),
 
 			"huaweicloud_kms_key_v1":      dew.DataSourceKmsKey(),
 			"huaweicloud_kms_data_key_v1": dew.DataSourceKmsDataKeyV1(),
@@ -997,8 +997,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_network_acl":              ResourceNetworkACL(),
 			"huaweicloud_network_acl_rule":         ResourceNetworkACLRule(),
-			"huaweicloud_networking_secgroup":      ResourceNetworkingSecGroup(),
-			"huaweicloud_networking_secgroup_rule": ResourceNetworkingSecGroupRule(),
+			"huaweicloud_networking_secgroup":      vpc.ResourceNetworkingSecGroup(),
+			"huaweicloud_networking_secgroup_rule": vpc.ResourceNetworkingSecGroupRule(),
 			"huaweicloud_networking_vip":           vpc.ResourceNetworkingVip(),
 			"huaweicloud_networking_vip_associate": vpc.ResourceNetworkingVIPAssociateV2(),
 
@@ -1185,8 +1185,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_mrs_cluster_v1": ResourceMRSClusterV1(),
 			"huaweicloud_mrs_job_v1":     ResourceMRSJobV1(),
 
-			"huaweicloud_networking_secgroup_v2":      ResourceNetworkingSecGroup(),
-			"huaweicloud_networking_secgroup_rule_v2": ResourceNetworkingSecGroupRule(),
+			"huaweicloud_networking_secgroup_v2":      vpc.ResourceNetworkingSecGroup(),
+			"huaweicloud_networking_secgroup_rule_v2": vpc.ResourceNetworkingSecGroupRule(),
 
 			"huaweicloud_smn_topic_v2":        smn.ResourceTopic(),
 			"huaweicloud_smn_subscription_v2": smn.ResourceSubscription(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroup_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_networking_secgroup_test.go
@@ -1,21 +1,22 @@
-package huaweicloud
+package vpc
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccNetworkingSecGroupV3DataSource_basic(t *testing.T) {
-	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "data.huaweicloud_networking_secgroup.test"
+	var rName = acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.huaweicloud_networking_secgroup.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkingSecGroupV3DataSource_group(rName),
@@ -23,9 +24,9 @@ func TestAccNetworkingSecGroupV3DataSource_basic(t *testing.T) {
 			{
 				Config: testAccNetworkingSecGroupV3DataSource_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSecGroupV3DataSourceID(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "rules.#"),
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
 				),
 			},
 		},
@@ -33,12 +34,13 @@ func TestAccNetworkingSecGroupV3DataSource_basic(t *testing.T) {
 }
 
 func TestAccNetworkingSecGroupV3DataSource_byID(t *testing.T) {
-	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "data.huaweicloud_networking_secgroup.test"
+	var rName = acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.huaweicloud_networking_secgroup.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkingSecGroupV3DataSource_group(rName),
@@ -46,28 +48,13 @@ func TestAccNetworkingSecGroupV3DataSource_byID(t *testing.T) {
 			{
 				Config: testAccNetworkingSecGroupV3DataSource_secGroupID(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingSecGroupV3DataSourceID(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "rules.#"),
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckNetworkingSecGroupV3DataSourceID(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find security group data source: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Security group data source ID not set")
-		}
-
-		return nil
-	}
 }
 
 func testAccNetworkingSecGroupV3DataSource_group(rName string) string {

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_secgroup_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_networking_secgroup_test.go
@@ -1,33 +1,48 @@
-package huaweicloud
+package vpc
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v1/security/securitygroups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
+
+func getNetworkSecGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NetworkingV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating HuaweiCloud VPC network v1 client: %s", err)
+	}
+
+	return securitygroups.Get(client, state.Primary.ID).Extract()
+}
 
 func TestAccNetworkingV3SecGroup_basic(t *testing.T) {
 	var secGroup securitygroups.SecurityGroup
-	name := fmt.Sprintf("seg-acc-test-%s", acctest.RandString(5))
+	name := acceptance.RandomAccResourceNameWithDash()
 	updatedName := fmt.Sprintf("%s-updated", name)
 	resourceName := "huaweicloud_networking_secgroup.secgroup_1"
 
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&secGroup,
+		getNetworkSecGroupResourceFunc,
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkingV3SecGroupDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecGroup_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV3SecGroupExists(resourceName, &secGroup),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "rules.#", "4"),
 				),
@@ -50,20 +65,26 @@ func TestAccNetworkingV3SecGroup_basic(t *testing.T) {
 
 func TestAccNetworkingV3SecGroup_withEpsId(t *testing.T) {
 	var secGroup securitygroups.SecurityGroup
-	name := fmt.Sprintf("seg-acc-test-%s", acctest.RandString(5))
+	name := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_networking_secgroup.secgroup_1"
 
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&secGroup,
+		getNetworkSecGroupResourceFunc,
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEpsID(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkingV3SecGroupDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecGroup_epsId(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV3SecGroupExists(resourceName, &secGroup),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -72,77 +93,30 @@ func TestAccNetworkingV3SecGroup_withEpsId(t *testing.T) {
 
 func TestAccNetworkingV3SecGroup_noDefaultRules(t *testing.T) {
 	var secGroup securitygroups.SecurityGroup
-	name := fmt.Sprintf("seg-acc-test-%s", acctest.RandString(5))
+	name := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_networking_secgroup.secgroup_1"
 
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&secGroup,
+		getNetworkSecGroupResourceFunc,
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNetworkingV3SecGroupDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecGroup_noDefaultRules(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV3SecGroupExists(resourceName, &secGroup),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "rules.#", "0"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckNetworkingV3SecGroupDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	networkingClient, err := config.NetworkingV1Client(HW_REGION_NAME)
-	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud networking v3 client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_networking_secgroup" {
-			continue
-		}
-
-		_, err := securitygroups.Get(networkingClient, rs.Primary.ID).Extract()
-		if err == nil {
-			return fmtp.Errorf("Security group still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckNetworkingV3SecGroupExists(n string, secGroup *securitygroups.SecurityGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*config.Config)
-		networkingClient, err := config.NetworkingV1Client(HW_REGION_NAME)
-		if err != nil {
-			return fmtp.Errorf("Error creating HuaweiCloud networking client: %s", err)
-		}
-
-		found, err := securitygroups.Get(networkingClient, rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("Security group not found")
-		}
-
-		*secGroup = *found
-
-		return nil
-	}
 }
 
 func testAccSecGroup_basic(name string) string {
@@ -170,7 +144,7 @@ resource "huaweicloud_networking_secgroup" "secgroup_1" {
   description           = "ecurity group acceptance test with eps ID"
   enterprise_project_id = "%s"
 }
-`, name, HW_ENTERPRISE_PROJECT_ID_TEST)
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccSecGroup_noDefaultRules(name string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkingV3SecGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingV3SecGroup -timeout 360m -parallel 4
=== RUN   TestAccNetworkingV3SecGroup_basic
=== PAUSE TestAccNetworkingV3SecGroup_basic
=== RUN   TestAccNetworkingV3SecGroup_withEpsId
=== PAUSE TestAccNetworkingV3SecGroup_withEpsId
=== RUN   TestAccNetworkingV3SecGroup_noDefaultRules
=== PAUSE TestAccNetworkingV3SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV3SecGroup_basic
=== CONT  TestAccNetworkingV3SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV3SecGroup_withEpsId
    acceptance.go:305: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccNetworkingV3SecGroup_withEpsId (0.00s)
--- PASS: TestAccNetworkingV3SecGroup_noDefaultRules (20.71s)
--- PASS: TestAccNetworkingV3SecGroup_basic (29.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       29.071s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkingSecGroupRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingSecGroupRule -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupRule_basic
=== PAUSE TestAccNetworkingSecGroupRule_basic
=== RUN   TestAccNetworkingSecGroupRule_oldPorts
=== PAUSE TestAccNetworkingSecGroupRule_oldPorts
=== RUN   TestAccNetworkingSecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingSecGroupRule_remoteGroup
=== RUN   TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== PAUSE TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== RUN   TestAccNetworkingSecGroupRule_noPorts
=== PAUSE TestAccNetworkingSecGroupRule_noPorts
=== RUN   TestAccNetworkingSecGroupRule_remoteAddressGroup
=== PAUSE TestAccNetworkingSecGroupRule_remoteAddressGroup
=== RUN   TestAccNetworkingSecGroupRule_action
=== PAUSE TestAccNetworkingSecGroupRule_action
=== RUN   TestAccNetworkingSecGroupRule_priority
=== PAUSE TestAccNetworkingSecGroupRule_priority
=== CONT  TestAccNetworkingSecGroupRule_basic
=== CONT  TestAccNetworkingSecGroupRule_noPorts
=== CONT  TestAccNetworkingSecGroupRule_remoteGroup
=== CONT  TestAccNetworkingSecGroupRule_oldPorts
--- PASS: TestAccNetworkingSecGroupRule_basic (34.98s)
=== CONT  TestAccNetworkingSecGroupRule_lowerCaseCIDR
--- PASS: TestAccNetworkingSecGroupRule_remoteGroup (35.58s)
=== CONT  TestAccNetworkingSecGroupRule_action
--- PASS: TestAccNetworkingSecGroupRule_oldPorts (35.93s)
=== CONT  TestAccNetworkingSecGroupRule_priority
--- PASS: TestAccNetworkingSecGroupRule_noPorts (36.08s)
=== CONT  TestAccNetworkingSecGroupRule_remoteAddressGroup
--- PASS: TestAccNetworkingSecGroupRule_lowerCaseCIDR (34.31s)
--- PASS: TestAccNetworkingSecGroupRule_priority (33.85s)
--- PASS: TestAccNetworkingSecGroupRule_remoteAddressGroup (33.93s)
--- PASS: TestAccNetworkingSecGroupRule_action (35.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       71.441s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkingSecGroupV3DataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingSecGroupV3DataSource -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupV3DataSource_basic
=== PAUSE TestAccNetworkingSecGroupV3DataSource_basic
=== RUN   TestAccNetworkingSecGroupV3DataSource_byID
=== PAUSE TestAccNetworkingSecGroupV3DataSource_byID
=== CONT  TestAccNetworkingSecGroupV3DataSource_basic
=== CONT  TestAccNetworkingSecGroupV3DataSource_byID
--- PASS: TestAccNetworkingSecGroupV3DataSource_byID (41.82s)
--- PASS: TestAccNetworkingSecGroupV3DataSource_basic (42.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       42.441s
```
