### PR TITLE
fix(config): compare the resource-level region only when it's not empty

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -256,7 +256,7 @@ func (c *Config) NewServiceClient(srv, region string) (*golangsdk.ServiceClient,
 	}
 
 	if endpoint, ok := c.Endpoints[srv]; ok {
-		if region != c.Region {
+		if region != "" && region != c.Region {
 			return nil, fmt.Errorf("Resource-level region must be the same as Provider-level region when using customizing endpoints")
 		}
 		return c.newServiceClientByEndpoint(client, srv, endpoint)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

For some global service, we get the client as follows:
```go
client, err := cfg.NewServiceClient(getOrganizationProduct, "")
``` 
as the region is **""**, it will fail in customizing endpoint sense.

```shell
Error: error creating xxx client: Resource-level region must be the same as Provider-level region when using customizing endpoints
```
we should compare the resource-level region only when it's not empty.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
