### PR TITLE
feat(eg/source): support new resource of custom event source

### DIFF
--- a/docs/resources/eg_custom_event_source.md
+++ b/docs/resources/eg_custom_event_source.md
@@ -1,0 +1,69 @@
+---
+subcategory: "EventGrid (EG)"
+---
+
+# huaweicloud_eg_custom_event_source
+
+Using this resource to manage an EG custom event source within Huaweicloud.
+
+## Example Usage
+
+```hcl
+variable "channel_id" {}
+variable "source_name" {}
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id  = var.channel_id
+  type        = "RABBITMQ"
+  name        = var.source_name
+  description = "Created by script"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the custom event channel and custom event source
+  are located. If omitted, the provider-level region will be used.  
+  Changing this will create a new resource.
+
+* `channel_id` - (Required, String, ForceNew) Specifies the ID of the custom event channel to which the custom event
+  source belongs.  
+  Changing this will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the custom event source.  
+  The valid length is limited from `1` to `128`, only lowercase letters, digits, hyphens (-), underscores (_) are
+  allowed. The name must start with a lowercase letter or digit.  
+  Changing this will create a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the type of the custom event source.
+  The valid values are as follows:
+  + **APPLICATION**
+  + **RABBITMQ**
+  + **ROCKETMQ**
+
+  Defaults to **APPLICATION**.  
+  Changing this will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the custom event source.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+* `status` - The status of the custom event source.
+
+* `created_at` - The (UTC) creation time of the custom event source, in RFC3339 format.
+
+* `updated_at` - The (UTC) update time of the custom event source, in RFC3339 format.
+
+## Import
+
+Custom event sources can be imported by their `id`, e.g.
+
+```bash
+terraform import huaweicloud_eg_custom_event_source.test <id>
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856
+	github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856 h1:n7MBwb9771gPTrB+eW73sII+IRSeFHSPMUPKrVRh6PQ=
-github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62 h1:GmvpNqRqlUfhbjqZvBBiq5ZFSZqH8IuX2hnenJbaNi0=
+github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -861,6 +861,10 @@ func (c *Config) ServiceStageV2Client(region string) (*golangsdk.ServiceClient, 
 	return c.NewServiceClient("servicestagev2", region)
 }
 
+func (c *Config) EgV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("eg", region)
+}
+
 // ********** client for Database **********
 func (c *Config) RdsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("rdsv1", region)

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -563,6 +563,18 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 		t.Fatalf("ServiceStage v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
 	}
 	t.Logf("ServiceStage v2 endpoint:\t %s", actualURL)
+
+	// test the endpoint of EG service
+	serviceClient, err = cfg.EgV1Client(HW_REGION_NAME)
+	if err != nil {
+		t.Fatalf("error creating EG v1 client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://eg.%s.%s/v1/%s/", HW_REGION_NAME, cfg.Cloud, cfg.TenantID)
+	actualURL = serviceClient.ResourceBaseURL()
+	if actualURL != expectedURL {
+		t.Fatalf("EG endpoint: expected %s, but got %s", green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("EG endpoint:\t %s", actualURL)
 }
 
 // TestAccServiceEndpoints_Compute test for endpoints of the clients used in ecs

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -831,7 +831,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_snapshot_policy":    dws.ResourceDwsSnapshotPolicy(),
 			"huaweicloud_dws_ext_data_source":    dws.ResourceDwsExtDataSource(),
 
-			"huaweicloud_eg_endpoint": eg.ResourceEndpoint(),
+			"huaweicloud_eg_custom_event_source": eg.ResourceCustomEventSource(),
+			"huaweicloud_eg_endpoint":            eg.ResourceEndpoint(),
 
 			"huaweicloud_elb_certificate":     elb.ResourceCertificateV3(),
 			"huaweicloud_elb_l7policy":        elb.ResourceL7PolicyV3(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -178,6 +178,8 @@ var (
 
 	HW_CODEARTS_RESOURCE_POOL_ID = os.Getenv("HW_CODEARTS_RESOURCE_POOL_ID")
 	HW_CODEARTS_ENABLE_FLAG      = os.Getenv("HW_CODEARTS_ENABLE_FLAG")
+
+	HW_EG_CHANNEL_ID = os.Getenv("HW_EG_CHANNEL_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -809,5 +811,12 @@ func TestAccPreCheckModelArtsHasSubscribeModel(t *testing.T) {
 	if HW_MODELARTS_HAS_SUBSCRIBE_MODEL == "" {
 		t.Skip("Subscribe two free models from market and set HW_MODELARTS_HAS_SUBSCRIBE_MODEL" +
 			" for modelarts service acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckEgChannelId(t *testing.T) {
+	if HW_EG_CHANNEL_ID == "" {
+		t.Skip("The sub-resource acceptance test of the EG channel must set 'HW_EG_CHANNEL_ID'")
 	}
 }

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_custom_event_source_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_custom_event_source_test.go
@@ -1,0 +1,94 @@
+package eg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/source/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getCustomEventSourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.EgV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	return custom.Get(client, state.Primary.ID)
+}
+
+func TestAccCustomEventSource_basic(t *testing.T) {
+	var (
+		obj custom.Source
+
+		rName = "huaweicloud_eg_custom_event_source.test"
+		name  = acceptance.RandomAccResourceName()
+		rc    = acceptance.InitResourceCheck(rName, &obj, getCustomEventSourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEgChannelId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomEventSource_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "channel_id", acceptance.HW_EG_CHANNEL_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "APPLICATION"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acceptance test"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccCustomEventSource_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "channel_id", acceptance.HW_EG_CHANNEL_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "APPLICATION"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCustomEventSource_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id  = "%[1]s"
+  name        = "%[2]s"
+  description = "Created by acceptance test"
+}
+`, acceptance.HW_EG_CHANNEL_ID, name)
+}
+
+func testAccCustomEventSource_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = "%[1]s"
+  name       = "%[2]s"
+}
+`, acceptance.HW_EG_CHANNEL_ID, name)
+}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_custom_event_source.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_custom_event_source.go
@@ -1,0 +1,174 @@
+package eg
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/source/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceCustomEventSource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCustomEventSourceCreate,
+		ReadContext:   resourceCustomEventSourceRead,
+		UpdateContext: resourceCustomEventSourceUpdate,
+		DeleteContext: resourceCustomEventSourceDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the custom event source is located.",
+			},
+			"channel_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the custom event channel to which the custom event source belong.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the custom event source.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The type of the custom event source.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the custom event source.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the custom event source.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the custom event source.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The update time of the custom event source.",
+			},
+		},
+	}
+}
+
+func resourceCustomEventSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+
+		opts = custom.CreateOpts{
+			ChannelId:   d.Get("channel_id").(string),
+			Type:        d.Get("type").(string),
+			Name:        d.Get("name").(string),
+			Description: d.Get("description").(string),
+		}
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	resp, err := custom.Create(client, opts)
+	if err != nil {
+		return diag.Errorf("error creating custom event source: %s", err)
+	}
+	d.SetId(resp.ID)
+	return resourceCustomEventSourceRead(ctx, d, meta)
+}
+
+func resourceCustomEventSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		sourceId = d.Id()
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	resp, err := custom.Get(client, sourceId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Custom Event Source")
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("channel_id", resp.ChannelId),
+		d.Set("type", resp.Type),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("status", resp.Status),
+		d.Set("created_at", resp.CreatedTime),
+		d.Set("updated_at", resp.UpdatedTime),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving EG custom event source fields: %s", err)
+	}
+	return nil
+}
+
+func resourceCustomEventSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		opts   = custom.UpdateOpts{
+			SourceId:    d.Id(),
+			Description: utils.String(d.Get("description").(string)),
+		}
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	_, err = custom.Update(client, opts)
+	if err != nil {
+		return diag.Errorf("error updating custom event source: %s", err)
+	}
+	return resourceCustomEventSourceRead(ctx, d, meta)
+}
+
+func resourceCustomEventSourceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		sourceId = d.Id()
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	err = custom.Delete(client, sourceId)
+	if err != nil {
+		return diag.Errorf("error deleting custom event source: %s", err)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/requests.go
@@ -1,0 +1,124 @@
+package custom
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create a new custom event source.
+type CreateOpts struct {
+	// The ID of the event channel to which the custom event source belongs.
+	ChannelId string `json:"channel_id" required:"true"`
+	// The name of the custom event source.
+	Name string `json:"name" required:"true"`
+	// The type of custom event source.
+	// The valid values are as follows:
+	// + APPLICATION (default)
+	// + RABBITMQ
+	// + ROCKETMQ
+	Type string `json:"type,omitempty"`
+	// The description of the custom event source.
+	Description string `json:"description,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method used to create a new custom event source using given parameters.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Source, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Source
+	_, err = client.Post(rootURL(client), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Get is a method to query an existing event source by its ID.
+func Get(client *golangsdk.ServiceClient, sourceId string) (*Source, error) {
+	var r Source
+	_, err := client.Get(resourceURL(client, sourceId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// ListOpts is the structure used to query event source list.
+type ListOpts struct {
+	// The ID of the event channel to which the event source belongs.
+	ChannelId string `q:"channel_id"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0.
+	// The valid value ranges from 0 to 100, defaults to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	// The valid value ranges from 1 to 1000, defaults to 15.
+	Limit int `q:"limit"`
+	// The query sorting.
+	// The default value is 'created_time:DESC'.
+	Sort string `q:"sort"`
+	// The type of the event source provider.
+	// + OFFICIAL: official cloud service event source.
+	// + CUSTOM: the user-defined event source.
+	// + PARTNER: partner event source.
+	ProviderType string `q:"provider_type"`
+	// The name of the event source.
+	Name string `q:"name"`
+	// The fuzzy name of the event source.
+	FuzzyName string `q:"fuzzy_name"`
+	// The fuzzy label of the event source.
+	FuzzyLabel string `q:"fuzzy_label"`
+}
+
+// List is a method to query the event source list using given parameters.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Source, error) {
+	url := rootURL(client)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := SourcePage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSources(pages)
+}
+
+// UpdateOpts is the structure used to update an existing custom event source.
+type UpdateOpts struct {
+	// The ID of the event source.
+	SourceId string `json:"-" required:"true"`
+	// The description of the event source.
+	Description *string `json:"description,omitempty"`
+}
+
+// Update is a method used to modify an existing custom event source using given parameters.
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Source, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r Source
+	_, err = client.Put(resourceURL(client, opts.SourceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Delete is a method to delete an existing custom event source using its ID.
+func Delete(client *golangsdk.ServiceClient, sourceId string) error {
+	_, err := client.Delete(resourceURL(client, sourceId), nil)
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/results.go
@@ -1,0 +1,62 @@
+package custom
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// Source is the structure that represents the event source detail.
+type Source struct {
+	// The ID of the event source.
+	ID string `json:"id"`
+	// The name of the event source.
+	Name string `json:"name"`
+	// The description of the event source.
+	Description string `json:"description"`
+	// The type of the event source provider.
+	// + OFFICIAL: official cloud service event source.
+	// + CUSTOM: the user-defined event source.
+	// + PARTNER: partner event source.
+	ProviderType string `json:"provider_type"`
+	// The list of event types provided by the event source.
+	// Only the official cloud service event source provides event types.
+	EventTypes []EventType `json:"event_types"`
+	// The creation time, in UTC format.
+	CreatedTime string `json:"created_time"`
+	// The update time, in UTC format.
+	UpdatedTime string `json:"updated_time"`
+	// The ID of the event channel to which the event source belongs.
+	ChannelId string `json:"channel_id"`
+	// The name of the event channel to which the event source belongs.
+	ChannelName string `json:"channel_name"`
+	// The type of the event source.
+	// + APPLICATION (default)
+	// + RABBITMQ
+	// + ROCKETMQ
+	Type string `json:"type"`
+	// The status of the event source
+	Status string `json:"status"`
+}
+
+// EventType is the structure that represents the event type that provided by the event source.
+type EventType struct {
+	// The name of the event type.
+	Name string `json:"name"`
+	// The description of the event type.
+	Description string `json:"description"`
+}
+
+// SourcePage is a single page maximum result representing a query by offset page.
+type SourcePage struct {
+	pagination.OffsetPageBase
+}
+
+// IsEmpty checks whether a SourcePage struct is empty.
+func (b SourcePage) IsEmpty() (bool, error) {
+	arr, err := ExtractSources(b)
+	return len(arr) == 0, err
+}
+
+// ExtractSources is a method to extract the list of custom event sources.
+func ExtractSources(r pagination.Page) ([]Source, error) {
+	var s []Source
+	err := r.(SourcePage).Result.ExtractIntoSlicePtr(&s, "items")
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/urls.go
@@ -1,0 +1,11 @@
+package custom
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("sources")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, sourceId string) string {
+	return c.ServiceURL("sources", sourceId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856
+# github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -143,6 +143,7 @@ github.com/chnsz/golangsdk/openstack/ecs/v1/flavors
 github.com/chnsz/golangsdk/openstack/ecs/v1/jobs
 github.com/chnsz/golangsdk/openstack/ecs/v1/powers
 github.com/chnsz/golangsdk/openstack/ecs/v1/servergroups
+github.com/chnsz/golangsdk/openstack/eg/v1/source/custom
 github.com/chnsz/golangsdk/openstack/elb/v2/certificates
 github.com/chnsz/golangsdk/openstack/elb/v2/l7policies
 github.com/chnsz/golangsdk/openstack/elb/v2/listeners


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new resource of custom event source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new resource (custom event source) for EG (Event Grid) service.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccCustomEventSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccCustomEventSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCustomEventSource_basic
=== PAUSE TestAccCustomEventSource_basic
=== CONT  TestAccCustomEventSource_basic
--- PASS: TestAccCustomEventSource_basic (19.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        19.138s
```
