### PR TITLE
feat(cbr/vault): consistent level can be updated

### DIFF
--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -157,13 +157,13 @@ The following arguments are supported:
 
   -> You cannot update `size` if the vault is **prePaid** mode.
 
-* `consistent_level` - (Optional, String, ForceNew) Specifies the consistent level (specification) of the vault.
+* `consistent_level` - (Optional, String) Specifies the consistent level (specification) of the vault.
   The valid values are as follows:
   + **[crash_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
   + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
 
-  Only **server** type vaults support application consistent and defaults to **crash_consistent**.
-  Changing this will create a new vault.
+  Only **server** type vaults support application consistent and defaults to **crash_consistent**, and only
+  **crash_consistent** can be updated to **app_consistent**.
 
 * `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
   Defaults to **false**.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856
+	github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856 h1:n7MBwb9771gPTrB+eW73sII+IRSeFHSPMUPKrVRh6PQ=
-github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62 h1:GmvpNqRqlUfhbjqZvBBiq5ZFSZqH8IuX2hnenJbaNi0=
+github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_vault_test.go
@@ -51,7 +51,7 @@ func TestAccVault_backupServer(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
 					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "size", "200"),
@@ -150,7 +150,7 @@ func testAccVault_backupServer_step1(basicConfig, name string) string {
 resource "huaweicloud_cbr_vault" "test" {
   name                  = "%[2]s"
   type                  = "server"
-  consistent_level      = "app_consistent"
+  consistent_level      = "crash_consistent"
   protection_type       = "backup"
   size                  = 200
   enterprise_project_id = "0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856
+# github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Parameter `consistent_level` can be updated.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. parameter consistent level can be updated.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccVault_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccVault_ -timeout 360m -parallel 4
=== RUN   TestAccVault_backupServer
=== PAUSE TestAccVault_backupServer
=== RUN   TestAccVault_replicationServer
=== PAUSE TestAccVault_replicationServer
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== RUN   TestAccVault_volume
=== PAUSE TestAccVault_volume
=== RUN   TestAccVault_backupTurbo
=== PAUSE TestAccVault_backupTurbo
=== RUN   TestAccVault_replicationTurbo
=== PAUSE TestAccVault_replicationTurbo
=== RUN   TestAccVault_AutoBind
=== PAUSE TestAccVault_AutoBind
=== RUN   TestAccVault_bindPolicies
=== PAUSE TestAccVault_bindPolicies
=== CONT  TestAccVault_backupServer
=== CONT  TestAccVault_bindPolicies
=== CONT  TestAccVault_AutoBind
=== CONT  TestAccVault_backupTurbo
=== NAME  TestAccVault_bindPolicies
    acceptance.go:419: Skip the replication policy acceptance tests.
--- SKIP: TestAccVault_bindPolicies (0.00s)
=== CONT  TestAccVault_replicationTurbo
--- PASS: TestAccVault_replicationTurbo (17.93s)
=== CONT  TestAccVault_prePaidServer
    acceptance.go:461: This environment does not support prepaid tests
--- SKIP: TestAccVault_prePaidServer (0.01s)
=== CONT  TestAccVault_volume
--- PASS: TestAccVault_AutoBind (26.39s)
=== CONT  TestAccVault_replicationServer
--- PASS: TestAccVault_replicationServer (16.78s)
--- PASS: TestAccVault_backupServer (461.83s)
--- PASS: TestAccVault_volume (448.21s)
--- PASS: TestAccVault_backupTurbo (1011.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       1011.186s
```
