### PR TITLE
feat(ecs): support metadata param

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -290,6 +290,13 @@ The following arguments are supported:
   -> **NOTE:** If the `user_data` field is specified for a Linux ECS that is created using an image with Cloud-Init
   installed, the `admin_pass` field becomes invalid.
 
+* `metadata` - (Optional, Map) Specifies the user-defined metadata key-value pair.
+
+  + A maximum of 10 key-value pairs can be injected.
+  + A metadata key consists of 1 to 255 characters and contains only uppercase letters, lowercase letters, spaces,
+    digits, hyphens (-), underscores (_), colons (:), and decimal points (.).
+  + A metadata value consists of a maximum of 255 characters.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
 
 * `scheduler_hints` - (Optional, List) Specifies the scheduler with hints on how the instance should be launched. The
@@ -505,7 +512,7 @@ terraform import huaweicloud_compute_instance.my_instance b11b407c-e604-4e8d-8bc
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason.
-The missing attributes include: `admin_pass`, `user_data`, `data_disks`, `scheduler_hints`, `stop_before_destroy`,
+The missing attributes include: `admin_pass`, `user_data`, `metadata`, `data_disks`, `scheduler_hints`, `stop_before_destroy`,
 `delete_disks_on_termination`, `delete_eip_on_termination`, `network/access_network`, `bandwidth`, `eip_type`,
 `power_action` and arguments for pre-paid and spot price.
 It is generally recommended running `terraform plan` after importing an instance.

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -45,6 +45,8 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "agency_name", "test111"),
 					resource.TestCheckResourceAttr(resourceName, "agent_list", "hss"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -58,6 +60,8 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "60"),
 					resource.TestCheckResourceAttr(resourceName, "agency_name", "test222"),
 					resource.TestCheckResourceAttr(resourceName, "agent_list", "ces"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.foo", "bar2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.key2", "value2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -67,7 +71,7 @@ func TestAccComputeInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"stop_before_destroy", "delete_eip_on_termination", "data_disks",
+					"stop_before_destroy", "delete_eip_on_termination", "data_disks", "metadata",
 				},
 			},
 		},
@@ -422,6 +426,11 @@ resource "huaweicloud_compute_instance" "test" {
     size = "10"
   }
 
+  metadata = {
+    foo = "bar"
+    key = "value"
+  }
+
   tags = {
     foo = "bar"
     key = "value"
@@ -457,8 +466,13 @@ resource "huaweicloud_compute_instance" "test" {
     size = "10"
   }
 
+  metadata = {
+    foo  = "bar2"
+    key2 = "value2"
+  }
+
   tags = {
-    foo = "bar2"
+    foo  = "bar2"
     key2 = "value2"
   }
 }

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -42,7 +42,6 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network.0.source_dest_check", "false"),
 					resource.TestCheckResourceAttr(resourceName, "stop_before_destroy", "true"),
 					resource.TestCheckResourceAttr(resourceName, "delete_eip_on_termination", "true"),
-					resource.TestCheckResourceAttr(resourceName, "agent_list", "hss"),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "agency_name", "test111"),
 					resource.TestCheckResourceAttr(resourceName, "agent_list", "hss"),

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -433,3 +433,18 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 	})
 	return
 }
+
+// UpdateMetadata updates (or creates) all the metadata specified by opts for
+// the given server ID. This operation does not affect already-existing metadata
+// that is not specified by opts.
+func UpdateMetadata(client *golangsdk.ServiceClient, id string, opts map[string]interface{}) (r UpdateMetadataResult) {
+	b := map[string]interface{}{"metadata": opts}
+	_, r.Err = client.Post(metadataURL(client, id), b, &r.Body, nil)
+	return
+}
+
+// DeleteMetadatItem will delete the key-value pair with the given key for the given server ID.
+func DeleteMetadatItem(client *golangsdk.ServiceClient, id, key string) (r DeleteMetadatItemResult) {
+	_, r.Err = client.Delete(metadatItemURL(client, id, key), nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
@@ -207,3 +207,23 @@ func ExtractServers(r pagination.Page) ([]CloudServer, error) {
 	err := (r.(ServerPage)).ExtractInto(&s)
 	return s.Servers, err
 }
+
+// UpdateMetadataResult contains the result of an UpdateMetadata operation.
+// Call its Extract method to interpret it as a map[string]interface{}.
+type UpdateMetadataResult struct {
+	golangsdk.Result
+}
+
+// DeleteMetadatItemResult contains the result of a DeleteMetadatItem operation.
+// Call its ExtractErr method to determine if the call succeeded or failed.
+type DeleteMetadatItemResult struct {
+	golangsdk.ErrResult
+}
+
+func (r UpdateMetadataResult) Extract() (map[string]interface{}, error) {
+	var s struct {
+		Metadata map[string]interface{} `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Metadata, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/urls.go
@@ -41,3 +41,11 @@ func passwordURL(client *golangsdk.ServiceClient, id string) string {
 func updateURL(sc *golangsdk.ServiceClient, serverID string) string {
 	return sc.ServiceURL("cloudservers", serverID)
 }
+
+func metadataURL(client *golangsdk.ServiceClient, serverID string) string {
+	return client.ServiceURL("cloudservers", serverID, "metadata")
+}
+
+func metadatItemURL(client *golangsdk.ServiceClient, serverID, key string) string {
+	return client.ServiceURL("cloudservers", serverID, "metadata", key)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 add **metadata** param for compute instance.

Note: the API will return system-defined and user-defined metadata, and we can not distinguish them, so we don't set it.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (254.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       254.482s
```
