### PR TITLE
fix(RDS): change rds instance password to optional

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -262,10 +262,9 @@ The `db` block supports:
   resource. Available values detailed in
   [DB Engines and Versions](https://support.huaweicloud.com/intl/en-us/productdesc-rds/en-us_topic_0043898356.html).
 
-* `password` - (Required, String) Specifies the database password. The value cannot be empty and should
-  contain 8 to 32 characters, including uppercase and lowercase letters, digits, and the following special
-  characters: ~!@#%^*-_=+? You are advised to enter a strong password to improve security, preventing security risks
-  such as brute force cracking.
+* `password` - (Optional, String) Specifies the database password. The value should contain 8 to 32 characters,
+  including uppercase and lowercase letters, digits, and the following special characters: ~!@#%^*-_=+? You are advised
+  to enter a strong password to improve security, preventing security risks such as brute force cracking.
 
 * `port` - (Optional, Int) Specifies the database port.
   + The MySQL database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230913050449-4c6afad3b19b
+	github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230913050449-4c6afad3b19b h1:mlOLnMAp+gYo8h/zXEd+kM4qTXZUx2U9vrvEwp3IyIo=
-github.com/chnsz/golangsdk v0.0.0-20230913050449-4c6afad3b19b/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856 h1:n7MBwb9771gPTrB+eW73sII+IRSeFHSPMUPKrVRh6PQ=
+github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -78,11 +78,6 @@ func ResourceRdsInstance() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"password": {
-							Type:      schema.TypeString,
-							Sensitive: true,
-							Required:  true,
-						},
 						"type": {
 							Type:             schema.TypeString,
 							Required:         true,
@@ -93,6 +88,11 @@ func ResourceRdsInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
+						},
+						"password": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Optional:  true,
 						},
 						"port": {
 							Type:     schema.TypeInt,

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -12,7 +12,7 @@ type CreateOpts struct {
 	Ha                  *Ha                `json:"ha,omitempty"`
 	ConfigurationId     string             `json:"configuration_id,omitempty"`
 	Port                string             `json:"port,omitempty"`
-	Password            string             `json:"password" required:"true"`
+	Password            string             `json:"password,omitempty"`
 	BackupStrategy      *BackupStrategy    `json:"backup_strategy,omitempty"`
 	EnterpriseProjectId string             `json:"enterprise_project_id,omitempty"`
 	DiskEncryptionId    string             `json:"disk_encryption_id,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230913050449-4c6afad3b19b
+# github.com/chnsz/golangsdk v0.0.0-20230913065838-de0074b92856
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  change rds instance password to optional
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  change rds instance password to optional
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_without_password
=== PAUSE TestAccRdsInstance_without_password
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_withEpsId
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_without_password
--- PASS: TestAccRdsInstance_withEpsId (617.53s)
--- PASS: TestAccRdsInstance_without_password (643.17s)
--- PASS: TestAccRdsInstance_ha (654.63s)
--- PASS: TestAccRdsInstance_basic (783.32s)
--- PASS: TestAccRdsInstance_prePaid (1005.56s)
--- PASS: TestAccRdsInstance_withParameters (1025.91s)
--- PASS: TestAccRdsInstance_sqlserver (1129.54s)
--- PASS: TestAccRdsInstance_mysql (1405.98s)
--- PASS: TestAccRdsInstance_restore_pg (2229.38s)
--- PASS: TestAccRdsInstance_restore_mysql (2749.20s)
--- PASS: TestAccRdsInstance_restore_sqlserver (3047.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3047.732s
```
