### PR TITLE
feat(CodeArts): add a new resource to manage codearts deploy application

### DIFF
--- a/docs/resources/codearts_deploy_application.md
+++ b/docs/resources/codearts_deploy_application.md
@@ -1,0 +1,197 @@
+---
+subcategory: "CodeArts Deploy"
+---
+
+# huaweicloud_codearts_deploy_application
+
+Manages a CodeArts deploy application resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "project_id" {}
+variable "operation_name" {}
+variable "operation_description" {}
+variable "operation_code" {}
+variable "operation_params" {}
+variable "operation_entrance" {}
+variable "operation_version" {}
+variable "operation_module_id" {}
+
+resource "huaweicloud_codearts_deploy_application" "test" {
+  project_id     = var.project_id
+  name           = "test_name"
+  description    = "test description"
+  is_draft       = true
+  create_type    = "template"
+  trigger_source = "0"
+
+  operation_list {
+    name        = var.operation_name
+    description = var.operation_description
+    code        = var.operation_code
+    params      = var.operation_params
+    entrance    = var.operation_entrance
+    version     = var.operation_version
+    module_id   = var.operation_module_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `project_id` - (Required, String, ForceNew) Specifies the project ID for CodeArts service.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the application name. The name consists of 3 to 128 characters,
+  including letters, digits, chinese characters or `-_` symbols.
+
+  Changing this parameter will create a new resource.
+
+* `is_draft` - (Required, Bool, ForceNew) Specifies whether the application is in draft status.
+  Changing this parameter will create a new resource. Valid values:
+  + **true**:  Draft state.
+  + **false**: Available state.
+
+  Only applications in available state can be deployed.
+  If `operation_list` is not specified, this field can only be set to **true**.
+
+* `create_type` - (Required, String, ForceNew) Specifies the creation type. Only **template** is supported.
+
+  Changing this parameter will create a new resource.
+
+* `trigger_source` - (Required, String, ForceNew) Specifies where a deployment task can be executed.
+  Changing this parameter will create a new resource. Valid values:
+  + **0**: Indicates that all execution requests can be triggered.
+  + **1**: Indicates that only pipeline can be triggered.
+
+* `artifact_source_system` - (Optional, String, ForceNew) Specifies the source information transferred by the pipeline.
+  This field is only valid when `trigger_source` is set to **1**. Only **CloudArtifact** is supported.
+  
+  Changing this parameter will create a new resource.
+
+* `artifact_type` - (Optional, String, ForceNew) Specifies the artifact type for the pipeline source.
+  This field is only valid when `trigger_source` is set to **1**. Valid values are **generic** and **docker**.
+
+  Changing this parameter will create a new resource.
+
+* `operation_list` - (Optional, List, ForceNew) Specifies the deployment orchestration list information.
+
+  Changing this parameter will create a new resource.
+  The [operation_list](#DeployApplication_operation_list) structure is documented below.
+
+* `description` - (Optional, String, ForceNew) Specifies the application description.
+
+  Changing this parameter will create a new resource.
+
+* `resource_pool_id` - (Optional, String, ForceNew) Specifies the resource pool ID. A resource pool is a collection
+  of physical environments that execute deployment commands when deploying software packages.
+  If not specified, the resource pool hosted by HuaweiCloud will be used.
+  If you want to use your own servers as resource pools, please fill your own resource pool ID.
+
+  Changing this parameter will create a new resource.
+
+  -> Please refer to the following documents to create your own resource pool:
+  [Creating an Agent Pool](https://support.huaweicloud.com/intl/en-us/usermanual-devcloud/devcloud_01_0016.html) and
+  [Creating an Agent](https://support.huaweicloud.com/intl/en-us/usermanual-devcloud/devcloud_01_0017.html).
+
+<a name="DeployApplication_operation_list"></a>
+The `operation_list` block supports:
+
+* `name` - (Optional, String, ForceNew) Specifies the step name.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the step description.
+
+  Changing this parameter will create a new resource.
+
+* `code` - (Optional, String, ForceNew) Specifies the download URL.
+
+  Changing this parameter will create a new resource.
+
+* `params` - (Optional, String, ForceNew) Specifies the parameter.
+
+  Changing this parameter will create a new resource.
+
+* `entrance` - (Optional, String, ForceNew) Specifies the entry function.
+
+  Changing this parameter will create a new resource.
+
+* `version` - (Optional, String, ForceNew) Specifies the version.
+
+  Changing this parameter will create a new resource.
+
+* `module_id` - (Optional, String, ForceNew) Specifies the module ID.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - The create time.
+
+* `updated_at` - The update time.
+
+* `project_name` - The project name.
+
+* `can_modify` - Indicates whether the user has the editing permission.
+
+* `can_delete` - Indicates whether the user has the deletion permission.
+
+* `can_view` - Indicates whether the user has the view permission.
+
+* `can_execute` - Indicates whether the user has the deployment permission
+
+* `can_copy` - Indicates whether the user has the copy permission.
+
+* `can_manage` - Check whether the user has the management permission, including adding, deleting, modifying,
+  querying deployment and permission modification.
+
+* `can_create_env` - Indicates whether the user has the permission to create an environment.
+
+* `task_id` - The deployment task ID.
+
+* `task_name` - The deployment task name.
+
+* `steps` - The deployment steps. The example value is `{"step1":"XXX", "step2":"XXX"}`.
+
+## Import
+
+The CodeArts deploy application resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_deploy_application.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `is_draft`, `trigger_source`,
+`artifact_source_system`, `artifact_type` and `operation_list`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_codearts_deploy_application" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      is_draft,
+      trigger_source,
+      artifact_source_system,
+      artifact_type,
+      operation_list,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1134,10 +1134,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cpts_task":    cpts.ResourceTask(),
 
 			// CodeArts
-			"huaweicloud_codearts_project":      codearts.ResourceProject(),
-			"huaweicloud_codearts_repository":   codearts.ResourceRepository(),
-			"huaweicloud_codearts_deploy_group": codearts.ResourceDeployGroup(),
-			"huaweicloud_codearts_deploy_host":  codearts.ResourceDeployHost(),
+			"huaweicloud_codearts_project":            codearts.ResourceProject(),
+			"huaweicloud_codearts_repository":         codearts.ResourceRepository(),
+			"huaweicloud_codearts_deploy_application": codearts.ResourceDeployApplication(),
+			"huaweicloud_codearts_deploy_group":       codearts.ResourceDeployGroup(),
+			"huaweicloud_codearts_deploy_host":        codearts.ResourceDeployHost(),
 
 			"huaweicloud_dsc_instance":  dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_asset_obs": dsc.ResourceAssetObs(),

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_application_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_application_test.go
@@ -1,0 +1,368 @@
+package codearts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDeployApplicationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/applications/{app_id}/info"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{app_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CodeArts deploy application: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+	errorCode := utils.PathSearch("error_code", getRespBody, "")
+	if errorCode == "Deploy.00011021" {
+		// 'Deploy.00011021' means the application is not exist
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	if errorCode != "" {
+		errorMsg := utils.PathSearch("error_msg", getRespBody, "")
+		return nil, fmt.Errorf("error retrieving CodeArts deploy application: error code: %s, error message: %s",
+			errorCode, errorMsg)
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccDeployApplication_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_application.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployApplicationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeployApplication_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "project_id",
+						"huaweicloud_codearts_project.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "is_draft", "true"),
+					resource.TestCheckResourceAttr(rName, "create_type", "template"),
+					resource.TestCheckResourceAttr(rName, "trigger_source", "0"),
+					resource.TestCheckResourceAttr(rName, "steps.step1", "Download Package"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "project_name"),
+					resource.TestCheckResourceAttrSet(rName, "can_modify"),
+					resource.TestCheckResourceAttrSet(rName, "can_delete"),
+					resource.TestCheckResourceAttrSet(rName, "can_view"),
+					resource.TestCheckResourceAttrSet(rName, "can_execute"),
+					resource.TestCheckResourceAttrSet(rName, "can_copy"),
+					resource.TestCheckResourceAttrSet(rName, "can_manage"),
+					resource.TestCheckResourceAttrSet(rName, "can_create_env"),
+					resource.TestCheckResourceAttrSet(rName, "task_id"),
+					resource.TestCheckResourceAttrSet(rName, "task_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_draft",
+					"trigger_source",
+					"operation_list",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDeployApplication_resourcePoolId(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_application.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployApplicationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCodeArtsDeployResourcePoolID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeployApplication_resourcePoolId(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "project_id",
+						"huaweicloud_codearts_project.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "is_draft", "true"),
+					resource.TestCheckResourceAttr(rName, "create_type", "template"),
+					resource.TestCheckResourceAttr(rName, "trigger_source", "1"),
+					resource.TestCheckResourceAttr(rName, "artifact_source_system", "CloudArtifact"),
+					resource.TestCheckResourceAttr(rName, "artifact_type", "generic"),
+					resource.TestCheckResourceAttr(rName, "resource_pool_id", acceptance.HW_CODEARTS_RESOURCE_POOL_ID),
+					resource.TestCheckResourceAttr(rName, "steps.step1", "Download Package"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "project_name"),
+					resource.TestCheckResourceAttrSet(rName, "can_modify"),
+					resource.TestCheckResourceAttrSet(rName, "can_delete"),
+					resource.TestCheckResourceAttrSet(rName, "can_view"),
+					resource.TestCheckResourceAttrSet(rName, "can_execute"),
+					resource.TestCheckResourceAttrSet(rName, "can_copy"),
+					resource.TestCheckResourceAttrSet(rName, "can_manage"),
+					resource.TestCheckResourceAttrSet(rName, "can_create_env"),
+					resource.TestCheckResourceAttrSet(rName, "task_id"),
+					resource.TestCheckResourceAttrSet(rName, "task_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_draft",
+					"trigger_source",
+					"artifact_source_system",
+					"artifact_type",
+					"operation_list",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDeployApplication_errorCheckInvalidArgument(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_application.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployApplicationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testDeployApplication_errorCheckInvalidArgument(name),
+				ExpectError: regexp.MustCompile(`is required when application is not in draft status`),
+			},
+		},
+	})
+}
+
+func TestAccDeployApplication_errorCheckErrorCode(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_deploy_application.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeployApplicationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testDeployApplication_errorCheckErrorCode(name),
+				ExpectError: regexp.MustCompile(`error creating CodeArts deploy application: error code:`),
+			},
+		},
+	})
+}
+
+func testDeployApplication_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_application" "test" {
+  project_id     = huaweicloud_codearts_project.test.id
+  name           = "%[2]s"
+  description    = "test description"
+  is_draft       = true
+  create_type    = "template"
+  trigger_source = "0"
+
+  operation_list {
+    name        = "Download Package"
+    description = "download package description"
+    code        = "https://example.com/xxx.zip"
+    entrance    = "main.yml"
+    version     = "1.1.282"
+    module_id   = "devcloud2018.select_deploy_source_task.select_deploy_source_tab"
+    params      = <<EOF
+[
+  {
+    "name":"groupId",
+    "label":"env",
+    "displaySettings":{
+      "DevCloud.ControlType":"DeploymentGroup",
+      "DevCloud.ControlType.Select":[
+        {
+          "displayName":"",
+          "value":""
+        }
+      ]
+    },
+    "defaultDisplay":[
+      {
+        "displayName":"$${host_group}",
+        "value":"$${host_group}",
+        "os":"linux"
+      }
+    ]
+  }
+]
+EOF
+  }
+}
+`, testProject_basic(name), name)
+}
+
+func testDeployApplication_resourcePoolId(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_application" "test" {
+  project_id             = huaweicloud_codearts_project.test.id
+  name                   = "%[2]s"
+  description            = "test description"
+  is_draft               = true
+  create_type            = "template"
+  trigger_source         = "1"
+  artifact_source_system = "CloudArtifact"
+  artifact_type          = "generic"
+  resource_pool_id       = "%[3]s"
+
+  operation_list {
+    name        = "Download Package"
+    description = "download package description"
+    code        = "https://example.com/xxx.zip"
+    entrance    = "main.yml"
+    version     = "1.1.282"
+    module_id   = "devcloud2018.select_deploy_source_task.select_deploy_source_tab"
+    params      = <<EOF
+[
+  {
+    "name":"groupId",
+    "label":"env",
+    "displaySettings":{
+      "DevCloud.ControlType":"DeploymentGroup",
+      "DevCloud.ControlType.Select":[
+        {
+          "displayName":"",
+          "value":""
+        }
+      ]
+    },
+    "defaultDisplay":[
+      {
+        "displayName":"$${host_group}",
+        "value":"$${host_group}",
+        "os":"linux"
+      }
+    ]
+  }
+]
+EOF
+  }
+}
+`, testProject_basic(name), name, acceptance.HW_CODEARTS_RESOURCE_POOL_ID)
+}
+
+func testDeployApplication_errorCheckInvalidArgument(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_application" "test" {
+  project_id     = huaweicloud_codearts_project.test.id
+  name           = "%[2]s"
+  description    = "test description"
+  is_draft       = false
+  create_type    = "template"
+  trigger_source = "0"
+}
+`, testProject_basic(name), name)
+}
+
+func testDeployApplication_errorCheckErrorCode(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_codearts_deploy_application" "test" {
+  project_id     = huaweicloud_codearts_project.test.id
+  name           = "%[2]s"
+  description    = "test description"
+  is_draft       = true
+  create_type    = "error_type"
+  trigger_source = "0"
+}
+`, testProject_basic(name), name)
+}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go
@@ -1,0 +1,467 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CodeArts
+// ---------------------------------------------------------------
+
+package codearts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	applicationNotFound = "Deploy.00011021"
+)
+
+func ResourceDeployApplication() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeployApplicationCreate,
+		ReadContext:   resourceDeployApplicationRead,
+		DeleteContext: resourceDeployApplicationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the project ID for CodeArts service.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the application name.`,
+			},
+			"is_draft": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies whether the application is in draft status.`,
+			},
+			"create_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the creation type.`,
+			},
+			"trigger_source": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies where a deployment task can be executed.`,
+			},
+			"artifact_source_system": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the source information transferred by the pipeline.`,
+			},
+			"artifact_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the artifact type for the pipeline source.`,
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "schema: Deprecated; Currently, the field is useless for creating API.",
+			},
+			"operation_list": {
+				Type:        schema.TypeList,
+				Elem:        deployApplicationOperationSchema(),
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the deployment orchestration list information.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the application description.`,
+			},
+			"resource_pool_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the custom slave resource pool ID.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The create time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time.`,
+			},
+			"project_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The project name.`,
+			},
+			"can_modify": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the editing permission.`,
+			},
+			"can_delete": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the deletion permission.`,
+			},
+			"can_view": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the view permission.`,
+			},
+			"can_execute": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the deployment permission`,
+			},
+			"can_copy": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the copy permission.`,
+			},
+			"can_manage": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Description: `Check whether the user has the management permission, including adding, deleting,
+modifying, querying deployment and permission modification.`,
+			},
+			"can_create_env": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the user has the permission to create an environment.`,
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The deployment task ID.`,
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The deployment task name.`,
+			},
+			"steps": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `The deployment steps.`,
+			},
+		},
+	}
+}
+
+func deployApplicationOperationSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the step name.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the step description.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the download URL.`,
+			},
+			"params": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the parameter.`,
+			},
+			"entrance": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the entry function.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the version.`,
+			},
+			"module_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the module ID.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func preCheckBeforeCreateApplication(d *schema.ResourceData) error {
+	rawArray, isArray := d.Get("operation_list").([]interface{})
+	if isArray && len(rawArray) == 0 {
+		if !d.Get("is_draft").(bool) {
+			return fmt.Errorf("the argument (operation_list) is required when application is not in draft status")
+		}
+	}
+	return nil
+}
+
+func resourceDeployApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if err := preCheckBeforeCreateApplication(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/applications"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+		JSONBody: utils.RemoveNil(buildCreateDeployApplicationBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy application: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(createRespBody, applicationNotFound); err != nil {
+		return diag.Errorf("error creating CodeArts deploy application: %s", err)
+	}
+
+	id, err := jmespath.Search("result.id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating DeployApplication: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceDeployApplicationRead(ctx, d, meta)
+}
+
+func buildCreateDeployApplicationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"project_id":       d.Get("project_id"),
+		"name":             d.Get("name"),
+		"description":      d.Get("description"),
+		"is_draft":         d.Get("is_draft"),
+		"create_type":      d.Get("create_type"),
+		"slave_cluster_id": d.Get("resource_pool_id"),
+		"trigger":          buildTriggerBodyParam(d),
+		"arrange_infos":    buildArrangeInfoBodyParam(d),
+	}
+	return bodyParams
+}
+
+func buildTriggerBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"trigger_source":         d.Get("trigger_source"),
+		"artifact_source_system": d.Get("artifact_source_system"),
+		"artifact_type":          d.Get("artifact_type"),
+	}
+}
+
+func buildArrangeInfoBodyParam(d *schema.ResourceData) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"template_id":    d.Get("template_id"),
+			"operation_list": buildArrangeInfoOperationListBodyParam(d),
+		},
+	}
+}
+
+func buildArrangeInfoOperationListBodyParam(d *schema.ResourceData) []map[string]interface{} {
+	if rawArray, ok := d.Get("operation_list").([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, 0, len(rawArray))
+		for _, v := range rawArray {
+			if raw, isMap := v.(map[string]interface{}); isMap {
+				rst = append(rst, map[string]interface{}{
+					"name":        raw["name"],
+					"description": raw["description"],
+					"code":        raw["code"],
+					"params":      raw["params"],
+					"entrance":    raw["entrance"],
+					"version":     raw["version"],
+					"module_id":   raw["module_id"],
+				})
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceDeployApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/applications/{app_id}/info"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{app_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CodeArts deploy application: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(getRespBody, applicationNotFound); err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts deploy application")
+	}
+
+	resultRespBody := utils.PathSearch("result", getRespBody, nil)
+	if resultRespBody == nil {
+		return diag.Errorf("error retrieving CodeArts deploy application: result is not found in API response")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("project_id", utils.PathSearch("project_id", resultRespBody, nil)),
+		d.Set("name", utils.PathSearch("name", resultRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", resultRespBody, nil)),
+		d.Set("create_type", utils.PathSearch("create_type", resultRespBody, nil)),
+		d.Set("resource_pool_id", utils.PathSearch("slave_cluster_id", resultRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", resultRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", resultRespBody, nil)),
+		d.Set("project_name", utils.PathSearch("project_name", resultRespBody, nil)),
+		d.Set("can_modify", utils.PathSearch("can_modify", resultRespBody, nil)),
+		d.Set("can_delete", utils.PathSearch("can_delete", resultRespBody, nil)),
+		d.Set("can_view", utils.PathSearch("can_view", resultRespBody, nil)),
+		d.Set("can_execute", utils.PathSearch("can_execute", resultRespBody, nil)),
+		d.Set("can_copy", utils.PathSearch("can_copy", resultRespBody, nil)),
+		d.Set("can_manage", utils.PathSearch("can_manage", resultRespBody, nil)),
+		d.Set("can_create_env", utils.PathSearch("can_create_env", resultRespBody, nil)),
+		d.Set("task_id", utils.PathSearch("arrange_infos|[0].id", resultRespBody, nil)),
+		d.Set("task_name", utils.PathSearch("arrange_infos|[0].name", resultRespBody, nil)),
+		d.Set("steps", flattenDeployApplicationSteps(resultRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// flattenDeployApplicationSteps use to flatten deployment steps.
+// An example of the return value of this function is as follows: '{"step1":"XXX", "step2":"XXX"}'
+func flattenDeployApplicationSteps(resp interface{}) interface{} {
+	steps := utils.PathSearch("arrange_infos|[0].steps", resp, nil)
+	if steps == nil {
+		return nil
+	}
+	rst := make(map[string]interface{})
+	if stepMap, ok := steps.(map[string]interface{}); ok {
+		for key, val := range stepMap {
+			rst[key] = utils.PathSearch("name", val, "")
+		}
+	}
+	return rst
+}
+
+func resourceDeployApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/applications/{app_id}"
+		product = "codearts_deploy"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts deploy client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{app_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CodeArts deploy application: %s", err)
+	}
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkResponseError(deleteRespBody, applicationNotFound); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting CodeArts deploy application")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 
***add a new resource to manage codearts deploy application

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Field `is_draft`, `trigger_source`, `artifact_source_system`, `artifact_type`, `operation_list` do not have response values.
- For `template_id`, this field is useless for creating API now. Just make this field consistent with the API.
- The Create\Delete\Read function need to add Header "Content-Type": "application/json;charset=utf-8".
- Even if the API response code is 200, the result may still be wrong, we need to parse the response body to check whether the request is success.
- If the application resource is not found, the response body will contain error code Deploy.00011021.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/fd6f56ab-f7c4-4d1f-9d16-748561168f9a)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployApplication_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployApplication_basic -timeout 360m -parallel 4
=== RUN   TestAccDeployApplication_basic
=== PAUSE TestAccDeployApplication_basic
=== CONT  TestAccDeployApplication_basic
--- PASS: TestAccDeployApplication_basic (9.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  9.291s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployApplication_resourcePoolId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployApplication_resourcePoolId -timeout 360m -parallel 4
=== RUN   TestAccDeployApplication_resourcePoolId 
=== PAUSE TestAccDeployApplication_resourcePoolId 
=== CONT  TestAccDeployApplication_resourcePoolId 
--- PASS: TestAccDeployApplication_resourcePoolId (10.02s) 
PASS                                                                                                            
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  10.071s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployApplication_errorCheckInvalidArgument'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployApplication_errorCheckInvalidArgument -timeout 360m -parallel 4 
=== RUN   TestAccDeployApplication_errorCheckInvalidArgument 
=== PAUSE TestAccDeployApplication_errorCheckInvalidArgument
=== CONT  TestAccDeployApplication_errorCheckInvalidArgument
--- PASS: TestAccDeployApplication_errorCheckInvalidArgument (5.04s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  5.094s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployApplication_errorCheckErrorCode'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccDeployApplication_errorCheckErrorCode -timeout 360m -parallel 4 
=== RUN   TestAccDeployApplication_errorCheckErrorCode 
=== PAUSE TestAccDeployApplication_errorCheckErrorCode
=== CONT  TestAccDeployApplication_errorCheckErrorCode
--- PASS: TestAccDeployApplication_errorCheckErrorCode (4.39s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  4.430s
```
