### PR TITLE
feat(eg/source): support new data source to query event sources

### DIFF
--- a/docs/data-sources/eg_custom_event_sources.md
+++ b/docs/data-sources/eg_custom_event_sources.md
@@ -1,0 +1,61 @@
+---
+subcategory: "EventGrid (EG)"
+---
+
+# huaweicloud_eg_custom_event_sources
+
+Use this data source to filter EG custom event sources within Huaweicloud.
+
+## Example Usage
+
+```hcl
+variable "source_name" {}
+
+data "huaweicloud_eg_custom_event_sources" "test" {
+  name = var.source_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the custom event sources are located.  
+  If omitted, the provider-level region will be used.
+
+* `channel_id` - (Optional, String) Specifies the ID of the custom event channel to which the custom event sources
+  belong.
+
+* `source_id` - (Optional, String) Specifies the event source ID used to query specified custom event source.
+
+* `name` - (Optional, String) Specifies the event source name used to query specified custom event source.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sources` - The filtered custom event source.
+  The [object](#eg_custom_event_sources) structure is documented below.
+
+<a name="eg_custom_event_sources"></a>
+The `sources` block supports:
+
+* `id` - The ID of the custom event source.
+
+* `channel_id` - The ID of the custom event channel to which the custom event source belong.
+
+* `channel_name` - The name of the custom event channel to which the custom event source belong.
+
+* `name` - The name of the custom event source.
+
+* `type` - The type of the custom event source.
+
+* `description` - The description of the custom event source.
+
+* `status` - The status of the custom event source.
+
+* `created_at` - The creation time of the custom event source.
+
+* `updated_at` - The update time of the custom event source.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -452,6 +452,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_zones":      dns.DataSourceZones(),
 			"huaweicloud_dns_recordsets": dns.DataSourceRecordsets(),
 
+			"huaweicloud_eg_custom_event_sources": eg.DataSourceCustomEventSources(),
+
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
 			"huaweicloud_er_attachments":  er.DataSourceAttachments(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_custom_event_sources_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_custom_event_sources_test.go
@@ -1,0 +1,238 @@
+package eg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/source/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataCustomEventSources_basic(t *testing.T) {
+	var (
+		baseRes      = "huaweicloud_eg_custom_event_source.test"
+		byName       = "data.huaweicloud_eg_custom_event_sources.filter_by_name"
+		nameNotFound = "data.huaweicloud_eg_custom_event_sources.name_not_found"
+
+		obj            custom.Source
+		rc             = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventSourceFunc)
+		dcByName       = acceptance.InitDataSourceCheck(byName)
+		dcNameNotFound = acceptance.InitDataSourceCheck(nameNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEgChannelId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCustomEventSources_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCustomEventSources_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = "%[1]s"
+  name       = "%[2]s"
+}
+`, acceptance.HW_EG_CHANNEL_ID, name)
+}
+
+func testAccDataCustomEventSources_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_eg_custom_event_sources" "filter_by_name" {
+  // The behavior of parameter 'name' of the resource is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_eg_custom_event_source.test,
+  ]
+
+  name = huaweicloud_eg_custom_event_source.test.name
+}
+
+data "huaweicloud_eg_custom_event_sources" "name_not_found" {
+  // Since a specified name is used, there is no dependency relationship with resource attachment, and the dependency
+  // needs to be manually set.
+  depends_on = [
+    huaweicloud_eg_custom_event_source.test,
+  ]
+
+  name = "resource_not_found"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_eg_custom_event_sources.filter_by_name.sources[*].id :
+                   v == huaweicloud_eg_custom_event_source.test.id]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_eg_custom_event_sources.name_not_found.sources) == 0
+}
+`, testAccDataCustomEventSources_base())
+}
+
+func TestAccDataCustomEventSources_filterById(t *testing.T) {
+	var (
+		baseRes    = "huaweicloud_eg_custom_event_source.test"
+		byId       = "data.huaweicloud_eg_custom_event_sources.filter_by_id"
+		idNotFound = "data.huaweicloud_eg_custom_event_sources.id_not_found"
+
+		obj          custom.Source
+		rc           = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventSourceFunc)
+		dcById       = acceptance.InitDataSourceCheck(byId)
+		dcIdNotFound = acceptance.InitDataSourceCheck(idNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEgChannelId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCustomEventSources_filterById(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					dcIdNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("id_not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCustomEventSources_filterById() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_eg_custom_event_sources" "filter_by_id" {
+  source_id = huaweicloud_eg_custom_event_source.test.id
+}
+
+data "huaweicloud_eg_custom_event_sources" "id_not_found" {
+  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_eg_custom_event_source.test,
+  ]
+
+  source_id = "%[2]s"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_eg_custom_event_sources.filter_by_id.sources[*].id :
+                   v == huaweicloud_eg_custom_event_source.test.id]
+}
+
+output "is_id_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "id_not_found_validation_pass" {
+  value = length(data.huaweicloud_eg_custom_event_sources.id_not_found.sources) == 0
+}
+`, testAccDataCustomEventSources_base(), randUUID)
+}
+
+func TestAccDataCustomEventSources_filterByChannelId(t *testing.T) {
+	var (
+		baseRes           = "huaweicloud_eg_custom_event_source.test"
+		byChannelId       = "data.huaweicloud_eg_custom_event_sources.filter_by_channel_id"
+		channelIdNotFound = "data.huaweicloud_eg_custom_event_sources.channel_id_not_found"
+
+		obj                 custom.Source
+		rc                  = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventSourceFunc)
+		dcByChannelId       = acceptance.InitDataSourceCheck(byChannelId)
+		dcChannelIdNotFound = acceptance.InitDataSourceCheck(channelIdNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEgChannelId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCustomEventSources_filterByChannelId(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					dcByChannelId.CheckResourceExists(),
+					resource.TestCheckOutput("is_channel_id_filter_useful", "true"),
+					dcChannelIdNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("channel_id_not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCustomEventSources_filterByChannelId() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_eg_custom_event_sources" "filter_by_channel_id" {
+  // The behavior of parameter 'channel_id' of the resource is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_eg_custom_event_source.test,
+  ]
+
+  channel_id = "%[2]s"
+}
+
+data "huaweicloud_eg_custom_event_sources" "channel_id_not_found" {
+  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_eg_custom_event_source.test,
+  ]
+
+  channel_id = "%[3]s"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_eg_custom_event_sources.filter_by_channel_id.sources[*].channel_id : v == "%[2]s"]
+}
+
+output "is_channel_id_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "channel_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_eg_custom_event_sources.channel_id_not_found.sources) == 0
+}
+`, testAccDataCustomEventSources_base(), acceptance.HW_EG_CHANNEL_ID, randUUID)
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_sources.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_sources.go
@@ -1,0 +1,173 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/source/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceCustomEventSources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCustomEventSourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the custom event sources are located.`,
+			},
+			"channel_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the custom event channel to which the custom event sources belong.`,
+			},
+			"source_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The event source ID used to query specified custom event source.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The event source name used to query specified custom event source.`,
+			},
+			"sources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the custom event source.`,
+						},
+						"channel_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the custom event channel to which the custom event source belong.`,
+						},
+						"channel_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the custom event channel to which the custom event source belong.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the custom event source.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the custom event source.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the custom event source.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the custom event source.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the custom event source.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The update time of the custom event source.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func filterEventSources(d *schema.ResourceData, eventSources []custom.Source) ([]interface{}, error) {
+	filter := map[string]interface{}{
+		"ID": d.Get("source_id"),
+	}
+
+	filterResult, err := utils.FilterSliceWithField(eventSources, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error filting list of custom event sources: %s", err)
+	}
+	return filterResult, nil
+}
+
+func flattenCustomEventSources(eventSources []interface{}) []map[string]interface{} {
+	if len(eventSources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(eventSources))
+	for i, val := range eventSources {
+		eventSource := val.(custom.Source)
+		result[i] = map[string]interface{}{
+			"id":           eventSource.ID,
+			"channel_id":   eventSource.ChannelId,
+			"channel_name": eventSource.ChannelName,
+			"name":         eventSource.Name,
+			"type":         eventSource.Type,
+			"description":  eventSource.Description,
+			"status":       eventSource.Status,
+			"created_at":   eventSource.CreatedTime,
+			"updated_at":   eventSource.UpdatedTime,
+		}
+	}
+	return result
+}
+
+func dataSourceCustomEventSourcesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		opts   = custom.ListOpts{
+			ChannelId:    d.Get("channel_id").(string),
+			ProviderType: "CUSTOM",
+			Name:         d.Get("name").(string),
+		}
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	resp, err := custom.List(client, opts)
+	if err != nil {
+		return diag.Errorf("error querying custom event sources: %s", err)
+	}
+	filterResult, err := filterEventSources(d, resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("sources", flattenCustomEventSources(filterResult)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving data source fields of EG custom event sources: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new data source to query custom event sources

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new data source used to query EG custom event sources.
2. support related acceptance and document.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccDataCustomEventSources_'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccDataCustomEventSources_ -timeout 360m -parallel 4
=== RUN   TestAccDataCustomEventSources_basic
=== PAUSE TestAccDataCustomEventSources_basic
=== RUN   TestAccDataCustomEventSources_filterById
=== PAUSE TestAccDataCustomEventSources_filterById
=== RUN   TestAccDataCustomEventSources_filterByChannelId
=== PAUSE TestAccDataCustomEventSources_filterByChannelId
=== CONT  TestAccDataCustomEventSources_basic
=== CONT  TestAccDataCustomEventSources_filterByChannelId
=== CONT  TestAccDataCustomEventSources_filterById
--- PASS: TestAccDataCustomEventSources_basic (10.92s)
--- PASS: TestAccDataCustomEventSources_filterByChannelId (10.99s)
--- PASS: TestAccDataCustomEventSources_filterById (11.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        11.108s
```
