### PR TITLE
docs(OMS): fix the field `max_bandwidth` document description

### DIFF
--- a/docs/resources/oms_migration_task.md
+++ b/docs/resources/oms_migration_task.md
@@ -172,7 +172,7 @@ The `destination_object` block supports:
 The `bandwidth_policy` block supports:
 
 * `max_bandwidth` - (Required, Int) Specifies the maximum traffic bandwidth allowed in the specified time
-  segment. The unit is byte/s. The value ranges from **1** MB/s to **200** MB/s.
+  segment. The value ranges from **1** to **200**. The unit is MB/s.
 
 * `start` - (Required, String) Specifies the start time of the traffic limit rule. The format is **hh:mm**,
   e.g. **12:03**.

--- a/docs/resources/oms_migration_task_group.md
+++ b/docs/resources/oms_migration_task_group.md
@@ -298,7 +298,7 @@ The `destination_object` block supports:
 The `bandwidth_policy` block supports:
 
 * `max_bandwidth` - (Required, Int) Specifies the maximum traffic bandwidth allowed in the specified time
-  segment. The unit is byte/s. The value ranges from **1** MB/s to **200** MB/s.
+  segment. The value ranges from **1** to **200**. The unit is MB/s.
 
 * `start` - (Required, String) Specifies the start time of the traffic limit rule. The format is **hh:mm**,
   e.g. **12:03**.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Fix the field `max_bandwidth` document description.
- The value range should be 1MB/s to 200MB/s.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

