### PR TITLE
fix(DCS): fix dcs instance delete func

### DIFF
--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -49,6 +49,8 @@ var (
 	}
 
 	operateErrorCode = map[string]bool{
+		// current state not support
+		"DCS.4026": true,
 		// backup
 		"DCS.4096": true,
 		// restore
@@ -1148,6 +1150,23 @@ func handleOperationError(err error) (bool, error) {
 			return true, err
 		}
 	}
+	// unsubscribe fail
+	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
+		}
+
+		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
+		if errorCodeErr != nil {
+			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
+		}
+
+		// CBC.99003651: Another operation is being performed.
+		if errorCode == "CBC.99003651" {
+			return true, err
+		}
+	}
 	return false, err
 }
 
@@ -1158,17 +1177,35 @@ func resourceDcsInstancesDelete(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating DCS Client(v2): %s", err)
 	}
 
+	var retryFunc func() (interface{}, bool, error)
 	// for prePaid mode, we should unsubscribe the resource
 	if d.Get("charging_mode").(string) == chargeModePrePaid {
-		err = common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()})
-		if err != nil {
-			return diag.Errorf("error unsubscribing DCS redis instance : %s", err)
+		retryFunc = func() (interface{}, bool, error) {
+			err = common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()})
+			retry, err := handleOperationError(err)
+			return nil, retry, err
 		}
 	} else {
-		err = instances.Delete(client, d.Id())
-		if err != nil {
-			return diag.FromErr(err)
+		retryFunc = func() (interface{}, bool, error) {
+			err = instances.Delete(client, d.Id())
+			retry, err := handleOperationError(err)
+			return nil, retry, err
 		}
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     refreshDcsInstanceState(client, d.Id()),
+		WaitTarget:   []string{"RUNNING"},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		if d.Get("charging_mode").(string) == chargeModePrePaid {
+			return diag.Errorf("error unsubscribing DCS redis instance : %s", err)
+		}
+		return diag.FromErr(err)
 	}
 
 	// Waiting to delete success

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -1203,7 +1203,7 @@ func resourceDcsInstancesDelete(ctx context.Context, d *schema.ResourceData, met
 	})
 	if err != nil {
 		if d.Get("charging_mode").(string) == chargeModePrePaid {
-			return diag.Errorf("error unsubscribing DCS redis instance : %s", err)
+			return diag.Errorf("error unsubscribing DCS redis instance: %s", err)
 		}
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 dcs instance delete func add retry
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  dcs instance delete func add retry
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dcs/' TESTARGS='-run TestAccDcsInstances_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances_ -timeout 360m -parallel 10
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_ha_to_proxy
=== CONT  TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_withEpsId
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_single (89.72s)
=== CONT  TestAccDcsInstances_cluster_change_capacity
--- PASS: TestAccDcsInstances_withEpsId (112.33s)
=== CONT  TestAccDcsInstances_proxy_to_ha
--- PASS: TestAccDcsInstances_tiny (122.73s)
=== CONT  TestAccDcsInstances_proxy_change_capacity
--- PASS: TestAccDcsInstances_whitelists (143.95s)
=== CONT  TestAccDcsInstances_rw_to_proxy
--- PASS: TestAccDcsInstances_basic (170.90s)
=== CONT  TestAccDcsInstances_rw_change_capacity
--- PASS: TestAccDcsInstances_rw_expand_replica (219.09s)
=== CONT  TestAccDcsInstances_ha_expand_replica
--- PASS: TestAccDcsInstances_prePaid (236.62s)
=== CONT  TestAccDcsInstances_ha_change_capacity
--- PASS: TestAccDcsInstances_rw_change_capacity (236.14s)
--- PASS: TestAccDcsInstances_ha_expand_replica (224.60s)
--- PASS: TestAccDcsInstances_ha_change_capacity (229.95s)
--- PASS: TestAccDcsInstances_cluster_expand_replica (523.86s)
--- PASS: TestAccDcsInstances_proxy_to_rw (597.68s)
--- PASS: TestAccDcsInstances_rw_to_proxy (566.90s)
--- PASS: TestAccDcsInstances_ha_to_proxy (712.01s)
--- PASS: TestAccDcsInstances_proxy_to_ha (644.82s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1178.43s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (1968.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       2091.611s
```
