### PR TITLE
chore: rename rms subcategory to config

### DIFF
--- a/docs/data-sources/rms_policy_definitions.md
+++ b/docs/data-sources/rms_policy_definitions.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Resource Management Service (RMS)"
+subcategory: "Config"
 ---
 
 # huaweicloud_rms_policy_definitions

--- a/docs/resources/rms_policy_assignment.md
+++ b/docs/resources/rms_policy_assignment.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Resource Management Service (RMS)"
+subcategory: "Config"
 ---
 
 # huaweicloud_rms_policy_assignment

--- a/docs/resources/rms_resource_aggregation_authorization.md
+++ b/docs/resources/rms_resource_aggregation_authorization.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Resource Management Service (RMS)"
+subcategory: "Config"
 ---
 
 # huaweicloud_rms_resource_aggregation_authorization

--- a/docs/resources/rms_resource_aggregator.md
+++ b/docs/resources/rms_resource_aggregator.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Resource Management Service (RMS)"
+subcategory: "Config"
 ---
 
 # huaweicloud_rms_resource_aggregator
@@ -20,6 +20,7 @@ resource "huaweicloud_rms_resource_aggregator" "account" {
   name        = var.name
   type        = "ACCOUNT"
   account_ids = var.source_account_list
+}
 ```
 
 ### Organization Based Aggregation
@@ -30,6 +31,7 @@ variable "name" {}
 resource "huaweicloud_rms_resource_aggregator" "organization" {
   name = var.name
   type = "ORGANIZATION"
+}
 ```
 
 ## Argument Reference

--- a/docs/resources/rms_resource_recorder.md
+++ b/docs/resources/rms_resource_recorder.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Resource Management Service (RMS)"
+subcategory: "Config"
 ---
 
 # huaweicloud_rms_resource_recorder

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -46,6 +46,7 @@ var multiCatalogKeys = map[string][]string{
 	"smn":          {"smn-tag"},
 	"ces":          {"cesv2"},
 	"ims":          {"imsv1"},
+	"config":       {"rms"}, // config is named as Resource Management Service(RMS) before
 }
 
 // GetServiceDerivedCatalogKeys returns the derived catalog keys of a service.
@@ -480,7 +481,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Scope:            "global",
 		Version:          "v1",
 		WithOutProjectID: true,
-		Product:          "RMS",
+		Product:          "Config",
 	},
 	"organizations": {
 		Name:             "organizations",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 
Resource Management Service(RMS) has been changed to **Config**, we should update the subcategory
https://support.huaweicloud.com/rms/index.html

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
