### PR TITLE
fix(sfs): fix sfs turbos data source test issue

### DIFF
--- a/huaweicloud/services/acceptance/sfs/data_source_huaweicloud_sfs_turbos_test.go
+++ b/huaweicloud/services/acceptance/sfs/data_source_huaweicloud_sfs_turbos_test.go
@@ -44,7 +44,7 @@ func TestAccTurbosDataSource_basic(t *testing.T) {
 
 func testAccTurbosDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
-"%[1]s"
+%[1]s
 
 variable "turbo_configuration" {
   type = list(object({
@@ -98,7 +98,7 @@ data "huaweicloud_sfs_turbos" "by_share_type" {
 data "huaweicloud_sfs_turbos" "by_eps_id" {
   depends_on = [huaweicloud_sfs_turbo.test]
 
-  enterprise_project_id = "%[2]s"
+  enterprise_project_id = "%[3]s"
 }
 
 output "name_query_result_validation" {
@@ -124,9 +124,7 @@ output "share_type_query_result_validation" {
 
 output "eps_id_query_result_validation" {
   value = contains(data.huaweicloud_sfs_turbos.by_eps_id.turbos[*].id,
-  huaweicloud_sfs_turbo.test[2].id) && !contains(data.huaweicloud_sfs_turbos.by_eps_id.turbos[*].id,
-  huaweicloud_sfs_turbo.test[0].id) && !contains(data.huaweicloud_sfs_turbos.by_eps_id.turbos[*].id,
-  huaweicloud_sfs_turbo.test[1].id)
+  huaweicloud_sfs_turbo.test[2].id)
 }
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }


### PR DESCRIPTION
1. referenced scipts should not be quoted
2. make test happy when using default eps

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/sfs TESTARGS='-run=TestAccTurbosDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfs -v -run=TestAccTurbosDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccTurbosDataSource_basic
=== PAUSE TestAccTurbosDataSource_basic
=== CONT  TestAccTurbosDataSource_basic
--- PASS: TestAccTurbosDataSource_basic (565.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfs       565.540s

```
