### PR TITLE
feat(eg): add new resource connection

### DIFF
--- a/docs/resources/eg_connection.md
+++ b/docs/resources/eg_connection.md
@@ -1,0 +1,138 @@
+---
+subcategory: "EventGrid (EG)"
+---
+
+# huaweicloud_eg_connection
+
+Manages an EG connection resource within HuaweiCloud.
+
+## Example Usage
+
+### Connection with WEBHOOK
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "huaweicloud_eg_connection" "test" {
+  name        = "test"
+  vpc_id      = var.vpc_id
+  subnet_id   = var.subnet_id
+  description = "created by terraform"
+  type        = "WEBHOOK"
+}
+```
+
+### Connection with KAFKA
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "kafka_instance_id"
+variable "kafka_connect_address"
+
+resource "huaweicloud_eg_connection" "test" {
+  name        = "test"
+  vpc_id      = var.vpc_id
+  subnet_id   = var.subnet_id
+  description = "created by terraform"
+  type        = "KAFKA"
+
+  kafka_detail {
+    instance_id     = var.kafka_instance_id
+    connect_address = var.kafka_connect_address
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the connection.
+  The value can contain no more than 128 characters, including letters, digits, underscores (_), hyphens (-),
+  and periods (.), and must start with a character or letter.
+
+  Changing this parameter will create a new resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC to which the connection belongs.
+
+  Changing this parameter will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the subnet to which the connection belongs.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the connection.
+
+* `type` - (Optional, String, ForceNew) Specifies the type of the connection.
+  The value can be **WEBHOOK** and **KAFKA**. Defaults to **WEBHOOK**.
+
+  Changing this parameter will create a new resource.
+
+* `kafka_detail` - (Optional, List, ForceNew) Specifies the configuration details of the kafka intance.
+  This parameter is required when the `type` is set to **KAFKA**.
+
+  Changing this parameter will create a new resource.
+The [KafkaDetail](#Connection_KafkaDetail) structure is documented below.
+
+<a name="Connection_KafkaDetail"></a>
+The `KafkaDetail` block supports:
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the kafka intance.
+
+  Changing this parameter will create a new resource.
+
+* `connect_address` - (Required, String, ForceNew) Specifies the IP address of the kafka intance.
+
+  Changing this parameter will create a new resource.
+
+* `username` - (Optional, String, ForceNew) Specifies the username of the kafka intance.
+
+  Changing this parameter will create a new resource.
+
+* `password` - (Optional, String, ForceNew) Specifies the password of the kafka intance.
+
+  Changing this parameter will create a new resource.
+
+* `acks` - (Optional, String, ForceNew) Specifies the number of confirmation signals the procuder needs to receive
+  to consider the message sent successfully. The acks represents the availability of data backup.
+  The value can be:
+  + **0**: Indicates that the producer does not need to wait for any confirmation of received information,
+    the backup will be immediately added to the socket buffer and considered to have been sent.
+    There is no guarantee that the server has successfully received the data in this case,
+    and the retry configuration will not take effect and the feedback offset will always be set to -1.
+  
+  + **1**: Indicates that at least waiting for the leader to successfully write the data to the local log,
+    but not waiting for all followers to successfully write the data. If the follower fails to successfully
+    backup the data and the leader cannot provide services at this time, the message will be lost.
+
+  + **all**: Indicates that the leader needs to wait for all backups in the ISR to be successfully written to the log.
+    As long as any backup survives, the data will not be lost.
+
+  Defaults to **1**.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - Indicates the status of the connection.
+
+* `created_at` - The creation time of the connection.
+
+* `updated_at` - The last update time of the connection.
+
+## Import
+
+The connection can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_eg_connection.test 3ea117f5-1ea3-4c27-af7f-c12c737f2ca4
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -835,6 +835,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_eg_custom_event_source": eg.ResourceCustomEventSource(),
 			"huaweicloud_eg_endpoint":            eg.ResourceEndpoint(),
+			"huaweicloud_eg_connection":          eg.ResourceConnection(),
 
 			"huaweicloud_elb_certificate":     elb.ResourceCertificateV3(),
 			"huaweicloud_elb_l7policy":        elb.ResourceL7PolicyV3(),

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_connection_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_connection_test.go
@@ -1,0 +1,240 @@
+package eg
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getConnectionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getConnection: Query the EG Connection detail
+	var (
+		getConnectionHttpUrl = "v1/{project_id}/connections/{id}"
+		getConnectionProduct = "eg"
+	)
+	getConnectionClient, err := cfg.NewServiceClient(getConnectionProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EG client: %s", err)
+	}
+
+	getConnectionPath := getConnectionClient.Endpoint + getConnectionHttpUrl
+	getConnectionPath = strings.ReplaceAll(getConnectionPath, "{project_id}", getConnectionClient.ProjectID)
+	getConnectionPath = strings.ReplaceAll(getConnectionPath, "{id}", state.Primary.ID)
+
+	getConnectionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getConnectionResp, err := getConnectionClient.Request("GET", getConnectionPath, &getConnectionOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Connection: %s", err)
+	}
+
+	getConnectionRespBody, err := utils.FlattenResponse(getConnectionResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Connection: %s", err)
+	}
+
+	return getConnectionRespBody, nil
+}
+
+func TestAccConnection_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_eg_connection.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getConnectionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testConnection_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testConnection_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testConnection_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_eg_connection" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  description = "created by terraform"
+}
+`, common.TestVpc(name), name)
+}
+
+func testConnection_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_eg_connection" "test" {
+  name      = "%s"
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+}
+`, common.TestVpc(name), name)
+}
+
+func TestAccConnection_kafka(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_eg_connection.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getConnectionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testConnection_kafka(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(rName, "type", "KAFKA"),
+					resource.TestCheckResourceAttrPair(rName, "kafka_detail.0.instance_id",
+						"huaweicloud_dms_kafka_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "kafka_detail.0.connect_address",
+						"huaweicloud_dms_kafka_instance.test", "connect_address"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testConnection_kafka_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_dms_kafka_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results = data.huaweicloud_dms_kafka_flavors.test
+
+  flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
+}
+
+resource "huaweicloud_dms_kafka_instance" "test" {
+  name              = "%s"
+  vpc_id            = huaweicloud_vpc.test.id
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  flavor_id          = local.flavor.id
+  storage_spec_code  = local.flavor.ios[0].storage_spec_code
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[1],
+    data.huaweicloud_availability_zones.test.names[2]
+  ]
+  engine_version = element(local.query_results.versions, length(local.query_results.versions)-1)
+  storage_space  = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
+  broker_num     = 3
+
+  access_user        = "user"
+  password           = "Kafkatest@123"
+  manager_user       = "kafka-user"
+  manager_password   = "Kafkatest@123"
+  security_protocol  = "SASL_PLAINTEXT"
+  enabled_mechanisms = ["SCRAM-SHA-512"]
+
+  cross_vpc_accesses {
+    advertised_ip = ""
+  }
+  cross_vpc_accesses {
+    advertised_ip = "www.terraform-test.com"
+  }
+  cross_vpc_accesses {
+    advertised_ip = "192.168.0.53"
+  }
+}`, common.TestBaseNetwork(rName), rName)
+}
+
+func testConnection_kafka(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_eg_connection" "test" {
+  name        = "%s"
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  description = "created by terraform"
+  type        = "KAFKA"
+
+  kafka_detail {
+    instance_id     = huaweicloud_dms_kafka_instance.test.id
+    connect_address = huaweicloud_dms_kafka_instance.test.connect_address
+  }
+}
+`, testConnection_kafka_base(name), name)
+}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_connection.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_connection.go
@@ -1,0 +1,382 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product EG
+// ---------------------------------------------------------------
+
+package eg
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceConnection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceConnectionCreate,
+		UpdateContext: resourceConnectionUpdate,
+		ReadContext:   resourceConnectionRead,
+		DeleteContext: resourceConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of the connection.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the VPC to which the connection belongs.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the subnet to which the connection belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description of the connection.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the type of the connection.`,
+			},
+			"kafka_detail": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Elem:        connectionKafkaDetailSchema(),
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the configuration details of the kafka intance.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status of the connection.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the connection.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The last update time of the connection.`,
+			},
+		},
+	}
+}
+
+func connectionKafkaDetailSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the kafka intance.`,
+			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the IP address of the kafka intance.`,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the username of the kafka intance.`,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `Specifies the password of the kafka intance.`,
+			},
+			"acks": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: `Specifies the number of confirmation signals the procuder
+                    needs to receive to consider the message sent successfully.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createConnection: Create an EG Connection.
+	var (
+		createConnectionHttpUrl = "v1/{project_id}/connections"
+		createConnectionProduct = "eg"
+	)
+	createConnectionClient, err := cfg.NewServiceClient(createConnectionProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	createConnectionPath := createConnectionClient.Endpoint + createConnectionHttpUrl
+	createConnectionPath = strings.ReplaceAll(createConnectionPath, "{project_id}", createConnectionClient.ProjectID)
+
+	createConnectionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	createConnectionOpt.JSONBody = utils.RemoveNil(buildCreateConnectionBodyParams(d))
+	createConnectionResp, err := createConnectionClient.Request("POST", createConnectionPath, &createConnectionOpt)
+	if err != nil {
+		return diag.Errorf("error creating Connection: %s", err)
+	}
+
+	createConnectionRespBody, err := utils.FlattenResponse(createConnectionResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("id", createConnectionRespBody)
+	if err != nil {
+		return diag.Errorf("error creating Connection: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceConnectionRead(ctx, d, meta)
+}
+
+func buildCreateConnectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":         d.Get("name"),
+		"vpc_id":       d.Get("vpc_id"),
+		"subnet_id":    d.Get("subnet_id"),
+		"description":  utils.ValueIngoreEmpty(d.Get("description")),
+		"type":         utils.ValueIngoreEmpty(d.Get("type")),
+		"kafka_detail": buildCreateConnectionRequestBodyKafkaDetail(d.Get("kafka_detail")),
+	}
+	return bodyParams
+}
+
+func buildCreateConnectionRequestBodyKafkaDetail(rawParams interface{}) map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+		raw, ok := rawArray[0].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		params := map[string]interface{}{
+			"instance_id": utils.ValueIngoreEmpty(raw["instance_id"]),
+			"addr":        utils.ValueIngoreEmpty(raw["connect_address"]),
+			"acks":        utils.ValueIngoreEmpty(raw["acks"]),
+		}
+
+		if raw["username"].(string) != "" {
+			params["sasl_ssl"] = true
+			params["username"] = raw["username"]
+			params["password"] = raw["password"]
+		}
+		return params
+	}
+	return nil
+}
+
+func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getConnection: Query the EG Connection detail
+	var (
+		getConnectionHttpUrl = "v1/{project_id}/connections/{id}"
+		getConnectionProduct = "eg"
+	)
+	getConnectionClient, err := cfg.NewServiceClient(getConnectionProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	getConnectionPath := getConnectionClient.Endpoint + getConnectionHttpUrl
+	getConnectionPath = strings.ReplaceAll(getConnectionPath, "{project_id}", getConnectionClient.ProjectID)
+	getConnectionPath = strings.ReplaceAll(getConnectionPath, "{id}", d.Id())
+
+	getConnectionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getConnectionResp, err := getConnectionClient.Request("GET", getConnectionPath, &getConnectionOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Connection")
+	}
+
+	getConnectionRespBody, err := utils.FlattenResponse(getConnectionResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", getConnectionRespBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", getConnectionRespBody, nil)),
+		d.Set("subnet_id", utils.PathSearch("subnet_id", getConnectionRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getConnectionRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getConnectionRespBody, nil)),
+		d.Set("kafka_detail", flattenGetConnectionResponseBodyKafkaDetail(getConnectionRespBody)),
+		d.Set("status", utils.PathSearch("status", getConnectionRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("created_time", getConnectionRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_time", getConnectionRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetConnectionResponseBodyKafkaDetail(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson, err := jmespath.Search("kafka_detail", resp)
+	if err != nil {
+		log.Printf("[ERROR] error parsing kafka_detail from response= %#v", resp)
+		return rst
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"instance_id":     utils.PathSearch("instance_id", curJson, nil),
+			"connect_address": utils.PathSearch("addr", curJson, nil),
+			"sasl_ssl":        utils.PathSearch("sasl_ssl", curJson, nil),
+			"username":        utils.PathSearch("username", curJson, nil),
+			"password":        utils.PathSearch("password", curJson, nil),
+			"acks":            utils.PathSearch("acks", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateConnectionChanges := []string{
+		"description",
+	}
+
+	if d.HasChanges(updateConnectionChanges...) {
+		// updateConnection: Update the EG Connection.
+		var (
+			updateConnectionHttpUrl = "v1/{project_id}/connections/{id}"
+			updateConnectionProduct = "eg"
+		)
+		updateConnectionClient, err := cfg.NewServiceClient(updateConnectionProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating EG client: %s", err)
+		}
+
+		updateConnectionPath := updateConnectionClient.Endpoint + updateConnectionHttpUrl
+		updateConnectionPath = strings.ReplaceAll(updateConnectionPath, "{project_id}", updateConnectionClient.ProjectID)
+		updateConnectionPath = strings.ReplaceAll(updateConnectionPath, "{id}", d.Id())
+
+		updateConnectionOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+			MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		}
+
+		updateConnectionOpt.JSONBody = utils.RemoveNil(buildUpdateConnectionBodyParams(d))
+		_, err = updateConnectionClient.Request("PUT", updateConnectionPath, &updateConnectionOpt)
+		if err != nil {
+			return diag.Errorf("error updating Connection: %s", err)
+		}
+	}
+	return resourceConnectionRead(ctx, d, meta)
+}
+
+func buildUpdateConnectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"description": d.Get("description"),
+	}
+	return bodyParams
+}
+
+func resourceConnectionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteConnection: Delete an existing EG Connection
+	var (
+		deleteConnectionHttpUrl = "v1/{project_id}/connections/{id}"
+		deleteConnectionProduct = "eg"
+	)
+	deleteConnectionClient, err := cfg.NewServiceClient(deleteConnectionProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	deleteConnectionPath := deleteConnectionClient.Endpoint + deleteConnectionHttpUrl
+	deleteConnectionPath = strings.ReplaceAll(deleteConnectionPath, "{project_id}", deleteConnectionClient.ProjectID)
+	deleteConnectionPath = strings.ReplaceAll(deleteConnectionPath, "{id}", d.Id())
+
+	deleteConnectionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = deleteConnectionClient.Request("DELETE", deleteConnectionPath, &deleteConnectionOpt)
+	if err != nil {
+		return diag.Errorf("error deleting Connection: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run  TestAccConnection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run  TestAccConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (70.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        70.620s

make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run  TestAccConnection_kafka'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run  TestAccConnection_kafka -timeout 360m -parallel 4
=== RUN   TestAccConnection_kafka
=== PAUSE TestAccConnection_kafka
=== CONT  TestAccConnection_kafka
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting Subnet: timeout while waiting for state to become 'DELETED' (last state: 'ACTIVE', timeout: 10m0s)
        
--- FAIL: TestAccConnection_kafka (1345.35s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        1345.419s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1

This test failed because the subnet is occupied by kafka, but all check passed.
```
