### PR TITLE
feat(eg/channel): support a new resource and a related data source 

### DIFF
--- a/docs/data-sources/eg_custom_event_channels.md
+++ b/docs/data-sources/eg_custom_event_channels.md
@@ -1,0 +1,59 @@
+---
+subcategory: "EventGrid (EG)"
+---
+
+# huaweicloud_eg_custom_event_channels
+
+Use this data source to filter EG custom event channels within Huaweicloud.
+
+## Example Usage
+
+```hcl
+variable "channel_name" {}
+
+data "huaweicloud_eg_custom_event_channels" "test" {
+  name = var.channel_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the custom event channels are located.  
+  If omitted, the provider-level region will be used.
+
+* `channel_id` - (Optional, String) Specifies the channel ID used to query specified custom event channel.
+
+* `name` - (Optional, String) Specifies the channel name used to query specified custom event channel.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the custom event
+  channels belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `channels` - The filtered custom event channels.
+  The [channels](#eg_custom_event_channels) structure is documented below.
+
+<a name="eg_custom_event_channels"></a>
+The `channels` block supports:
+
+* `id` - The ID of the custom event channel.
+
+* `name` - The name of the custom event channel.
+
+* `description` - The description of the custom event channel.
+
+* `provider_type` - The type of the custom event channel.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the custom event channel belongs.
+
+* `cross_account_ids` - The list of domain IDs (other tenants) for the cross-account policy.
+
+* `created_at` - The creation time of the custom event channel.
+
+* `updated_at` - The latest update time of the custom event channel.

--- a/docs/resources/eg_custom_event_channel.md
+++ b/docs/resources/eg_custom_event_channel.md
@@ -1,0 +1,92 @@
+---
+subcategory: "EventGrid (EG)"
+---
+
+# huaweicloud_eg_custom_event_channel
+
+Using this resource to manage an EG custom event channel within Huaweicloud.
+
+## Example Usage
+
+### Manage a basic channel without enterprise project configuation
+
+```hcl
+variable "channel_name" {}
+
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name        = var.channel_name
+  description = "Created by script"
+}
+```
+
+### Manage a basic channel under default enterprise project
+
+```hcl
+variable "channel_name" {}
+
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name                  = var.channel_name
+  description           = "Created by script"
+  enterprise_project_id = "0"
+}
+```
+
+### Enable cross-account configuation
+
+```hcl
+variable "channel_name" {}
+variable "target_domain_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name              = var.channel_name
+  cross_account_ids = var.target_domain_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the custom event channel is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the custom event channel.  
+  The valid length is limited from `1` to `128`, only letters, digits, dots (.), hyphens (-) and underscores (_) are
+  allowed. The name must start with a letter or digit, and cannot be **default**.
+  Changing this will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the custom event channel.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the custom
+  event channel belongs.  
+  The enterprise project is not used by default. Changing this will create a new resource.
+
+* `cross_account_ids` - (Optional, List) Specifies the list of domain IDs (other tenants) for the cross-account policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `created_at` - The (UTC) creation time of the custom channel, in RFC3339 format.
+
+* `updated_at` - The (UTC) update time of the custom channel, in RFC3339 format.
+
+## Import
+
+Custom channels can be imported by their `id` and `enterprise_project_id` (with enterprise project association), e.g.
+
+### without enterprise project association
+
+```bash
+terraform import huaweicloud_eg_custom_event_channel.test <id>
+```
+
+### with enterprise project association
+
+```bash
+terraform import huaweicloud_eg_custom_event_channel.test <id>/<enterprise_project_id>
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62
+	github.com/chnsz/golangsdk v0.0.0-20230925044853-f318769d238e
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62 h1:GmvpNqRqlUfhbjqZvBBiq5ZFSZqH8IuX2hnenJbaNi0=
-github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230925044853-f318769d238e h1:oAYOPbT7fqNGaluE2v3TbgsUSG9KyXdZg8zj+FGgbK8=
+github.com/chnsz/golangsdk v0.0.0-20230925044853-f318769d238e/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -454,7 +454,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_zones":      dns.DataSourceZones(),
 			"huaweicloud_dns_recordsets": dns.DataSourceRecordsets(),
 
-			"huaweicloud_eg_custom_event_sources": eg.DataSourceCustomEventSources(),
+			"huaweicloud_eg_custom_event_channels": eg.DataSourceCustomEventChannels(),
+			"huaweicloud_eg_custom_event_sources":  eg.DataSourceCustomEventSources(),
 
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -835,9 +835,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_snapshot_policy":    dws.ResourceDwsSnapshotPolicy(),
 			"huaweicloud_dws_ext_data_source":    dws.ResourceDwsExtDataSource(),
 
-			"huaweicloud_eg_custom_event_source": eg.ResourceCustomEventSource(),
-			"huaweicloud_eg_endpoint":            eg.ResourceEndpoint(),
-			"huaweicloud_eg_connection":          eg.ResourceConnection(),
+			"huaweicloud_eg_connection":           eg.ResourceConnection(),
+			"huaweicloud_eg_custom_event_channel": eg.ResourceCustomEventChannel(),
+			"huaweicloud_eg_custom_event_source":  eg.ResourceCustomEventSource(),
+			"huaweicloud_eg_endpoint":             eg.ResourceEndpoint(),
 
 			"huaweicloud_elb_certificate":     elb.ResourceCertificateV3(),
 			"huaweicloud_elb_l7policy":        elb.ResourceL7PolicyV3(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_custom_event_channels_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_custom_event_channels_test.go
@@ -1,0 +1,241 @@
+package eg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataCustomEventChannels_basic(t *testing.T) {
+	var (
+		baseRes      = "huaweicloud_eg_custom_event_channel.test"
+		byName       = "data.huaweicloud_eg_custom_event_channels.filter_by_name"
+		nameNotFound = "data.huaweicloud_eg_custom_event_channels.name_not_found"
+
+		obj            custom.Channel
+		rc             = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventChannelFunc)
+		dcByName       = acceptance.InitDataSourceCheck(byName)
+		dcNameNotFound = acceptance.InitDataSourceCheck(nameNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCustomEventChannels_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("name_not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCustomEventChannels_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name = "%[1]s"
+}
+`, name)
+}
+
+func testAccDataCustomEventChannels_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+data "huaweicloud_eg_custom_event_channels" "filter_by_name" {
+  // The behavior of parameter 'name' of the resource is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_eg_custom_event_channel.test,
+  ]
+
+  name = huaweicloud_eg_custom_event_channel.test.name
+}
+
+data "huaweicloud_eg_custom_event_channels" "name_not_found" {
+  // Since a specified name is used, there is no dependency relationship with resource attachment, and the dependency
+  // needs to be manually set.
+  depends_on = [
+    huaweicloud_eg_custom_event_channel.test,
+  ]
+
+  name = "resource_not_found"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_eg_custom_event_channels.filter_by_name.channels[*].id :
+                   v == huaweicloud_eg_custom_event_channel.test.id]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "name_not_found_validation_pass" {
+  value = length(data.huaweicloud_eg_custom_event_channels.name_not_found.channels) == 0
+}
+`, testAccDataCustomEventChannels_base())
+}
+
+func TestAccDataCustomEventChannels_filterById(t *testing.T) {
+	var (
+		baseRes    = "huaweicloud_eg_custom_event_channel.test"
+		byId       = "data.huaweicloud_eg_custom_event_channels.filter_by_id"
+		idNotFound = "data.huaweicloud_eg_custom_event_channels.id_not_found"
+
+		obj          custom.Channel
+		rc           = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventChannelFunc)
+		dcById       = acceptance.InitDataSourceCheck(byId)
+		dcIdNotFound = acceptance.InitDataSourceCheck(idNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCustomEventChannels_filterById(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					dcIdNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("id_not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCustomEventChannels_filterById() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_eg_custom_event_channels" "filter_by_id" {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+}
+
+data "huaweicloud_eg_custom_event_channels" "id_not_found" {
+  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_eg_custom_event_channel.test,
+  ]
+
+  channel_id = "%[2]s"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_eg_custom_event_channels.filter_by_id.channels[*].id :
+                   v == huaweicloud_eg_custom_event_channel.test.id]
+}
+
+output "is_id_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "id_not_found_validation_pass" {
+  value = length(data.huaweicloud_eg_custom_event_channels.id_not_found.channels) == 0
+}
+`, testAccDataCustomEventChannels_base(), randUUID)
+}
+
+func TestAccDataCustomEventChannels_filterByEpsId(t *testing.T) {
+	var (
+		baseRes           = "huaweicloud_eg_custom_event_channel.test"
+		byChannelId       = "data.huaweicloud_eg_custom_event_channels.filter_by_eps_id"
+		channelIdNotFound = "data.huaweicloud_eg_custom_event_channels.eps_id_not_found"
+
+		obj             custom.Channel
+		rc              = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventChannelFunc)
+		dcByEpsId       = acceptance.InitDataSourceCheck(byChannelId)
+		dcEpsIdNotFound = acceptance.InitDataSourceCheck(channelIdNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCustomEventChannels_filterByEpsId(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					dcByEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+					dcEpsIdNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("eps_id_not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCustomEventChannels_base_withEpsId() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDataCustomEventChannels_filterByEpsId() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_eg_custom_event_channels" "filter_by_eps_id" {
+  // The behavior of parameter 'channel_id' of the resource is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_eg_custom_event_channel.test,
+  ]
+
+  enterprise_project_id = "%[2]s"
+}
+
+data "huaweicloud_eg_custom_event_channels" "eps_id_not_found" {
+  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_eg_custom_event_channel.test,
+  ]
+
+  enterprise_project_id = "%[3]s"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_eg_custom_event_channels.filter_by_eps_id.channels[*].enterprise_project_id : v == "%[2]s"]
+}
+
+output "is_eps_id_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "eps_id_not_found_validation_pass" {
+  value = length(data.huaweicloud_eg_custom_event_channels.eps_id_not_found.channels) == 0
+}
+`, testAccDataCustomEventChannels_base_withEpsId(), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, randUUID)
+}

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_custom_event_channel_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_custom_event_channel_test.go
@@ -1,0 +1,205 @@
+package eg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getCustomEventChannelFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.EgV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	return custom.Get(client, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"])
+}
+
+// Without enterprise project association (Notes: not default enterprise project)
+func TestAccCustomEventChannel_basic(t *testing.T) {
+	var (
+		obj custom.Channel
+
+		rName = "huaweicloud_eg_custom_event_channel.test"
+		name  = acceptance.RandomAccResourceName()
+		rc    = acceptance.InitResourceCheck(rName, &obj, getCustomEventChannelFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomEventChannel_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acceptance test"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				Config: testAccCustomEventChannel_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.#", "2"),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.0", "account1"),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.1", "account2"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				// Restored test.
+				Config: testAccCustomEventChannel_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acceptance test"),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.#", "0"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCustomEventChannel_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name        = "%[1]s"
+  description = "Created by acceptance test"
+}
+`, name)
+}
+
+func testAccCustomEventChannel_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name              = "%[1]s"
+  cross_account_ids = ["account1", "account2"]
+}
+`, name)
+}
+
+func testAccCustomEventChannel_basic_step3(name string) string {
+	// Test whether the relevant parameter configuration of the resource can be restored.
+	return testAccCustomEventChannel_basic_step1(name)
+}
+
+func TestAccCustomEventChannel_withEpsId(t *testing.T) {
+	var (
+		obj custom.Channel
+
+		rName = "huaweicloud_eg_custom_event_channel.test"
+		name  = acceptance.RandomAccResourceName()
+		rc    = acceptance.InitResourceCheck(rName, &obj, getCustomEventChannelFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomEventChannel_withEpsId_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acceptance test"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				Config: testAccCustomEventChannel_withEpsId_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.#", "2"),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.0", "account1"),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.1", "account2"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccCustomEventChannel_withEpsId_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acceptance test"),
+					resource.TestCheckResourceAttr(rName, "cross_account_ids.#", "0"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCustomEventChannelImportIdWithEpsIdFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccCustomEventChannelImportIdWithEpsIdFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		channelId := rs.Primary.ID
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if channelId == "" || epsId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID (custom event channel with enterprise "+
+				"project associated), want '<id>/<enterprise_project_id>', but got '%s/%s'",
+				channelId, epsId)
+		}
+		return fmt.Sprintf("%s/%s", channelId, epsId), nil
+	}
+}
+
+func testAccCustomEventChannel_withEpsId_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name                  = "%[1]s"
+  description           = "Created by acceptance test"
+  enterprise_project_id = "%[2]s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccCustomEventChannel_withEpsId_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name                  = "%[1]s"
+  cross_account_ids     = ["account1", "account2"]
+  enterprise_project_id = "%[2]s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccCustomEventChannel_withEpsId_step3(name string) string {
+	// Test whether the relevant parameter configuration of the resource can be restored.
+	return testAccCustomEventChannel_withEpsId_step1(name)
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -1,0 +1,171 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceCustomEventChannels() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCustomEventChannelsRead,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region where the custom event channels are located.",
+			},
+			"channel_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The channel ID used to query specified custom event channel.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The channel name used to query specified custom event channel.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the enterprise project to which the custom event channels belong.",
+			},
+			"channels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the custom event channel.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the custom event channel.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the custom event channel.",
+						},
+						"provider_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the custom event channel.",
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the enterprise project to which the custom event channel belongs.",
+						},
+						"cross_account_ids": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: "The list of domain IDs (other tenants) for the cross-account policy.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the custom event channel.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The latest update time of the custom event channel.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func filterCustomEventChannels(channels []custom.Channel, epsId string) ([]interface{}, error) {
+	filter := map[string]interface{}{
+		"EnterpriseProjectId": epsId,
+	}
+
+	filterResult, err := utils.FilterSliceWithField(channels, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error filting list of custom event channels: %s", err)
+	}
+	return filterResult, nil
+}
+
+func flattenCustomEventChannels(channels []interface{}) []map[string]interface{} {
+	if len(channels) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(channels))
+	for i, val := range channels {
+		channel := val.(custom.Channel)
+		result[i] = map[string]interface{}{
+			"id":                    channel.ID,
+			"name":                  channel.Name,
+			"provider_type":         channel.ProviderType,
+			"enterprise_project_id": channel.EnterpriseProjectId,
+			"cross_account_ids":     channel.Policy.Principal.IAM,
+			"created_at":            channel.CreatedTime,
+			"updated_at":            channel.UpdatedTime,
+		}
+	}
+	return result
+}
+
+func dataSourceCustomEventChannelsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		opts   = custom.ListOpts{
+			ChannelId:    d.Get("channel_id").(string),
+			ProviderType: "CUSTOM",
+			Name:         d.Get("name").(string),
+		}
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	resp, err := custom.List(client, opts)
+	if err != nil {
+		return diag.Errorf("error querying custom event channels: %s", err)
+	}
+	filterResult, err := filterCustomEventChannels(resp, cfg.GetEnterpriseProjectID(d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("channels", flattenCustomEventChannels(filterResult)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving data source fields of EG custom event channels: %s", err)
+	}
+	return nil
+}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_custom_event_channel.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_custom_event_channel.go
@@ -1,0 +1,240 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceCustomEventChannel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCustomEventChannelCreate,
+		ReadContext:   resourceCustomEventChannelRead,
+		UpdateContext: resourceCustomEventChannelUpdate,
+		DeleteContext: resourceCustomEventChannelDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceChannelImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the custom event channel is located.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the custom event channel.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the custom event channel.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The ID of the enterprise project to which the custom event channel belongs.",
+			},
+			"cross_account_ids": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The list of domain IDs (other tenants) for the cross-account policy.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the custom event channel.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the custom event channel.",
+			},
+		},
+	}
+}
+
+func buildCustomEventChannelCreateOpts(d *schema.ResourceData, region, domainId, epsId string) (*custom.CreateOpts, error) {
+	var (
+		channelName = d.Get("name").(string)
+		result      = custom.CreateOpts{
+			Name:                channelName,
+			Description:         d.Get("description").(string),
+			EnterpriseProjectId: epsId,
+		}
+	)
+
+	if accountIds, ok := d.GetOk("cross_account_ids"); ok {
+		if domainId == "" {
+			return nil, fmt.Errorf("unable to find the domain ID, please check whether the 'domain_id' is " +
+				"configured in your script or IAM query agency is allowed")
+		}
+		result.CrossAccount = utils.Bool(true)
+		result.Policy = &custom.CrossAccountPolicy{
+			Sid:    "allow_account_to_put_events",
+			Effect: "Allow",
+			Principal: custom.PrincipalInfo{
+				IAM: utils.ExpandToStringListBySet(accountIds.(*schema.Set)),
+			},
+			Action:   "eg:channels:putEvents",
+			Resource: fmt.Sprintf("urn:eg:%s:%s:channel:%s", region, domainId, channelName),
+		}
+	}
+
+	return &result, nil
+}
+
+func resourceCustomEventChannelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	opts, err := buildCustomEventChannelCreateOpts(d, region, cfg.DomainID, cfg.GetEnterpriseProjectID(d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	resp, err := custom.Create(client, *opts)
+	if err != nil {
+		return diag.Errorf("error creating custom event channel: %s", err)
+	}
+	d.SetId(resp.ID)
+	return resourceCustomEventChannelRead(ctx, d, meta)
+}
+
+func resourceCustomEventChannelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		channelId = d.Id()
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	resp, err := custom.Get(client, channelId, cfg.GetEnterpriseProjectID(d))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "custom event channel")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
+		d.Set("cross_account_ids", resp.Policy.Principal.IAM),
+		d.Set("created_at", resp.CreatedTime),
+		d.Set("updated_at", resp.UpdatedTime),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving EG custom event channel (%s) fields: %s", channelId, err)
+	}
+	return nil
+}
+
+func buildCustomEventChannelUpdateOpts(d *schema.ResourceData, region, domainId, epsId string) (*custom.UpdateOpts, error) {
+	result := custom.UpdateOpts{
+		ChannelId:           d.Id(),
+		Description:         utils.String(d.Get("description").(string)),
+		EnterpriseProjectId: epsId,
+	}
+
+	if accountIds, ok := d.GetOk("cross_account_ids"); ok {
+		if domainId == "" {
+			return nil, fmt.Errorf("unable to find the domain ID, please check whether the 'domain_id' is " +
+				"configured in your script or IAM query agency is allowed")
+		}
+		result.CrossAccount = utils.Bool(true)
+		result.Policy = &custom.CrossAccountPolicy{
+			Sid:    "allow_account_to_put_events",
+			Effect: "Allow",
+			Principal: custom.PrincipalInfo{
+				IAM: utils.ExpandToStringListBySet(accountIds.(*schema.Set)),
+			},
+			Action:   "eg:channels:putEvents",
+			Resource: fmt.Sprintf("urn:eg:%s:%s:channel:%s", region, domainId, d.Get("name").(string)),
+		}
+	}
+
+	return &result, nil
+}
+
+func resourceCustomEventChannelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	opts, err := buildCustomEventChannelUpdateOpts(d, region, cfg.DomainID, cfg.GetEnterpriseProjectID(d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	_, err = custom.Update(client, *opts)
+	if err != nil {
+		return diag.Errorf("error updating custom event channel (%s): %s", d.Id(), err)
+	}
+	return resourceCustomEventChannelRead(ctx, d, meta)
+}
+
+func resourceCustomEventChannelDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		channelId = d.Id()
+	)
+	client, err := cfg.EgV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EG v1 client: %s", err)
+	}
+
+	err = custom.Delete(client, channelId, cfg.GetEnterpriseProjectID(d))
+	if err != nil {
+		return diag.Errorf("error deleting custom event channel (%s): %s", channelId, err)
+	}
+	return nil
+}
+
+func resourceChannelImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	var (
+		err      error
+		importId = d.Id()
+		parts    = strings.Split(importId, "/")
+	)
+	if len(parts) < 1 || len(parts) > 2 {
+		return nil, fmt.Errorf("invalid resource ID format for EG channel, want 'id' (without enterprise project "+
+			"association) or '<id>/<enterprise_project_id>' (with enterprise project association), but got '%s'", importId)
+	}
+	d.SetId(parts[0])
+	if len(parts) > 1 {
+		err = d.Set("enterprise_project_id", parts[1])
+	}
+	return []*schema.ResourceData{d}, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom/requests.go
@@ -1,0 +1,175 @@
+package custom
+
+import (
+	"fmt"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create a new custom channel.
+type CreateOpts struct {
+	// The name of the custom channel.
+	Name string `json:"name" required:"true"`
+	// The description of the custom channel.
+	Description string `json:"description,omitempty"`
+	// The ID of the enterprise project to which the custom channel belongs.
+	EnterpriseProjectId string `json:"eps_id,omitempty" q:"enterprise_project_id"`
+	// Whether enable cross-account configuration.
+	CrossAccount *bool `json:"cross_account,omitempty"`
+	// The event policy of the cross-account.
+	Policy *CrossAccountPolicy `json:"policy,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method used to create a new custom channel using given parameters.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Channel, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	url := rootURL(client)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var r Channel
+	_, err = client.Post(url, b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Get is a method to query an existing channel by its ID.
+func Get(client *golangsdk.ServiceClient, channelId, epsId string) (*Channel, error) {
+	var r Channel
+	url := resourceURL(client, channelId)
+	if epsId != "" {
+		url = fmt.Sprintf("%s?enterprise_project_id=%s", url, epsId)
+	}
+	_, err := client.Get(url, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// ListOpts is the structure used to query channel list.
+type ListOpts struct {
+	// The ID of the event channel to which the channel belongs.
+	ChannelId string `q:"channel_id"`
+	// The ID of the enterprise project to which the custom channel belongs.
+	EnterpriseProjectId string `q:"enterprise_project_id"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0.
+	// The valid value ranges from 0 to 100, defaults to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	// The valid value ranges from 1 to 1000, defaults to 15.
+	Limit int `q:"limit"`
+	// The query sorting.
+	// The default value is 'created_time:DESC'.
+	Sort string `q:"sort"`
+	// The type of the channel provider.
+	// + OFFICIAL: official cloud service channel.
+	// + CUSTOM: the user-defined channel.
+	// + PARTNER: partner channel.
+	ProviderType string `q:"provider_type"`
+	// The name of the channel.
+	Name string `q:"name"`
+	// The fuzzy name of the channel.
+	FuzzyName string `q:"fuzzy_name"`
+}
+
+// List is a method to query the channel list using given parameters.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Channel, error) {
+	url := rootURL(client)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := ChannelPage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractChannels(pages)
+}
+
+// UpdateOpts is the structure used to update an existing custom channel.
+type UpdateOpts struct {
+	// The ID of the channel.
+	ChannelId string `json:"-" required:"true"`
+	// The description of the channel.
+	Description *string `json:"description,omitempty"`
+	// Whether enable cross-account configuration.
+	CrossAccount *bool `json:"cross_account,omitempty"`
+	// The event policy of the cross-account.
+	Policy *CrossAccountPolicy `json:"policy,omitempty"`
+	// The ID of the enterprise project to which the custom channel belongs.
+	// Notes: this parameter does not support update, but it is required for request body and query parameter.
+	EnterpriseProjectId string `json:"eps_id,omitempty" q:"enterprise_project_id"`
+}
+
+// CrossAccountPolicy is the structure that represents the cross-account policy.
+type CrossAccountPolicy struct {
+	// The SID of the cross-account policy.
+	Sid string `json:"Sid"`
+	// The effect of the cross-account policy.
+	// + Allow
+	// + Deny
+	Effect string `json:"Effect"`
+	// The configuration of the IAM account.
+	Principal PrincipalInfo `json:"Principal"`
+	// The action of the cross-account policy, such as 'eg:channels:putEvents'.
+	Action string `json:"Action"`
+	// The URN of the custom channel.
+	// The format is 'urn:eg:{region}:{domain_id}:channel:{channel_name}'
+	// Before channel created, the channel name is empty.
+	Resource string `json:"Resource"`
+}
+
+// PrincipalInfo is the structure that represents the domain ID list of the cross-account policy.
+type PrincipalInfo struct {
+	// The account IDs.
+	IAM []string `json:"IAM"`
+}
+
+// Update is a method used to modify an existing custom channel using given parameters.
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Channel, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	url := resourceURL(client, opts.ChannelId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var r Channel
+	_, err = client.Put(url, b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// Delete is a method to delete an existing custom channel using its ID.
+func Delete(client *golangsdk.ServiceClient, channelId, epsId string) error {
+	url := resourceURL(client, channelId)
+	if epsId != "" {
+		url = fmt.Sprintf("%s?enterprise_project_id=%s", url, epsId)
+	}
+	_, err := client.Delete(url, nil)
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom/results.go
@@ -1,0 +1,44 @@
+package custom
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// Channel is the structure that represents the channel detail.
+type Channel struct {
+	// The ID of the channel.
+	ID string `json:"id"`
+	// The name of the channel.
+	Name string `json:"name"`
+	// The description of the channel.
+	Description string `json:"description"`
+	// The type of the channel provider.
+	// + OFFICIAL: official cloud service channel.
+	// + CUSTOM: the user-defined channel.
+	// + PARTNER: partner channel.
+	ProviderType string `json:"provider_type"`
+	// The ID of the enterprise project to which the custom channel belongs.
+	EnterpriseProjectId string `json:"eps_id"`
+	// The creation time, in UTC format.
+	CreatedTime string `json:"created_time"`
+	// The update time, in UTC format.
+	UpdatedTime string `json:"updated_time"`
+	// The cross-account policy configuration.
+	Policy CrossAccountPolicy `json:"policy"`
+}
+
+// ChannelPage is a single page maximum result representing a query by offset page.
+type ChannelPage struct {
+	pagination.OffsetPageBase
+}
+
+// IsEmpty checks whether a ChannelPage struct is empty.
+func (b ChannelPage) IsEmpty() (bool, error) {
+	arr, err := ExtractChannels(b)
+	return len(arr) == 0, err
+}
+
+// ExtractChannels is a method to extract the list of custom channels.
+func ExtractChannels(r pagination.Page) ([]Channel, error) {
+	var s []Channel
+	err := r.(ChannelPage).Result.ExtractIntoSlicePtr(&s, "items")
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom/urls.go
@@ -1,0 +1,11 @@
+package custom
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("channels")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, channelId string) string {
+	return c.ServiceURL("channels", channelId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20230913091123-7efd2a044f62
+# github.com/chnsz/golangsdk v0.0.0-20230925044853-f318769d238e
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -143,6 +143,7 @@ github.com/chnsz/golangsdk/openstack/ecs/v1/flavors
 github.com/chnsz/golangsdk/openstack/ecs/v1/jobs
 github.com/chnsz/golangsdk/openstack/ecs/v1/powers
 github.com/chnsz/golangsdk/openstack/ecs/v1/servergroups
+github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom
 github.com/chnsz/golangsdk/openstack/eg/v1/source/custom
 github.com/chnsz/golangsdk/openstack/elb/v2/certificates
 github.com/chnsz/golangsdk/openstack/elb/v2/l7policies


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The EG service support the APIs of custom event channel management.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new resource and a related data source
2. support related documents and acceptance tests.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccCustomEventChannel_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccCustomEventChannel_ -timeout 360m -parallel 4
=== RUN   TestAccCustomEventChannel_basic
=== PAUSE TestAccCustomEventChannel_basic
=== RUN   TestAccCustomEventChannel_withEpsId
=== PAUSE TestAccCustomEventChannel_withEpsId
=== CONT  TestAccCustomEventChannel_basic
=== CONT  TestAccCustomEventChannel_withEpsId
--- PASS: TestAccCustomEventChannel_basic (36.50s)
--- PASS: TestAccCustomEventChannel_withEpsId (36.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        36.660s
```
```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccDataCustomEventChannels_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccDataCustomEventChannels_ -timeout 360m -parallel 4
=== RUN   TestAccDataCustomEventChannels_basic
=== PAUSE TestAccDataCustomEventChannels_basic
=== RUN   TestAccDataCustomEventChannels_filterById
=== PAUSE TestAccDataCustomEventChannels_filterById
=== RUN   TestAccDataCustomEventChannels_filterByEpsId
=== PAUSE TestAccDataCustomEventChannels_filterByEpsId
=== CONT  TestAccDataCustomEventChannels_basic
=== CONT  TestAccDataCustomEventChannels_filterByEpsId
=== CONT  TestAccDataCustomEventChannels_filterById
--- PASS: TestAccDataCustomEventChannels_filterById (15.55s)
--- PASS: TestAccDataCustomEventChannels_filterByEpsId (15.56s)
--- PASS: TestAccDataCustomEventChannels_basic (15.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        15.677s
```
