### PR TITLE
feat(LTS): add new resource lts aom access

### DIFF
--- a/docs/resources/lts_aom_access.md
+++ b/docs/resources/lts_aom_access.md
@@ -1,0 +1,156 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# huaweicloud_lts_aom_access
+
+Manages an AOM to LTS log mapping rule resource within HuaweiCloud.
+
+-> The resource of connecting AOM logs to LTS is currently restricted. Please submit a service ticket to open this
+feature for you. Refer to
+[How to submit a service ticket](https://support.huaweicloud.com/intl/en-us/usermanual-ticket/topic_0065264094.html).
+
+## Example Usage
+
+### Creating with all workloads
+
+```hcl
+variable "cluster_id" {}
+variable "cluster_name" {}
+variable "log_group_id" {}
+variable "log_group_name" {}
+variable "log_stream_id" {}
+variable "log_stream_name" {}
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name         = "test_name"
+  cluster_id   = var.cluster_id
+  cluster_name = var.cluster_name
+  namespace    = "default"
+  workloads    = ["__ALL_DEPLOYMENTS__"]
+  
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+
+  access_rules {
+    file_name       = "/demo/demo.log"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+}
+```
+
+### Creating with specify workloads
+
+```hcl
+variable "cluster_id" {}
+variable "cluster_name" {}
+variable "log_group_id" {}
+variable "log_group_name" {}
+variable "log_stream_id" {}
+variable "log_stream_name" {}
+variable "workload" {}
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name         = "test_name"
+  cluster_id   = var.cluster_id
+  cluster_name = var.cluster_name
+  namespace    = "default"
+  workloads    = [var.workload]
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+}
+```
+
+### Creating with CCI cluster
+
+```hcl
+variable "log_group_id" {}
+variable "log_group_name" {}
+variable "log_stream_id" {}
+variable "log_stream_name" {}
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name         = "test_name"
+  cluster_id   = "CCI-ClusterID"
+  cluster_name = "CCI-Cluster"
+  namespace    = "default"
+  workloads    = ["__ALL_DEPLOYMENTS__"]
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = var.log_group_id
+    log_group_name  = var.log_group_name
+    log_stream_id   = var.log_stream_id
+    log_stream_name = var.log_stream_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the unique rule name. The name consists of 1 to 100 characters,
+  including letters, digits, underscores (_), hyphens (-) and dots (.).
+
+* `cluster_id` - (Required, String) Specifies the CCE or CCI cluster ID. It is fixed to **CCI-ClusterID** for CCI.
+
+* `cluster_name` - (Required, String) Specifies the CCE or CCI cluster name. It is fixed to **CCI-Cluster** for CCI.
+
+* `namespace` - (Required, String) Specifies the namespace.
+
+* `workloads` - (Required, List) Specifies the workloads.
+  + When creating with all workloads, this field should be `["__ALL_DEPLOYMENTS__"]`.
+  + When creating with specify workloads, this field should be the list of workloads.
+
+* `access_rules` - (Required, List) Specifies the access log details.
+The [access_rules](#AOMAccess_access_rules) structure is documented below.
+
+* `container_name` - (Optional, String) Specifies the container name.
+
+<a name="AOMAccess_access_rules"></a>
+The `access_rules` block supports:
+
+* `file_name` - (Required, String) Specifies the path name.
+  + When collecting access all logs, set this field to `__ALL_FILES__`.
+  + When collecting specify log paths, the matching rule should be `^\/[A-Za-z0-9.*_\/-]+|stdout\.log|`, such as
+  `/test/*` or `/test/demo.log`. Up to two asterisks (*) are allowed.
+
+* `log_group_id` - (Required, String) Specifies the log group ID.
+
+* `log_group_name` - (Required, String) Specifies the log group name.
+
+* `log_stream_id` - (Required, String) Specifies the log stream ID.
+
+* `log_stream_name` - (Required, String) Specifies the log stream name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The AOM to LTS log mapping rule can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_lts_aom_access.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -965,6 +965,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_live_snapshot":             live.ResourceLiveSnapshot(),
 			"huaweicloud_live_bucket_authorization": live.ResourceLiveBucketAuthorization(),
 
+			"huaweicloud_lts_aom_access": lts.ResourceAOMAccess(),
 			"huaweicloud_lts_group":      lts.ResourceLTSGroup(),
 			"huaweicloud_lts_stream":     lts.ResourceLTSStream(),
 			"huaweicloud_lts_host_group": lts.ResourceHostGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -140,6 +140,12 @@ var (
 
 	// The cluster ID of the CCE
 	HW_CCE_CLUSTER_ID = os.Getenv("HW_CCE_CLUSTER_ID")
+	// The cluster name of the CCE
+	HW_CCE_CLUSTER_NAME = os.Getenv("HW_CCE_CLUSTER_NAME")
+	// The cluster ID of the CCE
+	HW_CCE_CLUSTER_ID_ANOTHER = os.Getenv("HW_CCE_CLUSTER_ID_ANOTHER")
+	// The cluster name of the CCE
+	HW_CCE_CLUSTER_NAME_ANOTHER = os.Getenv("HW_CCE_CLUSTER_NAME_ANOTHER")
 	// The partition az of the CCE
 	HW_CCE_PARTITION_AZ = os.Getenv("HW_CCE_PARTITION_AZ")
 	// The namespace of the workload is located
@@ -821,5 +827,20 @@ func TestAccPreCheckModelArtsHasSubscribeModel(t *testing.T) {
 func TestAccPreCheckEgChannelId(t *testing.T) {
 	if HW_EG_CHANNEL_ID == "" {
 		t.Skip("The sub-resource acceptance test of the EG channel must set 'HW_EG_CHANNEL_ID'")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsAomAccess(t *testing.T) {
+	if HW_CCE_CLUSTER_ID == "" || HW_CCE_CLUSTER_NAME == "" {
+		t.Skip("HW_CCE_CLUSTER_ID and HW_CCE_CLUSTER_NAME must be set for LTS AOM access acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsAomAccessUpdate(t *testing.T) {
+	if HW_CCE_CLUSTER_ID_ANOTHER == "" || HW_CCE_CLUSTER_NAME_ANOTHER == "" {
+		t.Skip("HW_CCE_CLUSTER_ID_ANOTHER and HW_CCE_CLUSTER_NAME_ANOTHER must be set for LTS AOM access" +
+			" acceptance tests")
 	}
 }

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_aom_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_aom_access_test.go
@@ -1,0 +1,389 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAOMAccessResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/lts/aom-mapping/{rule_id}"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// there is no special error code here
+		return nil, fmt.Errorf("error retrieving AOM to LTS log mapping rule: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	arrayBody, ok := getRespBody.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error retrieving AOM to LTS log mapping rule: the API response is not array")
+	}
+	if len(arrayBody) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return arrayBody[0], nil
+}
+
+func TestAccAOMAccess_allWorkloads(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_lts_aom_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAOMAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsAomAccess(t)
+			acceptance.TestAccPreCheckLtsAomAccessUpdate(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMAccess_allWorkloads(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_CCE_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(rName, "namespace", "default"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/*"),
+					resource.TestCheckResourceAttr(rName, "access_rules.1.file_name", "/demo/demo.log"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_id",
+						"huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_name",
+						"huaweicloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_id",
+						"huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_name",
+						"huaweicloud_lts_stream.test", "stream_name"),
+				),
+			},
+			{
+				Config: testAOMAccess_allWorkloads_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CCE_CLUSTER_ID_ANOTHER),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_CCE_CLUSTER_NAME_ANOTHER),
+					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/update/*"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAOMAccess_specifyWorkloads(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_lts_aom_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAOMAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsAomAccess(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMAccess_specifyWorkloads(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_CCE_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(rName, "namespace", "default"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_1"),
+					resource.TestCheckResourceAttr(rName, "workloads.1", "WORKLOAD_2"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "__ALL_FILES__"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_id",
+						"huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_name",
+						"huaweicloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_id",
+						"huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_name",
+						"huaweicloud_lts_stream.test", "stream_name"),
+				),
+			},
+			{
+				Config: testAOMAccess_specifyWorkloads_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_3"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/*"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAOMAccess_withCCICluster(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_lts_aom_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAOMAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAOMAccess_withCCICluster(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", "CCI-ClusterID"),
+					resource.TestCheckResourceAttr(rName, "cluster_name", "CCI-Cluster"),
+					resource.TestCheckResourceAttr(rName, "namespace", "default"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "__ALL_FILES__"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_id",
+						"huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_group_name",
+						"huaweicloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_id",
+						"huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "access_rules.0.log_stream_name",
+						"huaweicloud_lts_stream.test", "stream_name"),
+				),
+			},
+			{
+				Config: testAOMAccess_withCCICluster_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
+					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_3"),
+					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
+					resource.TestCheckResourceAttr(rName, "access_rules.0.file_name", "/test/*"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAOMAccess_allWorkloads(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name           = "%[2]s"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "default"
+  workloads      = ["__ALL_DEPLOYMENTS__"]
+  container_name = "test_container"
+
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+
+  access_rules {
+    file_name       = "/demo/demo.log"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+}
+
+func testAOMAccess_allWorkloads_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name           = "%[2]s_update"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "test_namespace"
+  workloads      = ["__ALL_DEPLOYMENTS__"]
+  container_name = "test_container_update"
+
+  access_rules {
+    file_name       = "/test/update/*"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID_ANOTHER, acceptance.HW_CCE_CLUSTER_NAME_ANOTHER)
+}
+
+func testAOMAccess_specifyWorkloads(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name           = "%[2]s"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "default"
+  workloads      = ["WORKLOAD_1", "WORKLOAD_2"]
+  container_name = "test_container"
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+}
+
+func testAOMAccess_specifyWorkloads_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name           = "%[2]s_update"
+  cluster_id     = "%[3]s"
+  cluster_name   = "%[4]s"
+  namespace      = "test_namespace"
+  workloads      = ["WORKLOAD_3"]
+  container_name = "test_container_update"
+
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+}
+
+func testAOMAccess_withCCICluster(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name           = "%[2]s"
+  cluster_id     = "CCI-ClusterID"
+  cluster_name   = "CCI-Cluster"
+  namespace      = "default"
+  workloads      = ["__ALL_DEPLOYMENTS__"]
+  container_name = "test_container"
+
+  access_rules {
+    file_name       = "__ALL_FILES__"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsStream_basic(name), name)
+}
+
+func testAOMAccess_withCCICluster_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_aom_access" "test" {
+  name           = "%[2]s_update"
+  cluster_id     = "CCI-ClusterID"
+  cluster_name   = "CCI-Cluster"
+  namespace      = "test_namespace"
+  workloads      = ["WORKLOAD_3"]
+  container_name = "test_container_update"
+
+  access_rules {
+    file_name       = "/test/*"
+    log_group_id    = huaweicloud_lts_group.test.id
+    log_group_name  = huaweicloud_lts_group.test.group_name
+    log_stream_id   = huaweicloud_lts_stream.test.id
+    log_stream_name = huaweicloud_lts_stream.test.stream_name
+  }
+}
+`, testAccLtsStream_basic(name), name)
+}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_aom_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_aom_access.go
@@ -1,0 +1,354 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product LTS
+// ---------------------------------------------------------------
+
+package lts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceAOMAccess() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAOMAccessCreate,
+		UpdateContext: resourceAOMAccessUpdate,
+		ReadContext:   resourceAOMAccessRead,
+		DeleteContext: resourceAOMAccessDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the rule name.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the cluster ID.`,
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the cluster name.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the namespace.`,
+			},
+			"workloads": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Required:    true,
+				Description: `Specifies the deployments.`,
+			},
+			"access_rules": {
+				Type:        schema.TypeList,
+				Elem:        accessRuleSchema(),
+				Required:    true,
+				Description: `Specifies the log details.`,
+			},
+			"container_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the container name.`,
+			},
+		},
+	}
+}
+
+func accessRuleSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"file_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the path name.`,
+			},
+			"log_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the log group ID.`,
+			},
+			"log_group_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the log group name.`,
+			},
+			"log_stream_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the log stream ID.`,
+			},
+			"log_stream_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the log stream name.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceAOMAccessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/lts/aom-mapping?isBatch=false"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateAOMAccessBodyParams(client.ProjectID, d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating AOM to LTS log mapping rule: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("[0]|rule_id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating AOM to LTS log mapping rule: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceAOMAccessRead(ctx, d, meta)
+}
+
+func buildCreateAOMAccessBodyParams(projectID string, d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"project_id": projectID,
+		"rule_name":  d.Get("name"),
+		"rule_info":  buildAOMAccessRuleInfo(d),
+	}
+}
+
+func buildAOMAccessRuleInfo(d *schema.ResourceData) map[string]interface{} {
+	rst := map[string]interface{}{
+		"cluster_id":   d.Get("cluster_id"),
+		"cluster_name": d.Get("cluster_name"),
+		"namespace":    d.Get("namespace"),
+		"deployments":  d.Get("workloads"),
+		"files":        buildAccessRules(d.Get("access_rules")),
+	}
+	if v, ok := d.GetOk("container_name"); ok {
+		rst["container_name"] = v
+	}
+	return rst
+}
+
+func buildAccessRules(rawParams interface{}) []map[string]interface{} {
+	rawArray, ok := rawParams.([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		if raw, isMap := v.(map[string]interface{}); isMap {
+			rst = append(rst, map[string]interface{}{
+				"file_name":       raw["file_name"],
+				"log_stream_info": buildLogStreamInfo(raw),
+			})
+		}
+	}
+	return rst
+}
+
+func buildLogStreamInfo(rawMap map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"target_log_group_id":    rawMap["log_group_id"],
+		"target_log_group_name":  rawMap["log_group_name"],
+		"target_log_stream_id":   rawMap["log_stream_id"],
+		"target_log_stream_name": rawMap["log_stream_name"],
+	}
+}
+
+func resourceAOMAccessRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v2/{project_id}/lts/aom-mapping/{rule_id}"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// there is no special error code here
+		return diag.Errorf("error retrieving AOM to LTS log mapping rule: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resultBody, err := parseGetResponseBody(getRespBody)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving AOM to LTS log mapping rule")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("rule_name", resultBody, nil)),
+		d.Set("cluster_name", utils.PathSearch("rule_info.cluster_name", resultBody, nil)),
+		d.Set("cluster_id", utils.PathSearch("rule_info.cluster_id", resultBody, nil)),
+		d.Set("namespace", utils.PathSearch("rule_info.namespace", resultBody, nil)),
+		d.Set("container_name", utils.PathSearch("rule_info.container_name", resultBody, nil)),
+		d.Set("workloads", utils.PathSearch("rule_info.deployments", resultBody, nil)),
+		d.Set("access_rules", flattenAccessRules(resultBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// parseGetResponseBody use to parse the return value of the details interface.
+// The response body of the detail interface is an array.
+// If the resource is not exist, the response will be an empty array.
+func parseGetResponseBody(getRespBody interface{}) (interface{}, error) {
+	arrayBody, ok := getRespBody.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("the API response is not array")
+	}
+	if len(arrayBody) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return arrayBody[0], nil
+}
+
+func flattenAccessRules(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("rule_info.files", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, len(curArray))
+	for i, v := range curArray {
+		rst[i] = map[string]interface{}{
+			"file_name":       utils.PathSearch("file_name", v, nil),
+			"log_group_id":    utils.PathSearch("log_stream_info.target_log_group_id", v, nil),
+			"log_group_name":  utils.PathSearch("log_stream_info.target_log_group_name", v, nil),
+			"log_stream_id":   utils.PathSearch("log_stream_info.target_log_stream_id", v, nil),
+			"log_stream_name": utils.PathSearch("log_stream_info.target_log_stream_name", v, nil),
+		}
+	}
+	return rst
+}
+
+func resourceAOMAccessUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/lts/aom-mapping"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateAOMAccessBodyParams(client.ProjectID, d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating AOM to LTS log mapping rule: %s", err)
+	}
+	return resourceAOMAccessRead(ctx, d, meta)
+}
+
+func buildUpdateAOMAccessBodyParams(projectID string, d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"project_id": projectID,
+		"rule_id":    d.Id(),
+		"rule_name":  d.Get("name"),
+		"rule_info":  buildAOMAccessRuleInfo(d),
+	}
+}
+
+func resourceAOMAccessDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/lts/aom-mapping"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath += buildDeleteAOMAccessQueryParams(d)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting AOM to LTS log mapping rule: %s", err)
+	}
+
+	return nil
+}
+
+func buildDeleteAOMAccessQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?id=%s", d.Id())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new resource lts aom access

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Currently, the resource do not support `isBatch` and `deployments_prefix` in API request parameters.
- When the resource is not exists in server, the detail API will return an empty array.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/854a65c7-7c3d-425d-addb-08514a84dd88)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccAOMAccess_allWorkloads'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccAOMAccess_allWorkloads -timeout 360m -parallel 4 
=== RUN   TestAccAOMAccess_allWorkloads 
=== PAUSE TestAccAOMAccess_allWorkloads
=== CONT  TestAccAOMAccess_allWorkloads
--- PASS: TestAccAOMAccess_allWorkloads (18.78s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       18.822s
```

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccAOMAccess_specifyWorkloads'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccAOMAccess_specifyWorkloads -timeout 360m -parallel 4 
=== RUN   TestAccAOMAccess_specifyWorkloads 
=== PAUSE TestAccAOMAccess_specifyWorkloads
=== CONT  TestAccAOMAccess_specifyWorkloads
--- PASS: TestAccAOMAccess_specifyWorkloads (18.93s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       18.975s
```

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccAOMAccess_withCCICluster'

==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccAOMAccess_withCCICluster -timeout 360m -parallel 4 
=== RUN   TestAccAOMAccess_withCCICluster 
=== PAUSE TestAccAOMAccess_withCCICluster
=== CONT  TestAccAOMAccess_withCCICluster
--- PASS: TestAccAOMAccess_withCCICluster (18.79s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       18.832s
```

