### PR TITLE
feat(ELB): elb loadbalancer and listener suport force delete

### DIFF
--- a/docs/resources/elb_listener.md
+++ b/docs/resources/elb_listener.md
@@ -109,6 +109,9 @@ The following arguments are supported:
 * `protection_reason` - (Optional, String) The reason for update protection. Only valid when `protection_status` is
   **consoleProtection**.
 
+* `force_delete` - (Optional, Bool) Specifies whether to forcibly delete the listener, remove the listener, l7 policies,
+  unbind associated pools. Defaults to **false**.
+
 * `tags` - (Optional, Map) The key/value pairs to associate with the listener.
 
 ## Attribute Reference
@@ -131,4 +134,20 @@ ELB listener can be imported using the listener ID, e.g.
 
 ```
 $ terraform import huaweicloud_elb_listener.listener_1 5c20fdad-7288-11eb-b817-0255ac10158b
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `force_delete`. It is generally recommended
+running `terraform plan` after importing a listener. You can then decide if changes should be applied to the listener,
+or the resource definition should be updated to align with the listener. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_elb_listener" "listener_1" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      force_delete,
+    ]
+  }
+}
 ```

--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -196,6 +196,9 @@ The following arguments are supported:
 * `min_l7_flavor_id` - (Optional, String) Specifies the ID of the minimum Layer-7 flavor for elastic scaling.
   This parameter cannot be left blank if there are HTTP or HTTPS listeners.
 
+* `force_delete` - (Optional, Bool) Specifies whether to forcibly delete the LoadBalancer, remove the LoadBalancer,
+  listeners, unbind associated pools. Defaults to **false**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -224,17 +227,17 @@ $ terraform import huaweicloud_elb_loadbalancer.loadbalancer_1 5c20fdad-7288-11e
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `ipv6_bandwidth_id`, `iptype`,
-`bandwidth_charge_mode`, `sharetype`,  `bandwidth_size` and `bandwidth_id`.
+`bandwidth_charge_mode`, `sharetype`,  `bandwidth_size`, `bandwidth_id` and `force_delete`.
 It is generally recommended running `terraform plan` after importing a loadbalancer.
 You can then decide if changes should be applied to the loadbalancer, or the resource
 definition should be updated to align with the loadbalancer. Also you can ignore changes as below.
 
-```
+```hcl
 resource "huaweicloud_elb_loadbalancer" "loadbalancer_1" {
     ...
   lifecycle {
     ignore_changes = [
-      ipv6_bandwidth_id, iptype, bandwidth_charge_mode, sharetype, bandwidth_size, bandwidth_id,
+      ipv6_bandwidth_id, iptype, bandwidth_charge_mode, sharetype, bandwidth_size, bandwidth_id, force_delete,
     ]
   }
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -194,6 +194,11 @@ func ResourceLoadBalancerV3() *schema.Resource {
 				Optional: true,
 			},
 
+			"force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"tags": common.TagsSchema(),
 
 			// charge info: charging_mode, period_unit, period, auto_renew, auto_pay
@@ -661,8 +666,14 @@ func resourceLoadBalancerV3Delete(ctx context.Context, d *schema.ResourceData, m
 			return diag.Errorf("error unsubscribing ELB LoadBalancer : %s", err)
 		}
 	} else {
-		if err = loadbalancers.Delete(elbClient, d.Id()).ExtractErr(); err != nil {
-			return diag.Errorf("error deleting ELB LoadBalancer: %s", err)
+		if d.Get("force_delete").(bool) {
+			if err = loadbalancers.ForceDelete(elbClient, d.Id()).ExtractErr(); err != nil {
+				return diag.Errorf("error deleting ELB LoadBalancer: %s", err)
+			}
+		} else {
+			if err = loadbalancers.Delete(elbClient, d.Id()).ExtractErr(); err != nil {
+				return diag.Errorf("error deleting ELB LoadBalancer: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  elb loadbalancer and listener suport force delete
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  elb loadbalancer and listener suport force delete
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/elb/' TESTARGS='-run TestAccElbV3LoadBalancer_' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3LoadBalancer_ -timeout 360m -parallel 4 
=== RUN   TestAccElbV3LoadBalancer_basic 
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== PAUSE TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== CONT  TestAccElbV3LoadBalancer_withEIP
=== CONT  TestAccElbV3LoadBalancer_prePaid
--- PASS: TestAccElbV3LoadBalancer_withEIP (45.52s) 
=== CONT  TestAccElbV3LoadBalancer_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id (52.35s) 
--- PASS: TestAccElbV3LoadBalancer_withEpsId (29.33s) 
--- PASS: TestAccElbV3LoadBalancer_basic (116.69s) 
--- PASS: TestAccElbV3LoadBalancer_prePaid (175.73s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       175.784s

make testacc TEST='./huaweicloud/services/acceptance/elb/' TESTARGS='-run TestAccElbV3Listener_' 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3Listener_ -timeout 360m -parallel 4 
=== RUN   TestAccElbV3Listener_basic 
=== PAUSE TestAccElbV3Listener_basic             
=== RUN   TestAccElbV3Listener_with_default_pool 
=== PAUSE TestAccElbV3Listener_with_default_pool 
=== CONT  TestAccElbV3Listener_basic 
=== CONT  TestAccElbV3Listener_with_default_pool
--- PASS: TestAccElbV3Listener_with_default_pool (117.65s) 
--- PASS: TestAccElbV3Listener_basic (119.78s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       119.871s
```
