### PR TITLE
fix(WorkSpace): fix workspace resource account_expires time format conversion error issue

### DIFF
--- a/docs/resources/workspace_user.md
+++ b/docs/resources/workspace_user.md
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of user. The maximum length is `255` characters.
 
 * `account_expires` - (Optional, String) Specifies the user's valid period configuration.
+  Defaults to "0".
   + Never expires: **0**.
   + Expires at a certain time: account expires must in RFC3339 format like `yyyy-MM-ddTHH:mm:ssZ`.
     The times is in local time, depending on the timezone.

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
@@ -57,6 +57,7 @@ func ResourceUser() *schema.Resource {
 			"account_expires": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "0",
 			},
 			"password_never_expires": {
 				Type:     schema.TypeBool,
@@ -89,7 +90,7 @@ func ResourceUser() *schema.Resource {
 }
 
 func calculateExpireTime(timeStr string) (string, error) {
-	if timeStr == "0" {
+	if timeStr == "0" || timeStr == "" {
 		return "0", nil
 	}
 	return translateUTC0Time(timeStr)
@@ -148,7 +149,6 @@ func parseUserAccountExpires(expires int) string {
 	if expires == 0 {
 		return strconv.Itoa(expires)
 	}
-
 	return utils.FormatTimeStampRFC3339(int64(expires/1000), false, RFC3339NoT)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
fix workspace resource account_expires time format conversion error issue


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
