### PR TITLE
fix(er): using data source to query az

### DIFF
--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
@@ -120,16 +120,18 @@ func TestAccRouteTablesDataSource_byTags(t *testing.T) {
 
 func testAccRouteTablesDataSource_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_er_instance" "test" {
-  availability_zones = ["%[1]s"]
+data "huaweicloud_availability_zones" "test" {}
 
-  name = "%[2]s"
-  asn  = %[3]d
+resource "huaweicloud_er_instance" "test" {
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+
+  name = "%[1]s"
+  asn  = %[2]d
 }
 
 resource "huaweicloud_er_route_table" "test" {
   instance_id = huaweicloud_er_instance.test.id
-  name        = "%[2]s"
+  name        = "%[1]s"
 
   tags = {
     foo   = "bar"
@@ -139,13 +141,13 @@ resource "huaweicloud_er_route_table" "test" {
 
 resource "huaweicloud_er_route_table" "another" {
   instance_id = huaweicloud_er_instance.test.id
-  name        = "%[2]s_another"
+  name        = "%[1]s_another"
 
   tags = {
     owner = "terraform"
   }
 }
-`, acceptance.HW_AVAILABILITY_ZONE, name, bgpAsNum)
+`, name, bgpAsNum)
 }
 
 func testAccRouteTablesDataSource_basic(name string, bgpAsNum int) string {

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -91,6 +91,8 @@ func testAccAssociationImportStateFunc() resource.ImportStateIdFunc {
 
 func testAccAssociation_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
   cidr = "192.168.0.0/16"
@@ -105,10 +107,10 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = ["%[2]s"]
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
-  asn  = %[3]d
+  asn  = %[2]d
 }
 
 resource "huaweicloud_er_vpc_attachment" "test" {
@@ -125,7 +127,7 @@ resource "huaweicloud_er_route_table" "test" {
 
   name = "%[1]s"
 }
-`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+`, name, bgpAsNum)
 }
 
 func testAccAssociation_basic(name string, bgpAsNum int) string {

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
@@ -105,15 +105,15 @@ data "huaweicloud_availability_zones" "test" {}
 resource "huaweicloud_er_instance" "test" {
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
-  name = "%[2]s"
-  asn  = %[3]d
+  name = "%[1]s"
+  asn  = %[2]d
 
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, acceptance.HW_AVAILABILITY_ZONE, name, bgpAsNum)
+`, name, bgpAsNum)
 }
 
 func testInstance_basic_step2(name string, bgpAsNum int) string {
@@ -123,13 +123,13 @@ data "huaweicloud_availability_zones" "test" {}
 resource "huaweicloud_er_instance" "test" {
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
-  name = "%[2]s"
-  asn  = %[3]d
+  name = "%[1]s"
+  asn  = %[2]d
 
   tags = {
     foo    = "baar"
     newkey = "value"
   }
 }
-`, acceptance.HW_AVAILABILITY_ZONE, name, bgpAsNum)
+`, name, bgpAsNum)
 }

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
@@ -91,6 +91,8 @@ func testAccPropagationImportStateFunc() resource.ImportStateIdFunc {
 
 func testAccPropagation_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
   cidr = "192.168.0.0/16"
@@ -105,10 +107,10 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = ["%[2]s"]
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
-  asn  = %[3]d
+  asn  = %[2]d
 }
 
 resource "huaweicloud_er_vpc_attachment" "test" {
@@ -125,7 +127,7 @@ resource "huaweicloud_er_route_table" "test" {
 
   name = "%[1]s"
 }
-`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+`, name, bgpAsNum)
 }
 
 func testAccPropagation_basic(name string, bgpAsNum int) string {

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
@@ -95,12 +95,14 @@ func testAccRouteTableImportStateFunc() resource.ImportStateIdFunc {
 
 func testRouteTable_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = ["%[2]s"]
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   name               = "%[1]s"
-  asn                = %[3]d
+  asn                = %[2]d
 }
-`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+`, name, bgpAsNum)
 }
 
 func testRouteTable_basic(name string, bgpAsNum int) string {

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
@@ -95,6 +95,8 @@ func testAccVpcAttachmentImportStateFunc() resource.ImportStateIdFunc {
 
 func testVpcAttachment_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+	
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
   cidr = "192.168.0.0/16"
@@ -109,12 +111,12 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = ["%[2]s"]
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
-  asn  = %[3]d
+  asn  = %[2]d
 }
-`, name, acceptance.HW_AVAILABILITY_ZONE, bgpAsNum)
+`, name, bgpAsNum)
 }
 
 func testVpcAttachment_basic(name string, bgpAsNum int) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The ER instance creation will be failed if the availability_zone list is empty, and the post request will not return an error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using data source to query az.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_basic
=== PAUSE TestAccAttachmentsDataSource_basic
=== CONT  TestAccAttachmentsDataSource_basic
--- PASS: TestAccAttachmentsDataSource_basic (89.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        89.165s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccInstancesDataSource_basic
=== PAUSE TestAccInstancesDataSource_basic
=== CONT  TestAccInstancesDataSource_basic
--- PASS: TestAccInstancesDataSource_basic (48.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        49.080s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccRouteTablesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccRouteTablesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccRouteTablesDataSource_basic
=== PAUSE TestAccRouteTablesDataSource_basic
=== CONT  TestAccRouteTablesDataSource_basic
--- PASS: TestAccRouteTablesDataSource_basic (71.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        71.286s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccRouteTablesDataSource_byName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccRouteTablesDataSource_byName -timeout 360m -parallel 4
=== RUN   TestAccRouteTablesDataSource_byName
=== PAUSE TestAccRouteTablesDataSource_byName
=== CONT  TestAccRouteTablesDataSource_byName
--- PASS: TestAccRouteTablesDataSource_byName (75.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        75.927s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccRouteTablesDataSource_byId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccRouteTablesDataSource_byId -timeout 360m -parallel 4
=== RUN   TestAccRouteTablesDataSource_byId
=== PAUSE TestAccRouteTablesDataSource_byId
=== CONT  TestAccRouteTablesDataSource_byId
--- PASS: TestAccRouteTablesDataSource_byId (79.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        79.255s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccRouteTablesDataSource_byTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccRouteTablesDataSource_byTags -timeout 360m -parallel 4
=== RUN   TestAccRouteTablesDataSource_byTags
=== PAUSE TestAccRouteTablesDataSource_byTags
=== CONT  TestAccRouteTablesDataSource_byTags
--- PASS: TestAccRouteTablesDataSource_byTags (99.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        99.226s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAssociation_basic -timeout 360m -parallel 4
=== RUN   TestAccAssociation_basic
=== PAUSE TestAccAssociation_basic
=== CONT  TestAccAssociation_basic
--- PASS: TestAccAssociation_basic (104.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        104.155s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (53.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        53.942s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccPropagation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccPropagation_basic -timeout 360m -parallel 4
=== RUN   TestAccPropagation_basic
=== PAUSE TestAccPropagation_basic
=== CONT  TestAccPropagation_basic
--- PASS: TestAccPropagation_basic (127.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        127.532s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccRouteTable_basic -timeout 360m -parallel 4
=== RUN   TestAccRouteTable_basic
=== PAUSE TestAccRouteTable_basic
=== CONT  TestAccRouteTable_basic
--- PASS: TestAccRouteTable_basic (103.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        103.969s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccStaticRoute_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccStaticRoute_basic -timeout 360m -parallel 4
=== RUN   TestAccStaticRoute_basic
=== PAUSE TestAccStaticRoute_basic
=== CONT  TestAccStaticRoute_basic
--- PASS: TestAccStaticRoute_basic (171.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        171.087s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccVpcAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccVpcAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcAttachment_basic
=== PAUSE TestAccVpcAttachment_basic
=== CONT  TestAccVpcAttachment_basic
--- PASS: TestAccVpcAttachment_basic (189.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        189.314s
```
