### PR TITLE
fix(cbr/vault): fix the wrong acceptance check

### DIFF
--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -30,7 +30,7 @@ func TestAccDataVaults_backupServer(t *testing.T) {
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "app_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
 					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
During the acceptance scripts of the CBR vault has been modified, the related acceptance of the data sources need to2 update.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong acceptance check.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccDataBackup_basic
=== PAUSE TestAccDataBackup_basic
=== RUN   TestAccDataVaults_backupServer
=== PAUSE TestAccDataVaults_backupServer
=== RUN   TestAccDataVaults_replicationServer
=== PAUSE TestAccDataVaults_replicationServer
=== RUN   TestAccDataVaults_volume
=== PAUSE TestAccDataVaults_volume
=== RUN   TestAccDataVaults_backupTurbo
=== PAUSE TestAccDataVaults_backupTurbo
=== RUN   TestAccDataVaults_replicationTurbo
=== PAUSE TestAccDataVaults_replicationTurbo
=== RUN   TestAccPolicy_basic
=== PAUSE TestAccPolicy_basic
=== RUN   TestAccPolicy_retention
=== PAUSE TestAccPolicy_retention
=== RUN   TestAccPolicy_replication
=== PAUSE TestAccPolicy_replication
=== RUN   TestAccVault_backupServer
=== PAUSE TestAccVault_backupServer
=== RUN   TestAccVault_replicationServer
=== PAUSE TestAccVault_replicationServer
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== RUN   TestAccVault_volume
=== PAUSE TestAccVault_volume
=== RUN   TestAccVault_backupTurbo
=== PAUSE TestAccVault_backupTurbo
=== RUN   TestAccVault_replicationTurbo
=== PAUSE TestAccVault_replicationTurbo
=== RUN   TestAccVault_AutoBind
=== PAUSE TestAccVault_AutoBind
=== RUN   TestAccVault_bindPolicies
=== PAUSE TestAccVault_bindPolicies
=== CONT  TestAccDataBackup_basic
=== CONT  TestAccVault_backupServer
=== CONT  TestAccDataVaults_replicationTurbo
=== CONT  TestAccDataVaults_volume
--- PASS: TestAccDataVaults_replicationTurbo (17.74s)
=== CONT  TestAccDataVaults_backupTurbo
--- PASS: TestAccDataVaults_volume (333.76s)
=== CONT  TestAccVault_backupTurbo
--- PASS: TestAccVault_backupServer (359.07s)
=== CONT  TestAccVault_bindPolicies
    acceptance.go:443: Skip the replication policy acceptance tests.
--- SKIP: TestAccVault_bindPolicies (0.01s)
=== CONT  TestAccVault_AutoBind
--- PASS: TestAccVault_AutoBind (24.73s)
=== CONT  TestAccVault_replicationTurbo
--- PASS: TestAccVault_replicationTurbo (16.71s)
=== CONT  TestAccPolicy_replication
    acceptance.go:443: Skip the replication policy acceptance tests.
--- SKIP: TestAccPolicy_replication (0.01s)
=== CONT  TestAccPolicy_basic
--- PASS: TestAccPolicy_basic (19.99s)
=== CONT  TestAccVault_prePaidServer
    acceptance.go:485: This environment does not support prepaid tests
--- SKIP: TestAccVault_prePaidServer (0.01s)
=== CONT  TestAccVault_volume
--- PASS: TestAccDataVaults_backupTurbo (550.96s)
=== CONT  TestAccDataVaults_replicationServer
--- PASS: TestAccDataVaults_replicationServer (16.99s)
=== CONT  TestAccPolicy_retention
--- PASS: TestAccPolicy_retention (19.17s)
=== CONT  TestAccVault_replicationServer
--- PASS: TestAccVault_replicationServer (16.64s)
=== CONT  TestAccDataVaults_backupServer
--- PASS: TestAccDataBackup_basic (667.70s)
--- PASS: TestAccVault_volume (358.18s)
--- PASS: TestAccDataVaults_backupServer (396.75s)
--- PASS: TestAccVault_backupTurbo (1034.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       1368.701s
```
