### PR TITLE
fix(endpoint): fix wrong endpoint tests

### DIFF
--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -498,7 +498,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud dcs v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v1.0/%s/", HW_REGION_NAME, cfg.Cloud, cfg.TenantID)
+	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v1.0/", HW_REGION_NAME, cfg.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("DCS v1 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
@@ -510,7 +510,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud dcs v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v2/%s/", HW_REGION_NAME, cfg.Cloud, cfg.TenantID)
+	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v2/", HW_REGION_NAME, cfg.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("DCS v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
@@ -522,7 +522,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud DMS v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dms.%s.%s/v1.0/%s/", HW_REGION_NAME, cfg.Cloud, cfg.TenantID)
+	expectedURL = fmt.Sprintf("https://dms.%s.%s/v1.0/", HW_REGION_NAME, cfg.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("DMS v1 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
@@ -534,7 +534,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud DMS v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dms.%s.%s/v2/%s/", HW_REGION_NAME, cfg.Cloud, cfg.TenantID)
+	expectedURL = fmt.Sprintf("https://dms.%s.%s/v2/", HW_REGION_NAME, cfg.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	if actualURL != expectedURL {
 		t.Fatalf("DMS v2 endpoint: expected %s but got %s", green(expectedURL), yellow(actualURL))
@@ -554,6 +554,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	t.Logf("ServiceStage v1 endpoint:\t %s", actualURL)
 
 	// test the endpoint of ServiceStage v2 service
+	serviceClient, err = cfg.ServiceStageV2Client(HW_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating HuaweiCloud ServiceStage v2 client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some acceptance tests of the service endpoint are wrong.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix wrong endpoint tests
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
go test -v -run TestAccServiceEndpoints
=== RUN   TestAccServiceEndpoints_IAM
--- PASS: TestAccServiceEndpoints_IAM (0.30s)
=== RUN   TestAccServiceEndpoints_Global
--- PASS: TestAccServiceEndpoints_Global (0.21s)
=== RUN   TestAccServiceEndpoints_Management
--- PASS: TestAccServiceEndpoints_Management (0.21s)
=== RUN   TestAccServiceEndpoints_Database
--- PASS: TestAccServiceEndpoints_Database (0.22s)
=== RUN   TestAccServiceEndpoints_Security
--- PASS: TestAccServiceEndpoints_Security (0.17s)
=== RUN   TestAccServiceEndpoints_Application
--- PASS: TestAccServiceEndpoints_Application (0.16s)
=== RUN   TestAccServiceEndpoints_Compute
--- PASS: TestAccServiceEndpoints_Compute (1.29s)
=== RUN   TestAccServiceEndpoints_Storage
--- PASS: TestAccServiceEndpoints_Storage (0.63s)
=== RUN   TestAccServiceEndpoints_Network
--- PASS: TestAccServiceEndpoints_Network (0.47s)
=== RUN   TestAccServiceEndpoints_EnterpriseIntelligence
--- PASS: TestAccServiceEndpoints_EnterpriseIntelligence (0.20s)
=== RUN   TestAccServiceEndpoints_Edge
--- PASS: TestAccServiceEndpoints_Edge (0.21s)
=== RUN   TestAccServiceEndpoints_Others
--- PASS: TestAccServiceEndpoints_Others (0.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       4.845s
```
