### PR TITLE
chore(dli/queue): replace attribute ID value with the resource ID 

### DIFF
--- a/docs/resources/dli_database.md
+++ b/docs/resources/dli_database.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Resource ID. For database resources, the ID is the database name.
+* `id` - Resource ID in UUID format.
 
 ## Import
 

--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -106,8 +106,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-DLI queue can be imported by  `id`. For example,
+DLI queue can be imported by `name`. For example,
 
-```
-terraform import huaweicloud_dli_queue.example  abc123
+```bash
+terraform import huaweicloud_dli_queue.example terraform_dli_queue_test
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
During the TMS tags management need to use the queue ID to manage tags, but the UUID cannot be referenced by DLI queue resource attributes, bucause of the value of the `id` attribute is queue name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using queue id as the resource id
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDliQueue_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDliQueue_basic -timeout 360m -parallel 4
=== RUN   TestAccDliQueue_basic
=== PAUSE TestAccDliQueue_basic
=== CONT  TestAccDliQueue_basic
--- PASS: TestAccDliQueue_basic (250.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       251.020s
```
