### PR TITLE
fix(bms): fix codecheck for bms

### DIFF
--- a/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_flavors_test.go
+++ b/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_flavors_test.go
@@ -34,7 +34,7 @@ func testAccCheckBmsFlavorDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Can't find bms flavors data source: %s", n)
+			return fmt.Errorf("can't find bms flavors data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_flavors_test.go
+++ b/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_flavors_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 

--- a/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
+++ b/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -53,8 +54,8 @@ func TestAccBmsInstance_basic(t *testing.T) {
 }
 
 func testAccCheckBmsInstanceDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	bmsClient, err := config.BmsV1Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	bmsClient, err := cfg.BmsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating HuaweiCloud bms client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
+++ b/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
@@ -57,7 +57,7 @@ func testAccCheckBmsInstanceDestroy(s *terraform.State) error {
 	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 	bmsClient, err := cfg.BmsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating HuaweiCloud bms client: %s", err)
+		return fmt.Errorf("error creating bms client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -90,7 +90,7 @@ func testAccCheckBmsInstanceExists(n string, instance *baremetalservers.CloudSer
 		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 		bmsClient, err := cfg.BmsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating HuaweiCloud bms client: %s", err)
+			return fmt.Errorf("error creating bms client: %s", err)
 		}
 
 		found, err := baremetalservers.Get(bmsClient, rs.Primary.ID).Extract()

--- a/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
+++ b/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go
@@ -57,7 +57,7 @@ func testAccCheckBmsInstanceDestroy(s *terraform.State) error {
 	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 	bmsClient, err := cfg.BmsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating HuaweiCloud bms client: %s", err)
+		return fmt.Errorf("error creating HuaweiCloud bms client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -68,7 +68,7 @@ func testAccCheckBmsInstanceDestroy(s *terraform.State) error {
 		server, err := baremetalservers.Get(bmsClient, rs.Primary.ID).Extract()
 		if err == nil {
 			if server.Status != "DELETED" {
-				return fmt.Errorf("Instance still exists")
+				return fmt.Errorf("instance still exists")
 			}
 		}
 	}
@@ -80,17 +80,17 @@ func testAccCheckBmsInstanceExists(n string, instance *baremetalservers.CloudSer
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		bmsClient, err := config.BmsV1Client(acceptance.HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		bmsClient, err := cfg.BmsV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating HuaweiCloud bms client: %s", err)
+			return fmt.Errorf("error creating HuaweiCloud bms client: %s", err)
 		}
 
 		found, err := baremetalservers.Get(bmsClient, rs.Primary.ID).Extract()
@@ -99,7 +99,7 @@ func testAccCheckBmsInstanceExists(n string, instance *baremetalservers.CloudSer
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Instance not found")
+			return fmt.Errorf("instance not found")
 		}
 
 		*instance = *found

--- a/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
+++ b/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
@@ -2,18 +2,19 @@ package bms
 
 import (
 	"context"
+	"log"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/bms/v1/flavors"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func DataSourceBmsFlavors() *schema.Resource {
@@ -76,11 +77,11 @@ func DataSourceBmsFlavors() *schema.Resource {
 }
 
 func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	bmsClient, err := config.BmsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud BMS client: %s", err)
+		return diag.Errorf("Error creating Huawei Cloud BMS client: %s", err)
 	}
 
 	az := d.Get("availability_zone").(string)
@@ -90,7 +91,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	allFlavors, err := flavors.List(bmsClient, listOpts).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve BMS flavors: %s ", err)
+		return diag.Errorf("Unable to retrieve BMS flavors: %s ", err)
 	}
 
 	var vcpus string
@@ -107,9 +108,9 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	filterFlavors, err := utils.FilterSliceWithField(allFlavors, filter)
 	if err != nil {
-		return fmtp.DiagErrorf("filter BMS flavors failed: %s", err)
+		return diag.Errorf("filter BMS flavors failed: %s", err)
 	}
-	logp.Printf("filter %d bms flavors from %d through options %v", len(filterFlavors), len(allFlavors), filter)
+	log.Printf("filter %d bms flavors from %d through options %v", len(filterFlavors), len(allFlavors), filter)
 
 	var ids []string
 	var resultFlavors []map[string]interface{}
@@ -139,20 +140,21 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	}
 
 	if len(resultFlavors) < 1 {
-		return fmtp.DiagErrorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	d.SetId(hashcode.Strings(ids))
-	d.Set("region", region)
-	d.Set("flavors", resultFlavors)
-
-	return nil
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("flavors", resultFlavors),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func flattenBmsFlavor(flavor flavors.Flavor) map[string]interface{} {
 	vcpus, _ := strconv.Atoi(flavor.VCPUs)
-	ram := int(flavor.RAM / 1024)
+	ram := flavor.RAM / 1024
 
 	return map[string]interface{}{
 		"id":        flavor.ID,

--- a/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
+++ b/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
@@ -81,7 +81,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	region := cfg.GetRegion(d)
 	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huawei Cloud BMS client: %s", err)
+		return diag.Errorf("Error creating BMS client: %s", err)
 	}
 
 	az := d.Get("availability_zone").(string)

--- a/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
+++ b/huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go
@@ -81,7 +81,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	region := cfg.GetRegion(d)
 	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating BMS client: %s", err)
+		return diag.Errorf("error creating BMS client: %s", err)
 	}
 
 	az := d.Get("availability_zone").(string)
@@ -91,7 +91,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	allFlavors, err := flavors.List(bmsClient, listOpts).Extract()
 	if err != nil {
-		return diag.Errorf("Unable to retrieve BMS flavors: %s ", err)
+		return diag.Errorf("unable to retrieve BMS flavors: %s ", err)
 	}
 
 	var vcpus string
@@ -140,7 +140,7 @@ func dataSourceBmsFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	}
 
 	if len(resultFlavors) < 1 {
-		return diag.Errorf("Your query returned no results. " +
+		return diag.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -343,7 +343,7 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	n, err := baremetalservers.CreatePrePaid(bmsClient, createOpts).ExtractOrderResponse()
 	if err != nil {
-		return diag.Errorf("Error creating Huawei Cloud BMS server: %s", err)
+		return diag.Errorf("Error creating BMS server: %s", err)
 	}
 
 	bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
@@ -368,7 +368,7 @@ func resourceBmsInstanceRead(_ context.Context, d *schema.ResourceData, meta int
 	region := cfg.GetRegion(d)
 	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huawei Cloud compute client: %s", err)
+		return diag.Errorf("Error creating compute client: %s", err)
 	}
 
 	server, err := baremetalservers.Get(bmsClient, d.Id()).Extract()
@@ -426,7 +426,7 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 	cfg := meta.(*config.Config)
 	bmsClient, err := cfg.BmsV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huawei Cloud compute client: %s", err)
+		return diag.Errorf("Error creating compute client: %s", err)
 	}
 
 	if d.HasChange("name") {
@@ -435,7 +435,7 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		_, err = baremetalservers.Update(bmsClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return diag.Errorf("Error updating Huawei Cloud bms server: %s", err)
+			return diag.Errorf("Error updating bms server: %s", err)
 		}
 	}
 
@@ -457,7 +457,7 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 	region := cfg.GetRegion(d)
 	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating Huawei Cloud compute client: %s", err)
+		return diag.Errorf("Error creating compute client: %s", err)
 	}
 	serverID := d.Id()
 	publicIP := d.Get("public_ip").(string)
@@ -489,7 +489,7 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err := common.UnsubscribePrePaidResource(d, cfg, resourceIDs); err != nil {
-		return diag.Errorf("Error unsubscribing Huawei Cloud BMS server: %s", err)
+		return diag.Errorf("Error unsubscribing BMS server: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -503,7 +503,7 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting Huawei Cloud BMS instance: %s", err)
+		return diag.Errorf("Error deleting BMS instance: %s", err)
 	}
 
 	d.SetId("")
@@ -556,7 +556,7 @@ func flattenBmsInstanceNicsV1(d *schema.ResourceData, meta interface{},
 	cfg := meta.(*config.Config)
 	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
-		log.Printf("Error creating Huawei Cloud networking client: %s", err)
+		log.Printf("Error creating networking client: %s", err)
 	}
 
 	var network string

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -275,7 +275,7 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 	cfg := meta.(*config.Config)
 	bmsClient, err := cfg.BmsV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating Huawei Cloud bms client: %s", err)
+		return diag.Errorf("Error creating bms client: %s", err)
 	}
 
 	createOpts := &baremetalservers.CreateOpts{
@@ -608,7 +608,7 @@ func bmsPublicIP(server *baremetalservers.CloudServer) string {
 
 func waitForBmsInstanceDelete(bmsClient *golangsdk.ServiceClient, serverId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete Huawei Cloud BMS instance %s", serverId)
+		log.Printf("[DEBUG] Attempting to delete BMS instance %s", serverId)
 
 		r, err := baremetalservers.Get(bmsClient, serverId).Extract()
 

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -275,7 +275,7 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 	cfg := meta.(*config.Config)
 	bmsClient, err := cfg.BmsV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating bms client: %s", err)
+		return diag.Errorf("error creating bms client: %s", err)
 	}
 
 	createOpts := &baremetalservers.CreateOpts{
@@ -343,7 +343,7 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	n, err := baremetalservers.CreatePrePaid(bmsClient, createOpts).ExtractOrderResponse()
 	if err != nil {
-		return diag.Errorf("Error creating BMS server: %s", err)
+		return diag.Errorf("error creating BMS server: %s", err)
 	}
 
 	bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
@@ -368,7 +368,7 @@ func resourceBmsInstanceRead(_ context.Context, d *schema.ResourceData, meta int
 	region := cfg.GetRegion(d)
 	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating compute client: %s", err)
+		return diag.Errorf("error creating compute client: %s", err)
 	}
 
 	server, err := baremetalservers.Get(bmsClient, d.Id()).Extract()
@@ -426,7 +426,7 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 	cfg := meta.(*config.Config)
 	bmsClient, err := cfg.BmsV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("Error creating compute client: %s", err)
+		return diag.Errorf("error creating compute client: %s", err)
 	}
 
 	if d.HasChange("name") {
@@ -435,7 +435,7 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		_, err = baremetalservers.Update(bmsClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return diag.Errorf("Error updating bms server: %s", err)
+			return diag.Errorf("error updating bms server: %s", err)
 		}
 	}
 
@@ -457,7 +457,7 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 	region := cfg.GetRegion(d)
 	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return diag.Errorf("Error creating compute client: %s", err)
+		return diag.Errorf("error creating compute client: %s", err)
 	}
 	serverID := d.Id()
 	publicIP := d.Get("public_ip").(string)
@@ -477,19 +477,19 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 	if _, ok := d.GetOk("iptype"); ok && publicIP != "" && d.Get("eip_charge_mode").(string) == "prePaid" {
 		eipClient, err := cfg.NetworkingV1Client(region)
 		if err != nil {
-			return diag.Errorf("Error creating networking client: %s", err)
+			return diag.Errorf("error creating networking client: %s", err)
 		}
 
 		epsID := "all_granted_eps"
 		var eipID string
 		if eipID, err = common.GetEipIDbyAddress(eipClient, publicIP, epsID); err != nil {
-			return diag.Errorf("Error fetching EIP ID of BMS server (%s): %s", d.Id(), err)
+			return diag.Errorf("error fetching EIP ID of BMS server (%s): %s", d.Id(), err)
 		}
 		resourceIDs = append(resourceIDs, eipID)
 	}
 
 	if err := common.UnsubscribePrePaidResource(d, cfg, resourceIDs); err != nil {
-		return diag.Errorf("Error unsubscribing BMS server: %s", err)
+		return diag.Errorf("error unsubscribing BMS server: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -503,7 +503,7 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("Error deleting BMS instance: %s", err)
+		return diag.Errorf("error deleting BMS instance: %s", err)
 	}
 
 	d.SetId("")

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -2,20 +2,22 @@ package bms
 
 import (
 	"context"
+	"log"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers"
+	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceBmsInstance() *schema.Resource {
@@ -270,10 +272,10 @@ func ResourceBmsInstance() *schema.Resource {
 }
 
 func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	bmsClient, err := config.BmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	bmsClient, err := cfg.BmsV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud bms client: %s", err)
+		return diag.Errorf("Error creating Huawei Cloud bms client: %s", err)
 	}
 
 	createOpts := &baremetalservers.CreateOpts{
@@ -298,7 +300,7 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 			PeriodNum:           d.Get("period").(int),
 			IsAutoPay:           "true",
 			IsAutoRenew:         d.Get("auto_renew").(string),
-			EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 		},
 	}
 
@@ -307,7 +309,6 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 	if eipID, ok := d.GetOk("eip_id"); ok {
 		hasEIP = true
 		eipOpts.Id = eipID.(string)
-
 	} else if eipType, ok := d.GetOk("iptype"); ok {
 		hasEIP = true
 		eipOpts.Eip = &baremetalservers.Eip{
@@ -342,10 +343,10 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	n, err := baremetalservers.CreatePrePaid(bmsClient, createOpts).ExtractOrderResponse()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud BMS server: %s", err)
+		return diag.Errorf("Error creating Huawei Cloud BMS server: %s", err)
 	}
 
-	bssClient, err := config.BssV2Client(config.GetRegion(d))
+	bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating BSS v2 client: %s", err)
 	}
@@ -363,11 +364,11 @@ func resourceBmsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceBmsInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	bmsClient, err := config.BmsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
+		return diag.Errorf("Error creating Huawei Cloud compute client: %s", err)
 	}
 
 	server, err := baremetalservers.Get(bmsClient, d.Id()).Extract()
@@ -379,50 +380,53 @@ func resourceBmsInstanceRead(_ context.Context, d *schema.ResourceData, meta int
 		return nil
 	}
 
-	logp.Printf("[DEBUG] Retrieved Server %s: %+v", d.Id(), server)
-
-	d.Set("region", region)
-	d.Set("name", server.Name)
-	d.Set("image_id", server.Image.ID)
-	d.Set("flavor_id", server.Flavor.ID)
-	d.Set("host_id", server.HostID)
+	log.Printf("[DEBUG] Retrieved Server %s: %+v", d.Id(), server)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", server.Name),
+		d.Set("image_id", server.Image.ID),
+		d.Set("flavor_id", server.Flavor.ID),
+		d.Set("host_id", server.HostID),
+	)
 
 	// Set fixed and floating ip
 	if eip := bmsPublicIP(server); eip != "" {
-		d.Set("public_ip", eip)
+		mErr = multierror.Append(mErr, d.Set("public_ip", eip))
 	}
 	nics := flattenBmsInstanceNicsV1(d, meta, server.Addresses)
-	d.Set("nics", nics)
+	mErr = multierror.Append(mErr, d.Set("nics", nics))
 
-	d.Set("key_pair", server.KeyName)
+	mErr = multierror.Append(mErr, d.Set("key_pair", server.KeyName))
 	// Set security groups
 	secGrpIds := []string{}
 	for _, sg := range server.SecurityGroups {
 		secGrpIds = append(secGrpIds, sg.ID)
 	}
-	d.Set("security_groups", secGrpIds)
-	d.Set("status", server.Status)
-	d.Set("user_id", server.Metadata.OpSvcUserId)
-	d.Set("image_name", server.Metadata.ImageName)
-	d.Set("vpc_id", server.Metadata.VpcID)
-	d.Set("availability_zone", server.AvailabilityZone)
-	d.Set("description", server.Description)
-	d.Set("user_data", server.UserData)
-	d.Set("enterprise_project_id", server.EnterpriseProjectID)
+	mErr = multierror.Append(mErr,
+		d.Set("security_groups", secGrpIds),
+		d.Set("status", server.Status),
+		d.Set("user_id", server.Metadata.OpSvcUserId),
+		d.Set("image_name", server.Metadata.ImageName),
+		d.Set("vpc_id", server.Metadata.VpcID),
+		d.Set("availability_zone", server.AvailabilityZone),
+		d.Set("description", server.Description),
+		d.Set("user_data", server.UserData),
+		d.Set("enterprise_project_id", server.EnterpriseProjectID),
+	)
 	// Set disk ids
 	diskIds := []string{}
 	for _, disk := range server.VolumeAttached {
 		diskIds = append(diskIds, disk.ID)
 	}
-	d.Set("disk_ids", diskIds)
-	return nil
+	mErr = multierror.Append(mErr, d.Set("disk_ids", diskIds))
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	bmsClient, err := config.BmsV1Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	bmsClient, err := cfg.BmsV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
+		return diag.Errorf("Error creating Huawei Cloud compute client: %s", err)
 	}
 
 	if d.HasChange("name") {
@@ -431,12 +435,12 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		_, err = baremetalservers.Update(bmsClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmtp.DiagErrorf("Error updating HuaweiCloud bms server: %s", err)
+			return diag.Errorf("Error updating Huawei Cloud bms server: %s", err)
 		}
 	}
 
 	if d.HasChange("auto_renew") {
-		bssClient, err := config.BssV2Client(config.GetRegion(d))
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
@@ -449,11 +453,11 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	bmsClient, err := config.BmsV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bmsClient, err := cfg.BmsV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud compute client: %s", err)
+		return diag.Errorf("Error creating Huawei Cloud compute client: %s", err)
 	}
 	serverID := d.Id()
 	publicIP := d.Get("public_ip").(string)
@@ -471,21 +475,21 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	// unsubscribe the eip if necessary
 	if _, ok := d.GetOk("iptype"); ok && publicIP != "" && d.Get("eip_charge_mode").(string) == "prePaid" {
-		eipClient, err := config.NetworkingV1Client(region)
+		eipClient, err := cfg.NetworkingV1Client(region)
 		if err != nil {
-			return fmtp.DiagErrorf("Error creating networking client: %s", err)
+			return diag.Errorf("Error creating networking client: %s", err)
 		}
 
 		epsID := "all_granted_eps"
-		if eipID, err := common.GetEipIDbyAddress(eipClient, publicIP, epsID); err == nil {
-			resourceIDs = append(resourceIDs, eipID)
-		} else {
-			return fmtp.DiagErrorf("Error fetching EIP ID of BMS server (%s): %s", d.Id(), err)
+		var eipID string
+		if eipID, err = common.GetEipIDbyAddress(eipClient, publicIP, epsID); err != nil {
+			return diag.Errorf("Error fetching EIP ID of BMS server (%s): %s", d.Id(), err)
 		}
+		resourceIDs = append(resourceIDs, eipID)
 	}
 
-	if err := common.UnsubscribePrePaidResource(d, config, resourceIDs); err != nil {
-		return fmtp.DiagErrorf("Error unsubscribing HuaweiCloud BMS server: %s", err)
+	if err := common.UnsubscribePrePaidResource(d, cfg, resourceIDs); err != nil {
+		return diag.Errorf("Error unsubscribing Huawei Cloud BMS server: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -499,7 +503,7 @@ func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.DiagErrorf("Error deleting HuaweiCloud BMS instance: %s", err)
+		return diag.Errorf("Error deleting Huawei Cloud BMS instance: %s", err)
 	}
 
 	d.SetId("")
@@ -549,11 +553,10 @@ func resourceBmsInstanceSecGroupsV1(d *schema.ResourceData) []baremetalservers.S
 
 func flattenBmsInstanceNicsV1(d *schema.ResourceData, meta interface{},
 	addresses map[string][]baremetalservers.Address) []map[string]interface{} {
-
-	config := meta.(*config.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	networkingClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
 	if err != nil {
-		logp.Printf("Error creating HuaweiCloud networking client: %s", err)
+		log.Printf("Error creating Huawei Cloud networking client: %s", err)
 	}
 
 	var network string
@@ -569,7 +572,7 @@ func flattenBmsInstanceNicsV1(d *schema.ResourceData, meta interface{},
 			p, err := ports.Get(networkingClient, addr.PortID).Extract()
 			if err != nil {
 				network = ""
-				logp.Printf("[DEBUG] flattenInstanceNicsV1: failed to fetch port %s", addr.PortID)
+				log.Printf("[DEBUG] flattenInstanceNicsV1: failed to fetch port %s", addr.PortID)
 			} else {
 				network = p.NetworkID
 			}
@@ -584,7 +587,7 @@ func flattenBmsInstanceNicsV1(d *schema.ResourceData, meta interface{},
 		}
 	}
 
-	logp.Printf("[DEBUG] flattenInstanceNicsV1: %#v", nics)
+	log.Printf("[DEBUG] flattenInstanceNicsV1: %#v", nics)
 	return nics
 }
 
@@ -603,11 +606,11 @@ func bmsPublicIP(server *baremetalservers.CloudServer) string {
 	return publicIP
 }
 
-func waitForBmsInstanceDelete(bmsClient *golangsdk.ServiceClient, ServerId string) resource.StateRefreshFunc {
+func waitForBmsInstanceDelete(bmsClient *golangsdk.ServiceClient, serverId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		logp.Printf("[DEBUG] Attempting to delete HuaweiCloud BMS instance %s", ServerId)
+		log.Printf("[DEBUG] Attempting to delete Huawei Cloud BMS instance %s", serverId)
 
-		r, err := baremetalservers.Get(bmsClient, ServerId).Extract()
+		r, err := baremetalservers.Get(bmsClient, serverId).Extract()
 
 		if err != nil {
 			return r, "Deleting", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
Which issue this PR fixes:
fix apig/apigateway codecheck
1.The variable conflict with the imported package name
2.militi-error unused
3. import not standard

Unrepaired
the resource in resource_huaweicloud_bms_instance.go should can be imported

## Test
./scripts/codecheck.sh ./huaweicloud/services/bms/
```
==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       787       73         8      706         94            28.52
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~s/bms/resource_huaweicloud_bms_instance.go       621       53         7      561         71            12.66
~bms/data_source_huaweicloud_bms_flavors.go       166       20         1      145         23            15.86
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       787       73         8      706         94            28.52
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 21540 bytes, 0.022 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
15 bms dataSourceBmsFlavorsRead huaweicloud/services/bms/data_source_huaweicloud_bms_flavors.go:79:1
11 bms resourceBmsInstanceDelete huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:455:1
11 bms resourceBmsInstanceCreate huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:274:1
7 bms resourceBmsInstanceUpdate huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:425:1
7 bms resourceBmsInstanceRead huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:366:1
6 bms flattenBmsInstanceNicsV1 huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:554:1
4 bms bmsPublicIP huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:594:1
2 bms waitForBmsInstanceDelete huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:609:1
2 bms resourceBmsInstanceSecGroupsV1 huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:543:1
2 bms resourceBmsInstanceDataVolumesV1 huaweicloud/services/bms/resource_huaweicloud_bms_instance.go:528:1
Average: 5.14

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in bms...
  -> the resource in resource_huaweicloud_bms_instance.go should can be imported


==> Checking for misspell in bms...

==> Checking for code complexity in ./huaweicloud/services/acceptance/bms...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       221       28         0      193         21            18.90
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/resource_huaweicloud_bms_instance_test.go       169       20         0      149         18            12.08
~ata_source_huaweicloud_bms_flavors_test.go        52        8         0       44          3             6.82
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       221       28         0      193         21            18.90
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 6377 bytes, 0.006 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 bms testAccCheckBmsInstanceExists huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go:79:1
6 bms testAccCheckBmsInstanceDestroy huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go:56:1
3 bms testAccCheckBmsFlavorDataSourceID huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_flavors_test.go:33:1
1 bms testAccBmsInstance_basic huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go:126:1
1 bms testAccBmsInstance_base huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go:111:1
Average: 2.71

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/bms...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/bms...

==> Cleanup patch...

Check Completed!
```
## PR Checklist

* [ ] Tests added/passed.
Test huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go not executed，because the image is offline
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
Test huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_instance_test.go not executed，because the image is offline
```
make testacc TEST="./huaweicloud/services/acceptance/bms" TESTARGS="-run TestAccBmsFlav
orsDataSource_basic"                                                                                                                                                                
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms -v -run TestAccBmsFlavorsDataSource_basic -timeout 360m -parallel 4 
=== RUN   TestAccBmsFlavorsDataSource_basic 
=== PAUSE TestAccBmsFlavorsDataSource_basic
=== CONT  TestAccBmsFlavorsDataSource_basic
--- PASS: TestAccBmsFlavorsDataSource_basic (10.93s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       10.961s
...

```
