### PR TITLE
fix(as): fix codecheck errors in as service

### DIFF
--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_bandwidth_policy_test.go
@@ -5,23 +5,24 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getASBandWidthPolicyResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getASBandWidthPolicyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getBandwidthPolicy: Query the AS bandwidth scaling policy
 	var (
 		getBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
 		getBandwidthPolicyProduct = "autoscaling"
 	)
-	getBandwidthPolicyClient, err := config.NewServiceClient(getBandwidthPolicyProduct, region)
+	getBandwidthPolicyClient, err := conf.NewServiceClient(getBandwidthPolicyProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ASBandWidthPolicy Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -76,8 +77,8 @@ func TestAccASConfiguration_instance(t *testing.T) {
 }
 
 func testAccCheckASConfigurationDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := conf.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -127,6 +128,7 @@ func testAccCheckASConfigurationExists(n string, configuration *configurations.C
 	}
 }
 
+//nolint:revive
 func testAccASConfiguration_base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
@@ -157,8 +158,8 @@ func TestAccASGroup_sourceDestCheck(t *testing.T) {
 }
 
 func testAccCheckASGroupDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := conf.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -208,6 +209,7 @@ func testAccCheckASGroupExists(n string, group *groups.Group) resource.TestCheck
 	}
 }
 
+//nolint:revive
 func testASGroup_Base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -61,8 +62,8 @@ func TestAccASLifecycleHook_basic(t *testing.T) {
 }
 
 func testAccCheckASLifecycleHookDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := conf.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating autoscaling client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
@@ -100,8 +101,8 @@ func TestAccASPolicy_Alarm(t *testing.T) {
 }
 
 func testAccCheckASPolicyDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	asClient, err := config.AutoscalingV1Client(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	asClient, err := conf.AutoscalingV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -147,6 +148,7 @@ func testAccCheckASPolicyExists(n string, policy *policies.Policy) resource.Test
 	}
 }
 
+//nolint:revive
 func testASPolicy_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -83,14 +84,14 @@ func ResourceASBandWidthPolicy() *schema.Resource {
 			"scaling_policy_action": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
-				Elem:     ASBandWidthPolicyActionSchema(),
+				Elem:     BandWidthPolicyActionSchema(),
 				Optional: true,
 				Computed: true,
 			},
 			"scheduled_policy": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
-				Elem:     ASBandWidthScheduledPolicySchema(),
+				Elem:     BandWidthScheduledPolicySchema(),
 				Optional: true,
 				Computed: true,
 				ExactlyOneOf: []string{
@@ -111,7 +112,7 @@ func ResourceASBandWidthPolicy() *schema.Resource {
 	}
 }
 
-func ASBandWidthPolicyActionSchema() *schema.Resource {
+func BandWidthPolicyActionSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"operation": {
@@ -140,7 +141,7 @@ func ASBandWidthPolicyActionSchema() *schema.Resource {
 	return &sc
 }
 
-func ASBandWidthScheduledPolicySchema() *schema.Resource {
+func BandWidthScheduledPolicySchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"launch_time": {
@@ -181,15 +182,15 @@ func ASBandWidthScheduledPolicySchema() *schema.Resource {
 }
 
 func resourceASBandWidthPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// createBandwidthPolicy: create an AS bandwidth scaling policy
 	var (
 		createBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy"
 		createBandwidthPolicyProduct = "autoscaling"
 	)
-	createBandwidthPolicyClient, err := config.NewServiceClient(createBandwidthPolicyProduct, region)
+	createBandwidthPolicyClient, err := conf.NewServiceClient(createBandwidthPolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating ASBandWidthPolicy Client: %s", err)
 	}
@@ -203,7 +204,7 @@ func resourceASBandWidthPolicyCreate(ctx context.Context, d *schema.ResourceData
 			200,
 		},
 	}
-	createBandwidthPolicyOpt.JSONBody = utils.RemoveNil(buildCreateBandwidthPolicyBodyParams(d, config))
+	createBandwidthPolicyOpt.JSONBody = utils.RemoveNil(buildCreateBandwidthPolicyBodyParams(d))
 	createBandwidthPolicyResp, err := createBandwidthPolicyClient.Request("POST", createBandwidthPolicyPath, &createBandwidthPolicyOpt)
 	if err != nil {
 		return diag.Errorf("error creating ASBandWidthPolicy: %s", err)
@@ -223,7 +224,7 @@ func resourceASBandWidthPolicyCreate(ctx context.Context, d *schema.ResourceData
 	return resourceASBandWidthPolicyRead(ctx, d, meta)
 }
 
-func buildCreateBandwidthPolicyBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateBandwidthPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"scaling_policy_name":   utils.ValueIngoreEmpty(d.Get("scaling_policy_name")),
 		"scaling_policy_type":   utils.ValueIngoreEmpty(d.Get("scaling_policy_type")),
@@ -272,9 +273,9 @@ func buildCreateBandwidthPolicyScheduledPolicyChildBody(d *schema.ResourceData) 
 	return params
 }
 
-func resourceASBandWidthPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceASBandWidthPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -283,7 +284,7 @@ func resourceASBandWidthPolicyRead(ctx context.Context, d *schema.ResourceData, 
 		getBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
 		getBandwidthPolicyProduct = "autoscaling"
 	)
-	getBandwidthPolicyClient, err := config.NewServiceClient(getBandwidthPolicyProduct, region)
+	getBandwidthPolicyClient, err := conf.NewServiceClient(getBandwidthPolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating ASBandWidthPolicy Client: %s", err)
 	}
@@ -365,8 +366,8 @@ func flattenGetBandwidthPolicyResponseBodyScheduledPolicy(resp interface{}) []in
 }
 
 func resourceASBandWidthPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	updateBandwidthPolicyhasChanges := []string{
 		"scaling_policy_name",
@@ -386,7 +387,7 @@ func resourceASBandWidthPolicyUpdate(ctx context.Context, d *schema.ResourceData
 			updateBandwidthPolicyHttpUrl = "autoscaling-api/v2/{project_id}/scaling_policy/{id}"
 			updateBandwidthPolicyProduct = "autoscaling"
 		)
-		updateBandwidthPolicyClient, err := config.NewServiceClient(updateBandwidthPolicyProduct, region)
+		updateBandwidthPolicyClient, err := conf.NewServiceClient(updateBandwidthPolicyProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating ASBandWidthPolicy Client: %s", err)
 		}
@@ -401,7 +402,7 @@ func resourceASBandWidthPolicyUpdate(ctx context.Context, d *schema.ResourceData
 				200,
 			},
 		}
-		updateBandwidthPolicyOpt.JSONBody = utils.RemoveNil(buildUpdateBandwidthPolicyBodyParams(d, config))
+		updateBandwidthPolicyOpt.JSONBody = utils.RemoveNil(buildUpdateBandwidthPolicyBodyParams(d))
 		_, err = updateBandwidthPolicyClient.Request("PUT", updateBandwidthPolicyPath, &updateBandwidthPolicyOpt)
 		if err != nil {
 			return diag.Errorf("error updating ASBandWidthPolicy: %s", err)
@@ -410,7 +411,7 @@ func resourceASBandWidthPolicyUpdate(ctx context.Context, d *schema.ResourceData
 	return resourceASBandWidthPolicyRead(ctx, d, meta)
 }
 
-func buildUpdateBandwidthPolicyBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildUpdateBandwidthPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"scaling_policy_name":   utils.ValueIngoreEmpty(d.Get("scaling_policy_name")),
 		"scaling_policy_type":   utils.ValueIngoreEmpty(d.Get("scaling_policy_type")),

--- a/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
@@ -211,11 +211,9 @@ func resourceInstanceAttachUpdate(ctx context.Context, d *schema.ResourceData, m
 		action := "EXIT_STANDBY"
 		if d.Get("standby").(bool) {
 			action = "ENTER_STANDBY"
-
+			isAppend = "no"
 			if d.Get("append_instance").(bool) {
 				isAppend = "yes"
-			} else {
-				isAppend = "no"
 			}
 		}
 		actionList = append(actionList, instances.BatchOpts{

--- a/huaweicloud/services/as/resource_huaweicloud_as_lifecycle_hook.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_lifecycle_hook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -93,8 +94,8 @@ func ResourceASLifecycleHook() *schema.Resource {
 }
 
 func resourceASLifecycleHookCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	client, err := conf.AutoscalingV1Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -125,9 +126,9 @@ func resourceASLifecycleHookCreate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceASLifecycleHookRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.AutoscalingV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.AutoscalingV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -147,8 +148,8 @@ func resourceASLifecycleHookRead(_ context.Context, d *schema.ResourceData, meta
 }
 
 func resourceASLifecycleHookUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	client, err := conf.AutoscalingV1Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -186,8 +187,8 @@ func resourceASLifecycleHookUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceASLifecycleHookDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	client, err := conf.AutoscalingV1Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating autoscaling client: %s", err)
 	}
@@ -212,10 +213,8 @@ func setASLifecycleHookToState(d *schema.ResourceData, hook *lifecyclehooks.Hook
 		d.Set("notification_topic_name", hook.NotificationTopicName),
 		d.Set("create_time", hook.CreateTime),
 	)
-	if err := mErr.ErrorOrNil(); err != nil {
-		return err
-	}
-	return nil
+	err := mErr.ErrorOrNil()
+	return err
 }
 
 func setASLifecycleHookType(d *schema.ResourceData, hook *lifecyclehooks.Hook) error {
@@ -228,7 +227,7 @@ func setASLifecycleHookType(d *schema.ResourceData, hook *lifecyclehooks.Hook) e
 	return fmt.Errorf("the type of hook response is not in the map")
 }
 
-func resourceASLifecycleHookImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceASLifecycleHookImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid format specified for lifecycle hook, must be <scaling_group_id>/<hook_id>")

--- a/huaweicloud/services/as/resource_huaweicloud_as_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_policy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
@@ -196,8 +197,8 @@ func buildPolicyAction(rawPolicyAction map[string]interface{}) policies.ActionOp
 }
 
 func resourceASPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	asClient, err := config.AutoscalingV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	asClient, err := conf.AutoscalingV1Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating autoscaling client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix codecheck errors for as service

## Test
./scripts/codecheck.sh ./huaweicloud/services/as

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        9      3755      345        45     3365        420           107.57
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rvices/as/resource_huaweicloud_as_group.go       840       78        18      744        120            16.13
~resource_huaweicloud_as_instance_attach.go       396       52         9      335         73            21.79
~s/resource_huaweicloud_as_configuration.go       601       56         3      542         66            12.18
~vices/as/resource_huaweicloud_as_policy.go       351       35         0      316         53            16.77
~esource_huaweicloud_as_bandwidth_policy.go       461       47         7      407         31             7.62
~/resource_huaweicloud_as_lifecycle_hook.go       239       25         0      214         30            14.02
~as/resource_huaweicloud_as_notification.go       241       29         7      205         23            11.22
~es/as/data_source_huaweicloud_as_groups.go       356       10         1      345         15             4.35
~ta_source_huaweicloud_as_configurations.go       270       13         0      257          9             3.50
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     9      3755      345        45     3365        420           107.57
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 119848 bytes, 0.120 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
17 as resourceASGroupUpdate huaweicloud/services/as/resource_huaweicloud_as_group.go:673:1
13 as resourceASGroupDelete huaweicloud/services/as/resource_huaweicloud_as_group.go:768:1
12 as resourceASGroupCreate huaweicloud/services/as/resource_huaweicloud_as_group.go:488:1
12 as refreshInstancesLifeStates huaweicloud/services/as/resource_huaweicloud_as_group.go:402:1
10 as validateParameters huaweicloud/services/as/resource_huaweicloud_as_policy.go:142:1
10 as resourceInstanceAttachCreate huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go:88:1
9 as resourceASLifecycleHookUpdate huaweicloud/services/as/resource_huaweicloud_as_lifecycle_hook.go:150:1
9 as resourceInstanceAttachUpdate huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go:186:1
9 as dataSourceASGroupRead huaweicloud/services/as/data_source_huaweicloud_as_groups.go:269:1
7 as resourceASPolicyUpdate huaweicloud/services/as/resource_huaweicloud_as_policy.go:295:1
Average: 3.53

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./docs/resources/as_instance_attach.md:49:  <!--markdownlint-disable MD033-->

==> Checking for TF features in as...

==> Checking for misspell in as...

==> Checking for code complexity in ./huaweicloud/services/acceptance/as...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        9      1812      155         7     1650         99            51.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~urce_huaweicloud_as_lifecycle_hook_test.go       182       18         0      164         24            14.63
~ource_huaweicloud_as_configuration_test.go       228       21         1      206         16             7.77
~source_huaweicloud_as_notification_test.go       168       19         1      148         16            10.81
~e/as/resource_huaweicloud_as_group_test.go       448       30         3      415         16             3.86
~/as/resource_huaweicloud_as_policy_test.go       296       22         1      273         14             5.13
~rce_huaweicloud_as_instance_acctah_test.go       129       14         0      115          9             7.83
~ce_huaweicloud_as_bandwidth_policy_test.go       272       19         1      252          4             1.59
~urce_huaweicloud_as_configurations_test.go        45        6         0       39          0             0.00
~/data_source_huaweicloud_as_groups_test.go        44        6         0       38          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     9      1812      155         7     1650         99            51.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 57396 bytes, 0.057 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
7 as testAccCheckASLifecycleHookDestroy huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go:64:1
6 as testAccCheckASLifecycleHookExists huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_test.go:92:1
6 as getASInstanceAttachResourceFunc huaweicloud/services/acceptance/as/resource_huaweicloud_as_instance_acctah_test.go:16:1
6 as testAccCheckASGroupExists huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go:181:1
6 as testAccCheckASConfigurationExists huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go:100:1
Average: 1.98

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/as...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/as...
./huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go:131://nolint:revive
./huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go:212://nolint:revive
./huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go:151://nolint:revive

==> Cleanup patch...

Check Completed!


## PR Checklist

* [√ ] Tests added/passed.
* [ ] Documentation updated. 
* [ ] Schema updated.

## Acceptance Steps Performed

```
...
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (186.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        186.823s

...
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (21.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        21.920s

...
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASBandWidthPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_basic
^[--- PASS: TestAccASBandWidthPolicy_basic (44.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        44.814s

...
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASLifecycleHook_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASLifecycleHook_basic -timeout 360m -parallel 4
=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (142.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        142.979s

...
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== CONT  TestAccASPolicy_basic
--- PASS: TestAccASPolicy_basic (94.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        94.895s

...
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASInstanceAttach_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASInstanceAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccASInstanceAttach_basic
=== PAUSE TestAccASInstanceAttach_basic
=== CONT  TestAccASInstanceAttach_basic
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting Subnet: timeout while waiting for state to become 'DELETED' (last state: 'ACTIVE', timeout: 10m0s)
        
        
        Error: error deleting security group (e9678046-a5bb-4fba-9283-98c64ecbdae8): timeout while waiting for state to become 'DELETED' (last state: 'ACTIVE', timeout: 10m0s)
        
--- FAIL: TestAccASInstanceAttach_basic (959.97s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        960.048s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```
