### PR TITLE
feat(LTS): add a LTS data source to query custom templates

### DIFF
--- a/docs/data-sources/lts_structuring_custom_templates.md
+++ b/docs/data-sources/lts_structuring_custom_templates.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# huaweicloud_lts_structuring_custom_templates
+
+Use this data source to get the list of LTS structuring custom templates.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_lts_structuring_custom_templates" "test" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `template_id` - (Optional, String) Specifies the custom template ID to be queried.
+
+* `name` - (Optional, String) Specifies the custom template name to be queried.
+
+* `type` - (Optional, String) Specifies the custom template type to be queried. Valid values are: **regex**, **json**,
+  **split** and **nginx**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `templates` - The list of LTS structuring custom templates.
+  The [templates](#CustomTemplates_templates) structure is documented below.
+
+<a name="CustomTemplates_templates"></a>
+The `templates` block supports:
+
+* `id` - The structuring custom template ID.
+
+* `name` - The structuring custom template name.
+
+* `type` - The structuring custom template type.
+
+* `demo_log` - The sample log event.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -519,6 +519,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_certificate":  lb.DataSourceLBCertificateV2(),
 			"huaweicloud_lb_pools":        lb.DataSourcePools(),
 
+			"huaweicloud_lts_structuring_custom_templates": lts.DataSourceCustomTemplates(),
+
 			"huaweicloud_elb_certificate": elb.DataSourceELBCertificateV3(),
 			"huaweicloud_elb_flavors":     elb.DataSourceElbFlavorsV3(),
 			"huaweicloud_elb_pools":       elb.DataSourcePools(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -93,6 +93,7 @@ var (
 	HW_VOD_WATERMARK_FILE   = os.Getenv("HW_VOD_WATERMARK_FILE")
 	HW_VOD_MEDIA_ASSET_FILE = os.Getenv("HW_VOD_MEDIA_ASSET_FILE")
 
+	HW_LTS_ENABLE_FLAG                 = os.Getenv("HW_LTS_ENABLE_FLAG")
 	HW_LTS_STRUCT_CONFIG_TEMPLATE_ID   = os.Getenv("HW_LTS_STRUCT_CONFIG_TEMPLATE_ID")
 	HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME = os.Getenv("HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME")
 
@@ -862,5 +863,12 @@ func TestAccPreCheckLtsStructConfigCustom(t *testing.T) {
 	if HW_LTS_STRUCT_CONFIG_TEMPLATE_ID == "" || HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME == "" {
 		t.Skip("HW_LTS_STRUCT_CONFIG_TEMPLATE_ID and HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME must be" +
 			" set for LTS struct config custom acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLtsEnableFlag(t *testing.T) {
+	if HW_LTS_ENABLE_FLAG == "" {
+		t.Skip("Skip the LTS acceptance tests.")
 	}
 }

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_structuring_custom_templates_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_structuring_custom_templates_test.go
@@ -1,0 +1,78 @@
+package lts
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCustomTemplates_basic(t *testing.T) {
+	rName := "data.huaweicloud_lts_structuring_custom_templates.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCustomTemplates_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.demo_log"),
+
+					resource.TestCheckOutput("template_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCustomTemplates_basic() string {
+	return `
+data "huaweicloud_lts_structuring_custom_templates" "test" {
+}
+
+data "huaweicloud_lts_structuring_custom_templates" "template_id_filter" {
+  template_id = data.huaweicloud_lts_structuring_custom_templates.test.templates.0.id
+}
+
+output "template_id_filter_is_useful" {
+  value = length(data.huaweicloud_lts_structuring_custom_templates.template_id_filter.templates) > 0 && alltrue(
+    [for v in data.huaweicloud_lts_structuring_custom_templates.template_id_filter.templates[*].id :
+    v == data.huaweicloud_lts_structuring_custom_templates.template_id_filter.template_id]
+  )
+}
+
+data "huaweicloud_lts_structuring_custom_templates" "name_filter" {
+  name = data.huaweicloud_lts_structuring_custom_templates.test.templates.0.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_lts_structuring_custom_templates.name_filter.templates) > 0 && alltrue(
+    [for v in data.huaweicloud_lts_structuring_custom_templates.name_filter.templates[*].name :
+    v == data.huaweicloud_lts_structuring_custom_templates.name_filter.name]
+  )
+}
+
+data "huaweicloud_lts_structuring_custom_templates" "type_filter" {
+  type = data.huaweicloud_lts_structuring_custom_templates.test.templates.0.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_lts_structuring_custom_templates.type_filter.templates) > 0 && alltrue(
+    [for v in data.huaweicloud_lts_structuring_custom_templates.type_filter.templates[*].type :
+    v == data.huaweicloud_lts_structuring_custom_templates.type_filter.type]
+  )
+}
+`
+}

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_structuring_custom_templates.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_structuring_custom_templates.go
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product LTS
+// ---------------------------------------------------------------
+
+package lts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceCustomTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceCustomTemplatesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the template to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the custom template name to be queried.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the custom template type to be queried.`,
+			},
+			"templates": {
+				Type:        schema.TypeList,
+				Elem:        customTemplateSchema(),
+				Computed:    true,
+				Description: `The list of structuring custom templates`,
+			},
+		},
+	}
+}
+
+func customTemplateSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The structuring custom template ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The structuring custom template name.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The structuring custom template type.`,
+			},
+			"demo_log": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sample log event.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceCustomTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/lts/struct/customtemplate"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildListCustomTemplatesQueryParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving LTS structuring custom templates: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("templates", flattenAndFilterCustomTemplates(listRespBody, d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAndFilterCustomTemplates(resp interface{}, d *schema.ResourceData) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("results", resp, make([]interface{}, 0))
+	curArray, isArray := curJson.([]interface{})
+	if !isArray {
+		log.Printf("[WARN] error flatten LTS structuring custom templates: " +
+			"the results value is not array in API response")
+		return nil
+	}
+
+	rawName, nameExist := d.GetOk("name")
+	rawType, typeExist := d.GetOk("type")
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		templateName := utils.PathSearch("template_name", v, "")
+		templateType := utils.PathSearch("template_type", v, "")
+		if nameExist && rawName.(string) != templateName.(string) {
+			continue
+		}
+		if typeExist && rawType.(string) != templateType.(string) {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"name":     templateName,
+			"type":     templateType,
+			"id":       utils.PathSearch("id", v, nil),
+			"demo_log": utils.PathSearch("demo_log", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildListCustomTemplatesQueryParams(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("template_id"); ok {
+		return fmt.Sprintf("?id=%s", v.(string))
+	}
+	return ""
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add a LTS data source to query custom templates

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- There has no resource to create LTS structuring custom templates. Before running unit test, we need to create templates using console.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccDatasourceCustomTemplates_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccDatasourceCustomTemplates_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCustomTemplates_basic
=== PAUSE TestAccDatasourceCustomTemplates_basic
=== CONT  TestAccDatasourceCustomTemplates_basic
--- PASS: TestAccDatasourceCustomTemplates_basic (22.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       22.555s
```
