### PR TITLE
test(Organizations): fix organizations test

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -119,6 +119,7 @@ var (
 	HW_KMS_ENVIRONMENT = os.Getenv("HW_KMS_ENVIRONMENT")
 
 	HW_MULTI_ACCOUNT_ENVIRONMENT            = os.Getenv("HW_MULTI_ACCOUNT_ENVIRONMENT")
+	HW_ORGANIZATIONS_OPEN                   = os.Getenv("HW_ORGANIZATIONS_OPEN")
 	HW_ORGANIZATIONS_ACCOUNT_NAME           = os.Getenv("HW_ORGANIZATIONS_ACCOUNT_NAME")
 	HW_ORGANIZATIONS_INVITE_ACCOUNT_ID      = os.Getenv("HW_ORGANIZATIONS_INVITE_ACCOUNT_ID")
 	HW_ORGANIZATIONS_ORGANIZATIONAL_UNIT_ID = os.Getenv("HW_ORGANIZATIONS_ORGANIZATIONAL_UNIT_ID")
@@ -232,6 +233,15 @@ func preCheckRequiredEnvVars(t *testing.T) {
 func TestAccPreCheckMultiAccount(t *testing.T) {
 	if HW_MULTI_ACCOUNT_ENVIRONMENT == "" {
 		t.Skip("This environment does not support multi-account tests")
+	}
+}
+
+// when this variable is set, the Organizations service should be enabled, and the organization info
+// can be get by the API
+// lintignore:AT003
+func TestAccPreCheckOrganizationsOpen(t *testing.T) {
+	if HW_ORGANIZATIONS_OPEN == "" {
+		t.Skip("HW_ORGANIZATIONS_OPEN must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_accounts_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_accounts_test.go
@@ -17,6 +17,7 @@ func TestAccDatasourceAccounts_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -44,6 +45,7 @@ func TestAccDatasourceAccounts_name(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
 			acceptance.TestAccPreCheckOrganizationsAccountName(t)
 		},
@@ -62,8 +64,8 @@ func TestAccDatasourceAccounts_name(t *testing.T) {
 }
 
 func testAccDatasourceAccounts_basic() string {
-	return `
-data "huaweicloud_organizations_organization" "test" {}
+	return fmt.Sprintf(`
+%s
 
 data "huaweicloud_organizations_accounts" "all" {}
 
@@ -74,7 +76,7 @@ data "huaweicloud_organizations_accounts" "parent_id_filter" {
 output "parent_id_filter_is_useful" {
   value = length(data.huaweicloud_organizations_accounts.parent_id_filter.accounts) > 0
 }
-`
+`, testAccDatasourceOrganization_basic())
 }
 
 func testAccDatasourceAccounts_name(name string) string {

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_organization_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_organization_test.go
@@ -1,7 +1,6 @@
 package organizations
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -17,6 +16,7 @@ func TestAccDatasourceOrganization_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -33,11 +33,5 @@ func TestAccDatasourceOrganization_basic(t *testing.T) {
 }
 
 func testAccDatasourceOrganization_basic() string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_organizations_organization" "test" {
-  depends_on = [huaweicloud_organizations_organization.test]
-}
-`, testOrganization_basic())
+	return `data "huaweicloud_organizations_organization" "test" {}`
 }

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_organizational_units_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_organizational_units_test.go
@@ -1,6 +1,7 @@
 package organizations
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,6 +17,7 @@ func TestAccDatasourceOrganizationalUnits_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -35,11 +37,11 @@ func TestAccDatasourceOrganizationalUnits_basic(t *testing.T) {
 }
 
 func testAccDatasourceOrganizationalUnits_basic() string {
-	return `
-data "huaweicloud_organizations_organization" "test" {}
+	return fmt.Sprintf(`
+%s
 
 data "huaweicloud_organizations_organizational_units" "test" {
   parent_id = data.huaweicloud_organizations_organization.test.root_id
 }
-`
+`, testAccDatasourceOrganization_basic())
 }

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_associate_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_associate_test.go
@@ -57,6 +57,7 @@ func TestAccAccountAssociate_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 			acceptance.TestAccPreCheckOrganizationsOrganizationalUnitId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -98,16 +99,13 @@ func testAccountAssociate_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_organizations_organizational_unit" "test" {
-  name      = "%[2]s"
-  parent_id = huaweicloud_organizations_organization.test.root_id
-}
+%[2]s
 
 resource "huaweicloud_organizations_account_associate" "test" {
   account_id = huaweicloud_organizations_account.test.id
   parent_id  = huaweicloud_organizations_organizational_unit.test.id
 }
-`, testAccount_basic(name), name)
+`, testOrganizationalUnit_basic(name), testAccount_basic(name))
 }
 
 func testAccountAssociate_basic_update(name string) string {

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
@@ -56,6 +56,7 @@ func TestAccAccountInviteAccepter_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 			acceptance.TestAccPreCheckOrganizationsInvitationId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
@@ -85,6 +85,7 @@ func TestAccAccountInvite_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 			acceptance.TestAccPreCheckOrganizationsInviteAccountId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_test.go
@@ -56,6 +56,7 @@ func TestAccAccount_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 			acceptance.TestAccPreCheckOrganizationsOrganizationalUnitId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
@@ -61,6 +61,7 @@ func TestAccOrganizationalUnit_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -101,14 +102,14 @@ func testOrganizationalUnit_basic(name string) string {
 
 resource "huaweicloud_organizations_organizational_unit" "test" {
   name      = "%s"
-  parent_id = huaweicloud_organizations_organization.test.root_id
+  parent_id = data.huaweicloud_organizations_organization.test.root_id
 
   tags = {
     "key1" = "value1"
     "key2" = "value2"
   }
 }
-`, testOrganization_basic(), name)
+`, testAccDatasourceOrganization_basic(), name)
 }
 
 func testOrganizationalUnit_basic_update(name string) string {
@@ -117,12 +118,12 @@ func testOrganizationalUnit_basic_update(name string) string {
 
 resource "huaweicloud_organizations_organizational_unit" "test" {
   name      = "%s"
-  parent_id = huaweicloud_organizations_organization.test.root_id
+  parent_id = data.huaweicloud_organizations_organization.test.root_id
 
   tags = {
     "key3" = "value3"
     "key4" = "value4"
   }
 }
-`, testOrganization_basic(), name)
+`, testAccDatasourceOrganization_basic(), name)
 }

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_trusted_service_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_trusted_service_test.go
@@ -95,6 +95,7 @@ func TestAccTrustedService_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix organizations test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix organizations test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
go test ./huaweicloud/services/acceptance/organizations -v -run TestAccDatasourceAccounts_ -timeout 360m
=== RUN   TestAccDatasourceAccounts_basic
=== PAUSE TestAccDatasourceAccounts_basic
=== RUN   TestAccDatasourceAccounts_name 
=== PAUSE TestAccDatasourceAccounts_name
=== CONT  TestAccDatasourceAccounts_basic
=== CONT  TestAccDatasourceAccounts_name
--- PASS: TestAccDatasourceAccounts_name (7.73s)
--- PASS: TestAccDatasourceAccounts_basic (13.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     14.614s

go test ./huaweicloud/services/acceptance/organizations -v -run TestAccDatasourceOrganization_basic -timeout 360m 
=== RUN   TestAccDatasourceOrganization_basic
=== PAUSE TestAccDatasourceOrganization_basic
=== CONT  TestAccDatasourceOrganization_basic
--- PASS: TestAccDatasourceOrganization_basic (13.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     14.267s


go test ./huaweicloud/services/acceptance/organizations -v -run TestAccDatasourceOrganizationalUnits_basic -timeou
t 360m
=== RUN   TestAccDatasourceOrganizationalUnits_basic
=== PAUSE TestAccDatasourceOrganizationalUnits_basic
=== CONT  TestAccDatasourceOrganizationalUnits_basic
--- PASS: TestAccDatasourceOrganizationalUnits_basic (21.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     22.131s

go test ./huaweicloud/services/acceptance/organizations -v -run TestAccOrganizationalUnit_basic -timeout 360m     
=== RUN   TestAccOrganizationalUnit_basic
=== PAUSE TestAccOrganizationalUnit_basic
=== CONT  TestAccOrganizationalUnit_basic
--- PASS: TestAccOrganizationalUnit_basic (59.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     60.129s

go test ./huaweicloud/services/acceptance/organizations -v -run TestAccTrustedService_basic -timeout 360m
=== RUN   TestAccTrustedService_basic
=== PAUSE TestAccTrustedService_basic
=== CONT  TestAccTrustedService_basic
--- PASS: TestAccTrustedService_basic (588.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     589.109s
```
