### PR TITLE
feat(OBS): OBS bucket resource support user domain names

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -214,6 +214,17 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the OBS bucket.
   Defaults to `0`.
 
+* `user_domain_names` - (Optional, List) Specifies the user domain names. The restriction requirements for this field
+  are as follows:
+  + Each value must meet the domain name rules.
+  + The maximum length of a domain name is 256 characters.
+  + A maximum of 100 custom domain names can be set for a bucket.
+  + A custom domain name can only be used by one bucket.
+  + Ensure the domain name has been licensed by the Ministry of Industry and Information Technology.
+  + The bound user domain names only support access over HTTP now.
+
+  -> When creating or updating the OBS bucket user domain names, the original user domain names will be overwritten.
+
 The `logging` object supports the following:
 
 * `target_bucket` - (Required, String) The name of the bucket that will receive the log objects. The acl policy of the

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -44,6 +44,8 @@ var (
 
 	HW_OBS_BUCKET_NAME        = os.Getenv("HW_OBS_BUCKET_NAME")
 	HW_OBS_DESTINATION_BUCKET = os.Getenv("HW_OBS_DESTINATION_BUCKET")
+	HW_OBS_USER_DOMAIN_NAME1  = os.Getenv("HW_OBS_USER_DOMAIN_NAME1")
+	HW_OBS_USER_DOMAIN_NAME2  = os.Getenv("HW_OBS_USER_DOMAIN_NAME2")
 
 	HW_OMS_ENABLE_FLAG = os.Getenv("HW_OMS_ENABLE_FLAG")
 
@@ -476,6 +478,13 @@ func TestAccPreCheckOBSBucket(t *testing.T) {
 func TestAccPreCheckOBSDestinationBucket(t *testing.T) {
 	if HW_OBS_DESTINATION_BUCKET == "" {
 		t.Skip("HW_OBS_DESTINATION_BUCKET must be set for OBS destination tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckOBSUserDomainNames(t *testing.T) {
+	if HW_OBS_USER_DOMAIN_NAME1 == "" || HW_OBS_USER_DOMAIN_NAME2 == "" {
+		t.Skip("HW_OBS_USER_DOMAIN_NAME1 and HW_OBS_USER_DOMAIN_NAME2 must be set for OBS user domain name tests")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

OBS bucket resource support user domain names

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Add a new parameter `user_domain_names`.
- The user domain names will be overwritten when creating or updating OBS bucket user domain names.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_userDomainNames'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_userDomainNames -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_userDomainNames
=== PAUSE TestAccObsBucket_userDomainNames
=== CONT  TestAccObsBucket_userDomainNames
--- PASS: TestAccObsBucket_userDomainNames (23.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       23.422s
```
```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_basic -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (23.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       23.646s
```

