### PR TITLE
fix(cc/cci): fix codecheck errors in cc/cci service

### DIFF
--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_connection_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_connection_test.go
@@ -5,30 +5,31 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getCloudConnectionResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getCloudConnectionResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getCloudConnection: Query the Cloud Connection
 	var (
 		getCloudConnectionHttpUrl = "v3/{domain_id}/ccaas/cloud-connections/{id}"
 		getCloudConnectionProduct = "cc"
 	)
-	getCloudConnectionClient, err := config.NewServiceClient(getCloudConnectionProduct, region)
+	getCloudConnectionClient, err := conf.NewServiceClient(getCloudConnectionProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CloudConnection Client: %s", err)
 	}
 
 	getCloudConnectionPath := getCloudConnectionClient.Endpoint + getCloudConnectionHttpUrl
-	getCloudConnectionPath = strings.Replace(getCloudConnectionPath, "{domain_id}", config.DomainID, -1)
-	getCloudConnectionPath = strings.Replace(getCloudConnectionPath, "{id}", state.Primary.ID, -1)
+	getCloudConnectionPath = strings.ReplaceAll(getCloudConnectionPath, "{domain_id}", conf.DomainID)
+	getCloudConnectionPath = strings.ReplaceAll(getCloudConnectionPath, "{id}", state.Primary.ID)
 
 	getCloudConnectionOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go
@@ -5,30 +5,31 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getNetworkInstanceResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getNetworkInstanceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getNetworkInstance: Query the Network instance
 	var (
 		getNetworkInstanceHttpUrl = "v3/{domain_id}/ccaas/network-instances/{id}"
 		getNetworkInstanceProduct = "cc"
 	)
-	getNetworkInstanceClient, err := config.NewServiceClient(getNetworkInstanceProduct, region)
+	getNetworkInstanceClient, err := conf.NewServiceClient(getNetworkInstanceProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NetworkInstance Client: %s", err)
 	}
 
 	getNetworkInstancePath := getNetworkInstanceClient.Endpoint + getNetworkInstanceHttpUrl
-	getNetworkInstancePath = strings.Replace(getNetworkInstancePath, "{domain_id}", config.DomainID, -1)
-	getNetworkInstancePath = strings.Replace(getNetworkInstancePath, "{id}", state.Primary.ID, -1)
+	getNetworkInstancePath = strings.ReplaceAll(getNetworkInstancePath, "{domain_id}", conf.DomainID)
+	getNetworkInstancePath = strings.ReplaceAll(getNetworkInstancePath, "{id}", state.Primary.ID)
 
 	getNetworkInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cci/data_source_huaweicloud_cci_namespaces_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )

--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_namespace_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_namespace_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/cci/v1/namespaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cci/v1/namespaces"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -45,7 +46,7 @@ func TestAccCciNamespace_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "type", "gpu-accelerated"),
+					resource.TestCheckResourceAttr(resourceName, "type", "general-computing"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "auto_expend_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "warmup_pool_size", "0"),
@@ -90,7 +91,7 @@ func TestAccCciNamespace_network(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "type", "gpu-accelerated"),
+					resource.TestCheckResourceAttr(resourceName, "type", "general-computing"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "auto_expend_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "warmup_pool_size", "15"),
@@ -125,7 +126,7 @@ func testAccCciNamespace_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cci_namespace" "test" {
   name                      = "%s"
-  type                      = "gpu-accelerated"
+  type                      = "general-computing"
   auto_expend_enabled       = true
   rbac_enabled              = true
   enterprise_project_id     = "%s"
@@ -138,7 +139,7 @@ func testAccCciNamespace_network(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cci_namespace" "test" {
   name                      = "%s"
-  type                      = "gpu-accelerated"
+  type                      = "general-computing"
   auto_expend_enabled       = true
   warmup_pool_size          = 15
   recycling_interval        = 30

--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/cci/v1/networks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cci/v1/networks"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -89,7 +90,7 @@ func testAccCciNetwork_base(rName string) string {
 
 resource "huaweicloud_cci_namespace" "test" {
   name = "%s"
-  type = "gpu-accelerated"
+  type = "general-computing"
 }
 `, common.TestBaseNetwork(rName), rName)
 }

--- a/huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go
+++ b/huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/cci/v1/namespaces"
-	"github.com/chnsz/golangsdk/openstack/cci/v1/networks"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cci/v1/namespaces"
+	"github.com/chnsz/golangsdk/openstack/cci/v1/networks"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceCciNamespaces() *schema.Resource {
@@ -213,32 +214,32 @@ func filterDataCciNamespaces(d *schema.ResourceData, client *golangsdk.ServiceCl
 }
 
 func dataSourceCciNamespacesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.CciV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.CciV1Client(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud CCI v1 client: %s", err)
+		return diag.Errorf("Error creating CCI v1 client: %s", err)
 	}
-	betaClient, err := config.CciV1BetaClient(config.GetRegion(d))
+	betaClient, err := conf.CciV1BetaClient(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud CCI v1 beta1 client: %s", err)
+		return diag.Errorf("Error creating CCI v1 beta1 client: %s", err)
 	}
 
 	var nsList []namespaces.Namespace
 	if ns, ok := d.GetOk("name"); ok {
 		nsResp, err := namespaces.Get(client, ns.(string)).Extract()
 		if err != nil {
-			return fmtp.DiagErrorf("Error getting the namespace (%s) from the server: %s", ns.(string), err)
+			return diag.Errorf("Error getting the namespace (%s) from the server: %s", ns.(string), err)
 		}
 		nsList = append(nsList, *nsResp)
 	} else {
 		pages, err := namespaces.List(client, namespaces.ListOpts{}).AllPages()
 		if err != nil {
-			return fmtp.DiagErrorf("Error finding the namespace list from the server: %s", err)
+			return diag.Errorf("Error finding the namespace list from the server: %s", err)
 		}
 		nsList, err = namespaces.ExtractNamespaces(pages)
 		if err != nil {
-			return fmtp.DiagErrorf("Error extracting HuaweiCloud CCI namespaces: %s", err)
+			return diag.Errorf("Error extracting CCI namespaces: %s", err)
 		}
 	}
 
@@ -253,7 +254,7 @@ func dataSourceCciNamespacesRead(_ context.Context, d *schema.ResourceData, meta
 	)
 
 	if mErr.ErrorOrNil() != nil {
-		return fmtp.DiagErrorf("Error saving the namespace's (%v) fields to state: %s", ids, mErr)
+		return diag.Errorf("Error saving the namespace's (%v) fields to state: %s", ids, mErr)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix codecheck errors for cc/cci service

## Test

./scripts/codecheck.sh ./huaweicloud/services/cc

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        4      1449      184        29     1236        126            39.60
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~source_huaweicloud_cc_bandwidth_package.go       511       69         9      433         53            12.24
~e_huaweicloud_cc_inter_region_bandwidth.go       303       41         4      258         26            10.08
~esource_huaweicloud_cc_network_instance.go       333       37         8      288         24             8.33
~s/cc/resource_huaweicloud_cc_connection.go       302       37         8      257         23             8.95
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     4      1449      184        29     1236        126            39.60
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 51718 bytes, 0.052 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
11 cc resourceBandwidthPackageUpdate huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go:256:1
5 cc resourceNetworkInstanceCreate huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go:124:1
5 cc resourceInterRegionBandwidthCreate huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go:102:1
5 cc resourceCloudConnectionCreate huaweicloud/services/cc/resource_huaweicloud_cc_connection.go:105:1
5 cc updateBandwidthPackageTags huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go:409:1
5 cc resourceBandwidthPackageCreate huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go:125:1
4 cc resourceNetworkInstanceUpdate huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go:245:1
4 cc resourceNetworkInstanceRead huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go:189:1
4 cc resourceInterRegionBandwidthUpdate huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go:226:1
4 cc resourceInterRegionBandwidthRead huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go:158:1
Average: 2.74

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in cc...

==> Checking for misspell in cc...

==> Checking for code complexity in ./huaweicloud/services/acceptance/cc...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        4       649       63         3      583         20            14.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~e_huaweicloud_cc_bandwidth_package_test.go       175       16         1      158          6             3.80
~weicloud_cc_inter_region_bandwidth_test.go       143       15         0      128          6             4.69
~ce_huaweicloud_cc_network_instance_test.go       220       19         1      200          4             2.00
~resource_huaweicloud_cc_connection_test.go       111       13         1       97          4             4.12
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     4       649       63         3      583         20            14.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 23237 bytes, 0.023 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
4 cc getInterRegionBandwidthResourceFunc huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_inter_region_bandwidth_test.go:18:1
4 cc getBandwidthPackageResourceFunc huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go:18:1
3 cc getNetworkInstanceResourceFunc huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go:18:1
3 cc getCloudConnectionResourceFunc huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_connection_test.go:18:1
1 cc testNetworkInstance_multiple huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go:202:1
Average: 1.56

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cc...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cc...

==> Cleanup patch...

Check Completed!

----------------------------------------------------------------------------------------------

./scripts/codecheck.sh ./huaweicloud/services/cci

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3       861       81         1      779        101            38.31
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/cci/resource_huaweicloud_cci_namespace.go       334       32         1      301         46            15.28
~es/cci/resource_huaweicloud_cci_network.go       267       33         0      234         28            11.97
~/data_source_huaweicloud_cci_namespaces.go       260       16         0      244         27            11.07
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3       861       81         1      779        101            38.31
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 25359 bytes, 0.025 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 cci dataSourceCciNamespacesRead huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go:216:1
5 cci resourceCciNetworkCreate huaweicloud/services/cci/resource_huaweicloud_cci_network.go:109:1
5 cci GetCciNamespaceInfoById huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go:301:1
5 cci resourceCciNamespaceRead huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go:207:1
5 cci resourceCciNamespaceCreate huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go:151:1
5 cci isNamespaceParamMatch huaweicloud/services/cci/data_source_huaweicloud_cci_namespaces.go:147:1
4 cci resourceCciNetworkDelete huaweicloud/services/cci/resource_huaweicloud_cci_network.go:198:1
4 cci namespacestateRefreshFunc huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go:279:1
4 cci resourceCciNamespaceDelete huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go:233:1
4 cci buildCciNamespaceCreateParams huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go:122:1
Average: 3.15

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in cci...

==> Checking for misspell in cci...

==> Checking for code complexity in ./huaweicloud/services/acceptance/cci...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3       379       35         1      343         10             9.14
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~i/resource_huaweicloud_cci_network_test.go       112       11         0      101          7             6.93
~resource_huaweicloud_cci_namespace_test.go       151       14         1      136          3             2.21
~_source_huaweicloud_cci_namespaces_test.go       116       10         0      106          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3       379       35         1      343         10             9.14
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 13616 bytes, 0.014 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
4 cci testAccCciNetworkImportStateFunc huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go:73:1
2 cci getNetworkResourceFunc huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go:17:1
2 cci testAccCciNamespaceImportStateFunc huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_namespace_test.go:115:1
2 cci getNamespaceResourceFunc huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_namespace_test.go:17:1
1 cci testAccCciNetwork_basic huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go:98:1
Average: 1.38

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cci...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cci...

==> Cleanup patch...

Check Completed!



## PR Checklist

* [√] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.



## Acceptance Steps Performed



```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCloudConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCloudConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudConnection_basic
=== PAUSE TestAccCloudConnection_basic
=== CONT  TestAccCloudConnection_basic
--- PASS: TestAccCloudConnection_basic (18.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        18.311s


make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccNetworkInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccNetworkInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkInstance_basic
=== PAUSE TestAccNetworkInstance_basic
=== CONT  TestAccNetworkInstance_basic
--- PASS: TestAccNetworkInstance_basic (60.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        60.885s

make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccDataCciNamespaces_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccDataCciNamespaces_basic -timeout 360m -parallel 4
=== RUN   TestAccDataCciNamespaces_basic
=== PAUSE TestAccDataCciNamespaces_basic
=== CONT  TestAccDataCciNamespaces_basic
--- PASS: TestAccDataCciNamespaces_basic (57.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       57.556s

make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccCciNetwork_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccCciNetwork_basic -timeout 360m -parallel 4
=== RUN   TestAccCciNetwork_basic
=== PAUSE TestAccCciNetwork_basic
=== CONT  TestAccCciNetwork_basic
--- PASS: TestAccCciNetwork_basic (59.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       60.115s

make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccCciNamespace_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccCciNamespace_basic -timeout 360m -parallel 4
=== RUN   TestAccCciNamespace_basic
=== PAUSE TestAccCciNamespace_basic
=== CONT  TestAccCciNamespace_basic
--- PASS: TestAccCciNamespace_basic (17.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       17.038s


```
