### PR TITLE
fix(cdn/ces/cfw/cloudtable): fix codecheck errors in cdn/ces/cfw/cloudtable services

### DIFF
--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_policy_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_policy_test.go
@@ -3,18 +3,18 @@ package aom
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
 )
 
 func getAlarmPolicyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-
 	client, _ := httpclient_go.NewHttpClientGo(conf, "aom", acceptance.HW_REGION_NAME)
 
 	client.WithMethod(httpclient_go.MethodGet).WithUrlWithoutEndpoint(conf, "aom", conf.Region,

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_rule_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	aom "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/aom/v2/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prometheus_instance_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prometheus_instance_test.go
@@ -3,18 +3,19 @@ package aom
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
 	"io"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
 )
 
-func getPrometheusInstanceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getPrometheusInstanceResourceFunc(conf *config.Config, _ *terraform.ResourceState) (interface{}, error) {
 	client, _ := httpclient_go.NewHttpClientGo(conf, "aom", acceptance.HW_REGION_NAME)
 	client.WithMethod(httpclient_go.MethodGet).WithUrlWithoutEndpoint(conf, "aom",
 		conf.Region, "v1/"+conf.GetProjectID(conf.Region)+"/prometheus-instances?action=prom_for_cloud_service")

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_service_discovery_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_service_discovery_rule_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	aomservice "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 
 	aom "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/aom/v2/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	aomservice "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/aom"
 )
 
 func getServiceDiscoveryRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_protection_rule_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_protection_rule_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -17,14 +18,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getProtectionRuleResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getProtectionRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getProtectionRule: Query the CFW Protection Rule detail
 	var (
 		getProtectionRuleHttpUrl = "v1/{project_id}/acl-rules"
 		getProtectionRuleProduct = "cfw"
 	)
-	getProtectionRuleClient, err := config.NewServiceClient(getProtectionRuleProduct, region)
+	getProtectionRuleClient, err := conf.NewServiceClient(getProtectionRuleProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ProtectionRule Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
+++ b/huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/cloudtable/v2/clusters"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/chnsz/golangsdk/openstack/cloudtable/v2/clusters"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func getClusterResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -46,9 +46,9 @@ func TestAccCloudtableCluster_basic(t *testing.T) {
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "storage_type", "ULTRAHIGH"),
-					resource.TestCheckResourceAttr(resourceName, "storage_size", "10240"),
 					resource.TestCheckResourceAttr(resourceName, "rs_num", "4"),
 					resource.TestCheckResourceAttr(resourceName, "hbase_version", "1.0.6"),
+					resource.TestCheckResourceAttrSet(resourceName, "storage_size"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_policy.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
@@ -173,7 +174,6 @@ func schemeNoDataConditions() *schema.Schema {
 			},
 		},
 	}
-
 }
 
 func schemeAlarmTags() *schema.Schema {
@@ -372,7 +372,7 @@ func schemeAlarmNotifications() *schema.Schema {
 	}
 }
 
-func resourceAlarmPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAlarmPolicyCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := httpclient_go.NewHttpClientGo(conf, "aom", conf.GetRegion(d))
 	if err != nil {
@@ -390,7 +390,8 @@ func resourceAlarmPolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 		AlarmNotifications:   flattenAlarmNotifications(d.Get("alarm_notifications").([]interface{})),
 	}
 	region := conf.GetRegion(d)
-	client.WithMethod(httpclient_go.MethodPost).WithUrl("v4/" + conf.GetProjectID(region) + "/alarm-rules?action_id=add-alarm-action").WithBody(createOpts)
+	client.WithMethod(httpclient_go.MethodPost).WithUrl("v4/" + conf.GetProjectID(region) +
+		"/alarm-rules?action_id=add-alarm-action").WithBody(createOpts)
 	response, err := client.Do()
 
 	if err != nil {
@@ -412,7 +413,7 @@ func resourceAlarmPolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceAlarmPolicyRead(context.TODO(), d, meta)
 }
 
-func resourceAlarmPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAlarmPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	client, err := httpclient_go.NewHttpClientGo(conf, "aom", region)
@@ -540,7 +541,7 @@ func flattenAlarmNotificationsMap(notifications entity.AlarmNotifications) []map
 	return []map[string]interface{}{m}
 }
 
-func resourceAlarmPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAlarmPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	client, err := httpclient_go.NewHttpClientGo(conf, "aom", region)
@@ -566,11 +567,11 @@ func resourceAlarmPolicyDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func flattenMetricAlarmSpec(raw interface{}) entity.MetricAlarmSpec {
-	mas := make([]entity.MetricAlarmSpec, 0)
 	b, err := json.Marshal(raw)
 	if err != nil {
 		return entity.MetricAlarmSpec{}
 	}
+	var mas []entity.MetricAlarmSpec
 	err = json.Unmarshal(b, &mas)
 	if err != nil {
 		return entity.MetricAlarmSpec{}
@@ -582,11 +583,11 @@ func flattenMetricAlarmSpec(raw interface{}) entity.MetricAlarmSpec {
 }
 
 func flattenEventAlarmSpec(raw interface{}) entity.EventAlarmSpec {
-	mas := make([]entity.EventAlarmSpec, 0)
 	b, err := json.Marshal(raw)
 	if err != nil {
 		return entity.EventAlarmSpec{}
 	}
+	var mas []entity.EventAlarmSpec
 	err = json.Unmarshal(b, &mas)
 	if err != nil {
 		return entity.EventAlarmSpec{}
@@ -598,11 +599,11 @@ func flattenEventAlarmSpec(raw interface{}) entity.EventAlarmSpec {
 }
 
 func flattenAlarmNotifications(raw interface{}) entity.AlarmNotifications {
-	mas := make([]entity.AlarmNotifications, 0)
 	b, err := json.Marshal(raw)
 	if err != nil {
 		return entity.AlarmNotifications{}
 	}
+	var mas []entity.AlarmNotifications
 	err = json.Unmarshal(b, &mas)
 	if err != nil {
 		return entity.AlarmNotifications{}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prometheus_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prometheus_instance.go
@@ -3,16 +3,18 @@ package aom
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/entity"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/internal/httpclient_go"
-	"io"
-	"strings"
-	"time"
 )
 
 func ResourcePrometheusInstance() *schema.Resource {

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
@@ -7,11 +7,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
 	aom "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/aom/v2/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -242,8 +244,8 @@ func FilterRules(allRules []aom.AppRules, name string) (*aom.AppRules, error) {
 }
 
 func resourceServiceDiscoveryRuleCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcAomV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.HcAomV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating AOM client: %s", err)
 	}
@@ -253,7 +255,7 @@ func resourceServiceDiscoveryRuleCreateOrUpdate(ctx context.Context, d *schema.R
 		Enable:    d.Get("discovery_rule_enabled").(bool),
 		EventName: "aom_inventory_rules_event",
 		Name:      d.Get("name").(string),
-		Projectid: config.HwClient.ProjectID,
+		Projectid: cfg.HwClient.ProjectID,
 		Spec: &aom.AppRulesSpec{
 			AppType:       d.Get("service_type").(string),
 			DetectLog:     strconv.FormatBool(d.Get("detect_log_enabled").(bool)),
@@ -289,8 +291,8 @@ func resourceServiceDiscoveryRuleCreateOrUpdate(ctx context.Context, d *schema.R
 }
 
 func resourceServiceDiscoveryRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcAomV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.HcAomV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating AOM client: %s", err)
 	}
@@ -313,7 +315,7 @@ func resourceServiceDiscoveryRuleRead(_ context.Context, d *schema.ResourceData,
 	detectLogEnabled, _ := strconv.ParseBool(rule.Spec.DetectLog)
 
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", rule.Name),
 		d.Set("rule_id", rule.Id),
 		d.Set("discovery_rule_enabled", rule.Enable),
@@ -334,9 +336,9 @@ func resourceServiceDiscoveryRuleRead(_ context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceServiceDiscoveryRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.HcAomV2Client(config.GetRegion(d))
+func resourceServiceDiscoveryRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.HcAomV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating AOM client: %s", err)
 	}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go
@@ -10,12 +10,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -92,9 +94,9 @@ func DataSourceStatistics() *schema.Resource {
 	}
 }
 
-func resourceStatisticsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -103,7 +105,7 @@ func resourceStatisticsRead(ctx context.Context, d *schema.ResourceData, meta in
 		domainStatisticsHttpUrl = "v1.0/cdn/statistics/domain-location-stats"
 		domainStatisticsProduct = "cdn"
 	)
-	domainStatisticsClient, err := config.NewServiceClient(domainStatisticsProduct, region)
+	domainStatisticsClient, err := conf.NewServiceClient(domainStatisticsProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Statistics Client: %s", err)
 	}
@@ -111,7 +113,7 @@ func resourceStatisticsRead(ctx context.Context, d *schema.ResourceData, meta in
 	domainStatisticsPath := domainStatisticsClient.Endpoint + domainStatisticsHttpUrl
 
 	domainStatisticsqueryParams := buildDomainStatisticsQueryParams(d)
-	domainStatisticsPath = domainStatisticsPath + domainStatisticsqueryParams
+	domainStatisticsPath += domainStatisticsqueryParams
 
 	domainStatisticsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go
@@ -513,8 +513,8 @@ func buildPoliciesOpts(d *schema.ResourceData, globalMetricName string) []alarmr
 }
 
 func resourceAlarmRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	clientV2, err := config.CesV2Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	clientV2, err := conf.CesV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Cloud Eye Service v2 client: %s", err)
 	}
@@ -535,7 +535,7 @@ func resourceAlarmRuleCreate(ctx context.Context, d *schema.ResourceData, meta i
 		NotificationEndTime:   d.Get("notification_end_time").(string),
 		NotificationEnabled:   d.Get("alarm_action_enabled").(bool),
 		Enabled:               d.Get("alarm_enabled").(bool),
-		EnterpriseProjectID:   config.GetEnterpriseProjectID(d),
+		EnterpriseProjectID:   conf.GetEnterpriseProjectID(d),
 	}
 
 	log.Printf("[DEBUG] Create %s Options: %#v", nameCESAR, createOpts)
@@ -552,12 +552,12 @@ func resourceAlarmRuleCreate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceAlarmRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	clientV1, err := config.CesV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	clientV1, err := conf.CesV1Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Cloud Eye Service v1 client: %s", err)
 	}
-	clientV2, err := config.CesV2Client(config.GetRegion(d))
+	clientV2, err := conf.CesV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Cloud Eye Service v2 client: %s", err)
 	}
@@ -752,12 +752,12 @@ func buildUpdatePoliciesOptsWithMetricName(d *schema.ResourceData, level int, me
 }
 
 func resourceAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	clientV1, err := config.CesV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	clientV1, err := conf.CesV1Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Cloud Eye Service v1 client: %s", err)
 	}
-	clientV2, err := config.CesV2Client(config.GetRegion(d))
+	clientV2, err := conf.CesV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Cloud Eye Service v2 client: %s", err)
 	}
@@ -898,9 +898,9 @@ func resourceAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return resourceAlarmRuleRead(ctx, d, meta)
 }
 
-func resourceAlarmRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	clientV2, err := config.CesV2Client(config.GetRegion(d))
+func resourceAlarmRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	clientV2, err := conf.CesV2Client(conf.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Cloud Eye v2 Service client: %s", err)
 	}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewalls.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewalls.go
@@ -11,15 +11,17 @@ import (
 	"log"
 	"strings"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func DataSourceFirewalls() *schema.Resource {
@@ -118,8 +120,9 @@ func firewallsGetFirewallInstanceResponseRecordSchema() *schema.Resource {
 				Description: `Service type`,
 			},
 			"status": {
-				Type:        schema.TypeInt,
-				Computed:    true,
+				Type:     schema.TypeInt,
+				Computed: true,
+				//nolint:revive
 				Description: `Firewall status list. The options are as follows: -1: waiting for payment; 0: creating; 1: deleting; 2: running; 3: upgrading; 4: deletion completed; 5: freezing; 6: creation failed; 7: deletion failed; 8: freezing failed; 9: storage in progress; 10: storage failed; 11: upgrade failed`,
 			},
 			"support_ipv6": {
@@ -151,8 +154,9 @@ func firewallsGetFirewallInstanceResponseRecordFlavorSchema() *schema.Resource {
 				Description: `Log storage`,
 			},
 			"version": {
-				Type:        schema.TypeInt,
-				Computed:    true,
+				Type:     schema.TypeInt,
+				Computed: true,
+				//nolint:revive
 				Description: `Firewall version. The value can be 0 (standard edition), 1 (professional edition), 2 (platinum edition), or 3 (basic edition).`,
 			},
 			"vpc_count": {
@@ -217,8 +221,9 @@ func firewallsGetFirewallInstanceResponseRecordFirewallInstanceResourceSchema() 
 				Description: `Inventory unit code`,
 			},
 			"resource_type": {
-				Type:        schema.TypeString,
-				Computed:    true,
+				Type:     schema.TypeString,
+				Computed: true,
+				//nolint:revive
 				Description: `Resource type. The options are as follows:1. CFW: hws.resource.type.cfw 2. EIP:hws.resource.type.cfw.exp.eip 3. Bandwidth: hws.resource.type.cfw.exp.bandwidth 4. VPC: hws.resource.type.cfw.exp.vpc 5. Log storage: hws.resource.type.cfw.exp.logaudit`,
 			},
 		},
@@ -226,9 +231,9 @@ func firewallsGetFirewallInstanceResponseRecordFirewallInstanceResourceSchema() 
 	return &sc
 }
 
-func resourceFirewallsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceFirewallsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -237,7 +242,7 @@ func resourceFirewallsRead(ctx context.Context, d *schema.ResourceData, meta int
 		listFirewallsHttpUrl = "v1/{project_id}/firewall/exist"
 		listFirewallsProduct = "cfw"
 	)
-	listFirewallsClient, err := config.NewServiceClient(listFirewallsProduct, region)
+	listFirewallsClient, err := conf.NewServiceClient(listFirewallsProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Firewalls Client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix codecheck errors for cdn/ces/cfw/cloudtable services

## Test

./scripts/codecheck.sh ./huaweicloud/services/cdn

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       193       19         5      169         23            13.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ource_huaweicloud_cdn_domain_statistics.go       193       19         5      169         23            13.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       193       19         5      169         23            13.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 5466 bytes, 0.005 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
13 cdn buildDomainStatisticsQueryParams huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go:154:1
6 cdn resourceStatisticsRead huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go:97:1
1 cdn DataSourceStatistics huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go:26:1
Average: 6.67

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in cdn...

==> Checking for misspell in cdn...

==> Checking for code complexity in ./huaweicloud/services/acceptance/cdn...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1        40        6         0       34          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~_huaweicloud_cdn_domain_statistics_test.go        40        6         0       34          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1        40        6         0       34          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 1041 bytes, 0.001 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
1 cdn testAccDatasourceStatistics_basic huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_statistics_test.go:30:1
1 cdn TestAccDatasourceStatistics_basic huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_statistics_test.go:11:1
Average: 1

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cdn...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cdn...

==> Cleanup patch...

Check Completed!



./scripts/codecheck.sh ./huaweicloud/services/ces

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3      1743      237        27     1479        194            35.77
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/ces/resource_huaweicloud_ces_alarmrule.go       929      146         8      775        124            16.00
~resource_huaweicloud_ces_resource_group.go       431       52        11      368         41            11.14
~resource_huaweicloud_ces_alarm_template.go       383       39         8      336         29             8.63
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3      1743      237        27     1479        194            35.77
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 54108 bytes, 0.054 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
19 ces resourceAlarmRuleUpdate huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go:755:1
14 ces resourceAlarmRuleRead huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go:555:1
10 ces resourceConditionHash huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go:326:1
9 ces resourceResourceGroupUpdate huaweicloud/services/ces/resource_huaweicloud_ces_resource_group.go:303:1
8 ces updateCondition huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go:863:1
7 ces resourceResourceGroupCreate huaweicloud/services/ces/resource_huaweicloud_ces_resource_group.go:129:1
6 ces buildPoliciesOpts huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go:474:1
5 ces resourceCesAlarmTemplateCreate huaweicloud/services/ces/resource_huaweicloud_ces_alarm_template.go:143:1
4 ces resourceResourceGroupRead huaweicloud/services/ces/resource_huaweicloud_ces_resource_group.go:251:1
4 ces buildResourcesOptsDimensionOpts huaweicloud/services/ces/resource_huaweicloud_ces_resource_group.go:232:1
Average: 3.95

==> Checking for golangci-lint...
huaweicloud/services/ces/resource_huaweicloud_ces_alarmrule.go:754:1: cyclomatic complexity 25 of func `resourceAlarmRuleUpdate` is high (> 20) (gocyclo)
func resourceAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
==> Checking for Nolint directives...

==> Checking for TF features in ces...

==> Checking for misspell in ces...

==> Checking for code complexity in ./huaweicloud/services/acceptance/ces...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3      1120       71         3     1046         10             4.74
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rce_huaweicloud_ces_alarm_template_test.go       160       13         1      146          4             2.74
~rce_huaweicloud_ces_resource_group_test.go       263       25         2      236          4             1.69
~resource_huaweicloud_ces_alarmrule_test.go       697       33         0      664          2             0.30
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3      1120       71         3     1046         10             4.74
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 33627 bytes, 0.034 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
3 ces getResourceGroupResourceFunc huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_resource_group_test.go:19:1
3 ces getCesAlarmTemplateResourceFunc huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarm_template_test.go:18:1
2 ces getAlarmRuleResourceFunc huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_alarmrule_test.go:17:1
1 ces testResourceGroup_eps huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_resource_group_test.go:255:1
1 ces testResourceGroup_tags_update huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_resource_group_test.go:242:1
Average: 1.16

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/ces...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/ces...

==> Cleanup patch...

Check Completed!


./scripts/codecheck.sh ./huaweicloud/services/cfw

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      2877      340        73     2464        261            86.88
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~esource_huaweicloud_cfw_protection_rule.go       725       65        10      650         61             9.38
~resource_huaweicloud_cfw_eip_protection.go       418       50         7      361         53            14.68
~source_huaweicloud_cfw_black_white_list.go       333       47        13      273         32            11.72
~ce_huaweicloud_cfw_service_group_member.go       273       40         7      226         29            12.83
~/resource_huaweicloud_cfw_address_group.go       254       35        10      209         23            11.00
~/resource_huaweicloud_cfw_service_group.go       244       35         8      201         23            11.44
~ce_huaweicloud_cfw_address_group_member.go       249       39        10      200         20            10.00
~w/data_source_huaweicloud_cfw_firewalls.go       381       29         8      344         20             5.81
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      2877      340        73     2464        261            86.88
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 93586 bytes, 0.094 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
8 cfw syncedEipsRefreshFunc huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_protection.go:385:1
7 cfw resourceBlackWhiteListRead huaweicloud/services/cfw/resource_huaweicloud_cfw_black_white_list.go:145:1
6 cfw resourceServiceGroupMemberRead huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group_member.go:144:1
6 cfw resourceProtectionRuleUpdate huaweicloud/services/cfw/resource_huaweicloud_cfw_protection_rule.go:538:1
6 cfw resourceProtectionRuleRead huaweicloud/services/cfw/resource_huaweicloud_cfw_protection_rule.go:384:1
6 cfw resourceEipProtectionUpdate huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_protection.go:259:1
5 cfw resourceServiceGroupMemberCreate huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group_member.go:83:1
5 cfw resourceServiceGroupCreate huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group.go:62:1
5 cfw resourceProtectionRuleCreate huaweicloud/services/cfw/resource_huaweicloud_cfw_protection_rule.go:258:1
5 cfw resourceEipProtectionRead huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_protection.go:230:1
Average: 2.61

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewalls.go:125:                                //nolint:revive
./huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewalls.go:159:                                //nolint:revive
./huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewalls.go:226:                                //nolint:revive

==> Checking for TF features in cfw...

==> Checking for misspell in cfw...

==> Checking for code complexity in ./huaweicloud/services/acceptance/cfw...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      1085      131         9      945         64            48.21
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~e_huaweicloud_cfw_black_white_list_test.go       182       23         1      158         18            11.39
~ce_huaweicloud_cfw_protection_rule_test.go       222       22         1      199         13             6.53
~aweicloud_cfw_service_group_member_test.go       134       20         1      113         11             9.73
~aweicloud_cfw_address_group_member_test.go       125       19         1      105          9             8.57
~rce_huaweicloud_cfw_eip_protection_test.go       136       14         0      122          5             4.10
~urce_huaweicloud_cfw_address_group_test.go       116       13         1      102          4             3.92
~urce_huaweicloud_cfw_service_group_test.go       115       13         1      101          4             3.96
~a_source_huaweicloud_cfw_firewalls_test.go        55        7         3       45          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      1085      131         9      945         64            48.21
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 32360 bytes, 0.032 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
7 cfw getBlackWhiteListResourceFunc huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_black_white_list_test.go:19:1
5 cfw getServiceGroupMemberResourceFunc huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go:20:1
5 cfw getProtectionRuleResourceFunc huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_protection_rule_test.go:21:1
5 cfw testBlackWhiteListImportState huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_black_white_list_test.go:163:1
4 cfw testProtectionRuleImportState huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_protection_rule_test.go:206:1
Average: 1.92

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cfw...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cfw...

==> Cleanup patch...

Check Completed!


./scripts/codecheck.sh ./huaweicloud/services/cloudtable

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       339       27         5      307         28             9.12
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_cloudtable_cluster.go       339       27         5      307         28             9.12
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       339       27         5      307         28             9.12
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 9674 bytes, 0.010 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
4 cloudtable clusterStateRefreshFunc huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:324:1
4 cloudtable resourceCloudTableClusterDelete huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:275:1
4 cloudtable resourceCloudTableClusterRead huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:236:1
4 cloudtable resourceCloudTableClusterCreate huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:190:1
2 cloudtable waitForCloudTableClusterStateRefresh huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:304:1
2 cloudtable setCloudTableIntParam huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:227:1
2 cloudtable setCloudTableClusterStatus huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:219:1
2 cloudtable buildCloudTableClusterParams huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:161:1
1 cloudtable ResourceCloudTableCluster huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:41:1
Average: 2.78

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/cloudtable/resource_huaweicloud_cloudtable_cluster.go:230:               // lintignore:R001

==> Checking for TF features in cloudtable...

==> Checking for misspell in cloudtable...

==> Checking for code complexity in ./huaweicloud/services/acceptance/cloudtable...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1        87        9         0       78          2             2.56
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rce_huaweicloud_cloudtable_cluster_test.go        87        9         0       78          2             2.56
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1        87        9         0       78          2             2.56
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 3098 bytes, 0.003 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
2 cloudtable getClusterResourceObj huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go:17:1
1 cloudtable testAccCloudtableCluster_basic huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go:70:1
1 cloudtable TestAccCloudtableCluster_basic huaweicloud/services/acceptance/cloudtable/resource_huaweicloud_cloudtable_cluster_test.go:25:1
Average: 1.33

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cloudtable...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cloudtable...

==> Cleanup patch...

Check Completed!



## PR Checklist

* [√] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccDatasourceStatistics_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceStatistics_basic
=== PAUSE TestAccDatasourceStatistics_basic
=== CONT  TestAccDatasourceStatistics_basic
--- PASS: TestAccDatasourceStatistics_basic (4.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       4.829s


make testacc TEST="./huaweicloud/services/acceptance/ces" TESTARGS="-run TestAccCESAlarmRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccCESAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccCESAlarmRule_basic
=== PAUSE TestAccCESAlarmRule_basic
=== CONT  TestAccCESAlarmRule_basic
--- PASS: TestAccCESAlarmRule_basic (172.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       173.020s


make testacc TEST="./huaweicloud/services/acceptance/cloudtable" TESTARGS="-run TestAccCloudtableCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cloudtable -v -run TestAccCloudtableCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudtableCluster_basic
=== PAUSE TestAccCloudtableCluster_basic
=== CONT  TestAccCloudtableCluster_basic
--- PASS: TestAccCloudtableCluster_basic (606.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cloudtable        606.070s
```
