### PR TITLE
fix(apig): fix code check for resource apig/apigateway

### DIFF
--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_environments_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_environments_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getApplicationFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+func getApplicationFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
@@ -9,14 +9,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getApplicationFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
+func getApplicationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
@@ -8,14 +8,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 )
 
-func getEnvironmentFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
+func getEnvironmentFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 )
 
-func getEnvironmentFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+func getEnvironmentFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getGroupFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+func getGroupFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getGroupFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
+func getGroupFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
+func getInstanceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getInstanceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ApigV2Client(acceptance.HW_REGION_NAME)
+func getInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.ApigV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_environments.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_environments.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 )

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -200,7 +200,7 @@ func resourceApplicationRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", c.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
 		d.Set("registration_time", resp.RegistrationTime),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -183,8 +183,8 @@ func flattenApplicationCodes(codes []applications.AppCode) []interface{} {
 }
 
 func resourceApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -199,7 +199,7 @@ func resourceApplicationRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", c.GetRegion(d)),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
 		d.Set("registration_time", resp.RegistrationTime),
@@ -271,8 +271,8 @@ func updateApplicationCodes(client *golangsdk.ServiceClient, d *schema.ResourceD
 }
 
 func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -310,8 +310,8 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -329,7 +329,7 @@ func resourceApplicationDelete(_ context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceApplicationImportState(_ context.Context, d *schema.ResourceData,
-	meta interface{}) ([]*schema.ResourceData, error) {
+	_ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid format specified for import ID, must be <instance_id>/<id>")

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -184,8 +184,8 @@ func flattenApplicationCodes(codes []applications.AppCode) []interface{} {
 }
 
 func resourceApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -272,8 +272,8 @@ func updateApplicationCodes(client *golangsdk.ServiceClient, d *schema.ResourceD
 }
 
 func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -311,8 +311,8 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -259,7 +259,7 @@ func resourceCustomAuthorizerUpdate(ctx context.Context, d *schema.ResourceData,
 	return resourceCustomAuthorizerRead(ctx, d, meta)
 }
 
-func resourceCustomAuthorizerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomAuthorizerDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg = meta.(*config.Config)
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
@@ -123,8 +123,8 @@ func GetEnvironmentFormServer(client *golangsdk.ServiceClient, instanceId,
 }
 
 func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -134,7 +134,7 @@ func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta int
 		return common.CheckDeletedDiag(d, err, "dedicated environment")
 	}
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", c.GetRegion(d)),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
 		d.Set("created_at", resp.CreateTime),
@@ -146,8 +146,8 @@ func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -170,8 +170,8 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceEnvironmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -192,8 +192,8 @@ func resourceEnvironmentResourceImportState(_ context.Context, d *schema.Resourc
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid format specified for import ID, must be <instance_id>/<name>")
 	}
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_environment.go
@@ -124,8 +124,8 @@ func GetEnvironmentFormServer(client *golangsdk.ServiceClient, instanceId,
 }
 
 func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -135,7 +135,7 @@ func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta int
 		return common.CheckDeletedDiag(d, err, "dedicated environment")
 	}
 	mErr := multierror.Append(nil,
-		d.Set("region", c.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
 		d.Set("created_at", resp.CreateTime),
@@ -147,8 +147,8 @@ func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -171,8 +171,8 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceEnvironmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -193,8 +193,8 @@ func resourceEnvironmentResourceImportState(_ context.Context, d *schema.Resourc
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid format specified for import ID, must be <instance_id>/<name>")
 	}
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -276,7 +276,7 @@ func resourceGroupRead(_ context.Context, d *schema.ResourceData, meta interface
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", c.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
 		d.Set("registration_time", resp.RegistraionTime),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -179,8 +179,8 @@ func removeEnvironmentVariables(client *golangsdk.ServiceClient, instanceId stri
 }
 
 func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -259,8 +259,8 @@ func flattenEnvironmentVariables(variables []environments.Variable) []map[string
 }
 
 func resourceGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -309,8 +309,8 @@ func updateEnvironmentVariables(client *golangsdk.ServiceClient, d *schema.Resou
 }
 
 func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -340,8 +340,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups"
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -264,10 +264,10 @@ func buildInstanceAvailabilityZones(d *schema.ResourceData) ([]string, error) {
 		return utils.ExpandToStringList(v.([]interface{})), nil
 	}
 
-	return nil, fmt.Errorf("the parameter 'availability_zones' must be specified.")
+	return nil, fmt.Errorf("The parameter 'availability_zones' must be specified")
 }
 
-func buildInstanceCreateOpts(d *schema.ResourceData, config *config.Config) (instances.CreateOpts, error) {
+func buildInstanceCreateOpts(d *schema.ResourceData, c *config.Config) (instances.CreateOpts, error) {
 	result := instances.CreateOpts{
 		Name:                 d.Get("name").(string),
 		Edition:              d.Get("edition").(string),
@@ -277,7 +277,7 @@ func buildInstanceCreateOpts(d *schema.ResourceData, config *config.Config) (ins
 		Description:          d.Get("description").(string),
 		EipId:                d.Get("eip_id").(string),
 		BandwidthSize:        d.Get("bandwidth_size").(int), // Bandwidth 0 means turn off the egress access.
-		EnterpriseProjectId:  common.GetEnterpriseProjectID(d, config),
+		EnterpriseProjectId:  common.GetEnterpriseProjectID(d, c),
 		Ipv6Enable:           d.Get("ipv6_enable").(bool),
 		LoadbalancerProvider: d.Get("loadbalancer_provider").(string),
 		Tags:                 utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
@@ -316,13 +316,13 @@ func buildTagsUpdateOpts(tags map[string]interface{}, instanceId, action string)
 }
 
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	opts, err := buildInstanceCreateOpts(d, config)
+	opts, err := buildInstanceCreateOpts(d, c)
 	if err != nil {
 		return diag.Errorf("error creating the dedicated instance options: %s", err)
 	}
@@ -369,12 +369,12 @@ func parseInstanceAvailabilityZones(azStr string) []string {
 }
 
 // The response of ingress acess does not contain EIP ID, just the IP address.
-func parseInstanceIngressAccess(config *config.Config, region, publicAddress string) (*string, error) {
+func parseInstanceIngressAccess(c *config.Config, region, publicAddress string) (*string, error) {
 	if publicAddress == "" {
 		return nil, nil
 	}
 
-	client, err := config.NetworkingV1Client(region)
+	client, err := c.NetworkingV1Client(region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VPC v1 client: %s", err)
 	}
@@ -417,7 +417,7 @@ func parseVpcepServiceName(serviceName string) string {
 	return result[1]
 }
 
-func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.ApigV2Client(region)
@@ -593,8 +593,8 @@ func updateInstanceTags(client *golangsdk.ServiceClient, d *schema.ResourceData)
 }
 
 func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -644,8 +644,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -368,13 +368,13 @@ func parseInstanceAvailabilityZones(azStr string) []string {
 	return strings.Split(codesStr, ",")
 }
 
-// The response of ingress acess does not contain EIP ID, just the IP address.
-func parseInstanceIngressAccess(c *config.Config, region, publicAddress string) (*string, error) {
+// The response of ingress access does not contain EIP ID, just the IP address.
+func parseInstanceIngressAccess(cfg *config.Config, region, publicAddress string) (*string, error) {
 	if publicAddress == "" {
 		return nil, nil
 	}
 
-	client, err := c.NetworkingV1Client(region)
+	client, err := cfg.NetworkingV1Client(region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VPC v1 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -267,7 +267,7 @@ func buildInstanceAvailabilityZones(d *schema.ResourceData) ([]string, error) {
 	return nil, fmt.Errorf("The parameter 'availability_zones' must be specified")
 }
 
-func buildInstanceCreateOpts(d *schema.ResourceData, c *config.Config) (instances.CreateOpts, error) {
+func buildInstanceCreateOpts(d *schema.ResourceData, cfg *config.Config) (instances.CreateOpts, error) {
 	result := instances.CreateOpts{
 		Name:                 d.Get("name").(string),
 		Edition:              d.Get("edition").(string),
@@ -277,7 +277,7 @@ func buildInstanceCreateOpts(d *schema.ResourceData, c *config.Config) (instance
 		Description:          d.Get("description").(string),
 		EipId:                d.Get("eip_id").(string),
 		BandwidthSize:        d.Get("bandwidth_size").(int), // Bandwidth 0 means turn off the egress access.
-		EnterpriseProjectId:  common.GetEnterpriseProjectID(d, c),
+		EnterpriseProjectId:  common.GetEnterpriseProjectID(d, cfg),
 		Ipv6Enable:           d.Get("ipv6_enable").(bool),
 		LoadbalancerProvider: d.Get("loadbalancer_provider").(string),
 		Tags:                 utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -316,13 +316,13 @@ func buildTagsUpdateOpts(tags map[string]interface{}, instanceId, action string)
 }
 
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
-	opts, err := buildInstanceCreateOpts(d, c)
+	opts, err := buildInstanceCreateOpts(d, cfg)
 	if err != nil {
 		return diag.Errorf("error creating the dedicated instance options: %s", err)
 	}
@@ -593,8 +593,8 @@ func updateInstanceTags(client *golangsdk.ServiceClient, d *schema.ResourceData)
 }
 
 func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -644,8 +644,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -170,5 +171,6 @@ func resourceInstanceRoutesDelete(_ context.Context, d *schema.ResourceData, met
 
 func resourceInstanceRoutesImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
-	return []*schema.ResourceData{d}, d.Set("instance_id", d.Id())
+	mErr := multierror.Append(nil, d.Set("instance_id", d.Id()))
+	return []*schema.ResourceData{d}, mErr
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
@@ -172,5 +172,5 @@ func resourceInstanceRoutesDelete(_ context.Context, d *schema.ResourceData, met
 func resourceInstanceRoutesImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
 	mErr := multierror.Append(nil, d.Set("instance_id", d.Id()))
-	return []*schema.ResourceData{d}, mErr
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
@@ -244,8 +244,8 @@ func resourceCustomResponseImportState(_ context.Context, d *schema.ResourceData
 			"must be <instance_id>/<group_id>/<name>")
 	}
 
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
@@ -244,8 +244,8 @@ func resourceCustomResponseImportState(_ context.Context, d *schema.ResourceData
 			"must be <instance_id>/<group_id>/<name>")
 	}
 
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
@@ -201,11 +201,12 @@ func buildThrottlingPolicyOpts(d *schema.ResourceData) (throttles.ThrottlingPoli
 		Description:    d.Get("description").(string),
 	}
 	pType := d.Get("type").(string)
-	if val, ok := policyType[pType]; ok {
-		opt.Type = val
-	} else {
+	var val int
+	var ok bool
+	if val, ok = policyType[pType]; !ok {
 		return opt, fmt.Errorf("invalid throttling policy type: %s", pType)
 	}
+	opt.Type = val
 	return opt, nil
 }
 
@@ -229,8 +230,8 @@ func addSpecThrottlingPolicies(client *golangsdk.ServiceClient, policies *schema
 }
 
 func resourceThrottlingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	metaConfig := meta.(*config.Config)
+	client, err := metaConfig.ApigV2Client(metaConfig.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -309,8 +310,8 @@ func flattenSpecThrottlingPolicies(specThrottles []throttles.SpecThrottle) (user
 }
 
 func resourceThrottlingPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	metaConfig := meta.(*config.Config)
+	client, err := metaConfig.ApigV2Client(metaConfig.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -325,7 +326,7 @@ func resourceThrottlingPolicyRead(_ context.Context, d *schema.ResourceData, met
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", metaConfig.GetRegion(d)),
 		d.Set("type", analyseThrottlingPolicyType(resp.Type)),
 		d.Set("name", resp.Name),
 		d.Set("period", resp.TimeInterval),
@@ -432,8 +433,8 @@ func updateSpecThrottlingPolicies(d *schema.ResourceData, client *golangsdk.Serv
 }
 
 func resourceThrottlingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	metaConfig := meta.(*config.Config)
+	client, err := metaConfig.ApigV2Client(metaConfig.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -466,10 +467,10 @@ func resourceThrottlingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceThrottlingPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating HuaweiCloud APIG v2 client: %s", err)
+		return diag.Errorf("error creating Huawei Cloud APIG v2 client: %s", err)
 	}
 
 	var (
@@ -486,8 +487,8 @@ func resourceThrottlingPolicyDelete(_ context.Context, d *schema.ResourceData, m
 // The ID cannot find on the console, so we need to import by throttling policy name.
 func resourceThrottlingPolicyImportState(_ context.Context, d *schema.ResourceData,
 	meta interface{}) ([]*schema.ResourceData, error) {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
@@ -230,8 +230,8 @@ func addSpecThrottlingPolicies(client *golangsdk.ServiceClient, policies *schema
 }
 
 func resourceThrottlingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	metaConfig := meta.(*config.Config)
-	client, err := metaConfig.ApigV2Client(metaConfig.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -310,8 +310,8 @@ func flattenSpecThrottlingPolicies(specThrottles []throttles.SpecThrottle) (user
 }
 
 func resourceThrottlingPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	metaConfig := meta.(*config.Config)
-	client, err := metaConfig.ApigV2Client(metaConfig.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -433,8 +433,8 @@ func updateSpecThrottlingPolicies(d *schema.ResourceData, client *golangsdk.Serv
 }
 
 func resourceThrottlingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	metaConfig := meta.(*config.Config)
-	client, err := metaConfig.ApigV2Client(metaConfig.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -467,8 +467,8 @@ func resourceThrottlingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceThrottlingPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Huawei Cloud APIG v2 client: %s", err)
 	}
@@ -487,8 +487,8 @@ func resourceThrottlingPolicyDelete(_ context.Context, d *schema.ResourceData, m
 // The ID cannot find on the console, so we need to import by throttling policy name.
 func resourceThrottlingPolicyImportState(_ context.Context, d *schema.ResourceData,
 	meta interface{}) ([]*schema.ResourceData, error) {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
@@ -326,7 +326,7 @@ func resourceThrottlingPolicyRead(_ context.Context, d *schema.ResourceData, met
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", metaConfig.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("type", analyseThrottlingPolicyType(resp.Type)),
 		d.Set("name", resp.Name),
 		d.Set("period", resp.TimeInterval),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go
@@ -470,7 +470,7 @@ func resourceThrottlingPolicyDelete(_ context.Context, d *schema.ResourceData, m
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Huawei Cloud APIG v2 client: %s", err)
+		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
 
 	var (

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
@@ -59,8 +59,8 @@ func ResourceThrottlingPolicyAssociate() *schema.Resource {
 
 func resourceThrottlingPolicyAssociateCreate(ctx context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -107,8 +107,8 @@ func flattenApiPublishIds(apiList []throttles.ApiForThrottle) []string {
 
 func resourceThrottlingPolicyAssociateRead(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %v", err)
 	}
@@ -154,8 +154,8 @@ func unbindPolicy(client *golangsdk.ServiceClient, instanceId, policyId string, 
 
 func resourceThrottlingPolicyAssociateUpdate(ctx context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -192,8 +192,8 @@ func resourceThrottlingPolicyAssociateUpdate(ctx context.Context, d *schema.Reso
 
 func resourceThrottlingPolicyAssociateDelete(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ApigV2Client(config.GetRegion(d))
+	c := meta.(*config.Config)
+	client, err := c.ApigV2Client(c.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
@@ -60,8 +60,8 @@ func ResourceThrottlingPolicyAssociate() *schema.Resource {
 
 func resourceThrottlingPolicyAssociateCreate(ctx context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -108,8 +108,8 @@ func flattenApiPublishIds(apiList []throttles.ApiForThrottle) []string {
 
 func resourceThrottlingPolicyAssociateRead(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %v", err)
 	}
@@ -156,8 +156,8 @@ func unbindPolicy(client *golangsdk.ServiceClient, instanceId, policyId string, 
 
 func resourceThrottlingPolicyAssociateUpdate(ctx context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -194,8 +194,8 @@ func resourceThrottlingPolicyAssociateUpdate(ctx context.Context, d *schema.Reso
 
 func resourceThrottlingPolicyAssociateDelete(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
-	c := meta.(*config.Config)
-	client, err := c.ApigV2Client(c.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
@@ -129,7 +129,7 @@ func resourceThrottlingPolicyAssociateRead(_ context.Context, d *schema.Resource
 	}
 
 	mErr := multierror.Append(nil, d.Set("publish_ids", flattenApiPublishIds(resp)))
-	return diag.FromErr(mErr)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func unbindPolicy(client *golangsdk.ServiceClient, instanceId, policyId string, unbindSet *schema.Set) error {

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -127,7 +128,8 @@ func resourceThrottlingPolicyAssociateRead(_ context.Context, d *schema.Resource
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
-	return diag.FromErr(d.Set("publish_ids", flattenApiPublishIds(resp)))
+	mErr := multierror.Append(nil, d.Set("publish_ids", flattenApiPublishIds(resp)))
+	return diag.FromErr(mErr)
 }
 
 func unbindPolicy(client *golangsdk.ServiceClient, instanceId, policyId string, unbindSet *schema.Set) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**Which issue this PR fixes**:
fix apig/apigateway codecheck
1.The variable conflict with the imported package name
2.militi-error unused
3. import not standard

**Test**:
./scripts/codecheck.sh ./huaweicloud/services/apig
```
Refresh index: 100% (9818/9818), done. 

==> Checking for running environment... 

==> Applying patch... 

==> Checking for code complexity... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       23      8219      716       139     7364       1024           343.80
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ices/apig/resource_huaweicloud_apig_api.go      1679      100        15     1564        147             9.40
~apig/resource_huaweicloud_apig_instance.go       692       56        22      614        110            17.92
~source_huaweicloud_apig_api_publishment.go       404       38        24      342         85            24.85
~urce_huaweicloud_apig_throttling_policy.go       517       39        20      458         76            16.59
~g/resource_huaweicloud_apig_application.go       341       33         1      307         58            18.89
~weicloud_apig_application_authorization.go       343       35         4      304         50            16.45
~/apig/resource_huaweicloud_apig_channel.go       702       41         4      657         49             7.46
~es/apig/resource_huaweicloud_apig_group.go       365       29         4      332         48            14.46
~ce_huaweicloud_apig_signature_associate.go       314       38         6      270         46            17.04
~ource_huaweicloud_apig_plugin_associate.go       286       27         3      256         44            17.19
~urce_huaweicloud_apig_custom_authorizer.go       316       29         2      285         36            12.63
~apig/resource_huaweicloud_apig_response.go       287       24        12      251         34            13.55
~g/resource_huaweicloud_apig_environment.go       221       25         2      194         32            16.49
~e_huaweicloud_apig_acl_policy_associate.go       230       30         1      199         32            16.08
~icloud_apig_throttling_policy_associate.go       223       31         1      191         31            16.23
~source_huaweicloud_apig_instance_routes.go       176       23         3      150         26            17.33
~/apig/resource_huaweicloud_apig_appcode.go       171       20         0      151         23            15.23
~pig/resource_huaweicloud_apig_signature.go       212       20         1      191         23            12.04
~s/apig/resource_huaweicloud_apig_plugin.go       207       21         1      185         22            11.89
~ig/resource_huaweicloud_apig_acl_policy.go       190       20         3      167         20            11.98
~g/resource_huaweicloud_apig_certificate.go       185       20         0      165         18            10.91
~ta_source_huaweicloud_apig_environments.go       114       11         0      103          8             7.77
huaweicloud/services/apig/common.go                44        6        10       28          6            21.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    23      8219      716       139     7364       1024           343.80
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 258818 bytes, 0.259 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
13 apig buildApiCreateOpts huaweicloud/services/apig/resource_huaweicloud_apig_api.go:1172:1 
12 apig resourceInstanceUpdate huaweicloud/services/apig/resource_huaweicloud_apig_instance.go:595:1
12 apig ResourceApiPublishmentUpdate huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go:327:1
10 apig resourcePluginAssociateUpdate huaweicloud/services/apig/resource_huaweicloud_apig_plugin_associate.go:151:1
10 apig resourceApplicationUpdate huaweicloud/services/apig/resource_huaweicloud_apig_application.go:274:1
10 apig ResourceApiPublishmentCreate huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go:152:1
9 apig resourceThrottlingPolicyUpdate huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go:435:1
8 apig resourceThrottlingPolicyRead huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go:312:1
8 apig resourceThrottlingPolicyCreate huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy.go:232:1
8 apig resourceCustomResponseImportState huaweicloud/services/apig/resource_huaweicloud_apig_response.go:239:1
Average: 3.51

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in apig... 

==> Checking for misspell in apig... 

==> Checking for code complexity in ./huaweicloud/services/acceptance/apig... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       22      6583      380        26     6177        132            63.13
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~oud_apig_application_authorization_test.go       212       15         0      197         10             5.08
~aweicloud_apig_signature_associate_test.go       322       13         0      309         10             3.24
~/resource_huaweicloud_apig_appcode_test.go       158       16         2      140          9             6.43
~source_huaweicloud_apig_acl_policy_test.go       221       15         2      204          8             3.92
~esource_huaweicloud_apig_signature_test.go       414       28         7      379          8             2.11
~resource_huaweicloud_apig_response_test.go       228       18         2      208          8             3.85
~weicloud_apig_acl_policy_associate_test.go       264       13         0      251          8             3.19
~huaweicloud_apig_throttling_policy_test.go       319       19         0      300          7             2.33
~ig/resource_huaweicloud_apig_group_test.go       272       20         4      248          7             2.82
~huaweicloud_apig_custom_authorizer_test.go       262       19         0      243          7             2.88
~ource_huaweicloud_apig_environment_test.go       134       14         1      119          7             5.88
~e_huaweicloud_apig_instance_routes_test.go       127       14         2      111          7             6.31
~ource_huaweicloud_apig_application_test.go       130       13         2      115          7             6.09
~apig/resource_huaweicloud_apig_api_test.go       442       13         0      429          7             1.63
~/resource_huaweicloud_apig_channel_test.go       407       20         2      385          7             1.82
~g/resource_huaweicloud_apig_plugin_test.go       991       39         1      951          5             0.53
~_huaweicloud_apig_plugin_associate_test.go       579       13         0      566          2             0.35
~e_huaweicloud_apig_api_publishment_test.go        88       11         0       77          2             2.60
~d_apig_throttling_policy_associate_test.go       249       12         1      236          2             0.85
~ource_huaweicloud_apig_certificate_test.go       300       24         0      276          2             0.72
~resource_huaweicloud_apig_instance_test.go       412       25         0      387          2             0.52
~urce_huaweicloud_apig_environments_test.go        52        6         0       46          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    22      6583      380        26     6177        132            63.13
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 204527 bytes, 0.205 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 apig testAccResponseImportStateFunc huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_response_test.go:128:1 
5 apig getInstanceRoutesFunc huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go:17:1
5 apig testAccAppcodeImportIdFunc huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_appcode_test.go:60:1
4 apig testAccThrottlingPolicyImportStateFunc huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go:153:1
4 apig getSignatureFunc huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:20:1
Average: 1.46

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/apig...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/apig... 
./huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:47:          // lintignore:AT009 
./huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:50:          // lintignore:AT009
./huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:194:         // lintignore:AT009
./huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:197:         // lintignore:AT009
./huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:306:         // lintignore:AT009
./huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_signature_test.go:309:         // lintignore:AT009

==> Cleanup patch...

Check Completed! 

```
./scripts/codecheck.sh ./huaweicloud/services/apigateway
```

==> Checking for running environment... 

==> Applying patch... 

==> Checking for code complexity...
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       147       21         0      126         21            16.67
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ateway/resource_api_gateway_environment.go       147       21         0      126         21            16.67
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       147       21         0      126         21            16.67
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 4245 bytes, 0.004 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
the TOP10 most complex functions: 
4 apigateway getEnvironment huaweicloud/services/apigateway/resource_api_gateway_environment.go:75:1
3 apigateway resourceEnvironmentDelete huaweicloud/services/apigateway/resource_api_gateway_environment.go:134:1
3 apigateway resourceEnvironmentUpdate huaweicloud/services/apigateway/resource_api_gateway_environment.go:113:1
3 apigateway resourceEnvironmentRead huaweicloud/services/apigateway/resource_api_gateway_environment.go:91:1 
3 apigateway resourceEnvironmentCreate huaweicloud/services/apigateway/resource_api_gateway_environment.go:52:1
1 apigateway ResourceEnvironment huaweicloud/services/apigateway/resource_api_gateway_environment.go:19:1
Average: 2.83

==> Checking for golangci-lint...

==> Checking for Nolint directives... 

==> Checking for TF features in apigateway... 

==> Checking for misspell in apigateway... 

==> Checking for code complexity in ./huaweicloud/services/acceptance/apigateway... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1        99       12         0       87          7             8.05
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~uaweicloud_api_gateway_environment_test.go        99       12         0       87          7             8.05
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1        99       12         0       87          7             8.05
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Processed 2812 bytes, 0.003 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
the TOP5 most complex functions:
5 apigateway getEnvironmentFunc huaweicloud/services/acceptance/apigateway/resource_huaweicloud_api_gateway_environment_test.go:18:1
1 apigateway testAccEnvironment_update huaweicloud/services/acceptance/apigateway/resource_huaweicloud_api_gateway_environment_test.go:92:1 
1 apigateway testAccEnvironment_basic huaweicloud/services/acceptance/apigateway/resource_huaweicloud_api_gateway_environment_test.go:83:1
1 apigateway TestAccEnvironment_basic huaweicloud/services/acceptance/apigateway/resource_huaweicloud_api_gateway_environment_test.go:42:1
Average: 2

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/apigateway...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/apigateway... 

==> Cleanup patch...

Check Completed! 

```


## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed


```
...
 make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccDataEnvironments_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccDataEnvironments_basic -timeout 360m -parallel 4
=== RUN   TestAccDataEnvironments_basic
=== PAUSE TestAccDataEnvironments_basic
=== CONT  TestAccDataEnvironments_basic
--- PASS: TestAccDataEnvironments_basic (459.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      459.461s

...
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccApiPublishment_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccApiPublishment_basic -timeout 360m -parallel 4
=== RUN   TestAccApiPublishment_basic
=== PAUSE TestAccApiPublishment_basic
=== CONT  TestAccApiPublishment_basic
--- PASS: TestAccApiPublishment_basic (473.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      473.086s
...

...
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccApplication_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccApplication_basic -timeout 360m -parallel 4
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== CONT  TestAccApplication_basic
--- PASS: TestAccApplication_basic (497.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      497.114s

...
 make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccCustomAuthorizer_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccCustomAuthorizer_basic -timeout 360m -parallel 4
=== RUN   TestAccCustomAuthorizer_basic
=== PAUSE TestAccCustomAuthorizer_basic
=== CONT  TestAccCustomAuthorizer_basic
--- PASS: TestAccCustomAuthorizer_basic (495.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      495.989s
...

make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccEnvironment_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccEnvironment_basic -timeout 360m -parallel 4
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccEnvironment_basic (513.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      513.622s

...
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== CONT  TestAccGroup_basic
--- PASS: TestAccGroup_basic (516.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      516.088s

...
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (538.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      538.913s
...

 make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccInstanceRoutes_basic"                       
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstanceRoutes_basic -timeout 360m -parallel 4 
=== RUN   TestAccInstanceRoutes_basic 
=== PAUSE TestAccInstanceRoutes_basic
=== CONT  TestAccInstanceRoutes_basic
--- PASS: TestAccInstanceRoutes_basic (474.76s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      474.786s

...
 make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccInstanceRoutes_basic"                       
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstanceRoutes_basic -timeout 360m -parallel 4 
=== RUN   TestAccInstanceRoutes_basic 
=== PAUSE TestAccInstanceRoutes_basic
=== CONT  TestAccInstanceRoutes_basic
--- PASS: TestAccInstanceRoutes_basic (474.76s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      474.786s

 make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccRespon
se_basic"
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccResponse_basic -timeout 360m -parallel 4 
=== RUN   TestAccResponse_basic 
=== PAUSE TestAccResponse_basic 
=== CONT  TestAccResponse_basic
--- PASS: TestAccResponse_basic (479.02s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      479.071s 



make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccThrottlingPolicy_basic"
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccThrottlingPolicy_basic -timeout 360m -parallel 4 
=== RUN   TestAccThrottlingPolicy_basic 
=== PAUSE TestAccThrottlingPolicy_basic 
=== CONT  TestAccThrottlingPolicy_basic 
--- PASS: TestAccThrottlingPolicy_basic (647.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      647.603s 
...
 make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccThrottlingPolicyAs
sociate_basic"
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccThrottlingPolicyAssociate_basic -timeout 360m -parallel 4 
=== RUN   TestAccThrottlingPolicyAssociate_basic 
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (499.94s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      499.974s
