### PR TITLE
feat(LTS): LTS add a resource to manage LTS access WAF logs configura…

### DIFF
--- a/docs/resources/lts_waf_access.md
+++ b/docs/resources/lts_waf_access.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# huaweicloud_lts_waf_access
+
+Manages an LTS access WAF logs configuration resource within HuaweiCloud.
+
+-> **NOTE:** This resource depends on WAF instances, the instance can be Cloud Mode or Dedicated Mode.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "lts_group_id" {}
+variable "lts_attack_stream_id" {}
+variable "lts_access_stream_id" {}
+
+resource "huaweicloud_lts_waf_access" "test" {
+  enterprise_project_id = var.enterprise_project_id
+  lts_group_id          = var.lts_group_id
+  lts_attack_stream_id  = var.lts_attack_stream_id
+  lts_access_stream_id  = var.lts_access_stream_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `lts_group_id` - (Required, String) Specifies the log group ID.
+
+* `lts_attack_stream_id` - (Optional, String) Specifies the log stream ID for attack logs.
+
+* `lts_access_stream_id` - (Optional, String) Specifies the log stream ID for access logs.
+
+-> The fields `lts_attack_stream_id` and `lts_access_stream_id` must be specified as different log streams.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID. If not specified, the
+  default enterprise project will be used. The default enterprise project ID is **0**.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The LTS access WAF logs configuration can be imported using the `enterprise_project_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_lts_waf_access.test <enterprise_project_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -987,6 +987,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_sql_alarm_rule":                   lts.ResourceSQLAlarmRule(),
 			"huaweicloud_lts_notification_template":            lts.ResourceNotificationTemplate(),
 			"huaweicloud_lts_search_criteria":                  lts.ResourceSearchCriteria(),
+			"huaweicloud_lts_waf_access":                       lts.ResourceWAFAccess(),
 
 			"huaweicloud_mapreduce_cluster":         mrs.ResourceMRSClusterV2(),
 			"huaweicloud_mapreduce_job":             mrs.ResourceMRSJobV2(),

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go
@@ -1,0 +1,317 @@
+package lts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getWAFAccessResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/waf/config/lts"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	if epsId := state.Primary.Attributes["enterprise_project_id"]; epsId != "" {
+		getPath += fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := utils.PathSearch("enabled", getRespBody, false).(bool)
+	if !enabled {
+		// the WAF access is not exist
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccWAFAccess_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_lts_waf_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getWAFAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testWAFAccess_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"huaweicloud_lts_group.groupA", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"huaweicloud_lts_stream.streamA1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"huaweicloud_lts_stream.streamA2", "id"),
+				),
+			},
+			{
+				Config: testWAFAccess_basic_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"huaweicloud_lts_group.groupB", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"huaweicloud_lts_stream.streamB1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"huaweicloud_lts_stream.streamB2", "id"),
+				),
+			},
+			{
+				Config: testWAFAccess_basic_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"huaweicloud_lts_group.groupB", "id"),
+					resource.TestCheckResourceAttr(rName, "lts_attack_stream_id", ""),
+					resource.TestCheckResourceAttr(rName, "lts_access_stream_id", ""),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFAccessImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccWAFAccess_withEpsId(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_lts_waf_access.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getWAFAccessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testWAFAccess_withEpsId(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"huaweicloud_lts_group.groupA", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_attack_stream_id",
+						"huaweicloud_lts_stream.streamA1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_access_stream_id",
+						"huaweicloud_lts_stream.streamA2", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWAFAccessImportState(rName),
+			},
+		},
+	})
+}
+
+func testWAFAccess_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "groupA" {
+  group_name  = "%[1]s_a"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "streamA1" {
+  group_id    = huaweicloud_lts_group.groupA.id
+  stream_name = "%[1]s_a1"
+}
+
+resource "huaweicloud_lts_stream" "streamA2" {
+  group_id    = huaweicloud_lts_group.groupA.id
+  stream_name = "%[1]s_a2"
+}
+
+resource "huaweicloud_lts_group" "groupB" {
+  group_name  = "%[1]s_b"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "streamB1" {
+  group_id    = huaweicloud_lts_group.groupB.id
+  stream_name = "%[1]s_b1"
+}
+
+resource "huaweicloud_lts_stream" "streamB2" {
+  group_id    = huaweicloud_lts_group.groupB.id
+  stream_name = "%[1]s_b2"
+}
+
+%[2]s
+
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name               = "%[1]s"
+  available_zone     = data.huaweicloud_availability_zones.test.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.huaweicloud_compute_flavors.test.ids[0]
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  
+  security_group = [
+    huaweicloud_networking_secgroup.test.id
+  ]
+}
+`, name, common.TestBaseComputeResources(name))
+}
+
+func testWAFAccess_epsId(name, epsId string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "groupA" {
+  group_name  = "%[1]s_a"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "streamA1" {
+  group_id    = huaweicloud_lts_group.groupA.id
+  stream_name = "%[1]s_a1"
+}
+
+resource "huaweicloud_lts_stream" "streamA2" {
+  group_id    = huaweicloud_lts_group.groupA.id
+  stream_name = "%[1]s_a2"
+}
+
+%[2]s
+
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name                  = "%[1]s"
+  available_zone        = data.huaweicloud_availability_zones.test.names[1]
+  specification_code    = "waf.instance.professional"
+  ecs_flavor            = data.huaweicloud_compute_flavors.test.ids[0]
+  enterprise_project_id = "%[3]s"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  
+  security_group = [
+    huaweicloud_networking_secgroup.test.id
+  ]
+}
+`, name, common.TestBaseComputeResources(name), epsId)
+}
+
+func testWAFAccess_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_waf_access" "test" {
+  lts_group_id         = huaweicloud_lts_group.groupA.id
+  lts_attack_stream_id = huaweicloud_lts_stream.streamA1.id
+  lts_access_stream_id = huaweicloud_lts_stream.streamA2.id
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.test
+  ]
+}
+`, testWAFAccess_base(name))
+}
+
+func testWAFAccess_basic_update1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_waf_access" "test" {
+  lts_group_id         = huaweicloud_lts_group.groupB.id
+  lts_attack_stream_id = huaweicloud_lts_stream.streamB1.id
+  lts_access_stream_id = huaweicloud_lts_stream.streamB2.id
+}
+`, testWAFAccess_base(name))
+}
+
+func testWAFAccess_basic_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_waf_access" "test" {
+  lts_group_id = huaweicloud_lts_group.groupB.id
+}
+`, testWAFAccess_base(name))
+}
+
+func testWAFAccess_withEpsId(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_lts_waf_access" "test" {
+  enterprise_project_id = "%[2]s"
+  lts_group_id          = huaweicloud_lts_group.groupA.id
+  lts_attack_stream_id  = huaweicloud_lts_stream.streamA1.id
+  lts_access_stream_id  = huaweicloud_lts_stream.streamA2.id
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.test
+  ]
+}
+`, testWAFAccess_epsId(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testWAFAccessImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		if epsId == "" {
+			// the default enterprise project ID is `0`
+			epsId = "0"
+		}
+		return epsId, nil
+	}
+}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
@@ -1,0 +1,261 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product LTS
+// ---------------------------------------------------------------
+
+package lts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceWAFAccess() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWAFAccessCreate,
+		UpdateContext: resourceWAFAccessUpdate,
+		ReadContext:   resourceWAFAccessRead,
+		DeleteContext: resourceWAFAccessDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceWAFAccessImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"lts_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the log group ID.`,
+			},
+			"lts_attack_stream_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the log stream ID for attack logs.`,
+			},
+			"lts_access_stream_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the log stream ID for access logs.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+		},
+	}
+}
+
+func resourceWAFAccessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	detailRespBody, err := queryWAFAccessDetail(client, d, cfg)
+	if err != nil {
+		return diag.Errorf("error creating LTS access WAF logs configuration (failed to query detail): %s", err)
+	}
+
+	id, err := jmespath.Search("id", detailRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating LTS access WAF logs configuration: ID is not found in detail API response")
+	}
+
+	idString, isString := id.(string)
+	if !isString {
+		return diag.Errorf("error creating LTS access WAF logs configuration: ID is not string in detail API response")
+	}
+
+	if err := modifyWAFAccessConfiguration(client, d, cfg, idString); err != nil {
+		return diag.Errorf("error creating LTS access WAF logs configuration: %s", err)
+	}
+	d.SetId(idString)
+
+	return resourceWAFAccessRead(ctx, d, meta)
+}
+
+func modifyWAFAccessConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData,
+	cfg *config.Config, id string) error {
+	modifyPath := client.Endpoint + "v1/{project_id}/waf/config/lts/{ltsconfig_id}"
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+	modifyPath = strings.ReplaceAll(modifyPath, "{ltsconfig_id}", id)
+	modifyPath += buildAccessQueryParams(d, cfg)
+	modifyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildModifyWAFAccessBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", modifyPath, &modifyOpt)
+	return err
+}
+
+func buildAccessQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildModifyWAFAccessBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"enabled":   true,
+		"ltsIdInfo": buildWAFAccessLTSInfoBodyParams(d),
+	}
+	return bodyParams
+}
+
+func buildWAFAccessLTSInfoBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"ltsGroupId":        d.Get("lts_group_id"),
+		"ltsAttackStreamID": utils.ValueIngoreEmpty(d.Get("lts_attack_stream_id")),
+		"ltsAccessStreamID": utils.ValueIngoreEmpty(d.Get("lts_access_stream_id")),
+	}
+}
+
+func queryWAFAccessDetail(client *golangsdk.ServiceClient, d *schema.ResourceData,
+	cfg *config.Config) (interface{}, error) {
+	getPath := client.Endpoint + "v1/{project_id}/waf/config/lts"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildAccessQueryParams(d, cfg)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func resourceWAFAccessRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	detailRespBody, err := queryWAFAccessDetail(client, d, cfg)
+	if err != nil {
+		return diag.Errorf("error retrieving LTS access WAF logs configuration: %s", err)
+	}
+
+	enabled := utils.PathSearch("enabled", detailRespBody, false).(bool)
+	if !enabled {
+		// the WAF access is not exist
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{},
+			"error retrieving LTS access WAF logs configuration")
+	}
+
+	// update the resource ID for import operation
+	id := utils.PathSearch("id", detailRespBody, "")
+	if id != "" {
+		d.SetId(id.(string))
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("lts_group_id", utils.PathSearch("ltsIdInfo.ltsGroupId", detailRespBody, nil)),
+		d.Set("lts_attack_stream_id", utils.PathSearch("ltsIdInfo.ltsAttackStreamID",
+			detailRespBody, nil)),
+		d.Set("lts_access_stream_id", utils.PathSearch("ltsIdInfo.ltsAccessStreamID",
+			detailRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceWAFAccessUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	if err := modifyWAFAccessConfiguration(client, d, cfg, d.Id()); err != nil {
+		return diag.Errorf("error updating LTS access WAF logs configuration: %s", err)
+	}
+
+	return resourceWAFAccessRead(ctx, d, meta)
+}
+
+func resourceWAFAccessDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/config/lts/{ltsconfig_id}"
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{ltsconfig_id}", d.Id())
+	deletePath += buildAccessQueryParams(d, cfg)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteWAFAccessBodyParams(),
+	}
+
+	_, err = client.Request("PUT", deletePath, &deleteOpt)
+	if err != nil {
+		diag.Errorf("error deleting LTS access WAF logs configuration: %s", err)
+	}
+
+	return nil
+}
+
+func buildDeleteWAFAccessBodyParams() map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"enabled":   false,
+		"ltsIdInfo": make(map[string]interface{}),
+	}
+	return bodyParams
+}
+
+func resourceWAFAccessImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	// `0` means default enterprise project.
+	if d.Id() == "0" {
+		return []*schema.ResourceData{d}, nil
+	}
+	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", d.Id())
+}


### PR DESCRIPTION
…tion

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

LTS add a resource to manage LTS access WAF logs configuration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The resource ID is obtained from the details interface.
- The delete operation is to set `enabled` to false, and make `ltsIdInfo` empty.
- When enabled in the response body of the details interface is false, it is treated as if the resource does not exist.
- When the resource is not exist, run `terraform plan`:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/dadfe53b-b726-4f3c-8611-ee67dae047eb)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccWAFAccess_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccWAFAccess_basic -timeout 360m -parallel 4
=== RUN   TestAccWAFAccess_basic
=== PAUSE TestAccWAFAccess_basic
=== CONT  TestAccWAFAccess_basic
--- PASS: TestAccWAFAccess_basic (468.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       468.778s
```

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccWAFAccess_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccWAFAccess_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccWAFAccess_withEpsId
=== PAUSE TestAccWAFAccess_withEpsId
=== CONT  TestAccWAFAccess_withEpsId
--- PASS: TestAccWAFAccess_withEpsId (359.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       359.126s
```
