### PR TITLE
fix(cbh): fix codecheck for resource cbh

### DIFF
--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getCBHInstanceResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getCBHInstanceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getInstance: Query CBH instance
 	var (
 		getInstanceHttpUrl = "v1/{project_id}/cbs/instance/list"
 		getInstanceProduct = "cbh"
 	)
-	getInstanceClient, err := config.NewServiceClient(getInstanceProduct, region)
+	getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CBH Client: %s", err)
 	}

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
@@ -834,12 +834,11 @@ func resourceCBHInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("%s", err)
 	}
 
-	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
-		if err = common.UnsubscribePrePaidResource(d, cfg, []string{resourceId}); err != nil {
-			return diag.Errorf("error unsubscribe CBH instance: %s", err)
-		}
-	} else {
+	if v, ok := d.GetOk("charging_mode"); !ok || v.(string) != "prePaid" {
 		return diag.Errorf("only the charging_mode of prePaid is support")
+	}
+	if err = common.UnsubscribePrePaidResource(d, cfg, []string{resourceId}); err != nil {
+		return diag.Errorf("error unsubscribe CBH instance: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{


### PR DESCRIPTION
**Which issue this PR fixes**:
fix codecheck for resource cbh


**Test**:
```
./scripts/codecheck.sh ./huaweicloud/services/cbh 
Refresh index: 100% (9818/9818), done. 

==> Checking for running environment... 

==> Applying patch... 

==> Checking for code complexity... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2      1122      100        10     1012        205            36.83
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~s/cbh/resource_huaweicloud_cbh_instance.go       905       86         9      810        174            21.48
~h/data_source_huaweicloud_cbh_instances.go       217       14         1      202         31            15.35
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2      1122      100        10     1012        205            36.83
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 34646 bytes, 0.035 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
20 cbh resourceCbhInstancesRead huaweicloud/services/cbh/data_source_huaweicloud_cbh_instances.go:132:1 
16 cbh resourceCBHInstanceUpdate huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:557:1
11 cbh resourceCBHInstanceRead huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:744:1
8 cbh unbindEip huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:661:1
8 cbh resourceCBHInstanceCreate huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:164:1
7 cbh resourceCBHInstanceDelete huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:818:1
6 cbh cbhInstanceStateRefreshFunc huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:875:1
6 cbh bindEip huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:626:1
5 cbh getOrderProductId huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:490:1
5 cbh payOrder huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go:338:1
Average: 4.65

==> Checking for golangci-lint... 

==> Checking for Nolint directives... 

==> Checking for TF features in cbh... 

==> Checking for misspell in cbh... 

==> Checking for code complexity in ./huaweicloud/services/acceptance/cbh... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       275       21         1      253         10             4.93
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/resource_huaweicloud_cbh_instance_test.go       219       15         1      203         10             4.93
~a_source_huaweicloud_cbh_instances_test.go        56        6         0       50          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       275       21         1      253         10             4.93
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 8901 bytes, 0.009 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 cbh getCBHInstanceResourceFunc huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go:18:1 
3 cbh flattenGetInstancesResponseBodyInstanceTest huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go:119:1
1 cbh testCBHInstance_basic_update huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go:185:1
1 cbh testCBHInstance_basic huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go:163:1
1 cbh testCBHInstance_base huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go:132:1
Average: 1.75

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cbh...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cbh... 

==> Cleanup patch... 

Check Completed! 

```


## PR Checklist
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (1083.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1083.925s

```
