### PR TITLE
fix(WAF): fix waf rule web tamper protection lint error and add new fields

### DIFF
--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -20,6 +20,7 @@ resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
   enterprise_project_id = var.enterprise_project_id
   domain                = "www.your-domain.com"
   path                  = "/payment"
+  description           = "test description"
 }
 ```
 
@@ -39,6 +40,16 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF tamper protection
   rule. Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of WAF web tamper protection rule.
+  Changing this creates a new rule.
+
+* `status` - (Optional, Int) Specifies the status of WAF web tamper protection rule.
+  Valid values are as follows:
+  + **0**: Disabled.
+  + **1**: Enabled.
+
+  The default value is **1**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -17,10 +17,28 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+func getRuleWebTamperProtectionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	wafClient, err := cfg.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	policyID := state.Primary.Attributes["policy_id"]
+	epsID := state.Primary.Attributes["enterprise_project_id"]
+	return rules.GetWithEpsID(wafClient, policyID, state.Primary.ID, epsID).Extract()
+}
+
 func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
-	var rule rules.WebTamper
-	randName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleWebTamperProtectionResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -28,30 +46,37 @@ func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafRuleWebTamperProtection_basic(randName),
+				Config: testAccWafRuleWebTamperProtection_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
-					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(rName, "path", "/a"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testWAFRuleImportState(resourceName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
 }
 
 func TestAccWafRuleWebTamperProtection_withEpsID(t *testing.T) {
-	var rule rules.WebTamper
-	randName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_waf_rule_web_tamper_protection.rule_1"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleWebTamperProtectionResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -60,80 +85,25 @@ func TestAccWafRuleWebTamperProtection_withEpsID(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafRuleWebTamperProtection_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccWafRuleWebTamperProtection_basic_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
-					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(rName, "path", "/a"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testWAFRuleImportState(resourceName),
+				ImportStateIdFunc: testWAFRuleImportState(rName),
 			},
 		},
 	})
-}
-
-func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
-	if err != nil {
-		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_waf_rule_web_tamper_protection" {
-			continue
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
-		if err == nil {
-			return fmt.Errorf("WAF rule still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTamper) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.Id != rs.Primary.ID {
-			return fmt.Errorf("WAF web tamper protection rule not found")
-		}
-
-		*rule = *found
-
-		return nil
-	}
 }
 
 func testAccWafRuleWebTamperProtection_basic(name string) string {

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_web_tamper_protection_test.go
@@ -54,6 +54,15 @@ func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "domain", "www.abc.com"),
 					resource.TestCheckResourceAttr(rName, "path", "/a"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "status", "0"),
+				),
+			},
+			{
+				Config: testAccWafRuleWebTamperProtection_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
 				),
 			},
 			{
@@ -94,6 +103,7 @@ func TestAccWafRuleWebTamperProtection_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(rName, "domain", "www.abc.com"),
 					resource.TestCheckResourceAttr(rName, "path", "/a"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
 				),
 			},
 			{
@@ -111,9 +121,25 @@ func testAccWafRuleWebTamperProtection_basic(name string) string {
 %s
 
 resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
-  policy_id = huaweicloud_waf_policy.policy_1.id
-  domain    = "www.abc.com"
-  path      = "/a"
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  domain      = "www.abc.com"
+  path        = "/a"
+  description = "test description"
+  status      = 0
+}
+`, testAccWafPolicyV1_basic(name))
+}
+
+func testAccWafRuleWebTamperProtection_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  domain      = "www.abc.com"
+  path        = "/a"
+  description = "test description"
+  status      = 1
 }
 `, testAccWafPolicyV1_basic(name))
 }
@@ -126,6 +152,7 @@ resource "huaweicloud_waf_rule_web_tamper_protection" "rule_1" {
   policy_id             = huaweicloud_waf_policy.policy_1.id
   domain                = "www.abc.com"
   path                  = "/a"
+  description           = "test description"
   enterprise_project_id = "%s"
 }
 `, testAccWafPolicyV1_basic_withEpsID(name, epsID), epsID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- commit: fix WAF rule tamper protection lint error.
- commit: resource WAF rule web tamper protection add new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- add new fields: `description` and `status`. `status` support updating.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_basic
--- PASS: TestAccWafRuleWebTamperProtection_basic (459.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       459.162s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleWebTamperProtection_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafRuleWebTamperProtection_withEpsID
=== PAUSE TestAccWafRuleWebTamperProtection_withEpsID
=== CONT  TestAccWafRuleWebTamperProtection_withEpsID
--- PASS: TestAccWafRuleWebTamperProtection_withEpsID (430.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       430.142s
```
