### PR TITLE
fix(WAF): waf rule precise protection resource suppport new field and fix some error

### DIFF
--- a/docs/resources/waf_rule_precise_protection.md
+++ b/docs/resources/waf_rule_precise_protection.md
@@ -98,6 +98,8 @@ The following arguments are supported:
 * `end_time` - (Optional, String) Specifies the time when the precise protection rule expires.
   The time format is **yyyy-MM-dd HH:mm:ss**, e.g. **2023-05-02 15:04:05**.
 
+-> The precise protection rule will take effect immediately when `start_time` and `end_time` are not specified.
+
 * `description` - (Optional, String) Specifies the description of WAF precise protection rule.
 
 <a name="RulePreciseProtection_conditions"></a>

--- a/docs/resources/waf_rule_precise_protection.md
+++ b/docs/resources/waf_rule_precise_protection.md
@@ -77,6 +77,14 @@ The following arguments are supported:
 * `action` - (Optional, String) Specifies the protective action of WAF precise protection rule.
   Valid values are **block**, **pass**, **log**. The default value is **block**.
 
+* `known_attack_source_id` - (Optional, String) Specifies the known attack source ID.
+  The requirements for using this parameter are as follows:
+  + The field is valid only when the `action` is set to **block**.
+  + The policy needs to be bound to a domain name.
+  + Before enabling `Cookie` or `Params` known attack source rules, configure a session or user tag for the
+  corresponding website domain name.
+  Refer to [Configure Traffic Identifier](https://support.huaweicloud.com/intl/en-us/usermanual-waf/waf_01_0270.html)
+
 * `status` - (Optional, Int) Specifies the status of WAF precise protection rule.
   Valid values are as follows:
   + **0**: Disabled.

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
@@ -73,6 +73,11 @@ func ResourceRulePreciseProtection() *schema.Resource {
 				Default:     "block",
 				Description: `Specifies the protective action of the precise protection rule.`,
 			},
+			"known_attack_source_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the known attack source ID.`,
+			},
 			"status": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -255,9 +260,14 @@ func buildCreateOrUpdateBodyParams(d *schema.ResourceData) (map[string]interface
 
 func buildActionBodyParam(d *schema.ResourceData) map[string]interface{} {
 	if v, ok := d.GetOk("action"); ok {
-		return map[string]interface{}{
+		rst := map[string]interface{}{
 			"category": v,
 		}
+		// `known_attack_source_id` can only be configured when the category is `block`.
+		if knownAttackSourceId, valExist := d.GetOk("known_attack_source_id"); valExist {
+			rst["followed_action_id"] = knownAttackSourceId
+		}
+		return rst
 	}
 	return nil
 }
@@ -355,7 +365,8 @@ func resourceRulePreciseProtectionRead(_ context.Context, d *schema.ResourceData
 		d.Set("priority", utils.PathSearch("priority", getRuleRespBody, nil)),
 		d.Set("status", utils.PathSearch("status", getRuleRespBody, nil)),
 		d.Set("conditions", flattenRulePreciseProtectionConditions(getRuleRespBody)),
-		d.Set("action", flattenRulePreciseProtectionAction(getRuleRespBody)),
+		d.Set("action", utils.PathSearch("action.category", getRuleRespBody, nil)),
+		d.Set("known_attack_source_id", utils.PathSearch("action.followed_action_id", getRuleRespBody, nil)),
 		d.Set("start_time", flattenRulePreciseProtectionTime(getRuleRespBody, "start")),
 		d.Set("end_time", flattenRulePreciseProtectionTime(getRuleRespBody, "terminal")),
 	)
@@ -371,21 +382,6 @@ func flattenRulePreciseProtectionTime(resp interface{}, field string) string {
 		return ""
 	}
 	return utils.FormatTimeStampUTC(int64(timestamp.(float64)))
-}
-
-func flattenRulePreciseProtectionAction(resp interface{}) string {
-	if resp == nil {
-		return ""
-	}
-	customAction := utils.PathSearch("action", resp, nil)
-	if customAction == nil {
-		return ""
-	}
-	customActionMap := customAction.(map[string]interface{})
-	if v, ok := customActionMap["category"]; ok {
-		return v.(string)
-	}
-	return ""
 }
 
 func flattenRulePreciseProtectionConditions(resp interface{}) []interface{} {
@@ -421,6 +417,7 @@ func resourceRulePreciseProtectionUpdate(ctx context.Context, d *schema.Resource
 		"priority",
 		"conditions",
 		"action",
+		"known_attack_source_id",
 		"start_time",
 		"end_time",
 		"description",

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
@@ -236,6 +236,7 @@ func buildCreateOrUpdateBodyParams(d *schema.ResourceData) (map[string]interface
 		"conditions":  buildConditionBodyParam(d.Get("conditions")),
 		"action":      buildActionBodyParam(d),
 		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"time":        false,
 	}
 
 	if v, ok := d.GetOk("start_time"); ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- commit1: waf rule precise protection resource support known attack source id.
- commit2: waf rule precise protection resource set `time` field default to **false**, and add description.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRulePreciseProtection_knownAttackSourceId'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRulePreciseProtection_knownAttackSourceId -timeout 360m -parallel 4
=== RUN   TestAccRulePreciseProtection_knownAttackSourceId
=== PAUSE TestAccRulePreciseProtection_knownAttackSourceId
=== CONT  TestAccRulePreciseProtection_knownAttackSourceId
--- PASS: TestAccRulePreciseProtection_knownAttackSourceId (543.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       543.648s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRulePreciseProtection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRulePreciseProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccRulePreciseProtection_basic
=== PAUSE TestAccRulePreciseProtection_basic
=== CONT  TestAccRulePreciseProtection_basic
--- PASS: TestAccRulePreciseProtection_basic (447.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       447.148s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccRulePreciseProtection_WithEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRulePreciseProtection_WithEpsID -timeout 360m -parallel 4
=== RUN   TestAccRulePreciseProtection_WithEpsID
=== PAUSE TestAccRulePreciseProtection_WithEpsID
=== CONT  TestAccRulePreciseProtection_WithEpsID
--- PASS: TestAccRulePreciseProtection_WithEpsID (438.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       438.571s
```
