### PR TITLE
fix(WAF): waf rule data masking fix lint error and add new fields

### DIFF
--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -21,6 +21,7 @@ resource "huaweicloud_waf_rule_data_masking" "rule_1" {
   path                  = "/login"
   field                 = "params"
   subfield              = "password"
+  description           = "test description"
 }
 ```
 
@@ -45,6 +46,15 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF data masking rule.
   Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of WAF data masking rule.
+
+* `status` - (Optional, Int) Specifies the status of WAF web tamper protection rule.
+  Valid values are as follows:
+  + **0**: Disabled.
+  + **1**: Enabled.
+
+  The default value is **1**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -58,6 +58,8 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName1, "path", "/login"),
 					resource.TestCheckResourceAttr(resourceName1, "subfield", "password"),
 					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName1, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName1, "status", "0"),
 					resource.TestCheckResourceAttr(resourceName2, "field", "header"),
 					resource.TestCheckResourceAttr(resourceName3, "field", "form"),
 					resource.TestCheckResourceAttr(resourceName4, "field", "cookie"),
@@ -70,6 +72,8 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName1, "path", "/login_new"),
 					resource.TestCheckResourceAttr(resourceName1, "subfield", "secret"),
 					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName1, "description", "test description update"),
+					resource.TestCheckResourceAttr(resourceName1, "status", "1"),
 					resource.TestCheckResourceAttr(resourceName2, "field", "header"),
 					resource.TestCheckResourceAttr(resourceName3, "field", "form"),
 					resource.TestCheckResourceAttr(resourceName4, "field", "cookie"),
@@ -142,9 +146,11 @@ func testAccWafRuleDataMasking_basic(name string) string {
 
 resource "huaweicloud_waf_rule_data_masking" "rule_1" {
   policy_id = huaweicloud_waf_policy.policy_1.id
-  path      = "/login"
-  field     = "params"
-  subfield  = "password"
+  path        = "/login"
+  field       = "params"
+  subfield    = "password"
+  description = "test description"
+  status      = 0
 }
 resource "huaweicloud_waf_rule_data_masking" "rule_2" {
   policy_id = huaweicloud_waf_policy.policy_1.id
@@ -172,10 +178,12 @@ func testAccWafRuleDataMasking_update(name string) string {
 %s
 
 resource "huaweicloud_waf_rule_data_masking" "rule_1" {
-  policy_id = huaweicloud_waf_policy.policy_1.id
-  path      = "/login_new"
-  field     = "params"
-  subfield  = "secret"
+  policy_id   = huaweicloud_waf_policy.policy_1.id
+  path        = "/login_new"
+  field       = "params"
+  subfield    = "secret"
+  description = "test description update"
+  status      = 1
 }
 resource "huaweicloud_waf_rule_data_masking" "rule_2" {
   policy_id = huaweicloud_waf_policy.policy_1.id

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_data_masking_test.go
@@ -17,13 +17,31 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+func getRuleDataMaskingResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	wafClient, err := cfg.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	policyID := state.Primary.Attributes["policy_id"]
+	epsID := state.Primary.Attributes["enterprise_project_id"]
+	return rules.GetWithEpsID(wafClient, policyID, state.Primary.ID, epsID).Extract()
+}
+
 func TestAccWafRuleDataMasking_basic(t *testing.T) {
-	var rule rules.DataMasking
+	var obj interface{}
+
 	policyName := acceptance.RandomAccResourceName()
 	resourceName1 := "huaweicloud_waf_rule_data_masking.rule_1"
 	resourceName2 := "huaweicloud_waf_rule_data_masking.rule_2"
 	resourceName3 := "huaweicloud_waf_rule_data_masking.rule_3"
 	resourceName4 := "huaweicloud_waf_rule_data_masking.rule_4"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName1,
+		&obj,
+		getRuleDataMaskingResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -31,12 +49,12 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckWafRuleDataMaskingDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleDataMasking_basic(policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleDataMaskingExists(resourceName1, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName1, "path", "/login"),
 					resource.TestCheckResourceAttr(resourceName1, "subfield", "password"),
 					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
@@ -48,7 +66,7 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 			{
 				Config: testAccWafRuleDataMasking_update(policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleDataMaskingExists(resourceName1, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName1, "path", "/login_new"),
 					resource.TestCheckResourceAttr(resourceName1, "subfield", "secret"),
 					resource.TestCheckResourceAttr(resourceName1, "field", "params"),
@@ -68,9 +86,16 @@ func TestAccWafRuleDataMasking_basic(t *testing.T) {
 }
 
 func TestAccWafRuleDataMasking_withEpsID(t *testing.T) {
-	var rule rules.DataMasking
+	var obj interface{}
+
 	policyName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_waf_rule_data_masking.rule"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getRuleDataMaskingResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -79,12 +104,12 @@ func TestAccWafRuleDataMasking_withEpsID(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckWafRuleDataMaskingDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleDataMasking_basic_withEpsID(policyName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleDataMaskingExists(resourceName, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "path", "/login"),
 					resource.TestCheckResourceAttr(resourceName, "subfield", "password"),
@@ -94,7 +119,7 @@ func TestAccWafRuleDataMasking_withEpsID(t *testing.T) {
 			{
 				Config: testAccWafRuleDataMasking_update_withEpsID(policyName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleDataMaskingExists(resourceName, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "path", "/login_new"),
 					resource.TestCheckResourceAttr(resourceName, "subfield", "secret"),
@@ -109,60 +134,6 @@ func TestAccWafRuleDataMasking_withEpsID(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckWafRuleDataMaskingDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
-	if err != nil {
-		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
-	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_waf_rule_data_masking" {
-			continue
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
-		if err == nil {
-			return fmt.Errorf("WAF data masking rule still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckWafRuleDataMaskingExists(n string, rule *rules.DataMasking) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.GetWithEpsID(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.Id != rs.Primary.ID {
-			return fmt.Errorf("WAF data masking rule not found")
-		}
-
-		*rule = *found
-
-		return nil
-	}
 }
 
 func testAccWafRuleDataMasking_basic(name string) string {

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
@@ -5,6 +5,10 @@
 package waf
 
 import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -12,24 +16,21 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 const (
-	FIELD_POSITION_HEADER = "header"
-	FIELD_POSITION_PARAMS = "params"
-	FIELD_POSITION_COOKIE = "cookie"
-	FIELD_POSITION_FORM   = "form"
+	fieldPositionHeader = "header"
+	fieldPositionParams = "params"
+	fieldPositionCookie = "cookie"
+	fieldPositionForm   = "form"
 )
 
-// ResourceWafRuleDataMaskingV1 the resource of managing a WAF Data Masking Rule within HuaweiCloud.
 func ResourceWafRuleDataMaskingV1() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceWafRuleDataMaskingCreate,
-		Read:   resourceWafRuleDataMaskingRead,
-		Update: resourceWafRuleDataMaskingUpdate,
-		Delete: resourceWafRuleDataMaskingDelete,
+		CreateContext: resourceWafRuleDataMaskingCreate,
+		ReadContext:   resourceWafRuleDataMaskingRead,
+		UpdateContext: resourceWafRuleDataMaskingUpdate,
+		DeleteContext: resourceWafRuleDataMaskingDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceWAFRuleImportState,
 		},
@@ -54,7 +55,7 @@ func ResourceWafRuleDataMaskingV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					FIELD_POSITION_HEADER, FIELD_POSITION_PARAMS, FIELD_POSITION_COOKIE, FIELD_POSITION_FORM,
+					fieldPositionHeader, fieldPositionParams, fieldPositionCookie, fieldPositionForm,
 				}, false),
 			},
 			"subfield": {
@@ -70,12 +71,11 @@ func ResourceWafRuleDataMaskingV1() *schema.Resource {
 	}
 }
 
-// resourceWafRuleDataMaskingCreate create a rule
-func resourceWafRuleDataMaskingCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleDataMaskingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	wafClient, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	policyID := d.Get("policy_id").(string)
@@ -83,52 +83,47 @@ func resourceWafRuleDataMaskingCreate(d *schema.ResourceData, meta interface{}) 
 		Path:                d.Get("path").(string),
 		Category:            d.Get("field").(string),
 		Index:               d.Get("subfield").(string),
-		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
 
-	logp.Printf("[DEBUG] WAF Data Masking Rule creating opts: %#v", createOpts)
 	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Data Masking Rule: %s", err)
+		return diag.Errorf("error creating WAF data masking rule: %s", err)
 	}
-
-	logp.Printf("[DEBUG] WAF data masking rule created: %#v", rule)
 	d.SetId(rule.Id)
 
-	return resourceWafRuleDataMaskingRead(d, meta)
+	return resourceWafRuleDataMaskingRead(ctx, d, meta)
 }
 
-// resourceWafRuleDataMaskingRead get rule detail from HuaweiCloud by id and policy_id
-func resourceWafRuleDataMaskingRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleDataMaskingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	wafClient, err := cfg.WafV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	policyID := d.Get("policy_id").(string)
-	epsID := config.GetEnterpriseProjectID(d)
+	epsID := cfg.GetEnterpriseProjectID(d)
 	n, err := rules.GetWithEpsID(wafClient, policyID, d.Id(), epsID).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "WAF Data Masking Rule")
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF data masking rule")
 	}
-	logp.Printf("[DEBUG] fetching WAF data masking rule: %#v", n)
 
-	d.SetId(n.Id)
-	d.Set("path", n.Path)
-	d.Set("field", n.Category)
-	d.Set("subfield", n.Index)
-
-	return nil
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("path", n.Path),
+		d.Set("field", n.Category),
+		d.Set("subfield", n.Index),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-// resourceWafRuleDataMaskingUpdate update the existing rules.
-// Supported fields: path, field, subfield
-func resourceWafRuleDataMaskingUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleDataMaskingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	wafClient, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	if d.HasChanges("path", "field", "subfield") {
@@ -137,33 +132,29 @@ func resourceWafRuleDataMaskingUpdate(d *schema.ResourceData, meta interface{}) 
 			Path:                d.Get("path").(string),
 			Category:            d.Get("field").(string),
 			Index:               d.Get("subfield").(string),
-			EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 		}
 
-		logp.Printf("[DEBUG] WAF Data Masking Rule updating opts: %#v", updateOpts)
 		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmtp.Errorf("error updating HuaweiCloud WAF Data Masking Rule: %s", err)
+			return diag.Errorf("error updating WAF data masking rule: %s", err)
 		}
 	}
 
-	return resourceWafRuleDataMaskingRead(d, meta)
+	return resourceWafRuleDataMaskingRead(ctx, d, meta)
 }
 
-// resourceWafRuleDataMaskingDelete delete the rules from HuaweiCloud by id
-func resourceWafRuleDataMaskingDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleDataMaskingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	wafClient, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	policyID := d.Get("policy_id").(string)
-	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), config.GetEnterpriseProjectID(d)).ExtractErr()
+	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), cfg.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
-		return fmtp.Errorf("error deleting HuaweiCloud WAF Data Masking Rule: %s", err)
+		return diag.Errorf("error deleting WAF data masking rule: %s", err)
 	}
-
-	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

waf rule data masking fix lint error and add new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- commit1: fix waf rule data masking  lint error
- commit2: resource waf rule data masking support new fields.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleDataMasking_basic
=== PAUSE TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_basic
--- PASS: TestAccWafRuleDataMasking_basic (468.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       468.525s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleDataMasking_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafRuleDataMasking_withEpsID
=== PAUSE TestAccWafRuleDataMasking_withEpsID
=== CONT  TestAccWafRuleDataMasking_withEpsID
--- PASS: TestAccWafRuleDataMasking_withEpsID (385.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       385.813s
```
