### PR TITLE
fix(WAF): waf rule blacklist fix lint error and add new fields

### DIFF
--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -73,6 +73,13 @@ The following arguments are supported:
   + `1`: allow the request.
   + `2`: log the request only.
 
+* `status` - (Optional, Int) Specifies the status of WAF blacklist and whitelist rule.
+  Valid values are as follows:
+  + **0**: Disabled.
+  + **1**: Enabled.
+
+  The default value is **1**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -13,13 +13,30 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+func getRuleBlackListResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	wafClient, err := cfg.WafV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	policyID := state.Primary.Attributes["policy_id"]
+	epsID := state.Primary.Attributes["enterprise_project_id"]
+	return rules.GetWithEpsId(wafClient, policyID, state.Primary.ID, epsID).Extract()
+}
+
 func TestAccWafRuleBlackList_basic(t *testing.T) {
-	var rule rules.WhiteBlackIP
+	var obj interface{}
+
 	randName := acceptance.RandomAccResourceName()
 	rName1 := "huaweicloud_waf_rule_blacklist.rule_1"
 	rName2 := "huaweicloud_waf_rule_blacklist.rule_2"
 	rName3 := "huaweicloud_waf_rule_blacklist.rule_3"
-	addressGroupResourceName := "huaweicloud_waf_address_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName1,
+		&obj,
+		getRuleBlackListResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -27,20 +44,18 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 			acceptance.TestAccPrecheckWafInstance(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckWafRuleBlackListDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleBlackList_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleBlackListExists(rName1, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.0/24"),
 					resource.TestCheckResourceAttr(rName1, "action", "0"),
 
-					testAccCheckWafRuleBlackListExists(rName2, &rule),
 					resource.TestCheckResourceAttr(rName2, "ip_address", "192.165.0.0/24"),
 					resource.TestCheckResourceAttr(rName2, "action", "1"),
 
-					testAccCheckWafRuleBlackListExists(rName3, &rule),
 					resource.TestCheckResourceAttr(rName3, "ip_address", "192.160.0.0/24"),
 					resource.TestCheckResourceAttr(rName3, "action", "0"),
 					resource.TestCheckResourceAttr(rName3, "name", randName),
@@ -50,16 +65,15 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 			{
 				Config: testAccWafRuleBlackList_update(randName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleBlackListExists(rName1, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.125"),
 					resource.TestCheckResourceAttr(rName1, "action", "2"),
 
-					testAccCheckWafRuleBlackListExists(rName2, &rule),
 					resource.TestCheckResourceAttr(rName2, "ip_address", "192.150.0.0/24"),
 					resource.TestCheckResourceAttr(rName2, "action", "0"),
 
-					testAccCheckWafRuleBlackListExists(rName3, &rule),
-					resource.TestCheckResourceAttrPair(rName3, "address_group_id", addressGroupResourceName, "id"),
+					resource.TestCheckResourceAttrPair(rName3, "address_group_id",
+						"huaweicloud_waf_address_group.test", "id"),
 					resource.TestCheckResourceAttr(rName3, "action", "2"),
 					resource.TestCheckResourceAttr(rName3, "name", fmt.Sprintf("%s_update", randName)),
 					resource.TestCheckResourceAttr(rName3, "description", ""),
@@ -78,10 +92,16 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 }
 
 func TestAccWafRuleBlackList_withEpsID(t *testing.T) {
-	var rule rules.WhiteBlackIP
+	var obj interface{}
+
 	randName := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_waf_rule_blacklist.rule"
-	addressGroupResourceName := "huaweicloud_waf_address_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRuleBlackListResourceFunc,
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -90,12 +110,12 @@ func TestAccWafRuleBlackList_withEpsID(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckWafRuleBlackListDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWafRuleBlackList_basic_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleBlackListExists(rName, &rule),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(rName, "ip_address", "192.160.0.0/24"),
 					resource.TestCheckResourceAttr(rName, "action", "0"),
@@ -106,8 +126,9 @@ func TestAccWafRuleBlackList_withEpsID(t *testing.T) {
 			{
 				Config: testAccWafRuleBlackList_update_withEpsID(randName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafRuleBlackListExists(rName, &rule),
-					resource.TestCheckResourceAttrPair(rName, "address_group_id", addressGroupResourceName, "id"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "address_group_id",
+						"huaweicloud_waf_address_group.test", "id"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(rName, "action", "2"),
 					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", randName)),
@@ -124,61 +145,6 @@ func TestAccWafRuleBlackList_withEpsID(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckWafRuleBlackListDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
-	if err != nil {
-		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_waf_rule_blacklist" {
-			continue
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		_, err := rules.GetWithEpsId(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
-		if err == nil {
-			return fmt.Errorf("Waf rule still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckWafRuleBlackListExists(n string, rule *rules.WhiteBlackIP) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
-		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
-		}
-
-		policyID := rs.Primary.Attributes["policy_id"]
-		found, err := rules.GetWithEpsId(wafClient, policyID, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"]).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.Id != rs.Primary.ID {
-			return fmt.Errorf("WAF black list rule not found")
-		}
-
-		*rule = *found
-
-		return nil
-	}
 }
 
 func testAccWafRuleBlackList_basic(name string) string {

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_blacklist_test.go
@@ -52,6 +52,7 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.0/24"),
 					resource.TestCheckResourceAttr(rName1, "action", "0"),
+					resource.TestCheckResourceAttr(rName1, "status", "0"),
 
 					resource.TestCheckResourceAttr(rName2, "ip_address", "192.165.0.0/24"),
 					resource.TestCheckResourceAttr(rName2, "action", "1"),
@@ -68,6 +69,7 @@ func TestAccWafRuleBlackList_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.125"),
 					resource.TestCheckResourceAttr(rName1, "action", "2"),
+					resource.TestCheckResourceAttr(rName1, "status", "1"),
 
 					resource.TestCheckResourceAttr(rName2, "ip_address", "192.150.0.0/24"),
 					resource.TestCheckResourceAttr(rName2, "action", "0"),
@@ -154,6 +156,7 @@ func testAccWafRuleBlackList_basic(name string) string {
 resource "huaweicloud_waf_rule_blacklist" "rule_1" {
   policy_id  = huaweicloud_waf_policy.policy_1.id
   ip_address = "192.168.0.0/24"
+  status     = 0
 }
 
 resource "huaweicloud_waf_rule_blacklist" "rule_2" {
@@ -187,6 +190,7 @@ resource "huaweicloud_waf_rule_blacklist" "rule_1" {
   policy_id  = huaweicloud_waf_policy.policy_1.id
   ip_address = "192.168.0.125"
   action     = 2
+  status     = 1
 }
 
 resource "huaweicloud_waf_rule_blacklist" "rule_2" {

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
@@ -1,9 +1,11 @@
 package waf
 
 import (
+	"context"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -12,25 +14,23 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 const (
-	// PROTECTION_ACTION_BLOCK block the request
-	PROTECTION_ACTION_BLOCK = 0
-	// PROTECTION_ACTION_ALLOW allow the request
-	PROTECTION_ACTION_ALLOW = 1
-	// PROTECTION_ACTION_LOG log the request only
-	PROTECTION_ACTION_LOG = 2
+	// block the request
+	protectionActionBlock = 0
+	// allow the request
+	protectionActionAllow = 1
+	// log the request only
+	protectionActionLog = 2
 )
 
 func ResourceWafRuleBlackListV1() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceWafRuleBlackListCreate,
-		Read:   resourceWafRuleBlackListRead,
-		Update: resourceWafRuleBlackListUpdate,
-		Delete: resourceWafRuleBlackListDelete,
+		CreateContext: resourceWafRuleBlackListCreate,
+		ReadContext:   resourceWafRuleBlackListRead,
+		UpdateContext: resourceWafRuleBlackListUpdate,
+		DeleteContext: resourceWafRuleBlackListDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceWAFRuleImportState,
 		},
@@ -79,9 +79,9 @@ func ResourceWafRuleBlackListV1() *schema.Resource {
 			"action": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  PROTECTION_ACTION_BLOCK,
+				Default:  protectionActionBlock,
 				ValidateFunc: validation.IntInSlice([]int{
-					PROTECTION_ACTION_BLOCK, PROTECTION_ACTION_ALLOW, PROTECTION_ACTION_LOG,
+					protectionActionBlock, protectionActionAllow, protectionActionLog,
 				}),
 			},
 			"address_group_name": {
@@ -96,59 +96,48 @@ func ResourceWafRuleBlackListV1() *schema.Resource {
 	}
 }
 
-func resourceWafRuleBlackListCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleBlackListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	wafClient, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	policyID := d.Get("policy_id").(string)
-	epsID := config.GetEnterpriseProjectID(d)
+	epsID := cfg.GetEnterpriseProjectID(d)
 	createOpts := rules.CreateOpts{
-		White: d.Get("action").(int),
-	}
-	if v, ok := d.GetOk("name"); ok {
-		createOpts.Name = v.(string)
-	}
-	if v, ok := d.GetOk("ip_address"); ok {
-		createOpts.Addr = v.(string)
-	}
-	if v, ok := d.GetOk("address_group_id"); ok {
-		createOpts.IPGroupID = v.(string)
-	}
-	if v, ok := d.GetOk("description"); ok {
-		createOpts.Description = v.(string)
+		White:       d.Get("action").(int),
+		Name:        d.Get("name").(string),
+		Addr:        d.Get("ip_address").(string),
+		IPGroupID:   d.Get("address_group_id").(string),
+		Description: d.Get("description").(string),
 	}
 
-	logp.Printf("[DEBUG] WAF black list rule creating opts: %#v", createOpts)
 	rule, err := rules.CreateWithEpsId(wafClient, createOpts, policyID, epsID).Extract()
 	if err != nil {
-		return fmtp.Errorf("error creating WAF black list rule: %s", err)
+		return diag.Errorf("error creating WAF blacklist and whitelist rule: %s", err)
 	}
-	logp.Printf("[DEBUG] WAF black list rule created: %#v", rule)
-	// After the creation is successful, set the value id of the schema.
 	d.SetId(rule.Id)
 
-	return resourceWafRuleBlackListRead(d, meta)
+	return resourceWafRuleBlackListRead(ctx, d, meta)
 }
 
-func resourceWafRuleBlackListRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleBlackListRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	wafClient, err := cfg.WafV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	policyID := d.Get("policy_id").(string)
-	n, err := rules.GetWithEpsId(wafClient, policyID, d.Id(), config.GetEnterpriseProjectID(d)).Extract()
+	n, err := rules.GetWithEpsId(wafClient, policyID, d.Id(), cfg.GetEnterpriseProjectID(d)).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "WAF Black List Rule")
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF blacklist and whitelist rule")
 	}
-	logp.Printf("[DEBUG] fetching WAF black list rule: %#v", n)
 
-	d.SetId(n.Id)
 	mErr := multierror.Append(nil,
+		d.Set("region", region),
 		d.Set("policy_id", n.PolicyID),
 		d.Set("name", n.Name),
 		d.Set("ip_address", n.Addr),
@@ -170,58 +159,53 @@ func resourceWafRuleBlackListRead(d *schema.ResourceData, meta interface{}) erro
 			d.Set("address_group_size", 0),
 		)
 	}
-	if mErr.ErrorOrNil() != nil {
-		return fmtp.Errorf("error setting WAF rule blacklist fields: %s", mErr)
-	}
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceWafRuleBlackListUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleBlackListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	wafClient, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
-	if d.HasChanges("name", "ip_address", "address_group_id", "description", "action") {
+	updateChanges := []string{
+		"name",
+		"ip_address",
+		"address_group_id",
+		"description",
+		"action",
+	}
+
+	if d.HasChanges(updateChanges...) {
 		updateOpts := rules.UpdateOpts{
 			White:       utils.Int(d.Get("action").(int)),
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
+			Addr:        d.Get("ip_address").(string),
+			IPGroupID:   d.Get("address_group_id").(string),
 		}
-		if v, ok := d.GetOk("ip_address"); ok {
-			updateOpts.Addr = v.(string)
-		}
-		if v, ok := d.GetOk("address_group_id"); ok {
-			updateOpts.IPGroupID = v.(string)
-		}
-
-		logp.Printf("[DEBUG] updating blacklist and whitelist rule, updateOpts: %#v", updateOpts)
-
 		policyID := d.Get("policy_id").(string)
-		epsID := config.GetEnterpriseProjectID(d)
+		epsID := cfg.GetEnterpriseProjectID(d)
 		_, err = rules.UpdateWithEpsId(wafClient, updateOpts, policyID, d.Id(), epsID).Extract()
 		if err != nil {
-			return fmtp.Errorf("error updating HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
+			return diag.Errorf("error updating WAF blacklist and whitelist rule: %s", err)
 		}
 	}
-
-	return resourceWafRuleBlackListRead(d, meta)
+	return resourceWafRuleBlackListRead(ctx, d, meta)
 }
 
-func resourceWafRuleBlackListDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafRuleBlackListDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	wafClient, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	policyID := d.Get("policy_id").(string)
-	err = rules.DeleteWithEpsId(wafClient, policyID, d.Id(), config.GetEnterpriseProjectID(d)).ExtractErr()
+	err = rules.DeleteWithEpsId(wafClient, policyID, d.Id(), cfg.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
-		return fmtp.Errorf("error deleting HuaweiCloud WAF Blacklist and Whitelist Rule: %s", err)
+		return diag.Errorf("error deleting WAF blacklist and whitelist rule: %s", err)
 	}
-
-	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

waf rule blacklist fix lint error and add new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- commit1: fix waf rule blacklist and whitelist lint error.
- commit2: resource waf rule blacklist and whitelist add new fields.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleBlackList_basic
=== PAUSE TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_basic
--- PASS: TestAccWafRuleBlackList_basic (463.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       463.840s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafRuleBlackList_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafRuleBlackList_withEpsID
=== PAUSE TestAccWafRuleBlackList_withEpsID
=== CONT  TestAccWafRuleBlackList_withEpsID
--- PASS: TestAccWafRuleBlackList_withEpsID (432.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       432.301s
```
