### PR TITLE
feat(DCS): dcs instance support parameters

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -75,6 +75,17 @@ resource "huaweicloud_dcs_instance" "instance_2" {
     group_name = "test-group2"
     ip_address = ["172.16.10.100", "172.16.0.0/24"]
   }
+
+  parameters {
+    id    = "1"
+    name  = "timeout"
+    value = "500"
+  }
+  parameters {
+    id    = "3"
+    name  = "hash-max-ziplist-entries"
+    value = "4096"
+  }
 }
 ```
 
@@ -177,6 +188,10 @@ The following arguments are supported:
 
   -> **NOTE:** This parameter is not supported when the instance type is single.
 
+* `parameters` - (Optional, List) Specify an array of one or more parameters to be set to the DCS instance after
+  launched. You can check on console to see which parameters supported.
+  The [parameters](#DcsInstance_Parameters) structure is documented below.
+
 * `rename_commands` - (Optional, Map) Critical command renaming, which is supported only by Redis 4.0 and
   Redis 5.0 instances but not by Redis 3.0 instance.
   The valid commands that can be renamed are: **command**, **keys**, **flushdb**, **flushall** and **hgetall**.
@@ -246,6 +261,15 @@ The `backup_policy` block supports:
 * `begin_at` - (Required, String) Time at which backup starts.
   Format: `hh24:00-hh24:00`, "00:00-01:00" indicates that backup starts at 00:00:00.
 
+<a name="DcsInstance_Parameters"></a>
+The `parameters` block supports:
+
+* `id` - (Required, String) Specifies the ID of the configuration item.
+
+* `name` - (Required, String) Specifies the name of the configuration item.
+
+* `value` - (Required, String) Specifies the value of the configuration item.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -296,7 +320,7 @@ terraform import huaweicloud_dcs_instance.instance_1 80e373f9-872e-4046-aae9-ccd
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason.
 The missing attributes include: `password`, `auto_renew`, `period`, `period_unit`, `rename_commands`,
-`internal_version`, `save_days`, `backup_type`, `begin_at`, `period_type`, `backup_at`.
+`internal_version`, `save_days`, `backup_type`, `begin_at`, `period_type`, `backup_at`, `parameters`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to
 align with the instance. Also you can ignore changes as below.

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -55,6 +55,9 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "timeout"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "100"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
 				),
@@ -71,6 +74,9 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.begin_at", "01:00-02:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.save_days", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.backup_at.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "10"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "latency-monitor-threshold"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "120"),
 				),
 			},
 			{
@@ -78,7 +84,7 @@ func TestAccDcsInstances_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"password", "auto_renew", "period", "period_unit", "rename_commands",
-					"internal_version", "save_days", "backup_type", "begin_at", "period_type", "backup_at"},
+					"internal_version", "save_days", "backup_type", "begin_at", "period_type", "backup_at", "parameters"},
 			},
 		},
 	})
@@ -986,6 +992,12 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     hgetall  = "hgetall001"
   }
 
+  parameters {
+    id    = "1"
+    name  = "timeout"
+    value = "100"
+  }
+
   tags = {
     key   = "value"
     owner = "terraform"
@@ -1039,6 +1051,12 @@ resource "huaweicloud_dcs_instance" "instance_1" {
     flushall = "flushall001"
     flushdb  = "flushdb001"
     hgetall  = "hgetall001"
+  }
+
+  parameters {
+    id    = "10"
+    name  = "latency-monitor-threshold"
+    value = "120"
   }
 
   tags = {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/requests.go
@@ -186,3 +186,63 @@ func UpdatePassword(c *golangsdk.ServiceClient, id string, opts UpdatePasswordOp
 	})
 	return &r, err
 }
+
+type RestartOrFlushInstanceOpts struct {
+	Instances []string `json:"instances,omitempty"`
+	Action    string   `json:"action,omitempty"`
+}
+
+func RestartOrFlushInstance(c *golangsdk.ServiceClient, opts RestartOrFlushInstanceOpts) (*RestartResponse, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(restartOrFlushInstanceURL(c), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r RestartResponse
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+type ModifyRedisConfigOpts struct {
+	RedisConfig []RedisConfigOpt `json:"redis_config"`
+}
+
+type RedisConfigOpt struct {
+	ParamId    string `json:"param_id" required:"true"`
+	ParamName  string `json:"param_name" required:"true"`
+	ParamValue string `json:"param_value" required:"true"`
+}
+
+func ModifyConfiguration(c *golangsdk.ServiceClient, instanceId string, opts ModifyRedisConfigOpts) (*golangsdk.Result, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r golangsdk.Result
+	_, err = c.Put(configurationsURL(c, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{204},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+func GetConfigurations(c *golangsdk.ServiceClient, instanceID string) (*Configuration, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(configurationsURL(c, instanceID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r Configuration
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/results.go
@@ -67,3 +67,40 @@ type DcsBackupPolicy struct {
 type ResizeResponse struct {
 	OrderId string `json:"order_id"`
 }
+
+type RestartResponse struct {
+	Results []RestartResultResponse `json:"results"`
+}
+
+type RestartResultResponse struct {
+	Result   string `json:"result"`
+	Instance string `json:"instance"`
+}
+
+type Configuration struct {
+	ConfigTime   string        `json:"config_time"`
+	InstanceId   int           `json:"instance_id"`
+	RedisConfig  []RedisConfig `json:"redis_config"`
+	ConfigStatus string        `json:"config_status"`
+	Status       string        `json:"status"`
+}
+
+type RedisConfig struct {
+	Proxy              bool   `json:"proxy"`
+	ParamId            string `json:"param_id"`
+	ParamName          string `json:"param_name"`
+	DefaultValue       string `json:"default_value"`
+	ValueRange         string `json:"value_range"`
+	ValueType          string `json:"value_type"`
+	Description        string `json:"description"`
+	ParamValue         string `json:"param_value"`
+	NodeRole           string `json:"node_role"`
+	ParamType          string `json:"param_type"`
+	UserPermission     string `json:"user_permission"`
+	NeedRestart        bool   `json:"need_restart"`
+	SupportedVersion   string `json:"supported_version"`
+	InternationalKey   string `json:"international_key"`
+	NewVersionOnly     bool   `json:"new_version_only"`
+	SupportDataVersion string `json:"support_data_version"`
+	Customized         bool   `json:"customized"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/urls.go
@@ -17,3 +17,11 @@ func resizeResourceURL(c *golangsdk.ServiceClient, id string) string {
 func updatePasswordURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, "instances", id, "password")
 }
+
+func restartOrFlushInstanceURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, "instances/status")
+}
+
+func configurationsURL(c *golangsdk.ServiceClient, instancesId string) string {
+	return c.ServiceURL(c.ProjectID, "instances", instancesId, "configs")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/datamasking_rules/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/datamasking_rules/results.go
@@ -11,12 +11,18 @@ import (
 type DataMasking struct {
 	// DataMasking Rule ID
 	Id string `json:"id"`
+	// DataMasking policy ID
+	PolicyID string `json:"policyid"`
 	// DataMaksing Rule URL
 	Path string `json:"url"`
 	// Masked Field
 	Category string `json:"category"`
 	// Masked Subfield
 	Index string `json:"index"`
+	// DataMasking description
+	Description string `json:"description"`
+	// DataMasking status. Valid values are `0` and `1`
+	Status int `json:"status"`
 }
 
 type commonResult struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  dcs instance support parameters
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  dcs instance support parameters
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstances_' TEST_PARALLELISM=20
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances_ -timeout 360m -parallel 20
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_cluster_expand_replica
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_cluster_change_capacity
=== CONT  TestAccDcsInstances_withEpsId
=== CONT  TestAccDcsInstances_proxy_to_ha
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_rw_to_proxy
=== CONT  TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_rw_change_capacity
=== CONT  TestAccDcsInstances_ha_to_proxy
--- SKIP: TestAccDcsInstances_withEpsId (0.05s)
--- PASS: TestAccDcsInstances_single (144.81s)
--- PASS: TestAccDcsInstances_tiny (149.52s)
--- PASS: TestAccDcsInstances_whitelists (192.06s)
--- PASS: TestAccDcsInstances_basic (273.52s)
--- PASS: TestAccDcsInstances_prePaid (302.63s)
--- PASS: TestAccDcsInstances_ha_expand_replica (304.87s)
--- PASS: TestAccDcsInstances_rw_expand_replica (312.40s)
--- PASS: TestAccDcsInstances_rw_change_capacity (336.77s)
--- PASS: TestAccDcsInstances_ha_change_capacity (405.84s)
--- PASS: TestAccDcsInstances_rw_to_proxy (550.45s)
--- PASS: TestAccDcsInstances_cluster_expand_replica (610.46s)
--- PASS: TestAccDcsInstances_ha_to_proxy (704.72s)
--- PASS: TestAccDcsInstances_proxy_to_ha (770.53s)
--- PASS: TestAccDcsInstances_proxy_to_rw (778.98s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1278.02s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (1971.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       1971.117s
```
