### PR TITLE
feat(apig): support new data source

### DIFF
--- a/docs/data-sources/apig_groups.md
+++ b/docs/data-sources/apig_groups.md
@@ -1,0 +1,123 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# huaweicloud_apig_groups
+
+Use this data source to query and filter the group list under the APIG instance within Huaweicloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_name" {}
+
+data "huaweicloud_apig_groups" "test" {
+  instance_id = var.instance_id
+  name        = var.group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the API group list.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies an ID of the APIG dedicated instance to which the API group belongs.
+
+* `group_id` - (Optional, String) Specifies the API group ID used to query.
+
+* `name` - (Optional, String) Specifies the API group name used to query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `groups` - All groups that match the filter parameters.
+  The [groups](#APIG_Groups) structure is documented below.
+
+<a name="APIG_Groups"></a>
+The `groups` block supports:
+
+* `id` - The API group ID.
+
+* `name` - The API group name.
+
+* `status` - The current status of the API group.
+  The valid values are as follows:
+  + **1**: Normal.
+
+* `sl_domain` - The subdomain name assigned by the system by default.
+
+* `created_at` - The creation time of the API group.
+
+* `updated_at` - The latest update time of the API group.
+
+* `on_sell_status` - Whether it has been listed on the cloud store.
+  The valid values are as follows:
+  + **1**: Listed.
+  + **2**: Not listed.
+  + **3**: Under review.
+
+* `url_domains` - List of independent domains bound on the API group.
+  The [url_domains](#APIG_Groups_urlDomains) structure is documented below.
+
+* `sl_domains` - List of subdomain names assigned by the system by default.
+
+* `description` - The description of the API group.
+
+* `is_default` - Indicates whether the API group is the default group.
+
+* `environment` - The array of one or more environments of the API group.
+  The [environment](#APIG_Groups_environment_attr) structure is documented below.
+
+<a name="APIG_Groups_urlDomains"></a>
+The `url_domains` block supports:
+
+* `id` - The domain ID.
+
+* `name` - The domain name.
+
+* `cname_status` - CNAME resolution status of the domain name.
+  The valid values are as follows:
+  + **1**: Not resolved.
+  + **2**: Resolving.
+  + **3**: Resolved.
+  + **4**: Resolution failed.
+
+* `ssl_id` - The SSL certificate ID.
+
+* `ssl_name` - The SSL certificate name.
+
+* `min_ssl_version` - Minimum SSL version. The default is **TLSv1.1**.
+  The valid values are as follows:
+  + **TLSv1.1**
+  + **TLSv1.2**
+
+* `verified_client_certificate_enabled` - Whether to enable client certificate verification.
+  This parameter is available only when a certificate is bound. It is enabled by default if trusted_root_ca exists,
+  and disabled if trusted_root_ca does not exist. The default is **false**.
+
+* `is_has_trusted_root_ca` - Whether a trusted root certificate (CA) exists. The value is true
+  if trusted_root_ca exists in the bound certificate. The default is **false**.
+
+<a name="APIG_Groups_environment_attr"></a>
+The `environment` block supports:
+
+* `variable` - The array of one or more environment variables.  
+  The [variable](#APIG_Groups_environment_variable_attr) structure is documented below.
+
+* `environment_id` - The ID of the environment to which the variables belong.
+
+<a name="APIG_Groups_environment_variable_attr"></a>
+The `variable` block supports:
+
+* `name` - The variable name.
+
+* `value` - The variable value.
+
+* `id` - The variable ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -389,6 +389,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"huaweicloud_apig_environments": apig.DataSourceEnvironments(),
+			"huaweicloud_apig_groups":       apig.DataSourceGroups(),
 
 			"huaweicloud_as_configurations": as.DataSourceASConfigurations(),
 			"huaweicloud_as_groups":         as.DataSourceASGroups(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_groups_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_groups_test.go
@@ -1,0 +1,149 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGroupsDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_apig_groups.filter_by_name"
+		rName          = acceptance.RandomAccResourceName()
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupsDataSource_filterByName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGroupsDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+}
+`, testAccGroup_base(rName), rName)
+}
+
+func testAccGroupsDataSource_filterByName(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_groups" "filter_by_name" {
+  // The behavior of parameter 'name' is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_apig_group.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = huaweicloud_apig_group.test.name
+}
+
+data "huaweicloud_apig_groups" "not_found" {
+  // Since a specified name is used, there is no dependency relationship with resource attachment, and the dependency
+  // needs to be manually set.
+  depends_on = [
+    huaweicloud_apig_group.test,
+  ]  
+
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "resource_not_found"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_apig_groups.filter_by_name.groups[*].id : v == huaweicloud_apig_group.test.id]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_apig_groups.not_found.groups) == 0
+}
+`, testAccGroupsDataSource_base(name))
+}
+
+func TestAccGroupsDataSource_filterById(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_apig_groups.filter_by_id"
+		rName          = acceptance.RandomAccResourceName()
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupsDataSource_filterById(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGroupsDataSource_filterById(name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_groups" "filter_by_id" {
+
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = huaweicloud_apig_group.test.id
+}
+
+data "huaweicloud_apig_groups" "not_found" {
+  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
+  // to be manually set.
+  depends_on = [
+    huaweicloud_apig_group.test,
+  ]  
+
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = "%[2]s"
+}
+
+locals {
+  filter_result = [for v in data.huaweicloud_apig_groups.filter_by_id.groups[*].id : v == huaweicloud_apig_group.test.id]
+}
+
+output "is_id_filter_useful" {
+  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_apig_groups.not_found.groups) == 0
+}
+`, testAccGroupsDataSource_base(name), randUUID)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_group.go
@@ -1,0 +1,233 @@
+package apig
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func DataSourceGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"sl_domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"on_sell_status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"url_domains": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"cname_status": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"ssl_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ssl_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"min_ssl_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"verified_client_certificate_enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"is_has_trusted_root_ca": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"sl_domains": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_default": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"environment": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"variable": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The variable name.",
+												},
+												"value": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The variable value.",
+												},
+												"id": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "The ID of the variable that the group has.",
+												},
+											},
+										},
+										Description: "The array of one or more environment variables.",
+									},
+									"environment_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the environment to which the variables belongs.",
+									},
+								},
+							},
+							Description: "The array of one or more environments of the associated group.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenGroups(group apigroups.Group, variables []map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":             group.Id,
+		"name":           group.Name,
+		"status":         group.Status,
+		"sl_domain":      group.Subdomain,
+		"created_at":     group.RegistraionTime,
+		"updated_at":     group.UpdateTime,
+		"on_sell_status": group.OnSellStatus,
+		"url_domains":    group.UrlDomians,
+		"sl_domains":     group.Subdomains,
+		"description":    group.Description,
+		"is_default":     group.IsDefault,
+		"environment":    variables,
+	}
+
+	return result
+}
+
+func dataSourceGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.ApigV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating APIG v2 client: %s", err)
+	}
+
+	opt := apigroups.ListOpts{
+		Id:   d.Get("group_id").(string),
+		Name: d.Get("name").(string),
+	}
+	pages, err := apigroups.List(client, d.Get("instance_id").(string), opt).AllPages()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	resp, err := apigroups.ExtractGroups(pages)
+	if err != nil {
+		return diag.Errorf("unable to get the group list form server: %v", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	result := make([]map[string]interface{}, 0)
+	for _, group := range resp {
+		variables, err := queryEnvironmentVariables(client, d.Get("instance_id").(string), group.Id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		result = append(result, flattenGroups(group, flattenEnvironmentVariables(variables)))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", result),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving dedicated groups data source fields: %s", mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support new data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support new data source
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccGroupsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroupsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGroupsDataSource_basic
=== PAUSE TestAccGroupsDataSource_basic
=== CONT  TestAccGroupsDataSource_basic
--- PASS: TestAccGroupsDataSource_basic (472.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      472.553s

make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccGroupsDataSource_filterById"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroupsDataSource_filterById -timeout 360m -parallel 4
=== RUN   TestAccGroupsDataSource_filterById
=== PAUSE TestAccGroupsDataSource_filterById
=== CONT  TestAccGroupsDataSource_filterById
--- PASS: TestAccGroupsDataSource_filterById (581.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      581.901s

make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccGroupsDataSource_filterByPreciseSearch"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroupsDataSource_filterByPreciseSearch -timeout 360m -parallel 4
=== RUN   TestAccGroupsDataSource_filterByPreciseSearch
=== PAUSE TestAccGroupsDataSource_filterByPreciseSearch
=== CONT  TestAccGroupsDataSource_filterByPreciseSearch
--- PASS: TestAccGroupsDataSource_filterByPreciseSearch (483.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      483.992s

```
