### PR TITLE
chore(ci): disable unchecked-type-assertion rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,8 @@ linters-settings:
         disabled: true
       - name: use-any
         disabled: true
+      - name: unchecked-type-assertion
+        disabled: true
 
 issues:
   # List of regexps of issue texts to exclude.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**unchecked-type-assertion** is enabled in v1.55.0 of golangci-lint, and we will disable it.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
