### PR TITLE
fix(WAF): fix waf certificate lint error and support updating certificate and private key

### DIFF
--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -47,10 +47,13 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the certificate name. The maximum length is 256 characters. Only digits,
   letters, underscores(`_`), and hyphens(`-`) are allowed.
 
-* `certificate` - (Required, String, ForceNew) Specifies the certificate content. Changing this creates a new
-  certificate.
+* `certificate` - (Required, String) Specifies the certificate content.
 
-* `private_key` - (Required, String, ForceNew) Specifies the private key. Changing this creates a new certificate.
+* `private_key` - (Required, String) Specifies the private key. This field does not support individual editing.
+  Changes to this field will only take effect when `certificate` changes.
+
+-> Only `PEM` format supported for `certificate` and `private_key`, and the newline characters in the file must be
+replaced with `\n`.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF certificate.
   Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -25,7 +25,6 @@ func TestAccWafCertificateV1_basic(t *testing.T) {
 	var certificate certificates.Certificate
 	resourceName := "huaweicloud_waf_certificate.certificate_1"
 	name := acceptance.RandomAccResourceName()
-	updateName := name + "_update"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -49,10 +48,10 @@ func TestAccWafCertificateV1_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWafCertificateV1_conf(updateName),
+				Config: testAccWafCertificateV1_conf_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
 				),
 			},
 			{
@@ -172,6 +171,75 @@ FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
 f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
 x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
 X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+
+  depends_on = [
+    huaweicloud_waf_dedicated_instance.instance_1
+  ]
+}
+`, testAccWafDedicatedInstanceV1_conf(name), name)
+}
+
+func testAccWafCertificateV1_conf_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_certificate" "certificate_1" {
+  name = "%s_update"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLA
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNo
 -----END PRIVATE KEY-----
 EOT
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -14,7 +16,7 @@ import (
 func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := conf.WafV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
 	}
 	return certificates.GetWithEpsID(client, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"]).Extract()
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
@@ -1,10 +1,13 @@
 package waf
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -12,16 +15,14 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 func ResourceWafCertificateV1() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceWafCertificateV1Create,
-		Read:   resourceWafCertificateV1Read,
-		Update: resourceWafCertificateV1Update,
-		Delete: resourceWafCertificateV1Delete,
+		CreateContext: resourceWafCertificateV1Create,
+		ReadContext:   resourceWafCertificateV1Read,
+		UpdateContext: resourceWafCertificateV1Update,
+		DeleteContext: resourceWafCertificateV1Delete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceWAFImportState,
 		},
@@ -67,85 +68,82 @@ func ResourceWafCertificateV1() *schema.Resource {
 	}
 }
 
-func resourceWafCertificateV1Create(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafCertificateV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	createOpts := certificates.CreateOpts{
 		Name:                d.Get("name").(string),
 		Content:             strings.TrimSpace(d.Get("certificate").(string)),
 		Key:                 strings.TrimSpace(d.Get("private_key").(string)),
-		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
 
-	certificate, err := certificates.Create(wafClient, createOpts).Extract()
+	certificate, err := certificates.Create(client, createOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("error creating WAF Certificate: %w", err)
+		return diag.Errorf("error creating WAF certificate: %s", err)
 	}
-
-	logp.Printf("[DEBUG] Waf certificate created: %#v", certificate)
 	d.SetId(certificate.Id)
 
-	return resourceWafCertificateV1Read(d, meta)
+	return resourceWafCertificateV1Read(ctx, d, meta)
 }
 
-func resourceWafCertificateV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafCertificateV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.WafV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
-	epsID := config.GetEnterpriseProjectID(d)
-	n, err := certificates.GetWithEpsID(wafClient, d.Id(), epsID).Extract()
+	epsID := cfg.GetEnterpriseProjectID(d)
+	n, err := certificates.GetWithEpsID(client, d.Id(), epsID).Extract()
 	if err != nil {
-		return common.CheckDeleted(d, err, "Error obtain WAF certificate information")
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF certificate")
 	}
 
 	expires := time.Unix(int64(n.ExpireTime/1000), 0).UTC().Format("2006-01-02 15:04:05 MST")
-
-	d.Set("region", config.GetRegion(d))
-	d.Set("name", n.Name)
-	d.Set("expiration", expires)
-
-	return nil
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", n.Name),
+		d.Set("expiration", expires),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceWafCertificateV1Update(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafCertificateV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	updateOpts := certificates.UpdateOpts{
 		Name:                d.Get("name").(string),
-		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
 
-	_, err = certificates.Update(wafClient, d.Id(), updateOpts).Extract()
+	_, err = certificates.Update(client, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("error updating WAF Certificate: %w", err)
+		return diag.Errorf("error updating WAF certificate: %s", err)
 	}
-	return resourceWafCertificateV1Read(d, meta)
+	return resourceWafCertificateV1Read(ctx, d, meta)
 }
 
-func resourceWafCertificateV1Delete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafCertificateV1Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
-	epsID := config.GetEnterpriseProjectID(d)
-	err = certificates.DeleteWithEpsID(wafClient, d.Id(), epsID).ExtractErr()
+	epsID := cfg.GetEnterpriseProjectID(d)
+	err = certificates.DeleteWithEpsID(client, d.Id(), epsID).ExtractErr()
 	if err != nil {
-		return fmtp.Errorf("error deleting WAF Certificate: %s", err)
+		return diag.Errorf("error deleting WAF certificate: %s", err)
 	}
-
-	d.SetId("")
 	return nil
 }

--- a/huaweicloud/utils/diff_suppress_funcs.go
+++ b/huaweicloud/utils/diff_suppress_funcs.go
@@ -56,6 +56,10 @@ func SuppressUserData(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+func SuppressTrimSpace(_, old, new string, _ *schema.ResourceData) bool {
+	return strings.TrimSpace(old) == strings.TrimSpace(new)
+}
+
 func SuppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
 	if len(old) != len(new) {
 		return false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix waf certificate lint error and support updating certificate and private key

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- fix waf certificate lint error.
- support updating certificare and private key
- The API will return error in updating operation with an unchanged `certificate`.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafCertificateV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafCertificateV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafCertificateV1_basic
=== PAUSE TestAccWafCertificateV1_basic
=== CONT  TestAccWafCertificateV1_basic
--- PASS: TestAccWafCertificateV1_basic (453.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       453.313s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafCertificateV1_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafCertificateV1_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafCertificateV1_withEpsID
=== PAUSE TestAccWafCertificateV1_withEpsID
=== CONT  TestAccWafCertificateV1_withEpsID
--- PASS: TestAccWafCertificateV1_withEpsID (447.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       447.415s
```