### PR TITLE
fix(DC): fix dc task lint

### DIFF
--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_gateway_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_gateway_test.go
@@ -4,16 +4,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/dc/v3/gateways"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dc/v3/gateways"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getVirtualGatewayFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DcV3Client(acceptance.HW_REGION_NAME)
+func getVirtualGatewayFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.DcV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DC v3 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/dc/v3/interfaces"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getVirtualInterfaceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DcV3Client(acceptance.HW_REGION_NAME)
+func getVirtualInterfaceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.DcV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DC v3 client: %s", err)
 	}

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/dc/v3/gateways"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/dc/v3/interfaces"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fix(DC): fix dc task lint

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

huawei@ecs-zhangtao:~/go/src/github.com/terraform-providers/terraform-provider-huaweicloud (dev)$ ./scripts/codecheck.sh ./huaweicloud/services/dc

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       634       56         7      571         58            20.60
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~source_huaweicloud_dc_virtual_interface.go       442       34         6      402         40             9.95
~resource_huaweicloud_dc_virtual_gateway.go       192       22         1      169         18            10.65
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       634       56         7      571         58            20.60
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 20320 bytes, 0.020 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
8 dc openVirtualInterfaceNetworkDetection huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go:360:1
7 dc resourceVirtualInterfaceUpdate huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go:389:1
7 dc closeVirtualInterfaceNetworkDetection huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go:337:1
4 dc resourceVirtualInterfaceRead huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go:289:1
4 dc resourceVirtualGatewayRead huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go:124:1
3 dc resourceVirtualInterfaceDelete huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go:428:1
3 dc resourceVirtualInterfaceCreate huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go:272:1
3 dc resourceVirtualGatewayDelete huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go:178:1
3 dc resourceVirtualGatewayUpdate huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go:154:1
3 dc resourceVirtualGatewayCreate huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go:107:1
Average: 3.5

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in dc...

==> Checking for misspell in dc...

==> Checking for code complexity in ./huaweicloud/services/acceptance/dc...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       291       25         0      266          4             3.18
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~e_huaweicloud_dc_virtual_interface_test.go       177       13         0      164          2             1.22
~rce_huaweicloud_dc_virtual_gateway_test.go       114       12         0      102          2             1.96
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       291       25         0      266          4             3.18
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 9267 bytes, 0.009 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
2 dc getVirtualInterfaceFunc huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go:17:1
2 dc getVirtualGatewayFunc huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_gateway_test.go:16:1
1 dc testAccVirtualInterface_update huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go:152:1
1 dc testAccVirtualInterface_basic huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go:125:1
1 dc testAccVirtualInterface_base huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go:106:1
Average: 1.22

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/dc...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/dc...

==> Cleanup patch...

Check Completed!


## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/dc TESTARGS='-run TestAccVirtual'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc -v -run TestAccVirtual -timeout 360m -parallel 4
=== RUN   TestAccVirtualGateway_basic
=== PAUSE TestAccVirtualGateway_basic
=== RUN   TestAccVirtualInterface_basic
=== PAUSE TestAccVirtualInterface_basic
=== CONT  TestAccVirtualGateway_basic
=== CONT  TestAccVirtualInterface_basic
    acceptance.go:727: Skip the interface acceptance test because of the direct connection ID is missing.
--- SKIP: TestAccVirtualInterface_basic (0.00s)
--- PASS: TestAccVirtualGateway_basic (52.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc52.504s


