### PR TITLE
feat(eg/subscription): sources and targets can be saved and support i…

### DIFF
--- a/docs/resources/eg_event_subscription.md
+++ b/docs/resources/eg_event_subscription.md
@@ -11,7 +11,10 @@ Using this resource to manage an EG event subscription within Huaweicloud.
 ```hcl
 variable "source_channel_id" {}
 variable "target_channel_id" {}
+variable "custom_event_source_id" {}
 variable "custom_event_source_name" {}
+variable "official_eg_event_target_id" {}
+variable "official_smn_event_target_id" {}
 variable "project_id" {}
 variable "region_name" {}
 variable "smn_topic_urn" {}
@@ -21,6 +24,7 @@ resource "huaweicloud_eg_event_subscription" "test" {
   name       = var.subscription
 
   sources {
+    id            = var.custom_event_source_id
     provider_type = "CUSTOM"
     name          = var.custom_event_source_name
     filter_rule   = jsonencode({
@@ -32,6 +36,7 @@ resource "huaweicloud_eg_event_subscription" "test" {
   }
 
   targets {
+    id            = var.official_eg_event_target_id
     provider_type = "OFFICIAL"
     name          = "HC.EG"
     detail_name   = "eg_detail"
@@ -50,6 +55,7 @@ resource "huaweicloud_eg_event_subscription" "test" {
   }
 
   targets {
+    id            = var.official_smn_event_target_id
     provider_type = "OFFICIAL"
     name          = "HC.SMN"
     detail_name   = "smn_detail"
@@ -95,6 +101,11 @@ The following arguments are supported:
 <a name="subscription_sources"></a>
 The `sources` block supports:
 
+* `id` - (Required, String) Specifies the custom ID of the event source, in UUID format.
+
+  -> This `id` field is only used for internal management of event subscription resource and has no association with the
+     parameters or attributes of other resources.
+
 * `provider_type` - (Required, String) Specifies the provider type of the event source.
   The valid values are as follows:
   + **CUSTOM**
@@ -109,6 +120,8 @@ The `sources` block supports:
 
 <a name="subscription_targets"></a>
 The `targets` block supports:
+
+* `id` - (Required, String) Specifies the custom ID of the event target, in UUID format.
 
 * `provider_type` - (Required, String) Specifies the provider type of the event target.
   The valid values are as follows:
@@ -142,6 +155,34 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the event subscription.
 
+* `sources` - The list of the event sources.
+  The [sources](#subscription_sources_attr) structure is documented below.
+
+* `targets` - The list of the event targets.
+  The [targets](#subscription_targets_attr) structure is documented below.
+
 * `created_at` - The (UTC) creation time of the event subscription, in RFC3339 format.
 
 * `updated_at` - The (UTC) update time of the event subscription, in RFC3339 format.
+
+<a name="subscription_sources_attr"></a>
+The `sources` block supports:
+
+* `created_at` - The (UTC) creation time of the event source, in RFC3339 format.
+
+* `updated_at` - The (UTC) update time of the event source, in RFC3339 format.
+
+<a name="subscription_targets_attr"></a>
+The `targets` block supports:
+
+* `created_at` - The (UTC) creation time of the event target, in RFC3339 format.
+
+* `updated_at` - The (UTC) update time of the event target, in RFC3339 format.
+
+## Import
+
+Subscriptions can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_eg_event_subscription.test <id>
+```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `Read()` method can save the sources and targets configuration now.
And the import function also can be supported.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. sources and targets can be saved and support import function.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccEventSubscription_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccEventSubscription_basic -timeout 360m -parallel 4
=== RUN   TestAccEventSubscription_basic
=== PAUSE TestAccEventSubscription_basic
=== CONT  TestAccEventSubscription_basic
--- PASS: TestAccEventSubscription_basic (112.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        112.478s
```
