### PR TITLE
fix(vpc_subnet): update optional fields in the document to mandatory

### DIFF
--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -9,23 +9,33 @@ Provides a VPC subnet resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
+
+variable "vpc_name" {}
+variable "vpc_cidr" {}
+variable "subnet_name" {}
+variable "subnet_cidr" {}
+variable "subnet_gateway_ip" {}
+variable "availability_zone" {}
+
 resource "huaweicloud_vpc" "vpc" {
   name = var.vpc_name
   cidr = var.vpc_cidr
 }
 
 resource "huaweicloud_vpc_subnet" "subnet" {
-  name       = var.subnet_name
-  cidr       = var.subnet_cidr
-  gateway_ip = var.subnet_gateway_ip
-  vpc_id     = huaweicloud_vpc.vpc.id
+  name              = var.subnet_name
+  cidr              = var.subnet_cidr
+  gateway_ip        = var.subnet_gateway_ip
+  vpc_id            = huaweicloud_vpc.vpc.id
+  availability_zone = var.availability_zone
 }
 
 resource "huaweicloud_vpc_subnet" "subnet_with_tags" {
-  name       = var.subnet_name
-  cidr       = var.subnet_cidr
-  gateway_ip = var.subnet_gateway_ip
-  vpc_id     = huaweicloud_vpc.vpc.id
+  name              = var.subnet_name
+  cidr              = var.subnet_cidr
+  gateway_ip        = var.subnet_gateway_ip
+  vpc_id            = huaweicloud_vpc.vpc.id
+  availability_zone = var.availability_zone
 
   tags = {
     foo = "bar"
@@ -34,10 +44,11 @@ resource "huaweicloud_vpc_subnet" "subnet_with_tags" {
 }
 
 resource "huaweicloud_vpc_subnet" "subnet_with_dhcp" {
-  name       = var.subnet_name
-  cidr       = var.subnet_cidr
-  gateway_ip = var.subnet_gateway_ip
-  vpc_id     = huaweicloud_vpc.vpc.id
+  name              = var.subnet_name
+  cidr              = var.subnet_cidr
+  gateway_ip        = var.subnet_gateway_ip
+  vpc_id            = huaweicloud_vpc.vpc.id
+  availability_zone = var.availability_zone
 
   dhcp_lease_time    = "24h"
   ntp_server_address = "10.100.0.33,10.100.0.34"
@@ -65,6 +76,9 @@ The following arguments are supported:
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC to which the subnet belongs. Changing this creates
   a new subnet.
 
+* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone (AZ) to which the subnet belongs.
+  The value must be an existing AZ in the system. Changing this creates a new subnet.
+
 * `description` - (Optional, String) Specifies supplementary information about the subnet. The value is a string of
   no more than 255 characters and cannot contain angle brackets (< or >).
 
@@ -78,20 +92,17 @@ The following arguments are supported:
 * `secondary_dns` - (Optional, String) Specifies the IP address of DNS server 2 on the subnet. The value must be a valid
   IP address.
 
-* `dhcp_lease_time` - (Optional, String) Specifies the DHCP lease expiration time. The value can be -1, which indicates
-  unlimited lease time, or Number+h. the number ranges from 1 to 30,000. For example, the value can be 5h. The default
-  value is 24h.
+* `dns_list` - (Optional, List) Specifies the DNS server address list of a subnet. This field is required if you need to
+  use more than two DNS servers. This parameter value is the superset of both DNS server address 1 and DNS server
+  address 2.
 
 * `ntp_server_address` - (Optional, String) Specifies the NTP server address. Currently only IPv4 addresses are supported.
   A maximum of four IP addresses can be configured, and each address must be unique. Multiple IP addresses must be
   separated using commas(,). Removing this parameter indicates that no NTP server is configured.
 
-* `dns_list` - (Optional, List) Specifies the DNS server address list of a subnet. This field is required if you need to
-  use more than two DNS servers. This parameter value is the superset of both DNS server address 1 and DNS server
-  address 2.
-
-* `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone (AZ) to which the subnet belongs.
-  The value must be an existing AZ in the system. Changing this creates a new subnet.
+* `dhcp_lease_time` - (Optional, String) Specifies the DHCP lease expiration time. The value can be -1, which indicates
+  unlimited lease time, or Number+h. the number ranges from 1 to 30,000. For example, the value can be 5h. The default
+  value is 24h.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the subnet.
 

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_subnet.go
@@ -124,16 +124,23 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: utils.ValidateCIDR,
 			},
-			"vpc_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"gateway_ip": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: utils.ValidateIP,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"availability_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: "schema: Required",
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -168,12 +175,6 @@ func ResourceVpcSubnetV1() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: utils.ValidateIP,
 				},
-				Computed: true,
-			},
-			"availability_zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"ntp_server_address": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
update optional fields in the document to mandatory
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update optional fields in the document to mandatory
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcSubnetV1_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcSubnetV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== CONT  TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_basic (50.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       50.615s

```
