### PR TITLE
fix(VPCEP): VPCEP service support parameter `enable_policy`

### DIFF
--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -61,6 +61,9 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the VPC endpoint service.
 
+* `enable_policy` - (Optional, Bool, ForceNew) Specifies whether the VPC endpoint policy is enabled. Defaults to **false**.
+  Changing this creates a new VPC endpoint service resource.
+
 * `tags` - (Optional, Map) The key/value pairs to associate with the VPC endpoint service.
 
 The `port_mapping` block supports:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231025091400-016afad4156c
+	github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231025091400-016afad4156c h1:/LG9++KJvGkS35zjL1oc/uqWM9N0c8ffSr+2OFcbuuk=
-github.com/chnsz/golangsdk v0.0.0-20231025091400-016afad4156c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5 h1:RNaeq9hOMnDyQ3XryGJTjj0aRWzIpIhzN51b9OBHF9k=
+github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
@@ -38,6 +38,7 @@ func TestAccVPCEPService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "approval", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "enable_policy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "server_type", "VM"),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
@@ -59,6 +60,49 @@ func TestAccVPCEPService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8088"),
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCEPService_enablePolicy(t *testing.T) {
+	var service services.Service
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_vpcep_service.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&service,
+		getVpcepServiceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEPService_enablePolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "approval", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "enable_policy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server_type", "VM"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
 				),
 			},
 			{
@@ -144,6 +188,28 @@ resource "huaweicloud_vpcep_service" "test" {
   }
   tags = {
     owner = "tf-acc-update"
+  }
+}
+`, testAccVPCEPService_Precondition(rName), rName)
+}
+
+func testAccVPCEPService_enablePolicy(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpcep_service" "test" {
+  name          = "%s"
+  server_type   = "VM"
+  vpc_id        = data.huaweicloud_vpc.myvpc.id
+  port_id       = huaweicloud_compute_instance.ecs.network[0].port
+  approval      = false
+  description   = "test description"
+  enable_policy = true
+  permissions   = ["iam:domain::1234", "iam:domain::5678"]
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
   }
 }
 `, testAccVPCEPService_Precondition(rName), rName)

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
@@ -110,6 +110,12 @@ func ResourceVPCEndpointService() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"enable_policy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"tags": common.TagsSchema(),
 			"service_name": {
 				Type:     schema.TypeString,
@@ -189,15 +195,16 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	createOpts := services.CreateOpts{
-		VpcID:       d.Get("vpc_id").(string),
-		PortID:      d.Get("port_id").(string),
-		ServerType:  d.Get("server_type").(string),
-		ServiceName: d.Get("name").(string),
-		ServiceType: d.Get("service_type").(string),
-		Description: d.Get("description").(string),
-		Approval:    utils.Bool(d.Get("approval").(bool)),
-		Ports:       buildPortMappingOpts(d),
-		Tags:        utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+		VpcID:        d.Get("vpc_id").(string),
+		PortID:       d.Get("port_id").(string),
+		ServerType:   d.Get("server_type").(string),
+		ServiceName:  d.Get("name").(string),
+		ServiceType:  d.Get("service_type").(string),
+		Description:  d.Get("description").(string),
+		Approval:     utils.Bool(d.Get("approval").(bool)),
+		Ports:        buildPortMappingOpts(d),
+		Tags:         utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+		EnablePolicy: utils.Bool(d.Get("enable_policy").(bool)),
 	}
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	n, err := services.Create(vpcepClient, createOpts).Extract()
@@ -257,6 +264,7 @@ func resourceVPCEndpointServiceRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("description", n.Description),
 		d.Set("port_mapping", flattenVPCEndpointServicePorts(n)),
 		d.Set("tags", utils.TagsToMap(n.Tags)),
+		d.Set("enable_policy", n.EnablePolicy),
 	)
 
 	nameList := strings.Split(n.ServiceName, ".")

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
@@ -38,6 +38,8 @@ type CreateOpts struct {
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
 	// Specifies the description
 	Description string `json:"description,omitempty"`
+	// Specifies whether the VPC endpoint policy is enabled.
+	EnablePolicy *bool `json:"enable_policy,omitempty"`
 }
 
 // PortOpts contains the port mappings opened to the VPC endpoint service.

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
@@ -39,6 +39,8 @@ type Service struct {
 	Error []ErrorInfo `json:"error"`
 	// the description of the VPC endpoint service
 	Description string `json:"description"`
+	// whether the VPC endpoint policy is enabled.
+	EnablePolicy bool `json:"enable_policy"`
 	// the creation time of the VPC endpoint service
 	Created string `json:"created_at"`
 	// the update time of the VPC endpoint service

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231025091400-016afad4156c
+# github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

VPCEP service support parameter `enable_policy`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- add new field `enable_policy`, this field does not support updating.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEPService_'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPService_ -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== RUN   TestAccVPCEPService_enablePolicy
=== PAUSE TestAccVPCEPService_enablePolicy
=== CONT  TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_enablePolicy
--- PASS: TestAccVPCEPService_enablePolicy (187.10s)
--- PASS: TestAccVPCEPService_Basic (255.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     255.799s
```
