### PR TITLE
fix(CSE): fix cse lint

### DIFF
--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v2/engines"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -50,7 +51,7 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "RBAC"),
 					resource.TestCheckResourceAttrSet(resourceName, "admin_pass"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_limit"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_limit"),
@@ -117,7 +118,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   auth_type  = "RBAC"
   admin_pass = "AccTest!123"
 
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 3)
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
 }`, testAccMicroserviceEngine_base(rName), rName)
 }
@@ -153,7 +154,7 @@ func TestAccMicroserviceEngine_withEpsId(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "network_id", "huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "RBAC"),
 					resource.TestCheckResourceAttrSet(resourceName, "admin_pass"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
 						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_limit"),
@@ -206,7 +207,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   auth_type  = "RBAC"
   admin_pass = "AccTest!123"
 
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 3)
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
 }`, testAccMicroserviceEngine_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/instances"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
 )
 
-func getMicroserviceInstanceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getMicroserviceInstanceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	token, err := cse.GetAuthorizationToken(state.Primary.Attributes["connect_address"],
 		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
 	if err != nil {

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
 )
 
-func getMicroserviceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getMicroserviceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	token, err := cse.GetAuthorizationToken(state.Primary.Attributes["connect_address"],
 		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
 	if err != nil {
@@ -129,7 +130,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   auth_type  = "RBAC"
   admin_pass = "AccTest!123"
 
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 3)
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 }
 `, rName)
 }

--- a/huaweicloud/services/cse/config.go
+++ b/huaweicloud/services/cse/config.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/auth"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 )
 
-// getAuthorizationToken is a method to request the CSE API and get the authorization token.
+// getToken is a method to request the CSE API and get the authorization token.
 // The format of is "Bearer {token}".
-func getAuthorizationToken(c *golangsdk.ServiceClient, username, password string) (string, error) {
+func getToken(c *golangsdk.ServiceClient, username, password string) (string, error) {
 	tokenOpts := auth.CreateOpts{
 		Name:     username,
 		Password: password,
@@ -30,5 +31,5 @@ func GetAuthorizationToken(connAddr, username, password string) (string, error) 
 		return "", nil
 	}
 	client := common.NewCustomClient(true, connAddr, "v4")
-	return getAuthorizationToken(client, username, password)
+	return getToken(client, username, password)
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v2/engines"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -9,11 +9,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/instances"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/instances"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   fix cse lint
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/cse/ TESTARGS='-run TestAccMicroserviceEngine'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse/ -v -run TestAccMicroserviceEngine -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== RUN   TestAccMicroserviceEngine_withEpsId
=== PAUSE TestAccMicroserviceEngine_withEpsId
=== CONT  TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_withEpsId
    acceptance.go:344: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccMicroserviceEngine_withEpsId (0.01s)
--- PASS: TestAccMicroserviceEngine_basic (1231.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       1231.250s

make testacc TEST=./huaweicloud/services/acceptance/cse/ TESTARGS='-run TestAccMicroserviceInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse/ -v -run TestAccMicroserviceInstance -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceInstance_basic
=== PAUSE TestAccMicroserviceInstance_basic
=== CONT  TestAccMicroserviceInstance_basic
--- PASS: TestAccMicroserviceInstance_basic (982.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       982.475s

make testacc TEST=./huaweicloud/services/acceptance/cse/ TESTARGS='-run TestAccMicroservice_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse/ -v -run TestAccMicroservice_basic -timeout 360m -parallel 4
=== RUN   TestAccMicroservice_basic
=== PAUSE TestAccMicroservice_basic
=== CONT  TestAccMicroservice_basic
--- PASS: TestAccMicroservice_basic (1012.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse      1012.282s
```
