### PR TITLE
feat: chore(eps): refactor public method and support vpc param update

### DIFF
--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -56,8 +56,7 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the VPC.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the VPC. Changing this
-  creates a new VPC resource.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the VPC.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5
+	github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5 h1:RNaeq9hOMnDyQ3XryGJTjj0aRWzIpIhzN51b9OBHF9k=
-github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4 h1:Hwcokg8qsuPlybCcI2Q/ZRtcrA0oNNveB5Gt/XVYCdA=
+github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -21,7 +21,6 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/bss/v2/orders"
 	"github.com/chnsz/golangsdk/openstack/bss/v2/resources"
-	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -54,35 +53,6 @@ func GetRegion(d *schema.ResourceData, config *config.Config) string {
 	}
 
 	return config.Region
-}
-
-// GetEnterpriseProjectID returns the enterprise_project_id that was specified in the resource.
-// If it was not set, the provider-level value is checked. The provider-level value can
-// either be set by the `enterprise_project_id` argument or by HW_ENTERPRISE_PROJECT_ID.
-func GetEnterpriseProjectID(d *schema.ResourceData, config *config.Config) string {
-	if v, ok := d.GetOk("enterprise_project_id"); ok {
-		return v.(string)
-	}
-
-	return config.EnterpriseProjectID
-}
-
-func MigrateEnterpriseProject(client *golangsdk.ServiceClient, targetEPSId string, migrateOpts enterpriseprojects.MigrateResourceOpts) error {
-	if targetEPSId == "" {
-		targetEPSId = "0"
-	} else {
-		// check enterprise_project_id existed
-		if result := enterpriseprojects.Get(client, targetEPSId); result.Err != nil {
-			return fmt.Errorf("failed to query the target enterprise project %s: %s", targetEPSId, result.Err)
-		}
-	}
-
-	migrateResult := enterpriseprojects.Migrate(client, migrateOpts, targetEPSId)
-	if err := migrateResult.Err; err != nil {
-		return fmt.Errorf("failed to migrate %s to enterprise project %s, err: %s", migrateOpts.ResourceId, targetEPSId, err)
-	}
-
-	return nil
 }
 
 // GetEipIDbyAddress returns the EIP ID of address when success.

--- a/huaweicloud/common/eps_management.go
+++ b/huaweicloud/common/eps_management.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// GetEnterpriseProjectID returns the enterprise_project_id that was specified in the resource.
+// If it was not set, the provider-level value is checked. The provider-level value can
+// either be set by the `enterprise_project_id` argument or by HW_ENTERPRISE_PROJECT_ID.
+func GetEnterpriseProjectID(d *schema.ResourceData, cfg *config.Config) string {
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		return v.(string)
+	}
+
+	return cfg.EnterpriseProjectID
+}
+
+// MigrateEnterpriseProjectWithoutWait is a method that used to a migrate resource from an enterprise project to
+// another.
+// NOTE: Please read the following contents carefully before using this method.
+//   - This method only sends an asynchronous request and does not guarantee the result.
+func MigrateEnterpriseProjectWithoutWait(cfg *config.Config, d *schema.ResourceData,
+	opts enterpriseprojects.MigrateResourceOpts) error {
+	targetEpsId := cfg.GetEnterpriseProjectID(d)
+	if targetEpsId == "" {
+		targetEpsId = "0"
+	}
+
+	client, err := cfg.EnterpriseProjectClient(cfg.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating EPS client: %s", err)
+	}
+	_, err = enterpriseprojects.Migrate(client, opts, targetEpsId).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to migrate resource (%s) to the enterprise project (%s): %s",
+			opts.ResourceId, targetEpsId, err)
+	}
+	return nil
+}
+
+// MigrateEnterpriseProject is a method used to migrate a resource from an enterprise project to another enterprise
+// project and ensure the success of the EPS side migration.
+// NOTE: Please read the following contents carefully before using this method.
+//   - This method only calls the interfaces of the EPS service. For individual EPS IDs that are not updated due to
+//     out-of-synchronization of data on the server side, this method does not perform additional verification and
+//     requires developers to manually ensure the reliability of the code through testing.
+func MigrateEnterpriseProject(ctx context.Context, cfg *config.Config, d *schema.ResourceData,
+	opts enterpriseprojects.MigrateResourceOpts) error {
+	targetEpsId := cfg.GetEnterpriseProjectID(d)
+	if targetEpsId == "" {
+		targetEpsId = "0"
+	}
+
+	client, err := cfg.EnterpriseProjectClient(cfg.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating EPS client: %s", err)
+	}
+	_, err = enterpriseprojects.Migrate(client, opts, targetEpsId).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to migrate resource (%s) to the enterprise project (%s): %s",
+			opts.ResourceId, targetEpsId, err)
+	}
+
+	// Wait for the Enterprise Project ID changed.
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			s, err := getAssociatedResourceById(client, opts.ProjectId, targetEpsId, opts.ResourceType, opts.ResourceId)
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					return nil, "PENDING", nil
+				}
+				return nil, "ERROR", err
+			}
+			return s, "COMPLETED", nil
+		},
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for migrating enterprise poject complete: %s", err)
+	}
+	return nil
+}
+
+func getAssociatedResourceById(client *golangsdk.ServiceClient, projectId, epsId, resourceType,
+	resourceId string) (*enterpriseprojects.Resource, error) {
+	opts := enterpriseprojects.ListResourcesOpts{
+		EnterpriseProjectId: epsId,
+		Projects:            []string{projectId},
+		ResourceTypes:       []string{resourceType},
+	}
+	resourceList, err := enterpriseprojects.ListAssociatedResources(client, opts)
+	if err != nil {
+		return nil, err
+	}
+	for _, success := range resourceList.Resources {
+		if success.ResourceId == resourceId {
+			return &success, nil
+		}
+	}
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte(fmt.Sprintf("unable to find the resource under a specified enterprise_project_id (%s)", epsId)),
+		},
+	}
+}

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_test.go
@@ -115,18 +115,31 @@ func TestAccVpcV1_WithEpsId(t *testing.T) {
 	resourceName := "huaweicloud_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckEpsID(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckVpcV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcV1_epsId(rName),
+				Config: testAccVpcV1_epsId(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcV1Exists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "status", "OK"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				),
+			},
+			{
+				Config: testAccVpcV1_epsId(rName, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcV1Exists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "status", "OK"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -307,14 +320,14 @@ resource "huaweicloud_vpc" "test" {
 `, rName)
 }
 
-func testAccVpcV1_epsId(rName string) string {
+func testAccVpcV1_epsId(rName, epsId string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test" {
-  name                  = "%s"
+  name                  = "%[1]s"
   cidr                  = "192.168.0.0/16"
-  enterprise_project_id = "%s"
+  enterprise_project_id = "%[2]s"
 }
-`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, rName, epsId)
 }
 
 func testAccVpcV1_WithCustomRegion(name1, name2, region string) string {

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
 	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -63,7 +64,6 @@ func ResourceVirtualPrivateCloudV1() *schema.Resource {
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"status": {
@@ -272,6 +272,18 @@ func resourceVirtualPrivateCloudUpdate(ctx context.Context, d *schema.ResourceDa
 			if err := addSecondaryCIDR(v3Client, vpcID, newExtendCidr); err != nil {
 				return diag.Errorf("error adding VPC secondary CIDR: %s", err)
 			}
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := enterpriseprojects.MigrateResourceOpts{
+			ResourceId:   vpcID,
+			ResourceType: "vpcs",
+			RegionId:     region,
+			ProjectId:    vpcClient.ProjectID,
+		}
+		if err := common.MigrateEnterpriseProject(ctx, config, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects/requests.go
@@ -136,7 +136,10 @@ func Migrate(client *golangsdk.ServiceClient, opts MigrateResourceOpts, id strin
 	return
 }
 
-type ResourceOpts struct {
+type ListResourcesOpts struct {
+	// Target enterprise project ID.
+	EnterpriseProjectId string `json:"-" required:"true"`
+
 	ResourceTypes []string `json:"resource_types" required:"true"`
 
 	Projects []string `json:"projects,omitempty"`
@@ -154,15 +157,17 @@ type Match struct {
 	Value string `json:"value" required:"true"`
 }
 
-func ShowResource(client *golangsdk.ServiceClient, opts ResourceOpts, id string) (r ResourceResult) {
+// ListAssociatedResources is a method that used to query associated resources for specified enterprise project using
+// given parameters.
+func ListAssociatedResources(client *golangsdk.ServiceClient, opts ListResourcesOpts) (*FilterResult, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
 	if err != nil {
-		r.Err = err
-		return
+		return nil, err
 	}
 
-	_, r.Err = client.Post(resourceFilterURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+	var r FilterResult
+	_, err = client.Post(resourceFilterURL(client, opts.EnterpriseProjectId), b, &r, &golangsdk.RequestOpts{
 		MoreHeaders: RequestOpts.MoreHeaders,
 	})
-	return
+	return &r, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects/results.go
@@ -58,12 +58,12 @@ type ResourceResult struct {
 }
 
 type FilterResult struct {
-	Resources  []Resources `json:"resources"`
-	Errors     []Errors    `json:"errors"`
-	TotalCount int32       `json:"total_count"`
+	Resources  []Resource `json:"resources"`
+	Errors     []Errors   `json:"errors"`
+	TotalCount int32      `json:"total_count"`
 }
 
-type Resources struct {
+type Resource struct {
 	EnterpriseProjectId string `json:"enterprise_project_id"`
 
 	ProjectId string `json:"project_id"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231026085138-a2c9e44e2ef5
+# github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current enterprise project ID migration method is not universal enough, and each service must still provide corresponding status detection methods when docking this function.
So, we need to refactor this function.

And, the VPC resource parameter `enterprise_project_id` can also dock this function to support update.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor enterprise project migration function.
2. vpc can update the enterprise project ID.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ecs' TESTARGS='-run=TestAccComputeInstance_withEPS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run=TestAccComputeInstance_withEPS -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_withEPS
=== PAUSE TestAccComputeInstance_withEPS
=== CONT  TestAccComputeInstance_withEPS
--- PASS: TestAccComputeInstance_withEPS (199.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       199.295s
```
```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run=TestAccObsBucket_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run=TestAccObsBucket_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucket_withEpsId (72.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       72.419s
```
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run=TestAccWafDedicatedInstance_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run=TestAccWafDedicatedInstance_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_withEpsId
=== PAUSE TestAccWafDedicatedInstance_withEpsId
=== CONT  TestAccWafDedicatedInstance_withEpsId
--- PASS: TestAccWafDedicatedInstance_withEpsId (458.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       458.742s
```
```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run=TestAccVpcV1_WithEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run=TestAccVpcV1_WithEpsId -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcV1_WithEpsId
--- PASS: TestAccVpcV1_WithEpsId (50.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       50.308s
```
