### PR TITLE
fix(CodeArts): fix codearts instance resource lint error

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/huaweicloud/huaweicloud" {
+  version     = "1.56.1"
+  constraints = ">= 1.20.0"
+  hashes = [
+    "h1:I4NBQmT2bS/114yu1TAbl9k9enOUMuV6rbuKbTaJFhU=",
+    "zh:0651deeaeded59e308634e9a513c154a1919b4fa221bdac35cce07962fc9d2e7",
+    "zh:1a846d9e6af0a75a3af292ef1ca9f1bca3999e17a58ecb473289415e50debcbf",
+    "zh:25961e7a0ca36f812a779cf1a058d57dc6f45372a69b170c8a56770826e6c4d6",
+    "zh:4606db0e971929b1bb71617f9a1fc72aeeb53cbfb9ea2a335b8839b8c76418f4",
+    "zh:50d5cde9444548e26fb2a51f164d4bcac02dbc4efa6d4fc6535abcc5f8750464",
+    "zh:61640941049ee87cb8a8d3f4398b8ac2755663b42f148263e0041da2035a61f4",
+    "zh:78e4049dcf7f1f0b0431d7231ce7269b0bdf79604f2fa0b4ed5e1cd0a3f56432",
+    "zh:8b5244c6dd4b63b0a3839b48edbd379540cb0c1b89431221d241690c69e41999",
+    "zh:938282fea7335596d95af0c69b419d4e28bff215e09ac0a85639232e41d4dc66",
+    "zh:9cd6e83eee95b84528032f0b99f132287475f49df5aa15afdcffc989e536a198",
+    "zh:ae94bcb5bdfc66fa730fdba3b7062a88cdfa834363204bb9d18a9f7e1d3786af",
+    "zh:b2b72ec94e13dde4d0499c34e887514912991e59bc2e1d5d59efa7dc15cd04a6",
+    "zh:d7113575da6f0a8d40e88f4c19dc5706cafd7c3cdb5e794e54fb900433aa6d09",
+    "zh:e4538530322fe76c59f7f85131598f16174b2d0703a71500100744dd2108ca40",
+  ]
+}

--- a/.terraformrc
+++ b/.terraformrc
@@ -1,0 +1,6 @@
+provider_installation {
+	dev_overrides {
+		"huaweicloud/huaweicloud"="/home/huawei/go/bin"
+	}
+	direct {}
+}_

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go
@@ -242,7 +242,7 @@ resource "huaweicloud_compute_instance" "test" {
 
   name                        = "%[2]s"
   image_id                    = data.huaweicloud_images_image.test.id
-  flavor_id                   = "sn3.large.2"
+  flavor_id                   = data.huaweicloud_compute_flavors.test.ids[0]
   availability_zone           = data.huaweicloud_availability_zones.test.names[0]
   admin_pass                  = "Test@123"
   delete_disks_on_termination = true

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_project_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_project_test.go
@@ -5,29 +5,30 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getProjectResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getProjectResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getProject: Query the Project
 	var (
 		getProjectHttpUrl = "v4/projects/{id}"
 		getProjectProduct = "projectman"
 	)
-	getProjectClient, err := config.NewServiceClient(getProjectProduct, region)
+	getProjectClient, err := cfg.NewServiceClient(getProjectProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Project Client: %s", err)
 	}
 
 	getProjectPath := getProjectClient.Endpoint + getProjectHttpUrl
-	getProjectPath = strings.Replace(getProjectPath, "{id}", state.Primary.ID, -1)
+	getProjectPath = strings.ReplaceAll(getProjectPath, "{id}", state.Primary.ID)
 
 	getProjectOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_repository_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_repository_test.go
@@ -5,29 +5,30 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getRepositoryResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getRepositoryResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getRepository: Query the resource detail of the CodeHub repository
 	var (
 		getRepositoryHttpUrl = "v2/repositories/{repository_uuid}"
 		getRepositoryProduct = "codehub"
 	)
-	getRepositoryClient, err := config.NewServiceClient(getRepositoryProduct, region)
+	getRepositoryClient, err := cfg.NewServiceClient(getRepositoryProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating repository client: %s", err)
 	}
 
 	getRepositoryPath := getRepositoryClient.Endpoint + getRepositoryHttpUrl
-	getRepositoryPath = strings.Replace(getRepositoryPath, "{repository_uuid}", state.Primary.ID, -1)
+	getRepositoryPath = strings.ReplaceAll(getRepositoryPath, "{repository_uuid}", state.Primary.ID)
 
 	getRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_instance_test.go
+++ b/huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_instance_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -16,14 +17,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getInstanceResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getInstanceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getInstance: Query the DBSS instance detail
 	var (
 		getInstanceHttpUrl = "v1/{project_id}/dbss/audit/instances"
 		getInstanceProduct = "dbss"
 	)
-	getInstanceClient, err := config.NewServiceClient(getInstanceProduct, region)
+	getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Instance Client: %s", err)
 	}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
@@ -11,16 +11,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceRepository() *schema.Resource {
@@ -166,7 +168,7 @@ func waitForRepositoryActive(ctx context.Context, cfg *config.Config, d *schema.
 	}
 
 	getRepositoryPath := getRepositoryClient.Endpoint + getRepositoryHttpUrl
-	getRepositoryPath = strings.Replace(getRepositoryPath, "{repository_uuid}", d.Id(), -1)
+	getRepositoryPath = strings.ReplaceAll(getRepositoryPath, "{repository_uuid}", d.Id())
 
 	createRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -226,7 +228,7 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 			200,
 		},
 	}
-	createRepositoryOpt.JSONBody = buildCreateRepositoryBodyParams(d, cfg)
+	createRepositoryOpt.JSONBody = buildCreateRepositoryBodyParams(d)
 	createRepositoryResp, err := createRepositoryClient.Request("POST", createRepositoryPath, &createRepositoryOpt)
 	if err != nil {
 		return diag.Errorf("error creating CodeHub repository: %s", err)
@@ -248,7 +250,7 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceRepositoryRead(ctx, d, meta)
 }
 
-func buildCreateRepositoryBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateRepositoryBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"name":             utils.ValueIngoreEmpty(d.Get("name")),
 		"project_uuid":     utils.ValueIngoreEmpty(d.Get("project_id")),
@@ -263,7 +265,7 @@ func buildCreateRepositoryBodyParams(d *schema.ResourceData, config *config.Conf
 	return bodyParams
 }
 
-func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRepositoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// getRepository: Query the resource detail of the CodeHub repository
 	var (
 		getRepositoryHttpUrl = "v2/repositories/{repository_uuid}"
@@ -279,7 +281,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	getRepositoryPath := getRepositoryClient.Endpoint + getRepositoryHttpUrl
-	getRepositoryPath = strings.Replace(getRepositoryPath, "{repository_uuid}", d.Id(), -1)
+	getRepositoryPath = strings.ReplaceAll(getRepositoryPath, "{repository_uuid}", d.Id())
 
 	getRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -326,7 +328,7 @@ func parseRepositoryRequestError(respErr error) error {
 	return respErr
 }
 
-func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRepositoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// deleteRepository: Remove an existing CodeHub repository
 	var (
 		deleteRepositoryHttpUrl = "v1/repositories/{repository_uuid}"
@@ -341,7 +343,7 @@ func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	deleteRepositoryPath := deleteRepositoryClient.Endpoint + deleteRepositoryHttpUrl
-	deleteRepositoryPath = strings.Replace(deleteRepositoryPath, "{repository_uuid}", d.Id(), -1)
+	deleteRepositoryPath = strings.ReplaceAll(deleteRepositoryPath, "{repository_uuid}", d.Id())
 
 	deleteRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go
+++ b/huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go
@@ -11,17 +11,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceInstance() *schema.Resource {
@@ -184,15 +185,15 @@ func ResourceInstance() *schema.Resource {
 }
 
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createInstance: Create a DBSS instance.
 	var (
 		createInstanceHttpUrl = "v2/{project_id}/dbss/audit/charge/period/order"
 		createInstanceProduct = "dbss"
 	)
-	createInstanceClient, err := config.NewServiceClient(createInstanceProduct, region)
+	createInstanceClient, err := cfg.NewServiceClient(createInstanceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Instance Client: %s", err)
 	}
@@ -206,7 +207,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			200,
 		},
 	}
-	createInstanceOpt.JSONBody = utils.RemoveNil(buildCreateInstanceBodyParams(d, config))
+	createInstanceOpt.JSONBody = utils.RemoveNil(buildCreateInstanceBodyParams(d, cfg))
 	createInstanceResp, err := createInstanceClient.Request("POST", createInstancePath, &createInstanceOpt)
 	if err != nil {
 		return diag.Errorf("error creating Instance: %s", err)
@@ -227,7 +228,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		payOrderHttpUrl = "v3/orders/customer-orders/pay"
 		payOrderProduct = "bss"
 	)
-	payOrderClient, err := config.NewServiceClient(payOrderProduct, region)
+	payOrderClient, err := cfg.NewServiceClient(payOrderProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating BSS Client: %s", err)
 	}
@@ -246,7 +247,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error pay order=%s: %s", d.Id(), err)
 	}
 
-	bssClient, err := config.BssV2Client(config.GetRegion(d))
+	bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating BSS v2 client: %s", err)
 	}
@@ -277,20 +278,20 @@ func buildPayOrderBodyParams(orderId string) map[string]interface{} {
 	return bodyParams
 }
 
-func buildCreateInstanceBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateInstanceBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"region":                config.GetRegion(d),
+		"region":                cfg.GetRegion(d),
 		"name":                  utils.ValueIngoreEmpty(d.Get("name")),
 		"comment":               utils.ValueIngoreEmpty(d.Get("description")),
 		"availability_zone":     utils.ValueIngoreEmpty(d.Get("availability_zone")),
 		"cloud_service_type":    "hws.service.type.dbss",
 		"flavor_ref":            utils.ValueIngoreEmpty(d.Get("flavor")),
 		"vpc_id":                utils.ValueIngoreEmpty(d.Get("vpc_id")),
-		"nics":                  buildCreateInstanceRequestBodyCreateInstanceRequestBody_nics(d),
-		"security_groups":       buildCreateInstanceRequestBodyCreateInstanceRequestBody_security_groups(d),
-		"product_infos":         buildCreateInstanceRequestBodyCreateInstanceRequestBody_product_infos(d),
+		"nics":                  buildCreateInstanceRequestBodyCreateInstanceRequestBodyNics(d),
+		"security_groups":       buildCreateInstanceRequestBodyCreateInstanceRequestBodySecurityGroups(d),
+		"product_infos":         buildCreateInstanceRequestBodyCreateInstanceRequestBodyProductPnfos(d),
 		"subscription_num":      1,
-		"enterprise_project_id": utils.ValueIngoreEmpty(common.GetEnterpriseProjectID(d, config)),
+		"enterprise_project_id": utils.ValueIngoreEmpty(common.GetEnterpriseProjectID(d, cfg)),
 		"tags":                  utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
 		"period_num":            utils.ValueIngoreEmpty(d.Get("period")),
 	}
@@ -316,7 +317,7 @@ func buildCreateInstanceBodyParams(d *schema.ResourceData, config *config.Config
 	return bodyParams
 }
 
-func buildCreateInstanceRequestBodyCreateInstanceRequestBody_nics(d *schema.ResourceData) []map[string]interface{} {
+func buildCreateInstanceRequestBodyCreateInstanceRequestBodyNics(d *schema.ResourceData) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
 			"ip_address": utils.ValueIngoreEmpty(d.Get("ip_address")),
@@ -325,7 +326,7 @@ func buildCreateInstanceRequestBodyCreateInstanceRequestBody_nics(d *schema.Reso
 	}
 }
 
-func buildCreateInstanceRequestBodyCreateInstanceRequestBody_security_groups(d *schema.ResourceData) []map[string]interface{} {
+func buildCreateInstanceRequestBodyCreateInstanceRequestBodySecurityGroups(d *schema.ResourceData) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
 			"id": utils.ValueIngoreEmpty(d.Get("security_group_id")),
@@ -333,7 +334,7 @@ func buildCreateInstanceRequestBodyCreateInstanceRequestBody_security_groups(d *
 	}
 }
 
-func buildCreateInstanceRequestBodyCreateInstanceRequestBody_product_infos(d *schema.ResourceData) []map[string]interface{} {
+func buildCreateInstanceRequestBodyCreateInstanceRequestBodyProductPnfos(d *schema.ResourceData) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
 			"cloud_service_type": "hws.service.type.dbss",
@@ -350,13 +351,13 @@ func createInstaceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
+			cfg := meta.(*config.Config)
+			region := cfg.GetRegion(d)
 			var (
 				createInstaceWaitingHttpUrl = "v1/{project_id}/dbss/audit/jobs/{resource_id}"
 				createInstaceWaitingProduct = "dbss"
 			)
-			createInstaceWaitingClient, err := config.NewServiceClient(createInstaceWaitingProduct, region)
+			createInstaceWaitingClient, err := cfg.NewServiceClient(createInstaceWaitingProduct, region)
 			if err != nil {
 				return nil, "ERROR", fmt.Errorf("error creating Instance Client: %s", err)
 			}
@@ -403,7 +404,6 @@ func createInstaceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 			}
 
 			return createInstaceWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -413,9 +413,9 @@ func createInstaceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 	return err
 }
 
-func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -424,7 +424,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		getInstanceHttpUrl = "v1/{project_id}/dbss/audit/instances"
 		getInstanceProduct = "dbss"
 	)
-	getInstanceClient, err := config.NewServiceClient(getInstanceProduct, region)
+	getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Instance Client: %s", err)
 	}
@@ -494,9 +494,9 @@ func FilterInstances(instances []interface{}, id string) (interface{}, error) {
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
+	cfg := meta.(*config.Config)
 
-	if err := common.UnsubscribePrePaidResource(d, config, []string{d.Id()}); err != nil {
+	if err := common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()}); err != nil {
 		return diag.Errorf("Error unsubscribing DBSS order = %s: %s", d.Id(), err)
 	}
 
@@ -517,16 +517,16 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func waitForInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func waitForInstanceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	return func() (interface{}, string, error) {
 		var (
 			getInstanceHttpUrl = "v1/{project_id}/dbss/audit/instances"
 			getInstanceProduct = "dbss"
 		)
-		getInstanceClient, err := config.NewServiceClient(getInstanceProduct, region)
+		getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
 		if err != nil {
 			return nil, "error", fmt.Errorf("error creating Instance Client: %s", err)
 		}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,12 @@
+# Configure the HuaweiCloud Provider
+provider "huaweicloud" {
+  region     = "cn-south-1"
+  access_key = "IT1BRDH8SNDJN1SUED8O"
+  secret_key = "iZAsJnE1IoGmsi1sjEBkJG2JTzHPRZd1MIkiaaqH"
+}
+
+# Create a VPC
+resource "huaweicloud_vpc" "example" {
+  name = "zhangting_vpc"
+  cidr = "192.168.0.0/16"
+}

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    huaweicloud = {
+      source = "huaweicloud/huaweicloud"
+      version = ">= 1.20.0"
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fix(CodeArts) fix codearts instance resource lint error

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
./scripts/codecheck.sh ./huaweicloud/services/codearts

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5      1986      202        35     1749        203            57.22
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~source_huaweicloud_codearts_deploy_host.go       459       48         6      405         52            12.84
~ource_huaweicloud_codearts_deploy_group.go       418       47         7      364         50            13.74
~huaweicloud_codearts_deploy_application.go       467       37         6      424         45            10.61
~esource_huaweicloud_codearts_repository.go       360       35         8      317         33            10.41
~s/resource_huaweicloud_codearts_project.go       282       35         8      239         23             9.62
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5      1986      202        35     1749        203            57.22
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 61341 bytes, 0.061 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 codearts resourceDeployHostCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go:179:1
8 codearts resourceDeployApplicationCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go:245:1
7 codearts resourceDeployGroupCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go:156:1
6 codearts resourceRepositoryCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go:209:1
6 codearts repositoryRefreshFunc huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go:190:1
6 codearts resourceDeployHostRead huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go:265:1
6 codearts resourceDeployGroupRead huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go:212:1
6 codearts resourceDeployApplicationRead huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go:349:1
5 codearts resourceProjectCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go:103:1
5 codearts resourceDeployHostDelete huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go:404:1
Average: 3.12

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in codearts...

==> Checking for misspell in codearts...

==> Checking for code complexity in ./huaweicloud/services/acceptance/codearts...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5      1362      123         7     1232         44            18.28
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~_huaweicloud_codearts_deploy_group_test.go       277       29         2      246         13             5.28
~e_huaweicloud_codearts_deploy_host_test.go       432       34         2      396         13             3.28
~icloud_codearts_deploy_application_test.go       368       30         1      337         10             2.97
~ce_huaweicloud_codearts_repository_test.go       176       17         1      158          4             2.53
~ource_huaweicloud_codearts_project_test.go       109       13         1       95          4             4.21
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5      1362      123         7     1232         44            18.28
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 41115 bytes, 0.041 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 codearts getDeployHostResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go:20:1
6 codearts getDeployGroupResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_group_test.go:19:1
6 codearts getDeployApplicationResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_application_test.go:19:1
3 codearts getRepositoryResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_repository_test.go:18:1
3 codearts getProjectResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_project_test.go:18:1
Average: 1.56

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/codearts...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/codearts...

==> Cleanup patch...

Check Completed!

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployApplication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccDeployApplication -timeout 360m -parallel 4
=== RUN   TestAccDeployApplication_basic
=== PAUSE TestAccDeployApplication_basic
=== RUN   TestAccDeployApplication_resourcePoolId
=== PAUSE TestAccDeployApplication_resourcePoolId
=== RUN   TestAccDeployApplication_errorCheckInvalidArgument
=== PAUSE TestAccDeployApplication_errorCheckInvalidArgument
=== RUN   TestAccDeployApplication_errorCheckErrorCode
=== PAUSE TestAccDeployApplication_errorCheckErrorCode
=== CONT  TestAccDeployApplication_basic
=== CONT  TestAccDeployApplication_errorCheckInvalidArgument
=== CONT  TestAccDeployApplication_errorCheckErrorCode
=== CONT  TestAccDeployApplication_resourcePoolId
    acceptance.go:835: HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test
--- SKIP: TestAccDeployApplication_resourcePoolId (0.01s)
--- PASS: TestAccDeployApplication_errorCheckInvalidArgument (14.01s)
--- PASS: TestAccDeployApplication_errorCheckErrorCode (14.21s)
--- PASS: TestAccDeployApplication_basic (23.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  23.469s
 make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup -timeout 360m -parallel 4
=== RUN   TestAccDeployGroup_basic
=== PAUSE TestAccDeployGroup_basic
=== RUN   TestAccDeployGroup_resourcePoolId
=== PAUSE TestAccDeployGroup_resourcePoolId
=== RUN   TestAccDeployGroup_errorCheck
=== PAUSE TestAccDeployGroup_errorCheck
=== CONT  TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_errorCheck
=== CONT  TestAccDeployGroup_resourcePoolId
    acceptance.go:835: HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test
--- SKIP: TestAccDeployGroup_resourcePoolId (0.00s)
--- PASS: TestAccDeployGroup_errorCheck (11.30s)
--- PASS: TestAccDeployGroup_basic (30.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  30.183s
 make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost -timeout 360m -parallel 4
=== RUN   TestAccDeployHost_withProxyMode
=== PAUSE TestAccDeployHost_withProxyMode
=== RUN   TestAccDeployHost_withoutProxyMode
=== PAUSE TestAccDeployHost_withoutProxyMode
=== RUN   TestAccDeployHost_errorCheck
=== PAUSE TestAccDeployHost_errorCheck
=== CONT  TestAccDeployHost_withProxyMode
    acceptance.go:842: Skip the CodeArts acceptance tests.
--- SKIP: TestAccDeployHost_withProxyMode (0.00s)
=== CONT  TestAccDeployHost_errorCheck
=== CONT  TestAccDeployHost_withoutProxyMode
    acceptance.go:842: Skip the CodeArts acceptance tests.
--- SKIP: TestAccDeployHost_withoutProxyMode (0.01s)
--- PASS: TestAccDeployHost_errorCheck (190.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  190.337s
make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccProject -timeout 360m -parallel 4
=== RUN   TestAccProject_basic
=== PAUSE TestAccProject_basic
=== CONT  TestAccProject_basic
--- PASS: TestAccProject_basic (22.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  22.545s
 make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccRepository'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccRepository -timeout 360m -parallel 4
=== RUN   TestAccRepository_basic
=== PAUSE TestAccRepository_basic
=== RUN   TestAccRepository_default
=== PAUSE TestAccRepository_default
=== CONT  TestAccRepository_basic
=== CONT  TestAccRepository_default
--- PASS: TestAccRepository_basic (26.93s)
--- PASS: TestAccRepository_default (29.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  29.765s

```
